### PR TITLE
fix(ci): use force-with-lease and clean local branch on workflow rerun

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -130,10 +130,11 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git branch -D "$BRANCH" 2>/dev/null || true
           git checkout -b "$BRANCH"
           git add client/composeApp/build.gradle.kts iosApp/Configuration/Config.xcconfig
           git commit -m "chore: bump version to ${NEW_VERSION} (build ${NEW_BUILD})"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
 
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

- Replace `git push origin "$BRANCH"` with `git push --force-with-lease origin "$BRANCH"` so workflow reruns don't fail with a non-fast-forward rejection when the remote branch already exists from a prior run.
- Add `git branch -D "$BRANCH" 2>/dev/null || true` before `git checkout -b "$BRANCH"` so a stale local branch from a prior run doesn't block the checkout.

## Test plan

- [x] Trigger `bump-version` workflow once — verify branch is created and PR opened normally.
- [x] Trigger `bump-version` workflow a second time for the same version — verify it overwrites the branch and doesn't error on non-fast-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)