### PR TITLE
fix: delete grocery items from Supabase when batch deleting

### DIFF
--- a/client/database/core/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/Grocery.sq
+++ b/client/database/core/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/Grocery.sq
@@ -47,6 +47,9 @@ DELETE FROM Grocery;
 deleteByListId:
 DELETE FROM Grocery WHERE listId = ?;
 
+readCheckedByListId:
+SELECT * FROM Grocery WHERE listId = ? AND isChecked = 1;
+
 deleteCheckedByListId:
 DELETE FROM Grocery WHERE listId = ? AND isChecked = 1;
 

--- a/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
+++ b/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
@@ -591,11 +591,34 @@ class GroceryRepositoryImpl(
     }
 
     override suspend fun deleteAllGroceries(listId: Long) {
-        withContext(ioContext) { queries.deleteByListId(listId) }
+        val remoteIds =
+            withContext(ioContext) {
+                val items = queries.readByListId(listId).executeAsList()
+                queries.deleteByListId(listId)
+                items.mapNotNull { it.remoteId }
+            }
+        deleteRemoteItems(remoteIds)
     }
 
     override suspend fun deletePurchasedGroceries(listId: Long) {
-        withContext(ioContext) { queries.deleteCheckedByListId(listId) }
+        val remoteIds =
+            withContext(ioContext) {
+                val items = queries.readCheckedByListId(listId).executeAsList()
+                queries.deleteCheckedByListId(listId)
+                items.mapNotNull { it.remoteId }
+            }
+        deleteRemoteItems(remoteIds)
+    }
+
+    private fun deleteRemoteItems(remoteIds: List<String>) {
+        if (remoteIds.isEmpty()) return
+        scope.launch {
+            for (remoteId in remoteIds) {
+                try {
+                    remoteDataSource.deleteGroceryItem(remoteId)
+                } catch (_: Exception) {}
+            }
+        }
     }
 
     private fun fromEntity(entity: Grocery, syncing: Set<Long>): GroceryItem {

--- a/client/grocery/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImplTest.kt
+++ b/client/grocery/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImplTest.kt
@@ -204,4 +204,171 @@ class GroceryRepositoryImplTest {
                 items.map { it.name }.toSet() shouldBe setOf("Milk", "Eggs")
             }
         }
