### PR TITLE
feat: add month picker to meal planner

### DIFF
--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/RecipeExtractorService.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/RecipeExtractorService.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.browser.impl
 
 import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.parser.Parser
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.di.IO
 import dev.zacsweers.metro.ContributesBinding
@@ -100,13 +101,16 @@ class RecipeExtractorServiceImpl(@IO private val ioContext: CoroutineContext) :
         }
     }
 
+    private fun String.decodeHtmlEntities(): String = Parser.unescapeEntities(this, false)
+
     private fun parseRecipeFromJson(obj: JsonObject, sourceUrl: String): ExtractedRecipe {
-        val title = obj["name"]?.jsonPrimitive?.contentOrNull ?: ""
-        val description = obj["description"]?.jsonPrimitive?.contentOrNull
+        val title = obj["name"]?.jsonPrimitive?.contentOrNull?.decodeHtmlEntities() ?: ""
+        val description = obj["description"]?.jsonPrimitive?.contentOrNull?.decodeHtmlEntities()
 
         val ingredients =
-            obj["recipeIngredient"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull }
-                ?: emptyList()
+            obj["recipeIngredient"]?.jsonArray?.mapNotNull {
+                it.jsonPrimitive.contentOrNull?.decodeHtmlEntities()
+            } ?: emptyList()
 
         val directions = parseDirections(obj)
 
@@ -146,19 +150,25 @@ class RecipeExtractorServiceImpl(@IO private val ioContext: CoroutineContext) :
                     when {
                         element is JsonObject &&
                             element["@type"]?.jsonPrimitive?.contentOrNull == "HowToStep" ->
-                            listOfNotNull(element["text"]?.jsonPrimitive?.contentOrNull)
+                            listOfNotNull(
+                                element["text"]?.jsonPrimitive?.contentOrNull?.decodeHtmlEntities()
+                            )
                         element is JsonObject &&
                             element["@type"]?.jsonPrimitive?.contentOrNull == "HowToSection" -> {
                             val items =
                                 element["itemListElement"]?.jsonArray ?: return@flatMap emptyList()
                             items.mapNotNull { item ->
-                                item.jsonObject["text"]?.jsonPrimitive?.contentOrNull
+                                item.jsonObject["text"]
+                                    ?.jsonPrimitive
+                                    ?.contentOrNull
+                                    ?.decodeHtmlEntities()
                             }
                         }
-                        else -> listOfNotNull(element.jsonPrimitive.contentOrNull)
+                        else ->
+                            listOfNotNull(element.jsonPrimitive.contentOrNull?.decodeHtmlEntities())
                     }
                 }
-            else -> listOfNotNull(instructions.jsonPrimitive.contentOrNull)
+            else -> listOfNotNull(instructions.jsonPrimitive.contentOrNull?.decodeHtmlEntities())
         }
     }
 

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
@@ -16,6 +16,7 @@ import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.datetime.LocalDate
 
 @AssistedInject
 class MealPlanBlocImpl(
@@ -49,12 +50,22 @@ class MealPlanBlocImpl(
                     } else {
                         null
                     },
+                monthModel =
+                    if (it.viewMode == MealPlanBloc.ViewMode.MONTH) {
+                        viewModel.buildMonthModel(it.meals, it.selectedMonthDay)
+                    } else {
+                        null
+                    },
                 mealToDelete = it.mealToDelete,
             )
         }
 
