### PR TITLE
Add Claude Code Action workflow

### DIFF
--- a/.github/workflows/claude-code-action.yml
+++ b/.github/workflows/claude-code-action.yml
@@ -22,6 +22,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Claude Code Action
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-code-action.yml
+++ b/.github/workflows/claude-code-action.yml
@@ -1,0 +1,29 @@
+name: Claude Code Action
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Claude Code Action
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-code-action.yml
+++ b/.github/workflows/claude-code-action.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Claude Code Action
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow for Claude Code Action (`anthropics/claude-code-action@v1`)
- Triggers when `@claude` is mentioned in issues, issue comments, PR review comments, or PR reviews
- Requires `ANTHROPIC_API_KEY` repository secret to be configured

## Test plan
- [x] Add `ANTHROPIC_API_KEY` as a repository secret
- [x] Create a test issue or PR comment mentioning `@claude` and verify it responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)