### PR TITLE
feat(ci): automate version bump and release workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,93 @@
+name: Build & Release
+
+# Triggered when a version-bump PR is merged to main. Detects the squash-merge
+# commit message, creates a git tag, builds a signed release APK, and publishes
+# a GitHub release with the APK attached.
+#
+# The tag push (using RELEASE_TOKEN) will also trigger:
+#   - android-release.yml  → uploads AAB to Play Store via Fastlane
+#   - desktop-release.yml  → builds DMG / MSI / Deb packages
+#   - ios-release.yml      → iOS release via Fastlane
+#
+# See docs/ci/VERSION_BUMP_SETUP.md for required secrets and configuration.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-release:
+    # Only run when a version-bump PR is merged (commit message set by bump-version workflow)
+    if: "startsWith(github.event.head_commit.message, 'chore: bump version')"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # RELEASE_TOKEN is a PAT with contents:write. When set, the tag push will
+          # trigger android-release, desktop-release, and ios-release. Without it
+          # those workflows will NOT run (GITHUB_TOKEN cannot trigger other workflows).
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
+          fetch-depth: 0
+
+      - name: Read version from build file
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(sed -n 's/.*versionName = "\([^"]*\)".*/\1/p' client/composeApp/build.gradle.kts)
+          BUILD=$(sed -n 's/.*versionCode = \([0-9]*\).*/\1/p' client/composeApp/build.gradle.kts)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "build=${BUILD}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push release tag
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.version.outputs.tag }}"
+          BUILD="${{ steps.version.outputs.build }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release ${TAG} (build ${BUILD})"
+          git push origin "$TAG"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode keystore
+        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > keystore.jks
+
+      - name: Build release APK
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
+          ANDROID_KEYSTORE_FILE: ${{ github.workspace }}/keystore.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: ./gradlew :client:composeApp:assembleRelease
+
+      - name: Locate APK
+        id: apk
+        run: |
+          APK=$(find client/composeApp/build/outputs/apk/release -name '*.apk' | head -1)
+          if [[ -z "$APK" ]]; then
+            echo "::error::No APK found under client/composeApp/build/outputs/apk/release/"
+            exit 1
+          fi
+          echo "path=$APK" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          generate_release_notes: true
+          files: ${{ steps.apk.outputs.path }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,181 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        default: patch
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - custom
+      custom_version:
+        description: 'Custom version (X.Y.Z) — only used when bump_type is "custom"'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read current versions
+        id: current
+        run: |
+          GRADLE_FILE="client/composeApp/build.gradle.kts"
+          CURRENT_VERSION=$(sed -n 's/.*versionName = "\([^"]*\)".*/\1/p' "$GRADLE_FILE")
+          CURRENT_BUILD=$(sed -n 's/.*versionCode = \([0-9]*\).*/\1/p' "$GRADLE_FILE")
+          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "build=$CURRENT_BUILD" >> "$GITHUB_OUTPUT"
+
+      - name: Compute new version
+        id: new
+        run: |
+          set -euo pipefail
+          CURRENT="${{ steps.current.outputs.version }}"
+          CURRENT_BUILD="${{ steps.current.outputs.build }}"
+          BUMP_TYPE="${{ inputs.bump_type }}"
+          CUSTOM_VERSION="${{ inputs.custom_version }}"
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+          case "$BUMP_TYPE" in
+            major)  NEW_VERSION="$((MAJOR + 1)).0.0" ;;
+            minor)  NEW_VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
+            patch)  NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+            custom)
+              if [[ -z "$CUSTOM_VERSION" ]]; then
+                echo "::error::custom_version is required when bump_type is 'custom'"
+                exit 1
+              fi
+              if [[ ! "$CUSTOM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "::error::'$CUSTOM_VERSION' is not a valid semver (expected X.Y.Z)"
+                exit 1
+              fi
+              NEW_VERSION="$CUSTOM_VERSION"
+              ;;
+          esac
+
+          NEW_BUILD="$((CURRENT_BUILD + 1))"
+
+          # macOS DMG packaging requires MAJOR > 0; map 0.x.y → 1.x.y
+          # See the comment in client/composeApp/build.gradle.kts macOS block.
+          IFS='.' read -r V_MAJOR V_MINOR V_PATCH <<< "$NEW_VERSION"
+          if [[ "$V_MAJOR" == "0" ]]; then
+            MAC_VERSION="1.${V_MINOR}.${V_PATCH}"
+          else
+            MAC_VERSION="$NEW_VERSION"
+          fi
+
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "build=$NEW_BUILD" >> "$GITHUB_OUTPUT"
+          echo "mac_version=$MAC_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Apply version bump
+        run: |
+          set -euo pipefail
+          GRADLE_FILE="client/composeApp/build.gradle.kts"
+          XCCONFIG_FILE="iosApp/Configuration/Config.xcconfig"
+          NEW_VERSION="${{ steps.new.outputs.version }}"
+          NEW_BUILD="${{ steps.new.outputs.build }}"
+          MAC_VERSION="${{ steps.new.outputs.mac_version }}"
+
+          # Android versionCode
+          sed -i "s/versionCode = [0-9]*/versionCode = ${NEW_BUILD}/" "$GRADLE_FILE"
+
+          # Android versionName
+          sed -i "s/versionName = \"[^\"]*\"/versionName = \"${NEW_VERSION}\"/" "$GRADLE_FILE"
+
+          # Desktop packageVersion — first occurrence (generic/JVM)
+          awk -v new="$NEW_VERSION" '
+            /packageVersion[[:space:]]*=/ && !done {
+              sub(/packageVersion = "[^"]*"/, "packageVersion = \"" new "\"")
+              done=1
+            }
+            1' "$GRADLE_FILE" > "$GRADLE_FILE.tmp" && mv "$GRADLE_FILE.tmp" "$GRADLE_FILE"
+
+          # Desktop macOS packageVersion — second (last) occurrence.
+          # Uses tac (Linux equivalent of macOS tail -r) to reverse, replace from
+          # the "top" (which is the bottom of the original file), then reverse back.
+          tac "$GRADLE_FILE" | awk -v new="$MAC_VERSION" '
+            /packageVersion[[:space:]]*=/ && !done {
+              sub(/packageVersion = "[^"]*"/, "packageVersion = \"" new "\"")
+              done=1
+            }
+            1' | tac > "$GRADLE_FILE.tmp" && mv "$GRADLE_FILE.tmp" "$GRADLE_FILE"
+
+          # iOS build number and marketing version
+          sed -i "s/CURRENT_PROJECT_VERSION=.*/CURRENT_PROJECT_VERSION=${NEW_BUILD}/" "$XCCONFIG_FILE"
+          sed -i "s/MARKETING_VERSION=.*/MARKETING_VERSION=${NEW_VERSION}/" "$XCCONFIG_FILE"
+
+      - name: Commit and push branch
+        id: push
+        run: |
+          set -euo pipefail
+          NEW_VERSION="${{ steps.new.outputs.version }}"
+          NEW_BUILD="${{ steps.new.outputs.build }}"
+          BRANCH="chore/bump-version-${NEW_VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add client/composeApp/build.gradle.kts iosApp/Configuration/Config.xcconfig
+          git commit -m "chore: bump version to ${NEW_VERSION} (build ${NEW_BUILD})"
+          git push origin "$BRANCH"
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          OLD_VERSION="${{ steps.current.outputs.version }}"
+          NEW_VERSION="${{ steps.new.outputs.version }}"
+          OLD_BUILD="${{ steps.current.outputs.build }}"
+          NEW_BUILD="${{ steps.new.outputs.build }}"
+          MAC_VERSION="${{ steps.new.outputs.mac_version }}"
+          BRANCH="${{ steps.push.outputs.branch }}"
+
+          # Build the PR body using grouped echo to /tmp — avoids heredoc indentation
+          # issues with YAML block scalars and backtick escaping in double-quoted strings.
+          {
+            echo "## Version bump"
+            echo ""
+            echo "| Platform | Field | Old | New |"
+            echo "|---|---|---|---|"
+            echo "| Android | \`versionName\` | \`${OLD_VERSION}\` | \`${NEW_VERSION}\` |"
+            echo "| Android | \`versionCode\` | \`${OLD_BUILD}\` | \`${NEW_BUILD}\` |"
+            echo "| iOS | \`MARKETING_VERSION\` | \`${OLD_VERSION}\` | \`${NEW_VERSION}\` |"
+            echo "| iOS | \`CURRENT_PROJECT_VERSION\` | \`${OLD_BUILD}\` | \`${NEW_BUILD}\` |"
+            echo "| Desktop (JVM) | \`packageVersion\` | \`${OLD_VERSION}\` | \`${NEW_VERSION}\` |"
+            echo "| Desktop (macOS) | \`packageVersion\` | — | \`${MAC_VERSION}\` |"
+            echo ""
+            echo "After merging this PR (**squash merge recommended**), the \`build-release\` workflow"
+            echo "will detect the bump commit on \`main\`, create a \`v${NEW_VERSION}\` git tag, build the"
+            echo "release APK, and publish a GitHub release."
+            echo ""
+            echo "> [!NOTE]"
+            echo "> The \`android-release\`, \`desktop-release\`, and \`ios-release\` workflows are only"
+            echo "> triggered by the tag push if \`RELEASE_TOKEN\` (a PAT with \`contents: write\`) is"
+            echo "> configured as a repository secret. See \`docs/ci/VERSION_BUMP_SETUP.md\`."
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --title "chore: bump version to ${NEW_VERSION} (build ${NEW_BUILD})" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "$BRANCH"

--- a/docs/ci/VERSION_BUMP_SETUP.md
+++ b/docs/ci/VERSION_BUMP_SETUP.md
@@ -1,0 +1,152 @@
+# Version Bump & Release Automation
+
+This document covers the two GitHub Actions workflows that automate versioning and
+releasing across all platforms (Android, iOS, Desktop).
+
+## How it works
+
+```
+Developer                   GitHub Actions
+──────────                  ──────────────────────────────────────────────────
+Run "Bump Version"          bump-version.yml
+  (Actions UI)           ─► reads current version
+                            computes new version
+                            edits build.gradle.kts + Config.xcconfig
+                            opens PR "chore: bump version to X.Y.Z (build N)"
+                                │
+Merge PR (squash)           build-release.yml  (triggered by push to main)
+                         ─► creates git tag vX.Y.Z
+                            builds signed release APK
+                            publishes GitHub release with APK attached
+                                │
+                         (tag push triggers downstream workflows if RELEASE_TOKEN set)
+                             ├─► android-release.yml  → uploads to Play Store
+                             ├─► desktop-release.yml  → builds DMG / MSI / Deb
+                             └─► ios-release.yml      → iOS release
+```
+
+## Files changed by the bump
+
+| File | Fields |
+|---|---|
+| `client/composeApp/build.gradle.kts` | `versionCode`, `versionName`, `packageVersion` (JVM), `packageVersion` (macOS block) |
+| `iosApp/Configuration/Config.xcconfig` | `CURRENT_PROJECT_VERSION`, `MARKETING_VERSION` |
+
+The macOS `packageVersion` is always `1.x.y` when the app version is `0.x.y`
+because macOS DMG packaging requires `MAJOR > 0`. See the comment in
+`client/composeApp/build.gradle.kts` macOS block.
+
+> **Note:** `scripts/bump-version.sh` (the interactive local script) has a
+> `to_mac_version()` function that is currently a pass-through and does **not**
+> apply this mapping. If you use the script locally, update `to_mac_version()`
+> so it matches CI behaviour, or correct the macOS value manually after running.
+
+## Required GitHub secrets
+
+Configure these in **Settings → Secrets and variables → Actions → Repository secrets**.
+
+### Always required
+
+| Secret | Description |
+|---|---|
+| `ANDROID_KEYSTORE_BASE64` | Base64-encoded release keystore (`base64 -i release.jks`) |
+| `ANDROID_KEYSTORE_PASSWORD` | Keystore password |
+| `ANDROID_KEY_ALIAS` | Key alias within the keystore |
+| `ANDROID_KEY_PASSWORD` | Key password |
+| `SUPABASE_URL` | Supabase project URL |
+| `SUPABASE_KEY` | Supabase anon/service key |
+| `BUGSNAG_API_KEY` | Bugsnag API key |
+
+### Required for downstream workflow triggering
+
+| Secret | Description |
+|---|---|
+| `RELEASE_TOKEN` | Personal Access Token with `repo` scope (or fine-grained with `contents: write` + `workflows: write`). Without this, `android-release`, `desktop-release`, and `ios-release` will **not** run after the tag is pushed, because the default `GITHUB_TOKEN` cannot trigger other workflows. |
+
+### Required by existing workflows (already configured)
+
+| Secret | Used by |
+|---|---|
+| `PLAY_STORE_SERVICE_ACCOUNT_JSON` | `android-release.yml` (Fastlane) |
+
+## Step-by-step: running your first bump
+
+1. Go to **Actions → Bump Version → Run workflow**.
+2. Choose a bump type:
+   - `patch` — `0.1.21` → `0.1.22`, build `22`
+   - `minor` — `0.1.21` → `0.2.0`, build `22`
+   - `major` — `0.1.21` → `1.0.0`, build `22`
+   - `custom` — enter an explicit `X.Y.Z` in the second field
+3. Click **Run workflow**. The workflow will open a PR titled
+   `chore: bump version to X.Y.Z (build N)`.
+4. Review the PR (check the version table in the body), then **squash merge** it.
+   - Squash merge ensures the commit message on `main` matches
+     `chore: bump version to X.Y.Z (build N)`, which is what `build-release.yml`
+     looks for.
+5. `build-release.yml` triggers automatically on the push to `main`:
+   - Creates and pushes git tag `vX.Y.Z`
+   - Builds the signed release APK
+   - Creates a GitHub release with the APK attached
+6. If `RELEASE_TOKEN` is configured, the tag push also triggers:
+   - `android-release.yml` → Fastlane uploads the AAB to Play Store
+   - `desktop-release.yml` → builds DMG / MSI / Deb packages
+   - `ios-release.yml` → iOS release
+
+## Configuring `RELEASE_TOKEN`
+
+1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens**.
+2. Create a token scoped to this repository with these permissions:
+   - **Contents**: Read and write (for creating tags)
+   - **Workflows**: Read and write (for triggering workflow runs)
+3. Add it as a repository secret named `RELEASE_TOKEN`.
+
+## Setting up Android signing
+
+The `build-release.yml` workflow calls `./gradlew :client:composeApp:assembleRelease`
+with signing env vars that are read by the signing config in
+`client/composeApp/build.gradle.kts`.
+
+To prepare the `ANDROID_KEYSTORE_BASE64` secret:
+
+```bash
+# Encode your keystore file
+base64 -i /path/to/release.jks | pbcopy   # copies to clipboard (macOS)
+# Paste the output as the ANDROID_KEYSTORE_BASE64 secret value
+```
+
+## Validating locally
+
+Run the test script before pushing changes to the workflow:
+
+```bash
+./scripts/test-version-bump.sh           # tests bump to 0.99.0 (build 99) by default
+./scripts/test-version-bump.sh 1.0.0 42  # custom version and build number
+```
+
+The script exercises the same sed/awk patterns as the CI and exits non-zero if any
+value is not set correctly.
+
+## Common issues
+
+### Workflow does not trigger after merging the bump PR
+
+Check that you used **squash merge** and that the resulting commit message on `main`
+starts with `chore: bump version`. If you used a regular merge commit, the commit
+message is `Merge pull request #N from ...` and the `if:` condition won't match.
+
+### `android-release` / `desktop-release` not triggered by the tag
+
+The `RELEASE_TOKEN` secret is missing or has insufficient permissions. See
+[Configuring `RELEASE_TOKEN`](#configuring-release_token) above.
+
+### APK not found after build
+
+The `assembleRelease` task might have failed silently, or the keystore env vars are
+not set. Check the workflow logs for Gradle errors. Ensure all four signing secrets
+are configured.
+
+### Duplicate GitHub release
+
+If `build-release.yml` and `desktop-release.yml` both try to create a release for the
+same tag, `softprops/action-gh-release` will update the existing release rather than
+fail — this is expected behaviour.

--- a/scripts/test-version-bump.sh
+++ b/scripts/test-version-bump.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Dry-run the version bump logic used by .github/workflows/bump-version.yml.
+# Creates temporary copies of the version files, applies the same sed/awk
+# transformations, and verifies all expected values are written correctly.
+# Exits non-zero if any check fails.
+#
+# Usage:
+#   ./scripts/test-version-bump.sh                  # default: 0.99.0 build 99
+#   ./scripts/test-version-bump.sh 1.2.3 42         # custom version and build
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GRADLE_FILE="${ROOT_DIR}/client/composeApp/build.gradle.kts"
+XCCONFIG_FILE="${ROOT_DIR}/iosApp/Configuration/Config.xcconfig"
+
+# ── Platform-specific commands ───────────────────────────────────────────────
+# CI runs on Linux (uses sed -i and tac).
+# Local development typically runs on macOS (uses sed -i '' and tail -r).
+if [[ "$(uname)" == "Darwin" ]]; then
+    sed_inplace() { sed -i '' "$@"; }
+    reverse() { tail -r "$@"; }
+else
+    sed_inplace() { sed -i "$@"; }
+    reverse() { tac "$@"; }
+fi
+
+# ── Arguments ────────────────────────────────────────────────────────────────
+TEST_VERSION="${1:-0.99.0}"
+TEST_BUILD="${2:-99}"
+
+if [[ ! "${TEST_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: '${TEST_VERSION}' is not a valid semver (expected X.Y.Z)" >&2
+    exit 1
+fi
+
+# ── macOS version mapping ─────────────────────────────────────────────────────
+# macOS DMG packaging requires MAJOR > 0; map 0.x.y → 1.x.y.
+# See comment in client/composeApp/build.gradle.kts macOS block.
+IFS='.' read -r V_MAJOR V_MINOR V_PATCH <<< "${TEST_VERSION}"
+if [[ "${V_MAJOR}" == "0" ]]; then
+    EXPECTED_MAC_VERSION="1.${V_MINOR}.${V_PATCH}"
+else
+    EXPECTED_MAC_VERSION="${TEST_VERSION}"
+fi
+
+# ── Temp workspace ───────────────────────────────────────────────────────────
+TMPDIR_WORK="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_WORK}"' EXIT
+
+GRADLE_COPY="${TMPDIR_WORK}/build.gradle.kts"
+XCCONFIG_COPY="${TMPDIR_WORK}/Config.xcconfig"
+
+cp "${GRADLE_FILE}" "${GRADLE_COPY}"
+cp "${XCCONFIG_FILE}" "${XCCONFIG_COPY}"
+
+# ── Apply transformations (mirrors bump-version.yml "Apply version bump" step) ─
+
+# Android versionCode
+sed_inplace "s/versionCode = [0-9]*/versionCode = ${TEST_BUILD}/" "${GRADLE_COPY}"
+
+# Android versionName
+sed_inplace "s/versionName = \"[^\"]*\"/versionName = \"${TEST_VERSION}\"/" "${GRADLE_COPY}"
+
+# Desktop packageVersion — first occurrence (generic/JVM)
+awk -v new="${TEST_VERSION}" '
+    /packageVersion[[:space:]]*=/ && !done {
+        sub(/packageVersion = "[^"]*"/, "packageVersion = \"" new "\"")
+        done=1
+    }
+    1' "${GRADLE_COPY}" > "${GRADLE_COPY}.tmp" && mv "${GRADLE_COPY}.tmp" "${GRADLE_COPY}"
+
+# Desktop macOS packageVersion — second (last) occurrence
+reverse "${GRADLE_COPY}" | awk -v new="${EXPECTED_MAC_VERSION}" '
+    /packageVersion[[:space:]]*=/ && !done {
+        sub(/packageVersion = "[^"]*"/, "packageVersion = \"" new "\"")
+        done=1
+    }
+    1' | reverse > "${GRADLE_COPY}.tmp" && mv "${GRADLE_COPY}.tmp" "${GRADLE_COPY}"
+
+# iOS build number and marketing version
+sed_inplace "s/CURRENT_PROJECT_VERSION=.*/CURRENT_PROJECT_VERSION=${TEST_BUILD}/" "${XCCONFIG_COPY}"
+sed_inplace "s/MARKETING_VERSION=.*/MARKETING_VERSION=${TEST_VERSION}/" "${XCCONFIG_COPY}"
+
+# ── Verification ─────────────────────────────────────────────────────────────
+FAIL=0
+
+check() {
+    local label="${1}"
+    local expected="${2}"
+    local actual="${3}"
+    if [[ "${actual}" == "${expected}" ]]; then
+        printf "  \033[0;32m✓\033[0m %-42s %s\n" "${label}" "${actual}"
+    else
+        printf "  \033[0;31m✗\033[0m %-42s expected '%s', got '%s'\n" \
+            "${label}" "${expected}" "${actual}" >&2
+        FAIL=1
+    fi
+}
+
+ACTUAL_VCODE=$(sed -n 's/.*versionCode = \([0-9]*\).*/\1/p' "${GRADLE_COPY}")
+ACTUAL_VNAME=$(sed -n 's/.*versionName = "\([^"]*\)".*/\1/p' "${GRADLE_COPY}")
+ACTUAL_PKG_VERSIONS=$(sed -n 's/.*packageVersion = "\([^"]*\)".*/\1/p' "${GRADLE_COPY}")
+ACTUAL_PKG_FIRST=$(printf '%s\n' "${ACTUAL_PKG_VERSIONS}" | head -1)
+ACTUAL_PKG_LAST=$(printf '%s\n' "${ACTUAL_PKG_VERSIONS}" | tail -1)
+ACTUAL_IOS_BUILD=$(sed -n 's/CURRENT_PROJECT_VERSION=\(.*\)/\1/p' "${XCCONFIG_COPY}")
+ACTUAL_IOS_VERSION=$(sed -n 's/MARKETING_VERSION=\(.*\)/\1/p' "${XCCONFIG_COPY}")
+
+printf '\nTest: bump to version \033[1m%s\033[0m (build \033[1m%s\033[0m)\n\n' \
+    "${TEST_VERSION}" "${TEST_BUILD}"
+
+printf "Checking %s:\n" "${GRADLE_COPY}"
+check "versionCode" "${TEST_BUILD}" "${ACTUAL_VCODE}"
+check "versionName" "${TEST_VERSION}" "${ACTUAL_VNAME}"
+check "packageVersion (JVM/generic, first occurrence)" "${TEST_VERSION}" "${ACTUAL_PKG_FIRST}"
+check "packageVersion (macOS, last occurrence)" "${EXPECTED_MAC_VERSION}" "${ACTUAL_PKG_LAST}"
+
+printf "\nChecking %s:\n" "${XCCONFIG_COPY}"
+check "CURRENT_PROJECT_VERSION" "${TEST_BUILD}" "${ACTUAL_IOS_BUILD}"
+check "MARKETING_VERSION" "${TEST_VERSION}" "${ACTUAL_IOS_VERSION}"
+
+printf '\n'
+if [[ "${FAIL}" -ne 0 ]]; then
+    printf '\033[0;31mFAILED: one or more checks did not match.\033[0m\n' >&2
+    exit 1
+fi
+printf '\033[0;32mAll checks passed.\033[0m\n'


### PR DESCRIPTION
## Summary

Adds full GitHub Actions automation for cross-platform version bumping and release, as described in the spec.

## Files created

| File | Purpose |
|---|---|
| `.github/workflows/bump-version.yml` | Manual `workflow_dispatch` — bumps versions across all platforms, commits to a `chore/bump-version-X.Y.Z` branch, and opens a PR. Supports `major / minor / patch / custom` bump types. |
| `.github/workflows/build-release.yml` | Triggered on push to `main` when the commit starts with `chore: bump version` (i.e. after the bump PR is squash-merged). Creates a git tag, builds a signed release APK via Gradle, and publishes a GitHub release with the APK attached. |
| `docs/ci/VERSION_BUMP_SETUP.md` | Step-by-step setup guide: required secrets, `RELEASE_TOKEN` configuration, signing setup, common issues. |
| `scripts/test-version-bump.sh` | Local dry-run script that exercises the same sed/awk patterns as CI and exits non-zero on any mismatch. `chmod +x` already set. |

## Required GitHub secrets

Configure in **Settings → Secrets and variables → Actions → Repository secrets**.

| Secret | Required by | Notes |
|---|---|---|
| `ANDROID_KEYSTORE_BASE64` | `build-release.yml` | `base64 -i release.jks` |
| `ANDROID_KEYSTORE_PASSWORD` | `build-release.yml` | |
| `ANDROID_KEY_ALIAS` | `build-release.yml` | |
| `ANDROID_KEY_PASSWORD` | `build-release.yml` | |
| `SUPABASE_URL` | `build-release.yml` | |
| `SUPABASE_KEY` | `build-release.yml` | |
| `BUGSNAG_API_KEY` | `build-release.yml` | |
| `RELEASE_TOKEN` | `build-release.yml` | PAT with `repo` + `workflows` scope. **Without this**, the tag push from `build-release.yml` will NOT trigger `android-release`, `desktop-release`, or `ios-release` (GITHUB_TOKEN limitation). See setup guide. |

## Divergence from `bump-version.sh`

The interactive local script (`scripts/bump-version.sh`) has a `to_mac_version()` function that is a pass-through (returns the version unchanged). This means it would set the macOS `packageVersion` to `0.x.y`, breaking DMG packaging (which requires `MAJOR > 0`, as documented in the `build.gradle.kts` comment).

The CI workflow and test script implement the correct mapping: `0.x.y → 1.x.y`. The local script should be updated to match, but that is left as a follow-up since it is out of scope for this PR.

## Before you run

1. Configure the secrets listed above in GitHub Settings.
2. For downstream workflow triggering: create a `RELEASE_TOKEN` PAT (see `docs/ci/VERSION_BUMP_SETUP.md`).
3. Validate locally: `./scripts/test-version-bump.sh`
4. Go to **Actions → Bump Version → Run workflow** and select a bump type.
5. Review and **squash merge** the resulting PR — `build-release.yml` detects the commit message on `main`.