### PR TITLE
feat: add share functionality to recipe detail (#51)

### DIFF
--- a/client/recipe/core/public/build.gradle.kts
+++ b/client/recipe/core/public/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation(projects.client.shared)
             implementation(projects.client.ui.public)
+            implementation(projects.client.util.public)
             implementation(libs.arkivanov.decompose.compose.extensions)
             implementation(libs.arkivanov.decompose.core)
             implementation(compose.components.resources)

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -34,6 +34,10 @@
     <string name="recipe_detail_deleting_title">Deleting Recipe</string>
     <string name="recipe_detail_deleting_message">Please wait...</string>
 
+    <string name="recipe_detail_share">Share recipe</string>
+<string name="recipe_detail_share_url">Share recipe URL</string>
+<string name="recipe_detail_share_text">Share recipe text</string>
+
     <!-- Add to Meal Plan -->
     <string name="recipe_detail_add_to_meal_plan">Add to meal plan</string>
     <string name="add_meal_plan_choose_date">Choose Date</string>

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="recipe_detail_share">Share recipe</string>
 <string name="recipe_detail_share_url">Share recipe URL</string>
 <string name="recipe_detail_share_text">Share recipe text</string>
+    <string name="recipe_detail_copied_to_clipboard">Copied to clipboard</string>
 
     <!-- Add to Meal Plan -->
     <string name="recipe_detail_add_to_meal_plan">Add to meal plan</string>

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -55,6 +55,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -85,6 +87,7 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_meal_plan
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_calories
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_time
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_copied_to_clipboard
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_created
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_delete
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_delete_cancel
@@ -141,6 +144,9 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val shareLauncher = rememberShareLauncher()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    val copiedMessage = stringResource(Res.string.recipe_detail_copied_to_clipboard)
 
     // Delete confirmation dialog
     if (state.showDeleteConfirmationDialog) {
@@ -162,145 +168,173 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     var showShareMenu by remember { mutableStateOf(false) }
     var metadataCollapsed by rememberSaveable { mutableStateOf(false) }
 
-    PlusResponsiveContainer(modifier = modifier.fillMaxSize()) { windowSizeClass ->
-        val isCompact = windowSizeClass == WindowSizeClass.COMPACT
-        val showToolbar = isCompact || !metadataCollapsed
-        PlusHeaderContainer(
-            modifier = Modifier.fillMaxSize(),
-            data =
-                PlusHeaderData.Child(
-                    title = state.recipe.title.asTextData(),
-                    onBackClick = bloc::onBackClicked,
-                ),
-            verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingNormal),
-            scrollEnabled = false,
-            maxContentWidth = if (isCompact) 600.dp else Dp.Unspecified,
-            floatingToolbar =
-                if (showToolbar) {
-                    {
-                        HorizontalFloatingToolbar(
-                            expanded = true,
-                            floatingActionButton = {
-                                FloatingActionButton(
-                                    onClick = bloc::onAddToGroceryListClicked,
-                                    shape = ChefMateTheme.shapes.large,
-                                ) {
-                                    Icon(Icons.Default.AddShoppingCart, null)
-                                }
-                            },
-                        ) {
-                            IconButton(onClick = { bloc.onFavoriteToggled() }) {
-                                Icon(
-                                    imageVector =
-                                        if (state.recipe.isFavorite) {
-                                            Icons.Default.Favorite
-                                        } else {
-                                            Icons.Default.FavoriteBorder
-                                        },
-                                    contentDescription =
-                                        if (state.recipe.isFavorite) {
-                                            stringResource(Res.string.recipe_detail_remove_favorite)
-                                        } else {
-                                            stringResource(Res.string.recipe_detail_add_favorite)
-                                        },
-                                )
-                            }
-                            IconButton(onClick = { bloc.onAddToMealPlanClicked() }) {
-                                Icon(
-                                    imageVector = Icons.Default.CalendarMonth,
-                                    contentDescription =
-                                        stringResource(Res.string.recipe_detail_add_to_meal_plan),
-                                )
-                            }
-                            IconButton(onClick = { bloc.onEditClicked() }) {
-                                Icon(
-                                    imageVector = Icons.Default.Edit,
-                                    contentDescription =
-                                        stringResource(Res.string.recipe_detail_edit),
-                                )
-                            }
-                            Box {
-                                IconButton(onClick = { showShareMenu = true }) {
+    Box(modifier = modifier.fillMaxSize()) {
+        PlusResponsiveContainer(modifier = Modifier.fillMaxSize()) { windowSizeClass ->
+            val isCompact = windowSizeClass == WindowSizeClass.COMPACT
+            val showToolbar = isCompact || !metadataCollapsed
+            PlusHeaderContainer(
+                modifier = Modifier.fillMaxSize(),
+                data =
+                    PlusHeaderData.Child(
+                        title = state.recipe.title.asTextData(),
+                        onBackClick = bloc::onBackClicked,
+                    ),
+                verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingNormal),
+                scrollEnabled = false,
+                maxContentWidth = if (isCompact) 600.dp else Dp.Unspecified,
+                floatingToolbar =
+                    if (showToolbar) {
+                        {
+                            HorizontalFloatingToolbar(
+                                expanded = true,
+                                floatingActionButton = {
+                                    FloatingActionButton(
+                                        onClick = bloc::onAddToGroceryListClicked,
+                                        shape = ChefMateTheme.shapes.large,
+                                    ) {
+                                        Icon(Icons.Default.AddShoppingCart, null)
+                                    }
+                                },
+                            ) {
+                                IconButton(onClick = { bloc.onFavoriteToggled() }) {
                                     Icon(
-                                        imageVector = Icons.Default.Share,
+                                        imageVector =
+                                            if (state.recipe.isFavorite) {
+                                                Icons.Default.Favorite
+                                            } else {
+                                                Icons.Default.FavoriteBorder
+                                            },
                                         contentDescription =
-                                            stringResource(Res.string.recipe_detail_share),
+                                            if (state.recipe.isFavorite) {
+                                                stringResource(
+                                                    Res.string.recipe_detail_remove_favorite
+                                                )
+                                            } else {
+                                                stringResource(
+                                                    Res.string.recipe_detail_add_favorite
+                                                )
+                                            },
                                     )
                                 }
-                                DropdownMenu(
-                                    expanded = showShareMenu,
-                                    onDismissRequest = { showShareMenu = false },
-                                ) {
-                                    state.recipe.sourceUrl?.let { url ->
+                                IconButton(onClick = { bloc.onAddToMealPlanClicked() }) {
+                                    Icon(
+                                        imageVector = Icons.Default.CalendarMonth,
+                                        contentDescription =
+                                            stringResource(
+                                                Res.string.recipe_detail_add_to_meal_plan
+                                            ),
+                                    )
+                                }
+                                IconButton(onClick = { bloc.onEditClicked() }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Edit,
+                                        contentDescription =
+                                            stringResource(Res.string.recipe_detail_edit),
+                                    )
+                                }
+                                Box {
+                                    IconButton(onClick = { showShareMenu = true }) {
+                                        Icon(
+                                            imageVector = Icons.Default.Share,
+                                            contentDescription =
+                                                stringResource(Res.string.recipe_detail_share),
+                                        )
+                                    }
+                                    DropdownMenu(
+                                        expanded = showShareMenu,
+                                        onDismissRequest = { showShareMenu = false },
+                                    ) {
+                                        state.recipe.sourceUrl?.let { url ->
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Text(
+                                                        stringResource(
+                                                            Res.string.recipe_detail_share_url
+                                                        )
+                                                    )
+                                                },
+                                                onClick = {
+                                                    showShareMenu = false
+                                                    if (shareLauncher(url)) {
+                                                        scope.launch {
+                                                            snackbarHostState.showSnackbar(
+                                                                copiedMessage
+                                                            )
+                                                        }
+                                                    }
+                                                },
+                                            )
+                                        }
                                         DropdownMenuItem(
                                             text = {
                                                 Text(
                                                     stringResource(
-                                                        Res.string.recipe_detail_share_url
+                                                        Res.string.recipe_detail_share_text
                                                     )
                                                 )
                                             },
                                             onClick = {
                                                 showShareMenu = false
-                                                shareLauncher(url)
+                                                if (
+                                                    shareLauncher(formatRecipeAsText(state.recipe))
+                                                ) {
+                                                    scope.launch {
+                                                        snackbarHostState.showSnackbar(
+                                                            copiedMessage
+                                                        )
+                                                    }
+                                                }
                                             },
                                         )
                                     }
-                                    DropdownMenuItem(
-                                        text = {
-                                            Text(
-                                                stringResource(Res.string.recipe_detail_share_text)
-                                            )
-                                        },
-                                        onClick = {
-                                            showShareMenu = false
-                                            shareLauncher(formatRecipeAsText(state.recipe))
-                                        },
+                                }
+                                IconButton(onClick = { bloc.onDeleteClicked() }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Delete,
+                                        contentDescription =
+                                            stringResource(Res.string.recipe_detail_delete),
                                     )
                                 }
                             }
-                            IconButton(onClick = { bloc.onDeleteClicked() }) {
-                                Icon(
-                                    imageVector = Icons.Default.Delete,
-                                    contentDescription =
-                                        stringResource(Res.string.recipe_detail_delete),
-                                )
-                            }
                         }
+                    } else {
+                        null
+                    },
+            ) {
+                if (state.isLoading) {
+                    Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                        PlusLoadingIndicator()
                     }
+                } else if (isCompact) {
+                    RecipeDetailCompactContent(
+                        recipe = state.recipe,
+                        createdAt = state.createdAt,
+                        updatedAt = state.updatedAt,
+                        formattedPrepTime = state.formattedPrepTime,
+                        formattedCookTime = state.formattedCookTime,
+                        formattedTotalTime = state.formattedTotalTime,
+                        onSourceUrlClicked = bloc::onSourceUrlClicked,
+                        modifier = Modifier.weight(1f),
+                    )
                 } else {
-                    null
-                },
-        ) {
-            if (state.isLoading) {
-                Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
-                    PlusLoadingIndicator()
+                    RecipeDetailExpandedContent(
+                        recipe = state.recipe,
+                        createdAt = state.createdAt,
+                        updatedAt = state.updatedAt,
+                        formattedPrepTime = state.formattedPrepTime,
+                        formattedCookTime = state.formattedCookTime,
+                        formattedTotalTime = state.formattedTotalTime,
+                        onSourceUrlClicked = bloc::onSourceUrlClicked,
+                        metadataCollapsed = metadataCollapsed,
+                        onMetadataCollapsedChange = { metadataCollapsed = it },
+                    )
                 }
-            } else if (isCompact) {
-                RecipeDetailCompactContent(
-                    recipe = state.recipe,
-                    createdAt = state.createdAt,
-                    updatedAt = state.updatedAt,
-                    formattedPrepTime = state.formattedPrepTime,
-                    formattedCookTime = state.formattedCookTime,
-                    formattedTotalTime = state.formattedTotalTime,
-                    onSourceUrlClicked = bloc::onSourceUrlClicked,
-                    modifier = Modifier.weight(1f),
-                )
-            } else {
-                RecipeDetailExpandedContent(
-                    recipe = state.recipe,
-                    createdAt = state.createdAt,
-                    updatedAt = state.updatedAt,
-                    formattedPrepTime = state.formattedPrepTime,
-                    formattedCookTime = state.formattedCookTime,
-                    formattedTotalTime = state.formattedTotalTime,
-                    onSourceUrlClicked = bloc::onSourceUrlClicked,
-                    metadataCollapsed = metadataCollapsed,
-                    onMetadataCollapsedChange = { metadataCollapsed = it },
-                )
             }
         }
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 96.dp),
+        )
     }
 }
 

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -38,12 +38,15 @@ import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingActionButton
@@ -99,6 +102,9 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_kcal
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_prep_time
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_remove_favorite
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_servings
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_text
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_url
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_source
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_timestamps
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_total_time
@@ -121,6 +127,7 @@ import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import com.plusmobileapps.chefmate.util.rememberShareLauncher
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -133,6 +140,7 @@ import org.jetbrains.compose.resources.stringResource
 fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val shareLauncher = rememberShareLauncher()
 
     // Delete confirmation dialog
     if (state.showDeleteConfirmationDialog) {
@@ -151,6 +159,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     // Add to Grocery List Bottom Sheet
     RecipeDetailSheet(bloc = bloc, sheetState = sheetState)
 
+    var showShareMenu by remember { mutableStateOf(false) }
     var metadataCollapsed by rememberSaveable { mutableStateOf(false) }
 
     PlusResponsiveContainer(modifier = modifier.fillMaxSize()) { windowSizeClass ->
@@ -209,6 +218,46 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                     contentDescription =
                                         stringResource(Res.string.recipe_detail_edit),
                                 )
+                            }
+                            Box {
+                                IconButton(onClick = { showShareMenu = true }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Share,
+                                        contentDescription =
+                                            stringResource(Res.string.recipe_detail_share),
+                                    )
+                                }
+                                DropdownMenu(
+                                    expanded = showShareMenu,
+                                    onDismissRequest = { showShareMenu = false },
+                                ) {
+                                    state.recipe.sourceUrl?.let { url ->
+                                        DropdownMenuItem(
+                                            text = {
+                                                Text(
+                                                    stringResource(
+                                                        Res.string.recipe_detail_share_url
+                                                    )
+                                                )
+                                            },
+                                            onClick = {
+                                                showShareMenu = false
+                                                shareLauncher(url)
+                                            },
+                                        )
+                                    }
+                                    DropdownMenuItem(
+                                        text = {
+                                            Text(
+                                                stringResource(Res.string.recipe_detail_share_text)
+                                            )
+                                        },
+                                        onClick = {
+                                            showShareMenu = false
+                                            shareLauncher(formatRecipeAsText(state.recipe))
+                                        },
+                                    )
+                                }
                             }
                             IconButton(onClick = { bloc.onDeleteClicked() }) {
                                 Icon(
@@ -882,6 +931,24 @@ private fun DetailRow(
 }
 
 private fun splitLines(text: String): List<String> = text.split("\n").filter { it.isNotBlank() }
+
+private fun formatRecipeAsText(recipe: Recipe): String = buildString {
+    appendLine(recipe.title)
+    recipe.description?.let {
+        appendLine()
+        appendLine(it)
+    }
+    appendLine()
+    appendLine("Ingredients:")
+    appendLine(recipe.ingredients)
+    appendLine()
+    appendLine("Directions:")
+    appendLine(recipe.directions)
+    recipe.sourceUrl?.let {
+        appendLine()
+        append("Source: $it")
+    }
+}
 
 @Composable
 private fun IngredientLineItem(

--- a/client/util/public/build.gradle.kts
+++ b/client/util/public/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
             api(libs.kotlinx.datetime)
             api(projects.client.text.public)
             implementation(compose.components.resources)
+            implementation(compose.ui)
         }
 
         androidMain.dependencies { implementation(libs.androidx.annotation) }

--- a/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.android.kt
+++ b/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.android.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 
 @Composable
-actual fun rememberShareLauncher(): (text: String) -> Unit {
+actual fun rememberShareLauncher(): (text: String) -> Boolean {
     val context = LocalContext.current
     return remember(context) {
         { text ->
@@ -18,6 +18,7 @@ actual fun rememberShareLauncher(): (text: String) -> Unit {
                     putExtra(Intent.EXTRA_TEXT, text)
                 }
             context.startActivity(Intent.createChooser(sendIntent, null))
+            false
         }
     }
 }

--- a/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.android.kt
+++ b/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.android.kt
@@ -1,0 +1,23 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+actual fun rememberShareLauncher(): (text: String) -> Unit {
+    val context = LocalContext.current
+    return remember(context) {
+        { text ->
+            val sendIntent =
+                Intent(Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_TEXT, text)
+                }
+            context.startActivity(Intent.createChooser(sendIntent, null))
+        }
+    }
+}

--- a/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.kt
+++ b/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.kt
@@ -2,4 +2,8 @@ package com.plusmobileapps.chefmate.util
 
 import androidx.compose.runtime.Composable
 
-@Composable expect fun rememberShareLauncher(): (text: String) -> Unit
+/**
+ * Returns a share launcher function. The returned function accepts text to share and returns `true`
+ * if the content was copied to the clipboard (desktop) rather than shared via a system share sheet.
+ */
+@Composable expect fun rememberShareLauncher(): (text: String) -> Boolean

--- a/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.kt
+++ b/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.kt
@@ -1,0 +1,5 @@
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+
+@Composable expect fun rememberShareLauncher(): (text: String) -> Unit

--- a/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.ios.kt
+++ b/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.ios.kt
@@ -1,0 +1,18 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import platform.UIKit.UIActivityViewController
+import platform.UIKit.UIApplication
+
+@Composable
+actual fun rememberShareLauncher(): (text: String) -> Unit = { text ->
+    val rootVC =
+        UIApplication.sharedApplication.windows
+            .firstOrNull { (it as? platform.UIKit.UIWindow)?.isKeyWindow() == true }
+            ?.let { (it as platform.UIKit.UIWindow).rootViewController }
+    val activityVC =
+        UIActivityViewController(activityItems = listOf(text), applicationActivities = null)
+    rootVC?.presentViewController(activityVC, animated = true, completion = null)
+}

--- a/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.ios.kt
+++ b/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.ios.kt
@@ -7,7 +7,7 @@ import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
 
 @Composable
-actual fun rememberShareLauncher(): (text: String) -> Unit = { text ->
+actual fun rememberShareLauncher(): (text: String) -> Boolean = { text ->
     val rootVC =
         UIApplication.sharedApplication.windows
             .firstOrNull { (it as? platform.UIKit.UIWindow)?.isKeyWindow() == true }
@@ -15,4 +15,5 @@ actual fun rememberShareLauncher(): (text: String) -> Unit = { text ->
     val activityVC =
         UIActivityViewController(activityItems = listOf(text), applicationActivities = null)
     rootVC?.presentViewController(activityVC, animated = true, completion = null)
+    false
 }

--- a/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.ios.kt
+++ b/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.ios.kt
@@ -3,17 +3,40 @@
 package com.plusmobileapps.chefmate.util
 
 import androidx.compose.runtime.Composable
+import platform.Foundation.NSURL
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
+import platform.darwin.DISPATCH_TIME_NOW
+import platform.darwin.dispatch_after
+import platform.darwin.dispatch_get_main_queue
+import platform.darwin.dispatch_time
 
 @Composable
 actual fun rememberShareLauncher(): (text: String) -> Boolean = { text ->
-    val rootVC =
-        UIApplication.sharedApplication.windows
-            .firstOrNull { (it as? platform.UIKit.UIWindow)?.isKeyWindow() == true }
-            ?.let { (it as platform.UIKit.UIWindow).rootViewController }
-    val activityVC =
-        UIActivityViewController(activityItems = listOf(text), applicationActivities = null)
-    rootVC?.presentViewController(activityVC, animated = true, completion = null)
+    // Delay presentation so the Compose dropdown popup fully tears down first.
+    val delayNs = (0.3 * 1_000_000_000).toLong() // 300 ms
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delayNs), dispatch_get_main_queue()) {
+        val keyWindow =
+            UIApplication.sharedApplication.connectedScenes
+                .filterIsInstance<UIWindowScene>()
+                .flatMap { it.windows.map { w -> w as UIWindow } }
+                .firstOrNull { it.isKeyWindow() }
+        var topVC: UIViewController? = keyWindow?.rootViewController
+        while (topVC?.presentedViewController != null) {
+            topVC = topVC.presentedViewController
+        }
+        val items: List<Any> =
+            if (text.startsWith("http://") || text.startsWith("https://")) {
+                listOfNotNull(NSURL(string = text))
+            } else {
+                listOf(text)
+            }
+        val activityVC =
+            UIActivityViewController(activityItems = items, applicationActivities = null)
+        topVC?.presentViewController(activityVC, animated = true, completion = null)
+    }
     false
 }

--- a/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.jvm.kt
+++ b/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.jvm.kt
@@ -1,0 +1,16 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+
+@Composable
+actual fun rememberShareLauncher(): (text: String) -> Unit {
+    val clipboardManager = LocalClipboardManager.current
+    return remember(clipboardManager) {
+        { text -> clipboardManager.setText(AnnotatedString(text)) }
+    }
+}

--- a/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.jvm.kt
+++ b/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.jvm.kt
@@ -8,9 +8,12 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 
 @Composable
-actual fun rememberShareLauncher(): (text: String) -> Unit {
+actual fun rememberShareLauncher(): (text: String) -> Boolean {
     val clipboardManager = LocalClipboardManager.current
     return remember(clipboardManager) {
-        { text -> clipboardManager.setText(AnnotatedString(text)) }
+        { text ->
+            clipboardManager.setText(AnnotatedString(text))
+            true
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a **share icon button** to the recipe detail floating toolbar
- Tapping it shows a **dropdown menu** with two options:
  - **Share recipe URL** — only shown when a source URL exists on the recipe
  - **Share recipe text** — shares a formatted plain-text representation (title, description, ingredients, directions, source URL)
- Platform behaviour:
  - **Android** — opens the native system share sheet via `Intent.ACTION_SEND`
  - **iOS** — presents `UIActivityViewController`
  - **Desktop (JVM)** — copies the content to the system clipboard

## Implementation details

- New `rememberShareLauncher()` `@Composable expect fun` in `client/util/public` with platform-specific `actual` implementations for Android, iOS, and JVM
- `formatRecipeAsText()` private helper in `RecipeDetailScreen.kt` builds the shareable text
- String resources added for share action labels

## Test plan

- [x] Open a recipe that has a source URL → share button shows two dropdown items
- [x] Open a recipe without a source URL → share button shows only "Share recipe text"
- [x] Tap "Share recipe URL" on Android → system share sheet appears with the URL
- [x] Tap "Share recipe text" on Android → system share sheet appears with formatted recipe text
- [x] On Desktop — tap either option → content appears in clipboard (paste to verify)
- [x] Dropdown dismisses when tapping outside or selecting an item

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)