+
+    // ─── deleteAllGroceries ───────────────────────────────────────────────────
+
+    @Test
+    fun deleteAllGroceries_removes_all_items_from_local_db() =
+        runTest(testDispatcher) {
+            val listId = repository.ensureDefaultList()
+            repository.addGrocery(listId, "Apples")
+            repository.addGrocery(listId, "Bananas")
+
+            repository.deleteAllGroceries(listId)
+
+            repository.getGroceries(listId).test { awaitItem().isEmpty() shouldBe true }
+        }
+
+    @Test
+    fun deleteAllGroceries_calls_remote_delete_for_each_synced_item() =
+        runTest(testDispatcher) {
+            val listId = repository.ensureDefaultList()
+            val remoteListId = "remote-list-1"
+            val now = "2026-01-01T00:00:00"
+            db.groceryQueries.createWithRemoteId(
+                name = "Apples",
+                isChecked = false,
+                createdAt = now,
+                updatedAt = now,
+                remoteId = "remote-apple",
+                listRemoteId = remoteListId,
+                clientId = "client-apple",
+                listId = listId,
+                recipeName = null,
+            )
+            db.groceryQueries.createWithRemoteId(
+                name = "Bananas",
+                isChecked = false,
+                createdAt = now,
+                updatedAt = now,
+                remoteId = "remote-banana",
+                listRemoteId = remoteListId,
+                clientId = "client-banana",
+                listId = listId,
+                recipeName = null,
+            )
+            fakeRemote.remoteItems[remoteListId] =
+                mutableListOf(
+                    RemoteGroceryItem(id = "remote-apple", listId = remoteListId, name = "Apples"),
+                    RemoteGroceryItem(id = "remote-banana", listId = remoteListId, name = "Bananas"),
+                )
+
+            repository.deleteAllGroceries(listId)
+
+            fakeRemote.remoteItems[remoteListId].orEmpty().isEmpty() shouldBe true
+        }
+
+    @Test
+    fun deleteAllGroceries_skips_remote_delete_when_items_have_no_remote_id() =
+        runTest(testDispatcher) {
+            val listId = repository.ensureDefaultList()
+            repository.addGrocery(listId, "Apples") // no remoteId
+            val unrelatedListId = "unrelated-list"
+            fakeRemote.remoteItems[unrelatedListId] =
+                mutableListOf(
+                    RemoteGroceryItem(
+                        id = "remote-item-x",
+                        listId = unrelatedListId,
+                        name = "Other",
+                    )
+                )
+
+            repository.deleteAllGroceries(listId)
+
+            fakeRemote.remoteItems[unrelatedListId]!!.size shouldBe 1
+        }
+
+    @Test
+    fun deleteAllGroceries_only_deletes_items_from_the_specified_list() =
+        runTest(testDispatcher) {
+            val listId1 = repository.ensureDefaultList()
+            val listId2 = repository.createGroceryList("Second List")
+            repository.addGrocery(listId1, "Apples")
+            repository.addGrocery(listId2, "Bananas")
+
+            repository.deleteAllGroceries(listId1)
+
+            repository.getGroceries(listId1).test { awaitItem().isEmpty() shouldBe true }
+            repository.getGroceries(listId2).test { awaitItem().size shouldBe 1 }
+        }
+
+    // ─── deletePurchasedGroceries ─────────────────────────────────────────────
+
+    @Test
+    fun deletePurchasedGroceries_removes_only_checked_items_from_db() =
+        runTest(testDispatcher) {
+            val listId = repository.ensureDefaultList()
+            repository.addGrocery(listId, "Apples")
+            repository.addGrocery(listId, "Bananas")
+
+            val items = db.groceryQueries.readByListId(listId).executeAsList()
+            val toCheck = repository.getGrocery(items.first().id)!!
+            repository.updateChecked(toCheck, isChecked = true)
+
+            repository.deletePurchasedGroceries(listId)
+
+            repository.getGroceries(listId).test {
+                val remaining = awaitItem()
+                remaining.size shouldBe 1
+                remaining.first().isChecked shouldBe false
+            }
+        }
+
+    @Test
+    fun deletePurchasedGroceries_calls_remote_delete_only_for_checked_synced_items() =
+        runTest(testDispatcher) {
+            val listId = repository.ensureDefaultList()
+            val remoteListId = "remote-list-checked"
+            val now = "2026-01-01T00:00:00"
+            db.groceryQueries.createWithRemoteId(
+                name = "Milk",
+                isChecked = true,
+                createdAt = now,
+                updatedAt = now,
+                remoteId = "remote-milk",
+                listRemoteId = remoteListId,
+                clientId = "client-milk",
+                listId = listId,
+                recipeName = null,
+            )
+            db.groceryQueries.createWithRemoteId(
+                name = "Eggs",
+                isChecked = false,
+                createdAt = now,
+                updatedAt = now,
+                remoteId = "remote-eggs",
+                listRemoteId = remoteListId,
+                clientId = "client-eggs",
+                listId = listId,
+                recipeName = null,
+            )
+            fakeRemote.remoteItems[remoteListId] =
+                mutableListOf(
+                    RemoteGroceryItem(
+                        id = "remote-milk",
+                        listId = remoteListId,
+                        name = "Milk",
+                        isChecked = true,
+                    ),
+                    RemoteGroceryItem(id = "remote-eggs", listId = remoteListId, name = "Eggs"),
+                )
+
+            repository.deletePurchasedGroceries(listId)
+
+            val remaining = fakeRemote.remoteItems[remoteListId].orEmpty()
+            remaining.size shouldBe 1
+            remaining.first().name shouldBe "Eggs"
+        }
+
+    @Test
+    fun deletePurchasedGroceries_is_a_no_op_when_no_items_are_checked() =
+        runTest(testDispatcher) {
+            val listId = repository.ensureDefaultList()
+            repository.addGrocery(listId, "Apples")
+            repository.addGrocery(listId, "Bananas")
+
+            repository.deletePurchasedGroceries(listId)
+
+            repository.getGroceries(listId).test { awaitItem().size shouldBe 2 }
+        }
 }


### PR DESCRIPTION
## Summary
- Batch delete operations (delete all, delete purchased) now delete items from Supabase in addition to the local database
- Added `readCheckedByListId` SQLDelight query to fetch checked items before deletion
- Extracted `deleteRemoteItems()` helper following the same pattern as single-item deletion

Fixes #41

## Test plan
- [x] Add grocery items and sync to Supabase
- [x] Use "Delete Purchased" — verify items don't reappear after syncing
- [x] Use "Delete All" — verify items don't reappear after syncing
- [x] Verify single item deletion still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)