-    override fun onViewModeToggled() {
-        viewModel.toggleViewMode()
+    override fun onViewModeSelected(mode: MealPlanBloc.ViewMode) {
+        viewModel.selectViewMode(mode)
+    }
+
+    override fun onMonthDaySelected(date: LocalDate) {
+        viewModel.onMonthDaySelected(date)
     }
 
     override fun onPreviousClicked() {

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanViewModel.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanViewModel.kt
@@ -34,17 +34,13 @@ class MealPlanViewModel(
     private var observeJob: Job? = null
 
     init {
-        _state.update { it.copy(currentDate = dateTimeUtil.today()) }
+        val today = dateTimeUtil.today()
+        _state.update { it.copy(currentDate = today, selectedMonthDay = today) }
         observeMeals()
     }
 
-    fun toggleViewMode() {
-        val newMode =
-            when (_state.value.viewMode) {
-                MealPlanBloc.ViewMode.DAY -> MealPlanBloc.ViewMode.WEEK
-                MealPlanBloc.ViewMode.WEEK -> MealPlanBloc.ViewMode.DAY
-            }
-        _state.update { it.copy(viewMode = newMode) }
+    fun selectViewMode(mode: MealPlanBloc.ViewMode) {
+        _state.update { it.copy(viewMode = mode) }
         observeMeals()
     }
 
@@ -54,8 +50,16 @@ class MealPlanViewModel(
             when (current.viewMode) {
                 MealPlanBloc.ViewMode.DAY -> current.currentDate.plus(1, DateTimeUnit.DAY)
                 MealPlanBloc.ViewMode.WEEK -> current.currentDate.plus(7, DateTimeUnit.DAY)
+                MealPlanBloc.ViewMode.MONTH -> {
+                    val firstOfMonth =
+                        LocalDate(current.currentDate.year, current.currentDate.month, 1)
+                    firstOfMonth.plus(1, DateTimeUnit.MONTH)
+                }
             }
-        _state.update { it.copy(currentDate = newDate) }
+        val newSelectedMonthDay =
+            if (current.viewMode == MealPlanBloc.ViewMode.MONTH) newDate
+            else current.selectedMonthDay
+        _state.update { it.copy(currentDate = newDate, selectedMonthDay = newSelectedMonthDay) }
         observeMeals()
     }
 
@@ -65,9 +69,21 @@ class MealPlanViewModel(
             when (current.viewMode) {
                 MealPlanBloc.ViewMode.DAY -> current.currentDate.minus(1, DateTimeUnit.DAY)
                 MealPlanBloc.ViewMode.WEEK -> current.currentDate.minus(7, DateTimeUnit.DAY)
+                MealPlanBloc.ViewMode.MONTH -> {
+                    val firstOfMonth =
+                        LocalDate(current.currentDate.year, current.currentDate.month, 1)
+                    firstOfMonth.minus(1, DateTimeUnit.MONTH)
+                }
             }
-        _state.update { it.copy(currentDate = newDate) }
+        val newSelectedMonthDay =
+            if (current.viewMode == MealPlanBloc.ViewMode.MONTH) newDate
+            else current.selectedMonthDay
+        _state.update { it.copy(currentDate = newDate, selectedMonthDay = newSelectedMonthDay) }
         observeMeals()
+    }
+
+    fun onMonthDaySelected(date: LocalDate) {
+        _state.update { it.copy(selectedMonthDay = date) }
     }
 
     fun requestRemoveMeal(item: MealPlanItem) {
@@ -94,6 +110,11 @@ class MealPlanViewModel(
                 val endStr = dateTimeUtil.formatLocalDate(end)
                 "$startStr - $endStr"
             }
+            MealPlanBloc.ViewMode.MONTH -> {
+                val monthName =
+                    current.currentDate.month.name.lowercase().replaceFirstChar { it.uppercase() }
+                "$monthName ${current.currentDate.year}"
+            }
         }
     }
 
@@ -118,6 +139,22 @@ class MealPlanViewModel(
         }
     }
 
+    fun buildMonthModel(
+        meals: List<MealPlanItem>,
+        selectedDay: LocalDate,
+    ): MealPlanBloc.MonthModel {
+        val current = _state.value
+        val firstDayOfMonth = LocalDate(current.currentDate.year, current.currentDate.month, 1)
+        val daysWithMeals = meals.map { it.date }.toSet()
+        val selectedDayMeals = meals.filter { it.date == selectedDay.toString() }
+        return MealPlanBloc.MonthModel(
+            firstDayOfMonth = firstDayOfMonth,
+            selectedDay = selectedDay,
+            daysWithMeals = daysWithMeals,
+            selectedDayMeals = buildDayMeals(selectedDayMeals),
+        )
+    }
+
     private fun observeMeals() {
         observeJob?.cancel()
         observeJob = scope.launch {
@@ -128,6 +165,10 @@ class MealPlanViewModel(
                         repository.getMealsByDate(current.currentDate.toString())
                     MealPlanBloc.ViewMode.WEEK -> {
                         val (start, end) = getWeekRange(current.currentDate)
+                        repository.getMealsByDateRange(start.toString(), end.toString())
+                    }
+                    MealPlanBloc.ViewMode.MONTH -> {
+                        val (start, end) = getMonthRange(current.currentDate)
                         repository.getMealsByDateRange(start.toString(), end.toString())
                     }
                 }
@@ -142,10 +183,17 @@ class MealPlanViewModel(
         return start to end
     }
 
+    private fun getMonthRange(date: LocalDate): Pair<LocalDate, LocalDate> {
+        val start = LocalDate(date.year, date.month, 1)
+        val end = start.plus(1, DateTimeUnit.MONTH).minus(1, DateTimeUnit.DAY)
+        return start to end
+    }
+
     data class State(
         val isLoading: Boolean = true,
         val viewMode: MealPlanBloc.ViewMode = MealPlanBloc.ViewMode.DAY,
         val currentDate: LocalDate = LocalDate(2000, 1, 1),
+        val selectedMonthDay: LocalDate = LocalDate(2000, 1, 1),
         val meals: List<MealPlanItem> = emptyList(),
         val mealToDelete: MealPlanItem? = null,
     )

--- a/client/meal/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocTest.kt
+++ b/client/meal/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocTest.kt
@@ -153,13 +153,21 @@ class MealPlanBlocTest {
     }
 
     @Test
-    fun WHEN_view_mode_toggled_THEN_mode_switches_to_week() = runTest {
-        // Toggling to WEEK triggers getMealsByDateRange for the current week
+    fun WHEN_week_mode_selected_THEN_mode_switches_to_week() = runTest {
         every { repository.getMealsByDateRange("2026-04-12", "2026-04-18") } returns mealsFlow
 
-        bloc.onViewModeToggled()
+        bloc.onViewModeSelected(MealPlanBloc.ViewMode.WEEK)
 
         bloc.state.test { awaitItem().viewMode shouldBe MealPlanBloc.ViewMode.WEEK }
+    }
+
+    @Test
+    fun WHEN_month_mode_selected_THEN_mode_switches_to_month() = runTest {
+        every { repository.getMealsByDateRange("2026-04-01", "2026-04-30") } returns mealsFlow
+
+        bloc.onViewModeSelected(MealPlanBloc.ViewMode.MONTH)
+
+        bloc.state.test { awaitItem().viewMode shouldBe MealPlanBloc.ViewMode.MONTH }
     }
 
     @Test

--- a/client/meal/core/public/build.gradle.kts
+++ b/client/meal/core/public/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
         commonMain.dependencies {
             api(libs.kotlin.coroutines.core)
             api(libs.arkivanov.decompose.core)
+            api(libs.kotlinx.datetime)
             api(projects.client.shared)
             implementation(compose.components.resources)
             implementation(projects.client.meal.data.public)

--- a/client/meal/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/meal/core/public/src/commonMain/composeResources/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="meal_plan_title">Meals</string>
     <string name="meal_plan_day">Day</string>
     <string name="meal_plan_week">Week</string>
+    <string name="meal_plan_month">Month</string>
     <string name="meal_plan_week_range">{start} - {end}</string>
     <string name="meal_plan_short_day_date">{day}, {date}</string>
     <string name="meal_plan_breakfast">Breakfast</string>

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanBloc.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanBloc.kt
@@ -6,11 +6,12 @@ import com.plusmobileapps.chefmate.meal.data.MealPlanItem
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.TextData
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.datetime.LocalDate
 
 interface MealPlanBloc {
     val state: StateFlow<Model>
 
-    fun onViewModeToggled()
+    fun onViewModeSelected(mode: ViewMode)
 
     fun onPreviousClicked()
 
@@ -24,12 +25,15 @@ interface MealPlanBloc {
 
     fun onDeleteMealDismissed()
 
+    fun onMonthDaySelected(date: LocalDate)
+
     data class Model(
         val isLoading: Boolean = true,
         val viewMode: ViewMode = ViewMode.DAY,
         val dateLabel: TextData = FixedString(""),
         val dayMeals: DayMeals? = null,
         val weekMeals: List<DayGroup>? = null,
+        val monthModel: MonthModel? = null,
         val mealToDelete: MealPlanItem? = null,
     )
 
@@ -42,9 +46,17 @@ interface MealPlanBloc {
 
     data class DayGroup(val dateLabel: TextData, val meals: List<MealPlanItem>)
 
+    data class MonthModel(
+        val firstDayOfMonth: LocalDate,
+        val selectedDay: LocalDate,
+        val daysWithMeals: Set<String>,
+        val selectedDayMeals: DayMeals,
+    )
+
     enum class ViewMode {
         DAY,
         WEEK,
+        MONTH,
     }
 
     sealed class Output {

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
@@ -1,29 +1,36 @@
-@file:OptIn(ExperimentalFoundationApi::class)
+@file:OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 
 package com.plusmobileapps.chefmate.meal.core
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.CalendarViewDay
-import androidx.compose.material.icons.filled.CalendarViewWeek
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -31,8 +38,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import chefmate.client.meal.core.public.generated.resources.Res
 import chefmate.client.meal.core.public.generated.resources.meal_plan_breakfast
+import chefmate.client.meal.core.public.generated.resources.meal_plan_day
 import chefmate.client.meal.core.public.generated.resources.meal_plan_delete
 import chefmate.client.meal.core.public.generated.resources.meal_plan_delete_cancel
 import chefmate.client.meal.core.public.generated.resources.meal_plan_delete_confirm
@@ -40,9 +50,11 @@ import chefmate.client.meal.core.public.generated.resources.meal_plan_delete_mes
 import chefmate.client.meal.core.public.generated.resources.meal_plan_delete_title
 import chefmate.client.meal.core.public.generated.resources.meal_plan_dinner
 import chefmate.client.meal.core.public.generated.resources.meal_plan_lunch
+import chefmate.client.meal.core.public.generated.resources.meal_plan_month
 import chefmate.client.meal.core.public.generated.resources.meal_plan_no_meals
 import chefmate.client.meal.core.public.generated.resources.meal_plan_snacks
 import chefmate.client.meal.core.public.generated.resources.meal_plan_title
+import chefmate.client.meal.core.public.generated.resources.meal_plan_week
 import com.plusmobileapps.chefmate.meal.data.MealPlanItem
 import com.plusmobileapps.chefmate.meal.data.MealType
 import com.plusmobileapps.chefmate.text.ResourceString
@@ -52,6 +64,10 @@ import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.plus
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -70,26 +86,16 @@ fun MealPlanScreen(bloc: MealPlanBloc, modifier: Modifier = Modifier) {
     }
 
     PlusNavContainer(
-        data =
-            PlusHeaderData.Parent(
-                title = Res.string.meal_plan_title.asTextData(),
-                trailingAccessory =
-                    PlusHeaderData.TrailingAccessory.Custom {
-                        IconButton(onClick = bloc::onViewModeToggled) {
-                            Icon(
-                                imageVector =
-                                    when (state.viewMode) {
-                                        MealPlanBloc.ViewMode.DAY -> Icons.Default.CalendarViewWeek
-                                        MealPlanBloc.ViewMode.WEEK -> Icons.Default.CalendarViewDay
-                                    },
-                                contentDescription = null,
-                            )
-                        }
-                    },
-            ),
+        data = PlusHeaderData.Parent(title = Res.string.meal_plan_title.asTextData()),
         scrollEnabled = false,
         content = {
             Column(modifier = Modifier.fillMaxSize()) {
+                ViewModeSegmentedControl(
+                    selectedMode = state.viewMode,
+                    onModeSelected = bloc::onViewModeSelected,
+                    modifier = Modifier.padding(horizontal = ChefMateTheme.dimens.paddingNormal),
+                )
+
                 DateNavigationRow(
                     dateLabel = state.dateLabel.localized(),
                     onPrevious = bloc::onPreviousClicked,
@@ -116,12 +122,48 @@ fun MealPlanScreen(bloc: MealPlanBloc, modifier: Modifier = Modifier) {
                                 onDeleteClicked = bloc::onDeleteMealClicked,
                                 modifier = Modifier.weight(1f),
                             )
+                        MealPlanBloc.ViewMode.MONTH ->
+                            MonthView(
+                                monthModel = state.monthModel,
+                                onDaySelected = bloc::onMonthDaySelected,
+                                onMealClicked = bloc::onMealClicked,
+                                onDeleteClicked = bloc::onDeleteMealClicked,
+                                modifier = Modifier.weight(1f),
+                            )
                     }
                 }
             }
         },
         modifier = modifier.fillMaxSize(),
     )
+}
+
+@Composable
+private fun ViewModeSegmentedControl(
+    selectedMode: MealPlanBloc.ViewMode,
+    onModeSelected: (MealPlanBloc.ViewMode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val modes = MealPlanBloc.ViewMode.entries
+    SingleChoiceSegmentedButtonRow(modifier = modifier.fillMaxWidth()) {
+        modes.forEachIndexed { index, mode ->
+            SegmentedButton(
+                selected = selectedMode == mode,
+                onClick = { onModeSelected(mode) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = modes.size),
+            ) {
+                Text(
+                    text =
+                        when (mode) {
+                            MealPlanBloc.ViewMode.DAY -> stringResource(Res.string.meal_plan_day)
+                            MealPlanBloc.ViewMode.WEEK -> stringResource(Res.string.meal_plan_week)
+                            MealPlanBloc.ViewMode.MONTH ->
+                                stringResource(Res.string.meal_plan_month)
+                        }
+                )
+            }
+        }
+    }
 }
 
 @Composable
@@ -142,6 +184,143 @@ private fun DateNavigationRow(
         Text(text = dateLabel, style = MaterialTheme.typography.titleMedium)
         IconButton(onClick = onNext) {
             Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+        }
+    }
+}
+
+@Composable
+private fun MonthView(
+    monthModel: MealPlanBloc.MonthModel?,
+    onDaySelected: (LocalDate) -> Unit,
+    onMealClicked: (MealPlanItem) -> Unit,
+    onDeleteClicked: (MealPlanItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (monthModel == null) {
+        EmptyMealsMessage(modifier)
+        return
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        MonthCalendar(
+            firstDayOfMonth = monthModel.firstDayOfMonth,
+            selectedDay = monthModel.selectedDay,
+            daysWithMeals = monthModel.daysWithMeals,
+            onDaySelected = onDaySelected,
+            modifier = Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal),
+        )
+        DayView(
+            dayMeals = monthModel.selectedDayMeals,
+            onMealClicked = onMealClicked,
+            onDeleteClicked = onDeleteClicked,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun MonthCalendar(
+    firstDayOfMonth: LocalDate,
+    selectedDay: LocalDate,
+    daysWithMeals: Set<String>,
+    onDaySelected: (LocalDate) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val daysInMonth = firstDayOfMonth.plus(1, DateTimeUnit.MONTH).plus(-1, DateTimeUnit.DAY).day
+    val firstDayOffset =
+        when (firstDayOfMonth.dayOfWeek) {
+            DayOfWeek.SUNDAY -> 0
+            DayOfWeek.MONDAY -> 1
+            DayOfWeek.TUESDAY -> 2
+            DayOfWeek.WEDNESDAY -> 3
+            DayOfWeek.THURSDAY -> 4
+            DayOfWeek.FRIDAY -> 5
+            DayOfWeek.SATURDAY -> 6
+        }
+    val totalCells = firstDayOffset + daysInMonth
+    val rows = (totalCells + 6) / 7
+
+    Column(modifier = modifier, verticalArrangement = spacedBy(4.dp)) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            for (dayLabel in listOf("S", "M", "T", "W", "T", "F", "S")) {
+                Text(
+                    text = dayLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+        for (row in 0 until rows) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                for (col in 0..6) {
+                    val cellIndex = row * 7 + col
+                    val dayNumber = cellIndex - firstDayOffset + 1
+                    if (dayNumber in 1..daysInMonth) {
+                        val date = LocalDate(firstDayOfMonth.year, firstDayOfMonth.month, dayNumber)
+                        DayCell(
+                            day = dayNumber,
+                            isSelected = date == selectedDay,
+                            hasMeals = date.toString() in daysWithMeals,
+                            onClick = { onDaySelected(date) },
+                            modifier = Modifier.weight(1f),
+                        )
+                    } else {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DayCell(
+    day: Int,
+    isSelected: Boolean,
+    hasMeals: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val onPrimaryColor = MaterialTheme.colorScheme.onPrimary
+    val onSurfaceColor = MaterialTheme.colorScheme.onSurface
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.clickable(onClick = onClick).padding(vertical = 2.dp),
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier =
+                Modifier.size(32.dp)
+                    .background(
+                        color =
+                            if (isSelected) primaryColor
+                            else androidx.compose.ui.graphics.Color.Transparent,
+                        shape = CircleShape,
+                    ),
+        ) {
+            Text(
+                text = day.toString(),
+                style = MaterialTheme.typography.bodySmall,
+                color = if (isSelected) onPrimaryColor else onSurfaceColor,
+                textAlign = TextAlign.Center,
+            )
+        }
+        Box(modifier = Modifier.height(6.dp), contentAlignment = Alignment.Center) {
+            if (hasMeals) {
+                Box(
+                    modifier =
+                        Modifier.size(4.dp)
+                            .background(
+                                color = if (isSelected) onPrimaryColor else primaryColor,
+                                shape = CircleShape,
+                            )
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #53

## Summary
- Adds a `SingleChoiceSegmentedButtonRow` (Day | Week | Month) replacing the old icon toggle button
- Month view displays a calendar grid for the current month with dot indicators on days that have meals
- Tapping a day in the calendar selects it and shows its meals below using the existing day view layout
- Prev/next arrows navigate months in month mode; the date label shows "April 2026"-style

## Changes
- `MealPlanBloc` — added `MONTH` to `ViewMode`, new `MonthModel`, `onViewModeSelected(mode)`, `onMonthDaySelected(date)`
- `MealPlanViewModel` — month navigation, `buildMonthModel`, `getMonthRange`, month label formatting
- `MealPlanBlocImpl` — wires new methods and `monthModel` state mapping
- `MealPlanScreen` — segmented control, `MonthView` with `MonthCalendar` + `DayCell` composables
- `strings.xml` — added `meal_plan_month`
- `build.gradle.kts` (public) — added `kotlinx-datetime` API dependency
- Tests updated for renamed `onViewModeSelected`, new month mode test added

## Test plan
- [ ] Segmented control switches between Day, Week, and Month views
- [ ] Month calendar renders correct grid for the current month
- [ ] Days with planned meals show a dot indicator
- [ ] Tapping a day selects it (highlighted circle) and shows its meals below
- [ ] Prev/next arrows navigate to previous/next month
- [ ] Date label shows "Month Year" format in month mode
- [ ] All existing day and week view functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)