### PR TITLE
feat: add privacy policy, terms of use, and about to more tab

### DIFF
--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -166,6 +166,7 @@ class BottomNavBlocImpl(
         when (output) {
             SettingsBloc.Output.OpenSignIn -> OpenSignIn
             SettingsBloc.Output.OpenSignUp -> OpenSignUp
+            is SettingsBloc.Output.OpenUrl -> BottomNavBloc.Output.OpenUrl(output.url)
         }.let { this.output.onNext(it) }
     }
 

--- a/client/bottomnav/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/bottomnav/public/src/commonMain/composeResources/values/strings.xml
@@ -3,5 +3,5 @@
     <string name="tab_grocery">Grocery</string>
     <string name="tab_meals">Meals</string>
     <string name="tab_recipes">Recipes</string>
-    <string name="tab_settings">Settings</string>
+    <string name="tab_more">More</string>
 </resources>

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -52,6 +52,8 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc {
         data object OpenSignIn : Output()
 
         data object OpenSignUp : Output()
+
+        data class OpenUrl(val url: String) : Output()
     }
 
     fun interface Factory {

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Language
-import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Icon
@@ -29,8 +29,8 @@ import chefmate.client.bottomnav.public.generated.resources.Res
 import chefmate.client.bottomnav.public.generated.resources.tab_browser
 import chefmate.client.bottomnav.public.generated.resources.tab_grocery
 import chefmate.client.bottomnav.public.generated.resources.tab_meals
+import chefmate.client.bottomnav.public.generated.resources.tab_more
 import chefmate.client.bottomnav.public.generated.resources.tab_recipes
-import chefmate.client.bottomnav.public.generated.resources.tab_settings
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.Children
 import com.arkivanov.decompose.extensions.compose.stack.animation.fade
@@ -163,7 +163,7 @@ private fun BottomNavBloc.Tab.getLabel(): StringResource =
         GROCERIES -> Res.string.tab_grocery
         MEALS -> Res.string.tab_meals
         BROWSER -> Res.string.tab_browser
-        SETTINGS -> Res.string.tab_settings
+        SETTINGS -> Res.string.tab_more
     }
 
 private fun BottomNavBloc.Tab.getIcon() =
@@ -172,5 +172,5 @@ private fun BottomNavBloc.Tab.getIcon() =
         GROCERIES -> Icons.Default.ShoppingCart
         MEALS -> Icons.Default.CalendarMonth
         BROWSER -> Icons.Default.Language
-        SETTINGS -> Icons.Default.Settings
+        SETTINGS -> Icons.Default.Menu
     }

--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserBlocImpl.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserBlocImpl.kt
@@ -20,12 +20,17 @@ import kotlinx.coroutines.flow.StateFlow
 class BrowserBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<BrowserBloc.Output>,
+    @Assisted private val showControls: Boolean,
     viewModelFactory: Provider<BrowserViewModel>,
 ) : BrowserBloc, BlocContext by context {
 
     @AssistedFactory
     fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<BrowserBloc.Output>): BrowserBlocImpl
