### PR TITLE
fix: hide download button when browser opened from recipe detail

### DIFF
--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserBlocImpl.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserBlocImpl.kt
@@ -20,12 +20,17 @@ import kotlinx.coroutines.flow.StateFlow
 class BrowserBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<BrowserBloc.Output>,
+    @Assisted private val showDownload: Boolean,
     viewModelFactory: Provider<BrowserViewModel>,
 ) : BrowserBloc, BlocContext by context {
 
     @AssistedFactory
     fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<BrowserBloc.Output>): BrowserBlocImpl
+        fun create(
+            context: BlocContext,
+            output: Consumer<BrowserBloc.Output>,
+            showDownload: Boolean,
+        ): BrowserBlocImpl
     }
 
     private val viewModel = instanceKeeper.getViewModel {
@@ -47,6 +52,7 @@ class BrowserBlocImpl(
                                 createExtractionFailedMessage()
                         }
                     },
+                showDownload = showDownload,
             )
         }
 
@@ -75,7 +81,11 @@ class BrowserBlocImpl(
 interface BrowserBlocBindingModule {
     @Provides
     fun provideBrowserBlocFactory(factory: BrowserBlocImpl.ManagedFactory): BrowserBloc.Factory =
-        BrowserBloc.Factory { context, output ->
-            factory.create(context, output)
+        object : BrowserBloc.Factory {
+            override fun create(
+                context: BlocContext,
+                output: Consumer<BrowserBloc.Output>,
+                showDownload: Boolean,
+            ): BrowserBloc = factory.create(context, output, showDownload)
         }
 }

--- a/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserBloc.kt
+++ b/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserBloc.kt
@@ -27,13 +27,18 @@ interface BrowserBloc {
         val addressBarText: String = "",
         val isExtracting: Boolean = false,
         val extractionMessage: TextData? = null,
+        val showDownload: Boolean = true,
     )
 
     sealed class Output {
         data class RecipeExtracted(val recipeId: Long) : Output()
     }
 
-    fun interface Factory {
-        fun create(context: BlocContext, output: Consumer<Output>): BrowserBloc
+    interface Factory {
+        fun create(
+            context: BlocContext,
+            output: Consumer<Output>,
+            showDownload: Boolean = true,
+        ): BrowserBloc
     }
 }

--- a/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserScreen.kt
+++ b/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserScreen.kt
@@ -59,7 +59,7 @@ fun BrowserScreen(bloc: BrowserBloc, modifier: Modifier = Modifier) {
                 url = viewState.addressBarText,
                 onUrlChanged = bloc::onUrlChanged,
                 onNavigate = bloc::onNavigate,
-                showExtract = viewState.currentUrl.isNotBlank(),
+                showExtract = viewState.showDownload && viewState.currentUrl.isNotBlank(),
                 isExtracting = viewState.isExtracting,
                 onExtractRecipe = bloc::onExtractRecipe,
             )

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -175,6 +175,7 @@ class RecipeDetailBlocImpl(
                                             sheetNavigation.dismiss()
                                     }
                                 },
+                                showDownload = false,
                             )
                             .also { bloc ->
                                 bloc.onUrlChanged(config.url)


### PR DESCRIPTION
## Summary
- Adds a `showDownload` flag to `BrowserBloc.Factory` and `BrowserBloc.Model` (defaults to `true`)
- Passes `showDownload = false` when the browser is launched as a sheet from the recipe detail view
- The standalone browser tab is unaffected and still shows the download button

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)