### PR TITLE
test: add Paparazzi snapshot tests for grocery list screen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/*snapshots*/**/*.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
-      - run: ./gradlew jvmTest testDebugUnitTest koverXmlReport koverHtmlReport --continue
+      - run: ./gradlew jvmTest testDebugUnitTest -x :client:grocery:core:snapshots:testDebugUnitTest koverXmlReport koverHtmlReport --continue
+      - run: ./gradlew :client:grocery:core:snapshots:verifyPaparazziDebug
       - name: Publish test report
         uses: dorny/test-reporter@v2
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.ktfmt) apply false
     alias(libs.plugins.mokkery) apply false
+    alias(libs.plugins.paparazzi) apply false
     alias(libs.plugins.kover)
 }
 

--- a/client/grocery/core/snapshots/build.gradle.kts
+++ b/client/grocery/core/snapshots/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.paparazzi)
+    alias(libs.plugins.plusKtfmt)
+}
+
+apply(plugin = "org.jetbrains.kotlin.android")
+
+androidComponents {
+    finalizeDsl {
+        it.namespace = "com.plusmobileapps.chefmate.grocery.core.snapshots"
+        it.compileSdk = libs.versions.android.compileSdk.get().toInt()
+        it.defaultConfig.minSdk = libs.versions.android.minSdk.get().toInt()
+        it.compileOptions.sourceCompatibility = JavaVersion.VERSION_11
+        it.compileOptions.targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11) }
+}
+
+dependencies {
+    implementation(projects.client.grocery.core.public)
+    implementation(projects.client.grocery.data.public)
+    implementation(projects.client.ui.public)
+    implementation(projects.client.shared)
+    implementation(projects.client.text.public)
+
+    testImplementation(libs.junit)
+}

--- a/client/grocery/core/snapshots/src/main/AndroidManifest.xml
+++ b/client/grocery/core/snapshots/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/client/grocery/core/snapshots/src/test/kotlin/com/plusmobileapps/chefmate/grocery/core/snapshots/GroceryListScreenLandscapeSnapshotTest.kt
+++ b/client/grocery/core/snapshots/src/test/kotlin/com/plusmobileapps/chefmate/grocery/core/snapshots/GroceryListScreenLandscapeSnapshotTest.kt
@@ -1,0 +1,88 @@
+package com.plusmobileapps.chefmate.grocery.core.snapshots
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalInspectionMode
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListScreen
+import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
+import com.plusmobileapps.chefmate.grocery.data.GroceryItem
+import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
+import com.plusmobileapps.chefmate.grocery.data.SyncStatus
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import org.junit.Rule
+import org.junit.Test
+
+class GroceryListScreenLandscapeSnapshotTest {
+
+    @get:Rule
+    val paparazzi =
+        Paparazzi(
+            deviceConfig =
+                DeviceConfig.PIXEL_6.copy(
+                    screenWidth = DeviceConfig.PIXEL_6.screenHeight,
+                    screenHeight = DeviceConfig.PIXEL_6.screenWidth,
+                ),
+            maxPercentDifference = 1.0,
+        )
+
+    @Test
+    fun groceryListScreen_landscape() {
+        val defaultList = GroceryListModel(id = 1L, name = "My Groceries")
+        val sampleItems =
+            listOf(
+                GroceryListBloc.GroceryGroup(
+                    category = GroceryCategory.PRODUCE,
+                    items =
+                        listOf(
+                            GroceryItem(
+                                id = 1,
+                                name = "Apples",
+                                quantity = "6",
+                                category = GroceryCategory.PRODUCE,
+                                syncStatus = SyncStatus.SYNCED,
+                            ),
+                            GroceryItem(
+                                id = 2,
+                                name = "Bananas",
+                                quantity = "1 bunch",
+                                category = GroceryCategory.PRODUCE,
+                                isChecked = true,
+                                syncStatus = SyncStatus.SYNCED,
+                            ),
+                        ),
+                ),
+                GroceryListBloc.GroceryGroup(
+                    category = GroceryCategory.DAIRY,
+                    items =
+                        listOf(
+                            GroceryItem(
+                                id = 3,
+                                name = "Milk",
+                                quantity = "1 gallon",
+                                category = GroceryCategory.DAIRY,
+                                syncStatus = SyncStatus.NOT_SYNCED,
+                            )
+                        ),
+                ),
+            )
+        paparazzi.snapshot {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                ChefMateTheme {
+                    GroceryListScreen(
+                        bloc =
+                            StubGroceryListBloc(
+                                model =
+                                    GroceryListBloc.Model(
+                                        groupedItems = sampleItems,
+                                        lists = listOf(defaultList),
+                                        selectedList = defaultList,
+                                    )
+                            )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/client/grocery/core/snapshots/src/test/kotlin/com/plusmobileapps/chefmate/grocery/core/snapshots/GroceryListScreenSnapshotTest.kt
+++ b/client/grocery/core/snapshots/src/test/kotlin/com/plusmobileapps/chefmate/grocery/core/snapshots/GroceryListScreenSnapshotTest.kt
@@ -1,0 +1,200 @@
+package com.plusmobileapps.chefmate.grocery.core.snapshots
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalInspectionMode
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryFilter
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryGroup
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListScreen
+import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
+import com.plusmobileapps.chefmate.grocery.data.GroceryItem
+import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
+import com.plusmobileapps.chefmate.grocery.data.SyncStatus
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import org.junit.Rule
+import org.junit.Test
+
+class GroceryListScreenSnapshotTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(deviceConfig = DeviceConfig.PIXEL_6, maxPercentDifference = 1.0)
+
+    private val defaultList = GroceryListModel(id = 1L, name = "My Groceries")
+    private val secondList =
+        GroceryListModel(id = 2L, name = "Party Supplies", syncStatus = SyncStatus.SYNCED)
+
+    private val sampleItems =
+        listOf(
+            GroceryGroup(
+                category = GroceryCategory.PRODUCE,
+                items =
+                    listOf(
+                        GroceryItem(
+                            id = 1,
+                            name = "Apples",
+                            quantity = "6",
+                            category = GroceryCategory.PRODUCE,
+                            syncStatus = SyncStatus.SYNCED,
+                        ),
+                        GroceryItem(
+                            id = 2,
+                            name = "Bananas",
+                            quantity = "1 bunch",
+                            category = GroceryCategory.PRODUCE,
+                            isChecked = true,
+                            syncStatus = SyncStatus.SYNCED,
+                        ),
+                    ),
+            ),
+            GroceryGroup(
+                category = GroceryCategory.DAIRY,
+                items =
+                    listOf(
+                        GroceryItem(
+                            id = 3,
+                            name = "Milk",
+                            quantity = "1 gallon",
+                            category = GroceryCategory.DAIRY,
+                            syncStatus = SyncStatus.NOT_SYNCED,
+                        )
+                    ),
+            ),
+            GroceryGroup(
+                category = GroceryCategory.BAKERY,
+                items =
+                    listOf(
+                        GroceryItem(
+                            id = 4,
+                            name = "Sourdough Bread",
+                            category = GroceryCategory.BAKERY,
+                            syncStatus = SyncStatus.SYNCED,
+                        )
+                    ),
+            ),
+        )
+
+    @Test
+    fun groceryListScreen_default() {
+        paparazzi.snapshot {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                ChefMateTheme {
+                    GroceryListScreen(
+                        bloc =
+                            StubGroceryListBloc(
+                                model =
+                                    GroceryListBloc.Model(
+                                        groupedItems = sampleItems,
+                                        lists = listOf(defaultList),
+                                        selectedList = defaultList,
+                                    )
+                            )
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun groceryListScreen_empty() {
+        paparazzi.snapshot {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                ChefMateTheme {
+                    GroceryListScreen(
+                        bloc =
+                            StubGroceryListBloc(
+                                model =
+                                    GroceryListBloc.Model(
+                                        lists = listOf(defaultList),
+                                        selectedList = defaultList,
+                                    )
+                            )
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun groceryListScreen_syncing() {
+        paparazzi.snapshot {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                ChefMateTheme {
+                    GroceryListScreen(
+                        bloc =
+                            StubGroceryListBloc(
+                                model =
+                                    GroceryListBloc.Model(
+                                        groupedItems = sampleItems,
+                                        isSyncing = true,
+                                        lists = listOf(defaultList),
+                                        selectedList = defaultList,
+                                    )
+                            )
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun groceryListScreen_purchasedFilter() {
+        val purchasedOnly =
+            listOf(
+                GroceryGroup(
+                    category = GroceryCategory.PRODUCE,
+                    items =
+                        listOf(
+                            GroceryItem(
+                                id = 2,
+                                name = "Bananas",
+                                quantity = "1 bunch",
+                                category = GroceryCategory.PRODUCE,
+                                isChecked = true,
+                                syncStatus = SyncStatus.SYNCED,
+                            )
+                        ),
+                )
+            )
+        paparazzi.snapshot {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                ChefMateTheme {
+                    GroceryListScreen(
+                        bloc =
+                            StubGroceryListBloc(
+                                model =
+                                    GroceryListBloc.Model(
+                                        groupedItems = purchasedOnly,
+                                        filter = GroceryFilter.PURCHASED,
+                                        lists = listOf(defaultList),
+                                        selectedList = defaultList,
+                                    )
+                            )
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun groceryListScreen_multipleLists() {
+        paparazzi.snapshot {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                ChefMateTheme {
+                    GroceryListScreen(
+                        bloc =
+                            StubGroceryListBloc(
+                                model =
+                                    GroceryListBloc.Model(
+                                        groupedItems = sampleItems,
+                                        lists = listOf(defaultList, secondList),
+                                        selectedList = defaultList,
+                                    )
+                            )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/client/grocery/core/snapshots/src/test/kotlin/com/plusmobileapps/chefmate/grocery/core/snapshots/StubGroceryListBloc.kt
+++ b/client/grocery/core/snapshots/src/test/kotlin/com/plusmobileapps/chefmate/grocery/core/snapshots/StubGroceryListBloc.kt
@@ -1,0 +1,52 @@
+package com.plusmobileapps.chefmate.grocery.core.snapshots
+
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryFilter
+import com.plusmobileapps.chefmate.grocery.data.GroceryItem
+import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+internal class StubGroceryListBloc(
+    model: GroceryListBloc.Model = GroceryListBloc.Model(),
+    newItemName: String = "",
+) : GroceryListBloc {
+    override val state: StateFlow<GroceryListBloc.Model> = MutableStateFlow(model)
+    override val newGroceryItemName: StateFlow<String> = MutableStateFlow(newItemName)
+
+    override fun onGroceryItemCheckedChange(item: GroceryItem, isChecked: Boolean) {}
+
+    override fun onGroceryItemDelete(item: GroceryItem) {}
+
+    override fun onNewGroceryItemNameChange(name: String) {}
+
+    override fun saveGroceryItem() {}
+
+    override fun onGroceryItemClicked(item: GroceryItem) {}
+
+    override fun onSyncClicked() {}
+
+    override fun onListSelected(list: GroceryListModel) {}
+
+    override fun onCreateListClicked() {}
+
+    override fun onCreateListDismissed() {}
+
+    override fun onCreateListConfirmed(name: String) {}
+
+    override fun onDeleteListClicked(list: GroceryListModel) {}
+
+    override fun onFilterChanged(filter: GroceryFilter) {}
+
+    override fun onDeleteClicked() {}
+
+    override fun onDeleteDismissed() {}
+
+    override fun onDeletePurchasedConfirmed() {}
+
+    override fun onDeleteAllConfirmed() {}
+
+    override fun onListSelectorClicked() {}
+
+    override fun onListSelectorDismissed() {}
+}

--- a/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenLandscapeSnapshotTest_groceryListScreen_landscape.png
+++ b/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenLandscapeSnapshotTest_groceryListScreen_landscape.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34702cb2e72f84cc220fe8eb6c2d872e3c76e85e6f6880c34724fe5ea8e34bf6
+size 15970

--- a/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenSnapshotTest_groceryListScreen_default.png
+++ b/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenSnapshotTest_groceryListScreen_default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e2c8c3e86b80adce31aa33392b48a8cfec6e0cf5f464ae2a4d6495fadfa9f5
+size 19702

--- a/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenSnapshotTest_groceryListScreen_empty.png
+++ b/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenSnapshotTest_groceryListScreen_empty.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e2e2b641d0f5607e0b458e35b16a0f2af9d5a3cf169896fac842749c5d0a0c7
+size 7988

--- a/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenSnapshotTest_groceryListScreen_multipleLists.png
+++ b/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenSnapshotTest_groceryListScreen_multipleLists.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e2c8c3e86b80adce31aa33392b48a8cfec6e0cf5f464ae2a4d6495fadfa9f5
+size 19702

--- a/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenSnapshotTest_groceryListScreen_purchasedFilter.png
+++ b/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenSnapshotTest_groceryListScreen_purchasedFilter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85b6ba7abffdcfffca9036a9378f5e09d27e294affc7b47ff14ebedadd6fd84d
+size 11515

--- a/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenSnapshotTest_groceryListScreen_syncing.png
+++ b/client/grocery/core/snapshots/src/test/snapshots/images/com.plusmobileapps.chefmate.grocery.core.snapshots_GroceryListScreenSnapshotTest_groceryListScreen_syncing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:896616898bec5fd3d96497dff2d6a2c51f12e6297e2a47c7d0e4fff870015093
+size 19240

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ ksp = "2.3.6"
 logback = "1.5.18"
 sqldelight = "2.1.0"
 supabase = "3.2.6"
+paparazzi = "2.0.0-alpha04"
 turbine = "1.2.1"
 
 [libraries]
@@ -126,6 +127,7 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 mokkery = { id = "dev.mokkery",  version.ref = "mokkery" }
+paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 metroDi = { id = "com.plusmobileapps.chefmate.metro" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -58,6 +58,8 @@ include(":client:grocery:core:impl")
 
 include(":client:grocery:core:public")
 
+include(":client:grocery:core:snapshots")
+
 include(":client:grocery:data:impl")
 
 include(":client:grocery:data:public")


### PR DESCRIPTION
## Summary
- Add Paparazzi snapshot test infrastructure with a dedicated `client/grocery/core/snapshots` module
- Add 6 snapshot tests covering the compact grocery list header: default state, empty list, syncing, purchased filter, multiple lists, and landscape
- Configure git-lfs to track snapshot PNG files
- Use Paparazzi 2.0.0-alpha04 with `CompositionLocalProvider(LocalInspectionMode provides true)` workaround for Compose Multiplatform resource compatibility

## Notes
- Paparazzi 2.0.0-alpha04 has a minor Gradle API incompatibility (`TestResultsProvider.hasOutput`) that causes `testDebugUnitTest` to report as failed despite snapshots recording correctly. This is tracked in [cashapp/paparazzi#2026](https://github.com/cashapp/paparazzi/issues/2026) and expected to be fixed in the next alpha release
- The `recordPaparazziDebug` task generates the golden snapshots; `verifyPaparazziDebug` compares against them

## Test plan
- [x] Run `./gradlew :client:grocery:core:snapshots:recordPaparazziDebug` to generate golden snapshots
- [x] Verify 6 snapshot PNGs are created in `src/test/snapshots/images/`
- [x] Confirm git-lfs is tracking the PNG files
- [x] Verify existing tests still pass: `./gradlew test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)