+        fun create(
+            context: BlocContext,
+            output: Consumer<BrowserBloc.Output>,
+            showControls: Boolean,
+        ): BrowserBlocImpl
     }
 
     private val viewModel = instanceKeeper.getViewModel {
@@ -39,6 +44,7 @@ class BrowserBlocImpl(
                 navigateUrl = it.currentUrl,
                 addressBarText = it.addressBarText,
                 isExtracting = it.isExtracting,
+                showControls = showControls,
                 extractionMessage =
                     it.extractionMessage?.let { msg ->
                         when (msg) {
@@ -75,7 +81,11 @@ class BrowserBlocImpl(
 interface BrowserBlocBindingModule {
     @Provides
     fun provideBrowserBlocFactory(factory: BrowserBlocImpl.ManagedFactory): BrowserBloc.Factory =
-        BrowserBloc.Factory { context, output ->
-            factory.create(context, output)
+        object : BrowserBloc.Factory {
+            override fun create(
+                context: BlocContext,
+                output: Consumer<BrowserBloc.Output>,
+                showControls: Boolean,
+            ): BrowserBloc = factory.create(context, output, showControls)
         }
 }

--- a/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserBloc.kt
+++ b/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserBloc.kt
@@ -27,13 +27,18 @@ interface BrowserBloc {
         val addressBarText: String = "",
         val isExtracting: Boolean = false,
         val extractionMessage: TextData? = null,
+        val showControls: Boolean = true,
     )
 
     sealed class Output {
         data class RecipeExtracted(val recipeId: Long) : Output()
     }
 
-    fun interface Factory {
-        fun create(context: BlocContext, output: Consumer<Output>): BrowserBloc
+    interface Factory {
+        fun create(
+            context: BlocContext,
+            output: Consumer<Output>,
+            showControls: Boolean = true,
+        ): BrowserBloc
     }
 }

--- a/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserScreen.kt
+++ b/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserScreen.kt
@@ -51,18 +51,23 @@ fun BrowserScreen(bloc: BrowserBloc, modifier: Modifier = Modifier) {
 
     PlusNavContainer(
         modifier = modifier.fillMaxSize(),
-        data = PlusHeaderData.Parent(title = Res.string.tab_browser.asTextData()),
+        data =
+            if (viewState.showControls)
+                PlusHeaderData.Parent(title = Res.string.tab_browser.asTextData())
+            else PlusHeaderData.None,
         scrollEnabled = false,
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = {
-            AddressBar(
-                url = viewState.addressBarText,
-                onUrlChanged = bloc::onUrlChanged,
-                onNavigate = bloc::onNavigate,
-                showExtract = viewState.currentUrl.isNotBlank(),
-                isExtracting = viewState.isExtracting,
-                onExtractRecipe = bloc::onExtractRecipe,
-            )
+            if (viewState.showControls) {
+                AddressBar(
+                    url = viewState.addressBarText,
+                    onUrlChanged = bloc::onUrlChanged,
+                    onNavigate = bloc::onNavigate,
+                    showExtract = viewState.currentUrl.isNotBlank(),
+                    isExtracting = viewState.isExtracting,
+                    onExtractRecipe = bloc::onExtractRecipe,
+                )
+            }
             PlatformWebView(
                 url = viewState.navigateUrl,
                 onUrlLoaded = bloc::onUrlLoadedInWebView,

--- a/client/recipe/core/impl/build.gradle.kts
+++ b/client/recipe/core/impl/build.gradle.kts
@@ -9,7 +9,6 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.client.recipe.data.public)
             implementation(projects.client.recipe.core.public)
-            implementation(projects.client.browser.public)
             implementation(libs.arkivanov.decompose.core)
             implementation(projects.client.shared)
             implementation(libs.kotlinx.serialization.json)

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -8,7 +8,6 @@ import com.arkivanov.decompose.router.slot.dismiss
 import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
-import com.plusmobileapps.chefmate.browser.BrowserBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
@@ -38,7 +37,6 @@ class RecipeDetailBlocImpl(
     private val timeFormatterUtil: TimeFormatterUtil,
     private val addToGroceryList: AddRecipeToGroceryListBloc.Factory,
     private val mealPlannerRootFactory: MealPlannerRootBloc.Factory,
-    private val browserBlocFactory: BrowserBloc.Factory,
 ) : RecipeDetailBloc, BlocContext by context {
     @AssistedFactory
     fun interface ManagedFactory {
@@ -123,7 +121,7 @@ class RecipeDetailBlocImpl(
     }
 
     override fun onSourceUrlClicked(url: String) {
-        sheetNavigation.activate(SheetConfig.BrowserLauncher(url))
+        output.onNext(Output.OpenUrl(url))
     }
 
     override fun onDismissSheet() {
@@ -163,24 +161,6 @@ class RecipeDetailBlocImpl(
                             },
                         )
                 )
-            is SheetConfig.BrowserLauncher ->
-                RecipeDetailBloc.Sheet.BrowserLauncher(
-                    bloc =
-                        browserBlocFactory
-                            .create(
-                                context = context,
-                                output = { browserOutput ->
-                                    when (browserOutput) {
-                                        is BrowserBloc.Output.RecipeExtracted ->
-                                            sheetNavigation.dismiss()
-                                    }
-                                },
-                            )
-                            .also { bloc ->
-                                bloc.onUrlChanged(config.url)
-                                bloc.onNavigate()
-                            }
-                )
         }
 
     @Serializable
@@ -188,8 +168,6 @@ class RecipeDetailBlocImpl(
         data class AddToGroceryList(val recipeId: Long) : SheetConfig()
 
         data class AddToMealPlan(val recipeId: Long) : SheetConfig()
-
-        data class BrowserLauncher(val url: String) : SheetConfig()
     }
 }
 

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
@@ -105,6 +105,9 @@ class RecipeRootBlocImpl(
             is RecipeDetailBloc.Output.EditRecipe -> {
                 navigation.bringToFront(Configuration.Edit(recipeId = output.recipeId))
             }
+            is RecipeDetailBloc.Output.OpenUrl -> {
+                this.output.onNext(RecipeRootBloc.Output.OpenUrl(output.url))
+            }
         }
     }
 

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImplTest.kt
@@ -1,0 +1,96 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.recipe.core.impl.root
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
+import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc
+import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
+import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.plusmobileapps.chefmate.testing.TestConsumer
+import dev.mokkery.mock
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+
+class RecipeRootBlocImplTest {
+
+    private val context = TestBlocContext.create()
+    private val output = TestConsumer<RecipeRootBloc.Output>()
+    private var detailOutput: Consumer<RecipeDetailBloc.Output> = Consumer {}
+    private var editOutput: Consumer<EditRecipeBloc.Output> = Consumer {}
+
+    private fun createBloc(
+        props: RecipeRootBloc.Props = RecipeRootBloc.Props.Detail(1L)
+    ): RecipeRootBlocImpl =
+        RecipeRootBlocImpl(
+            context = context,
+            props = props,
+            output = output,
+            detailBloc =
+                object : RecipeDetailBloc.Factory {
+                    override fun create(
+                        context: BlocContext,
+                        recipeId: Long,
+                        output: Consumer<RecipeDetailBloc.Output>,
+                    ): RecipeDetailBloc {
+                        detailOutput = output
+                        return mock()
+                    }
+                },
+            editBloc =
+                EditRecipeBloc.Factory { context, _, output ->
+                    editOutput = output
+                    mock()
+                },
+        )
+
+    @Test
+    fun When_created_with_detail_props_Then_detail_child_is_shown() {
+        val bloc = createBloc(RecipeRootBloc.Props.Detail(42L))
+        bloc.routerState.value.active.instance.shouldBeInstanceOf<RecipeRootBloc.Child.Detail>()
+    }
+
+    @Test
+    fun When_created_with_create_props_Then_edit_child_is_shown() {
+        val bloc = createBloc(RecipeRootBloc.Props.Create)
+        bloc.routerState.value.active.instance.shouldBeInstanceOf<RecipeRootBloc.Child.Edit>()
+    }
+
+    @Test
+    fun When_detail_outputs_finished_Then_root_outputs_finished() {
+        createBloc(RecipeRootBloc.Props.Detail(1L))
+        detailOutput.onNext(RecipeDetailBloc.Output.Finished)
+        output.lastValue shouldBe RecipeRootBloc.Output.Finished
+    }
+
+    @Test
+    fun When_detail_outputs_edit_recipe_Then_edit_child_is_shown() {
+        val bloc = createBloc(RecipeRootBloc.Props.Detail(1L))
+        detailOutput.onNext(RecipeDetailBloc.Output.EditRecipe(1L))
+        bloc.routerState.value.active.instance.shouldBeInstanceOf<RecipeRootBloc.Child.Edit>()
+    }
+
+    @Test
+    fun When_detail_outputs_open_url_Then_root_outputs_open_url() {
+        createBloc(RecipeRootBloc.Props.Detail(1L))
+        detailOutput.onNext(RecipeDetailBloc.Output.OpenUrl("https://example.com/recipe"))
+        output.lastValue shouldBe RecipeRootBloc.Output.OpenUrl("https://example.com/recipe")
+    }
+
+    @Test
+    fun When_edit_outputs_cancelled_from_create_Then_root_outputs_finished() {
+        createBloc(RecipeRootBloc.Props.Create)
+        editOutput.onNext(EditRecipeBloc.Output.Cancelled)
+        output.lastValue shouldBe RecipeRootBloc.Output.Finished
+    }
+
+    @Test
+    fun When_edit_outputs_finished_Then_detail_child_is_shown() {
+        val bloc = createBloc(RecipeRootBloc.Props.Detail(1L))
+        detailOutput.onNext(RecipeDetailBloc.Output.EditRecipe(1L))
+        editOutput.onNext(EditRecipeBloc.Output.Finished(1L))
+        bloc.routerState.value.active.instance.shouldBeInstanceOf<RecipeRootBloc.Child.Detail>()
+    }
+}

--- a/client/recipe/core/public/build.gradle.kts
+++ b/client/recipe/core/public/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
 
             api(projects.client.meal.data.public)
             implementation(libs.kotlinx.datetime)
-            implementation(projects.client.browser.public)
             implementation(projects.client.shared)
             implementation(projects.client.ui.public)
             implementation(libs.arkivanov.decompose.compose.extensions)

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -5,7 +5,6 @@ import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.BackClickBloc
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
-import com.plusmobileapps.chefmate.browser.BrowserBloc
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.data.Recipe
@@ -51,12 +50,12 @@ interface RecipeDetailBloc : BackClickBloc {
         data object Finished : Output()
 
         data class EditRecipe(val recipeId: Long) : Output()
+
+        data class OpenUrl(val url: String) : Output()
     }
 
     sealed class Sheet {
         data class AddToGroceryList(val bloc: AddRecipeToGroceryListBloc) : Sheet()
-
-        data class BrowserLauncher(val bloc: BrowserBloc) : Sheet()
 
         data class AddToMealPlan(val bloc: MealPlannerRootBloc) : Sheet()
     }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -107,7 +107,6 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
-import com.plusmobileapps.chefmate.browser.BrowserScreen
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListScreen
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootScreen
 import com.plusmobileapps.chefmate.recipe.data.Recipe
@@ -285,7 +284,6 @@ private fun RecipeDetailSheet(
                 when (val current = sheetChild) {
                     is RecipeDetailBloc.Sheet.AddToGroceryList -> current.bloc.onBackClicked()
                     is RecipeDetailBloc.Sheet.AddToMealPlan -> bloc.onDismissSheet()
-                    is RecipeDetailBloc.Sheet.BrowserLauncher -> bloc.onDismissSheet()
                     null -> {}
                 }
             },
@@ -296,7 +294,6 @@ private fun RecipeDetailSheet(
                 is RecipeDetailBloc.Sheet.AddToGroceryList ->
                     AddRecipeToGroceryListScreen(current.bloc)
                 is RecipeDetailBloc.Sheet.AddToMealPlan -> MealPlannerRootScreen(current.bloc)
-                is RecipeDetailBloc.Sheet.BrowserLauncher -> BrowserScreen(current.bloc)
                 null -> {}
             }
         }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/root/RecipeRootBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/root/RecipeRootBloc.kt
@@ -21,6 +21,8 @@ interface RecipeRootBloc : BackHandlerOwner, BackClickBloc {
 
     sealed class Output {
         data object Finished : Output()
+
+        data class OpenUrl(val url: String) : Output()
     }
 
     @Serializable

--- a/client/root/impl/build.gradle.kts
+++ b/client/root/impl/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
             implementation(libs.arkivanov.decompose.core)
             implementation(projects.client.shared)
             implementation(projects.client.bottomnav.public)
+            implementation(projects.client.browser.public)
             implementation(projects.client.grocery.core.public)
             implementation(projects.client.recipe.core.public)
             implementation(projects.client.auth.ui.public)

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -11,6 +11,7 @@ import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc
+import com.plusmobileapps.chefmate.browser.BrowserBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
@@ -30,6 +31,7 @@ import kotlinx.serialization.Serializable
 class RootBlocImpl(
     @Assisted context: BlocContext,
     private val bottomNav: BottomNavBloc.Factory,
+    private val browserBlocFactory: BrowserBloc.Factory,
     private val groceryDetail: GroceryDetailBloc.Factory,
     private val recipeRoot: RecipeRootBloc.Factory,
     private val authentication: AuthenticationBloc.Factory,
@@ -94,6 +96,21 @@ class RootBlocImpl(
                             output = ::handleAuthenticationOutput,
                         )
                 )
+
+            is Configuration.Browser ->
+                RootBloc.Child.Browser(
+                    bloc =
+                        browserBlocFactory
+                            .create(
+                                context = context,
+                                output = { navigation.pop() },
+                                showControls = false,
+                            )
+                            .also { bloc ->
+                                bloc.onUrlChanged(config.url)
+                                bloc.onNavigate()
+                            }
+                )
         }
 
     private fun handleBottomNavOutput(output: BottomNavBloc.Output) {
@@ -121,6 +138,10 @@ class RootBlocImpl(
                     Configuration.Authentication(AuthenticationBloc.Props.SignUp)
                 )
             }
+
+            is BottomNavBloc.Output.OpenUrl -> {
+                navigation.bringToFront(Configuration.Browser(output.url))
+            }
         }
     }
 
@@ -141,8 +162,6 @@ class RootBlocImpl(
             AuthenticationBloc.Output.Finished -> navigation.pop()
             AuthenticationBloc.Output.AuthenticationSuccess -> navigation.pop()
             is AuthenticationBloc.Output.EmailVerificationRequired -> {
-                // User signed up successfully but needs to verify email
-                // Pop back to settings where they'll see the verification message
                 navigation.pop()
             }
         }
@@ -158,6 +177,8 @@ class RootBlocImpl(
 
         @Serializable
         data class Authentication(val props: AuthenticationBloc.Props) : Configuration()
+
+        @Serializable data class Browser(val url: String) : Configuration()
     }
 }
 

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -154,6 +154,9 @@ class RootBlocImpl(
     private fun handleRecipeRootOutput(output: RecipeRootBloc.Output) {
         when (output) {
             RecipeRootBloc.Output.Finished -> navigation.pop()
+            is RecipeRootBloc.Output.OpenUrl -> {
+                navigation.bringToFront(Configuration.Browser(output.url))
+            }
         }
     }
 

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -2,7 +2,9 @@
 
 package com.plusmobileapps.chefmate.root
 
+import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.browser.BrowserBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
@@ -28,6 +30,14 @@ class RootBlocTest {
                 bottomNavOutput = output
                 mock()
             },
+            browserBlocFactory =
+                object : BrowserBloc.Factory {
+                    override fun create(
+                        context: BlocContext,
+                        output: Consumer<BrowserBloc.Output>,
+                        showControls: Boolean,
+                    ): BrowserBloc = mock()
+                },
             recipeRoot = { context, props, output ->
                 recipeOutput = output
                 recipeProps = props

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -9,6 +9,7 @@ import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.testing.TestBlocContext
+import dev.mokkery.MockMode
 import dev.mokkery.mock
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -36,7 +37,7 @@ class RootBlocTest {
                         context: BlocContext,
                         output: Consumer<BrowserBloc.Output>,
                         showControls: Boolean,
-                    ): BrowserBloc = mock()
+                    ): BrowserBloc = mock(MockMode.autoUnit)
                 },
             recipeRoot = { context, props, output ->
                 recipeOutput = output
@@ -96,5 +97,22 @@ class RootBlocTest {
 
         recipeOutput.onNext(RecipeRootBloc.Output.Finished)
         rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+    }
+
+    @Test
+    fun When_bottom_nav_outputs_open_url_Then_browser_is_shown() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenUrl("https://example.com"))
+        rootBloc.instance() should instanceOf<RootBloc.Child.Browser>()
+        rootBloc.state.value.backStack.size shouldBe 1
+    }
+
+    @Test
+    fun When_recipe_root_outputs_open_url_Then_browser_is_shown() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenRecipe(123L))
+        rootBloc.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
+
+        recipeOutput.onNext(RecipeRootBloc.Output.OpenUrl("https://example.com/recipe"))
+        rootBloc.instance() should instanceOf<RootBloc.Child.Browser>()
+        rootBloc.state.value.backStack.size shouldBe 2
     }
 }

--- a/client/root/public/build.gradle.kts
+++ b/client/root/public/build.gradle.kts
@@ -7,6 +7,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(projects.client.bottomnav.public)
+            api(projects.client.browser.public)
             api(projects.client.grocery.core.public)
             api(projects.client.recipe.core.public)
             api(projects.client.auth.ui.public)

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -6,6 +6,7 @@ import com.arkivanov.essenty.backhandler.BackHandlerOwner
 import com.plusmobileapps.chefmate.BackClickBloc
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc
+import com.plusmobileapps.chefmate.browser.BrowserBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
@@ -21,6 +22,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class RecipeRoot(val bloc: RecipeRootBloc) : Child()
 
         data class Authentication(val bloc: AuthenticationBloc) : Child()
+
+        data class Browser(val bloc: BrowserBloc) : Child()
     }
 
     fun interface Factory {

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -1,15 +1,29 @@
+@file:OptIn(ExperimentalDecomposeApi::class)
+
 package com.plusmobileapps.chefmate.root
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Dp
+import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.Children
+import com.arkivanov.decompose.extensions.compose.stack.animation.StackAnimator
+import com.arkivanov.decompose.extensions.compose.stack.animation.isFront
+import com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback.predictiveBackAnimation
+import com.arkivanov.decompose.extensions.compose.stack.animation.slide
+import com.arkivanov.decompose.extensions.compose.stack.animation.stackAnimation
+import com.arkivanov.decompose.extensions.compose.stack.animation.stackAnimator
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationScreen
+import com.plusmobileapps.chefmate.browser.BrowserScreen
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailScreen
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavigationScreen
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootScreen
-import com.plusmobileapps.chefmate.ui.backAnimation
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
 @Composable
@@ -20,15 +34,52 @@ fun RootScreen(rootBloc: RootBloc, modifier: Modifier = Modifier) {
             modifier = modifier.fillMaxSize(),
             stack = state.value,
             animation =
-                backAnimation(backHandler = rootBloc.backHandler, onBack = rootBloc::onBackClicked),
+                predictiveBackAnimation(
+                    backHandler = rootBloc.backHandler,
+                    fallbackAnimation =
+                        stackAnimation { child, otherChild, _ ->
+                            if (
+                                child.instance is RootBloc.Child.Browser ||
+                                    otherChild.instance is RootBloc.Child.Browser
+                            ) {
+                                verticalSlide()
+                            } else {
+                                slide()
+                            }
+                        },
+                    onBack = rootBloc::onBackClicked,
+                ),
             content = {
                 when (val child = it.instance) {
                     is RootBloc.Child.BottomNavigation -> BottomNavigationScreen(child.bloc)
                     is RootBloc.Child.GroceryDetail -> GroceryDetailScreen(child.bloc)
                     is RootBloc.Child.RecipeRoot -> RecipeRootScreen(child.bloc)
                     is RootBloc.Child.Authentication -> AuthenticationScreen(child.bloc)
+                    is RootBloc.Child.Browser ->
+                        PlusHeaderContainer(
+                            modifier = Modifier.fillMaxSize(),
+                            data =
+                                PlusHeaderData.Modal(
+                                    title = FixedString(""),
+                                    onCloseClick = rootBloc::onBackClicked,
+                                ),
+                            scrollEnabled = false,
+                            maxContentWidth = Dp.Unspecified,
+                            content = { BrowserScreen(child.bloc, modifier = Modifier.weight(1f)) },
+                        )
                 }
             },
         )
+    }
+}
+
+private fun verticalSlide(): StackAnimator = stackAnimator { factor, direction, content ->
+    content(Modifier.offsetYFactor(if (direction.isFront) factor else 0f))
+}
+
+private fun Modifier.offsetYFactor(factor: Float): Modifier = layout { measurable, constraints ->
+    val placeable = measurable.measure(constraints)
+    layout(placeable.width, placeable.height) {
+        placeable.placeRelative(x = 0, y = (placeable.height.toFloat() * factor).toInt())
     }
 }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -54,6 +54,10 @@ class SettingsBlocImpl(
     override fun onSignOutClicked() {
         viewModel.signOut()
     }
+
+    override fun onUrlClicked(url: String) {
+        output.onNext(Output.OpenUrl(url))
+    }
 }
 
 @ContributesTo(AppScope::class)

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -1,5 +1,8 @@
 <resources>
-    <string name="settings">Settings</string>
+    <string name="more">More</string>
+    <string name="privacy_policy">Privacy Policy</string>
+    <string name="terms_of_use">Terms of Use</string>
+    <string name="about">About</string>
     <string name="sign_in">Sign In</string>
     <string name="sign_out">Sign Out</string>
     <string name="sign_up">Sign Up</string>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -14,6 +14,8 @@ interface SettingsBloc {
 
     fun onSignOutClicked()
 
+    fun onUrlClicked(url: String)
+
     data class Model(
         val isAuthenticated: Boolean = false,
         val greeting: TextData? = null,
@@ -24,6 +26,8 @@ interface SettingsBloc {
         data object OpenSignUp : Output()
 
         data object OpenSignIn : Output()
+
+        data class OpenUrl(val url: String) : Output()
     }
 
     fun interface Factory {

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
@@ -25,15 +25,19 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import chefmate.client.settings.public.generated.resources.Res
+import chefmate.client.settings.public.generated.resources.about
 import chefmate.client.settings.public.generated.resources.greeting_authenticated
-import chefmate.client.settings.public.generated.resources.settings
+import chefmate.client.settings.public.generated.resources.more
+import chefmate.client.settings.public.generated.resources.privacy_policy
 import chefmate.client.settings.public.generated.resources.sign_in
 import chefmate.client.settings.public.generated.resources.sign_out
 import chefmate.client.settings.public.generated.resources.sign_up
+import chefmate.client.settings.public.generated.resources.terms_of_use
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
@@ -43,9 +47,10 @@ import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 @Composable
 fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
     val viewState by bloc.state.collectAsState()
+    val uriHandler = LocalUriHandler.current
 
     PlusNavContainer(
-        data = PlusHeaderData.Parent(title = Res.string.settings.asTextData()),
+        data = PlusHeaderData.Parent(title = Res.string.more.asTextData()),
         content = {
             if (viewState.isAuthenticated) {
                 // Show greeting and sign out button when authenticated
@@ -68,11 +73,30 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
                 HorizontalDivider()
                 SettingsRow(name = Res.string.sign_up.asTextData(), onClick = bloc::onSignUpClicked)
             }
+            HorizontalDivider()
+            SettingsRow(
+                name = Res.string.privacy_policy.asTextData(),
+                onClick = {
+                    uriHandler.openUri("https://chefmate.plusmobileapps.com/privacy-policy/")
+                },
+            )
+            HorizontalDivider()
+            SettingsRow(
+                name = Res.string.terms_of_use.asTextData(),
+                onClick = {
+                    uriHandler.openUri("https://chefmate.plusmobileapps.com/terms-of-use/")
+                },
+            )
+            HorizontalDivider()
+            SettingsRow(
+                name = Res.string.about.asTextData(),
+                onClick = { uriHandler.openUri("https://chefmate.plusmobileapps.com/") },
+            )
         },
     )
     Column(modifier = modifier.fillMaxSize()) {
         TopAppBar(
-            title = { Text(Res.string.settings.asTextData().localized()) },
+            title = { Text(Res.string.more.asTextData().localized()) },
             windowInsets = WindowInsets(),
         )
     }

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
@@ -47,13 +46,11 @@ import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 @Composable
 fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
     val viewState by bloc.state.collectAsState()
-    val uriHandler = LocalUriHandler.current
 
     PlusNavContainer(
         data = PlusHeaderData.Parent(title = Res.string.more.asTextData()),
         content = {
             if (viewState.isAuthenticated) {
-                // Show greeting and sign out button when authenticated
                 viewState.greeting?.let { greeting ->
                     GreetingSection(greeting = greeting)
                     HorizontalDivider()
@@ -63,12 +60,10 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
                     onClick = bloc::onSignOutClicked,
                 )
             } else {
-                // Show email verification message if present
                 viewState.verificationMessage?.let { message ->
                     EmailVerificationMessage(message = message)
                     HorizontalDivider()
                 }
-                // Show sign in/sign up buttons when not authenticated
                 SettingsRow(name = Res.string.sign_in.asTextData(), onClick = bloc::onSignInClicked)
                 HorizontalDivider()
                 SettingsRow(name = Res.string.sign_up.asTextData(), onClick = bloc::onSignUpClicked)
@@ -77,20 +72,18 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
             SettingsRow(
                 name = Res.string.privacy_policy.asTextData(),
                 onClick = {
-                    uriHandler.openUri("https://chefmate.plusmobileapps.com/privacy-policy/")
+                    bloc.onUrlClicked("https://chefmate.plusmobileapps.com/privacy-policy/")
                 },
             )
             HorizontalDivider()
             SettingsRow(
                 name = Res.string.terms_of_use.asTextData(),
-                onClick = {
-                    uriHandler.openUri("https://chefmate.plusmobileapps.com/terms-of-use/")
-                },
+                onClick = { bloc.onUrlClicked("https://chefmate.plusmobileapps.com/terms-of-use/") },
             )
             HorizontalDivider()
             SettingsRow(
                 name = Res.string.about.asTextData(),
-                onClick = { uriHandler.openUri("https://chefmate.plusmobileapps.com/") },
+                onClick = { bloc.onUrlClicked("https://chefmate.plusmobileapps.com/") },
             )
         },
     )
@@ -164,6 +157,8 @@ private val previewBlocUnauthenticated =
         override fun onSignUpClicked() = Unit
 
         override fun onSignOutClicked() = Unit
+
+        override fun onUrlClicked(url: String) = Unit
     }
 
 private val previewBlocAuthenticated =
@@ -185,6 +180,8 @@ private val previewBlocAuthenticated =
         override fun onSignUpClicked() = Unit
 
         override fun onSignOutClicked() = Unit
+
+        override fun onUrlClicked(url: String) = Unit
     }
 
 @Preview(showBackground = true)


### PR DESCRIPTION
## Summary
- Rename Settings tab to "More" with a hamburger menu icon; add Privacy Policy, Terms of Use, and About list items that open URLs in a full-screen in-app browser
- Add a `showControls` flag to `BrowserBloc` so the address bar and extract button can be hidden when used as a read-only viewer
- Refactor recipe detail source URL to use the same root-level full-screen browser instead of a `ModalBottomSheet`, routing `OpenUrl` output up through `RecipeRootBloc` to `RootBloc`
- Add `RecipeRootBlocImplTest` and new `RootBlocTest` cases covering URL routing through the browser

## Test plan
- [x] Tap Privacy Policy, Terms of Use, and About on the More tab — each should open a full-screen browser with slide-up animation and no address bar
- [x] Close the browser with the X button or back gesture — should slide down and return to the More tab
- [x] Open a recipe with a source URL and tap it — should open the same full-screen browser
- [x] Verify edge-to-edge display works correctly on Android
- [x] Verify browser content width is not capped at 600dp on desktop
- [x] Run `./gradlew :client:root:impl:test :client:recipe:core:impl:test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)