### PR TITLE
feat: add grocery list and recipe collaboration

### DIFF
--- a/client/auth/data/impl/build.gradle.kts
+++ b/client/auth/data/impl/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
             implementation(libs.supabase.client)
             implementation(libs.supabase.auth)
             implementation(libs.supabase.postgrest)
+            implementation(libs.supabase.realtime)
         }
         jvmMain.dependencies { implementation(libs.ktor.client.cio) }
         androidMain.dependencies { implementation(libs.ktor.client.cio) }

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseModule.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseModule.kt
@@ -9,6 +9,7 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.realtime.Realtime
 
 @SingleIn(AppScope::class)
 @ContributesTo(AppScope::class)
@@ -25,5 +26,6 @@ interface SupabaseModule {
                 host = "auth"
             }
             install(Postgrest)
+            install(Realtime)
         }
 }

--- a/client/database/src/commonMain/kotlin/com/plusmobileapps/chefmate/client/database/di/DatabaseComponent.kt
+++ b/client/database/src/commonMain/kotlin/com/plusmobileapps/chefmate/client/database/di/DatabaseComponent.kt
@@ -2,6 +2,7 @@ package com.plusmobileapps.chefmate.client.database.di
 
 import com.plusmobileapps.chefmate.client.database.DriverFactory
 import com.plusmobileapps.chefmate.database.Database
+import com.plusmobileapps.chefmate.database.GroceryListMemberQueries
 import com.plusmobileapps.chefmate.database.GroceryListQueries
 import com.plusmobileapps.chefmate.database.GroceryQueries
 import com.plusmobileapps.chefmate.database.MealPlanQueries
@@ -35,4 +36,9 @@ interface DatabaseComponent {
     @SingleIn(AppScope::class)
     @Provides
     fun providesRecipeQueries(database: Database): RecipeQueries = database.recipeQueries
+
+    @SingleIn(AppScope::class)
+    @Provides
+    fun providesGroceryListMemberQueries(database: Database): GroceryListMemberQueries =
+        database.groceryListMemberQueries
 }

--- a/client/database/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/GroceryList.sq
+++ b/client/database/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/GroceryList.sq
@@ -7,7 +7,10 @@ CREATE TABLE GroceryList (
     updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
     remoteId TEXT UNIQUE,
     clientId TEXT,
-    isDirty INTEGER AS Boolean NOT NULL DEFAULT 0
+    isDirty INTEGER AS Boolean NOT NULL DEFAULT 0,
+    ownerId TEXT,
+    role TEXT NOT NULL DEFAULT 'owner',
+    isShared INTEGER AS Boolean NOT NULL DEFAULT 0
 );
 
 getAll:
@@ -51,3 +54,12 @@ UPDATE GroceryList SET isDirty = 0 WHERE id = ?;
 
 updateClientId:
 UPDATE GroceryList SET clientId = ? WHERE id = ?;
+
+updateOwnership:
+UPDATE GroceryList SET ownerId = ?, role = ?, isShared = ? WHERE id = ?;
+
+getSharedLists:
+SELECT * FROM GroceryList WHERE isShared = 1 ORDER BY createdAt ASC;
+
+getOwnedLists:
+SELECT * FROM GroceryList WHERE role = 'owner' ORDER BY createdAt ASC;

--- a/client/database/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/GroceryListMember.sq
+++ b/client/database/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/GroceryListMember.sq
@@ -1,0 +1,39 @@
+CREATE TABLE GroceryListMember (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    listLocalId INTEGER NOT NULL,
+    remoteId TEXT UNIQUE,
+    userId TEXT,
+    userEmail TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'editor',
+    status TEXT NOT NULL DEFAULT 'pending',
+    displayName TEXT,
+    FOREIGN KEY (listLocalId) REFERENCES GroceryList(id) ON DELETE CASCADE
+);
+
+getByListId:
+SELECT * FROM GroceryListMember WHERE listLocalId = ?;
+
+getByRemoteId:
+SELECT * FROM GroceryListMember WHERE remoteId = ?;
+
+insert:
+INSERT INTO GroceryListMember (listLocalId, remoteId, userId, userEmail, role, status, displayName)
+VALUES (?, ?, ?, ?, ?, ?, ?);
+
+updateStatus:
+UPDATE GroceryListMember SET status = ? WHERE id = ?;
+
+deleteById:
+DELETE FROM GroceryListMember WHERE id = ?;
+
+deleteByListId:
+DELETE FROM GroceryListMember WHERE listLocalId = ?;
+
+deleteByListAndUser:
+DELETE FROM GroceryListMember WHERE listLocalId = ? AND userId = ?;
+
+getAll:
+SELECT * FROM GroceryListMember;
+
+getPendingForUser:
+SELECT * FROM GroceryListMember WHERE userEmail = ? AND status = 'pending';

--- a/client/database/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/Recipe.sq
+++ b/client/database/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/Recipe.sq
@@ -20,7 +20,11 @@ CREATE TABLE Recipe (
     remoteId TEXT UNIQUE,
     clientId TEXT,
     isDirty INTEGER AS Boolean NOT NULL DEFAULT 0,
-    ownerId TEXT
+    ownerId TEXT,
+    forkedFromRemoteId TEXT,
+    forkedFromTitle TEXT,
+    role TEXT NOT NULL DEFAULT 'owner',
+    isShared INTEGER AS Boolean NOT NULL DEFAULT 0
 );
 
 getAll:
@@ -87,3 +91,15 @@ UPDATE Recipe SET clientId = ? WHERE id = ?;
 
 clearDirty:
 UPDATE Recipe SET isDirty = 0 WHERE id = ?;
+
+updateForkedFrom:
+UPDATE Recipe SET forkedFromRemoteId = ?, forkedFromTitle = ? WHERE id = ?;
+
+updateOwnership:
+UPDATE Recipe SET role = ?, isShared = ? WHERE id = ?;
+
+getShared:
+SELECT * FROM Recipe WHERE isShared = 1 ORDER BY title ASC;
+
+getOwned:
+SELECT * FROM Recipe WHERE role = 'owner' ORDER BY title DESC;

--- a/client/database/src/commonMain/sqldelight/migrations/4.sqm
+++ b/client/database/src/commonMain/sqldelight/migrations/4.sqm
@@ -1,0 +1,23 @@
+-- Grocery list collaboration columns
+ALTER TABLE GroceryList ADD COLUMN ownerId TEXT;
+ALTER TABLE GroceryList ADD COLUMN role TEXT NOT NULL DEFAULT 'owner';
+ALTER TABLE GroceryList ADD COLUMN isShared INTEGER NOT NULL DEFAULT 0;
+
+-- Grocery list members (local cache of collaborators)
+CREATE TABLE GroceryListMember (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    listLocalId INTEGER NOT NULL,
+    remoteId TEXT UNIQUE,
+    userId TEXT,
+    userEmail TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'editor',
+    status TEXT NOT NULL DEFAULT 'pending',
+    displayName TEXT,
+    FOREIGN KEY (listLocalId) REFERENCES GroceryList(id) ON DELETE CASCADE
+);
+
+-- Recipe fork and sharing columns
+ALTER TABLE Recipe ADD COLUMN forkedFromRemoteId TEXT;
+ALTER TABLE Recipe ADD COLUMN forkedFromTitle TEXT;
+ALTER TABLE Recipe ADD COLUMN role TEXT NOT NULL DEFAULT 'owner';
+ALTER TABLE Recipe ADD COLUMN isShared INTEGER NOT NULL DEFAULT 0;

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
@@ -8,6 +8,8 @@ import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryFilter
 import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
+import com.plusmobileapps.chefmate.grocery.data.ListCollaborator
+import com.plusmobileapps.chefmate.grocery.data.ListRole
 import com.plusmobileapps.chefmate.mapState
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
@@ -45,6 +47,10 @@ class GroceryListBlocImpl(
                 showCreateListDialog = it.showCreateListDialog,
                 showDeleteDialog = it.showDeleteDialog,
                 showListSelector = it.showListSelector,
+                showShareDialog = it.showShareDialog,
+                collaborators = it.collaborators,
+                pendingInvitations = it.pendingInvitations,
+                currentUserRole = it.currentUserRole,
             )
         }
 
@@ -124,6 +130,30 @@ class GroceryListBlocImpl(
 
     override fun onListSelectorDismissed() {
         viewModel.onListSelectorDismissed()
+    }
+
+    override fun onShareListClicked() {
+        viewModel.onShareListClicked()
+    }
+
+    override fun onShareListDismissed() {
+        viewModel.onShareListDismissed()
+    }
+
+    override fun onInviteCollaborator(email: String, role: ListRole) {
+        viewModel.onInviteCollaborator(email, role)
+    }
+
+    override fun onRemoveCollaborator(collaborator: ListCollaborator) {
+        viewModel.onRemoveCollaborator(collaborator)
+    }
+
+    override fun onAcceptInvitation(list: GroceryListModel) {
+        viewModel.onAcceptInvitation(list)
+    }
+
+    override fun onRejectInvitation(list: GroceryListModel) {
+        viewModel.onRejectInvitation(list)
     }
 }
 

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
@@ -9,6 +9,8 @@ import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryGrou
 import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
 import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
+import com.plusmobileapps.chefmate.grocery.data.ListCollaborator
+import com.plusmobileapps.chefmate.grocery.data.ListRole
 import dev.zacsweers.metro.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -86,6 +88,26 @@ class GroceryListViewModel(
                 }
                 .collect { grouped -> _state.update { it.copy(groupedItems = grouped) } }
         }
+
+        scope.launch {
+            selectedListId
+                .flatMapLatest { listId ->
+                    if (listId != null) {
+                        repository.getListCollaborators(listId)
+                    } else {
+                        flowOf(emptyList())
+                    }
+                }
+                .collect { collaborators ->
+                    _state.update { it.copy(collaborators = collaborators) }
+                }
+        }
+
+        scope.launch {
+            repository.getPendingInvitations().collect { invitations ->
+                _state.update { it.copy(pendingInvitations = invitations) }
+            }
+        }
     }
 
     fun onGroceryItemCheckedChange(item: GroceryItem, isChecked: Boolean) {
@@ -121,7 +143,9 @@ class GroceryListViewModel(
 
     fun onListSelected(list: GroceryListModel) {
         selectedListId.value = list.id
-        _state.update { it.copy(selectedList = list, showListSelector = false) }
+        _state.update {
+            it.copy(selectedList = list, showListSelector = false, currentUserRole = list.role)
+        }
     }
 
     fun onCreateListClicked() {
@@ -186,6 +210,35 @@ class GroceryListViewModel(
         scope.launch { repository.deleteAllGroceries(listId) }
     }
 
+    fun onShareListClicked() {
+        _state.update { it.copy(showShareDialog = true) }
+    }
+
+    fun onShareListDismissed() {
+        _state.update { it.copy(showShareDialog = false) }
+    }
+
+    fun onInviteCollaborator(email: String, role: ListRole) {
+        val listId = selectedListId.value ?: return
+        scope.launch { repository.inviteCollaborator(listId, email, role) }
+    }
+
+    fun onRemoveCollaborator(collaborator: ListCollaborator) {
+        val listId = selectedListId.value ?: return
+        scope.launch { repository.removeCollaborator(listId, collaborator.id) }
+    }
+
+    fun onAcceptInvitation(list: GroceryListModel) {
+        scope.launch {
+            repository.acceptInvitation(list.id)
+            repository.syncAllUnsynced()
+        }
+    }
+
+    fun onRejectInvitation(list: GroceryListModel) {
+        scope.launch { repository.rejectInvitation(list.id) }
+    }
+
     data class State(
         val groupedItems: List<GroceryGroup> = emptyList(),
         val filter: GroceryFilter = GroceryFilter.ALL,
@@ -195,5 +248,9 @@ class GroceryListViewModel(
         val showCreateListDialog: Boolean = false,
         val showDeleteDialog: Boolean = false,
         val showListSelector: Boolean = false,
+        val showShareDialog: Boolean = false,
+        val collaborators: List<ListCollaborator> = emptyList(),
+        val pendingInvitations: List<GroceryListModel> = emptyList(),
+        val currentUserRole: ListRole = ListRole.OWNER,
     )
 }

--- a/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
@@ -40,4 +40,19 @@
     <string name="grocery_category_baking">Baking</string>
     <string name="grocery_category_spices">Spices &amp; Seasonings</string>
     <string name="grocery_category_other">Other</string>
+    <string name="grocery_share_list">Share List</string>
+    <string name="grocery_collaborators">Collaborators</string>
+    <string name="grocery_invite">Invite</string>
+    <string name="grocery_invite_hint">Email address</string>
+    <string name="grocery_invitation_sent">Invitation sent</string>
+    <string name="grocery_remove_collaborator">Remove</string>
+    <string name="grocery_pending_invitations">Pending Invitations</string>
+    <string name="grocery_accept">Accept</string>
+    <string name="grocery_reject">Reject</string>
+    <string name="grocery_shared_with_you">Shared with you</string>
+    <string name="grocery_my_lists">My Lists</string>
+    <string name="grocery_role_owner">Owner</string>
+    <string name="grocery_role_editor">Editor</string>
+    <string name="grocery_role_viewer">Viewer</string>
+    <string name="grocery_shared_badge">Shared</string>
 </resources>

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
@@ -5,6 +5,8 @@ import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
 import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
+import com.plusmobileapps.chefmate.grocery.data.ListCollaborator
+import com.plusmobileapps.chefmate.grocery.data.ListRole
 import kotlinx.coroutines.flow.StateFlow
 
 interface GroceryListBloc {
@@ -48,6 +50,18 @@ interface GroceryListBloc {
 
     fun onListSelectorDismissed()
 
+    fun onShareListClicked()
+
+    fun onShareListDismissed()
+
+    fun onInviteCollaborator(email: String, role: ListRole)
+
+    fun onRemoveCollaborator(collaborator: ListCollaborator)
+
+    fun onAcceptInvitation(list: GroceryListModel)
+
+    fun onRejectInvitation(list: GroceryListModel)
+
     data class GroceryGroup(val category: GroceryCategory, val items: List<GroceryItem>)
 
     enum class GroceryFilter {
@@ -65,6 +79,10 @@ interface GroceryListBloc {
         val showCreateListDialog: Boolean = false,
         val showDeleteDialog: Boolean = false,
         val showListSelector: Boolean = false,
+        val showShareDialog: Boolean = false,
+        val collaborators: List<ListCollaborator> = emptyList(),
+        val pendingInvitations: List<GroceryListModel> = emptyList(),
+        val currentUserRole: ListRole = ListRole.OWNER,
     )
 
     sealed class Output {

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -19,6 +19,9 @@ import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.PersonRemove
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.outlined.CloudDone
 import androidx.compose.material.icons.outlined.CloudOff
@@ -55,6 +58,7 @@ import chefmate.client.grocery.core.public.generated.resources.Res
 import chefmate.client.grocery.core.public.generated.resources.grocery_add_item
 import chefmate.client.grocery.core.public.generated.resources.grocery_cancel
 import chefmate.client.grocery.core.public.generated.resources.grocery_checked
+import chefmate.client.grocery.core.public.generated.resources.grocery_collaborators
 import chefmate.client.grocery.core.public.generated.resources.grocery_create_list_cancel
 import chefmate.client.grocery.core.public.generated.resources.grocery_create_list_confirm
 import chefmate.client.grocery.core.public.generated.resources.grocery_create_list_hint
@@ -71,16 +75,29 @@ import chefmate.client.grocery.core.public.generated.resources.grocery_filter
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_all
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_purchased
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_unpurchased
+import chefmate.client.grocery.core.public.generated.resources.grocery_invite
+import chefmate.client.grocery.core.public.generated.resources.grocery_invite_hint
 import chefmate.client.grocery.core.public.generated.resources.grocery_list
+import chefmate.client.grocery.core.public.generated.resources.grocery_my_lists
 import chefmate.client.grocery.core.public.generated.resources.grocery_not_checked
-import chefmate.client.grocery.core.public.generated.resources.grocery_select_list
+import chefmate.client.grocery.core.public.generated.resources.grocery_remove_collaborator
+import chefmate.client.grocery.core.public.generated.resources.grocery_role_editor
+import chefmate.client.grocery.core.public.generated.resources.grocery_role_owner
+import chefmate.client.grocery.core.public.generated.resources.grocery_role_viewer
+import chefmate.client.grocery.core.public.generated.resources.grocery_share_list
+import chefmate.client.grocery.core.public.generated.resources.grocery_shared_badge
+import chefmate.client.grocery.core.public.generated.resources.grocery_shared_with_you
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_all
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_not_synced
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_synced
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_syncing
 import com.plusmobileapps.chefmate.grocery.core.displayName
+import com.plusmobileapps.chefmate.grocery.data.CollaborationStatus
 import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
 import com.plusmobileapps.chefmate.grocery.data.GroceryItem
+import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
+import com.plusmobileapps.chefmate.grocery.data.ListCollaborator
+import com.plusmobileapps.chefmate.grocery.data.ListRole
 import com.plusmobileapps.chefmate.grocery.data.SyncStatus
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
@@ -111,6 +128,14 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
                     }
                 },
                 actions = {
+                    if (state.currentUserRole == ListRole.OWNER) {
+                        IconButton(onClick = bloc::onShareListClicked) {
+                            Icon(
+                                Icons.Default.Share,
+                                contentDescription = stringResource(Res.string.grocery_share_list),
+                            )
+                        }
+                    }
                     FilterButton(filter = state.filter, onFilterChanged = bloc::onFilterChanged)
                     IconButton(onClick = bloc::onDeleteClicked) {
                         Icon(
@@ -149,11 +174,13 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
                     }
                 }
             }
-            GroceryListInput(
-                name = bloc.newGroceryItemName,
-                onNameChange = bloc::onNewGroceryItemNameChange,
-                onAddClick = bloc::saveGroceryItem,
-            )
+            if (state.currentUserRole != ListRole.VIEWER) {
+                GroceryListInput(
+                    name = bloc.newGroceryItemName,
+                    onNameChange = bloc::onNewGroceryItemNameChange,
+                    onAddClick = bloc::saveGroceryItem,
+                )
+            }
         },
     )
 
@@ -179,6 +206,15 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
             onDismiss = bloc::onDeleteDismissed,
             onDeletePurchased = bloc::onDeletePurchasedConfirmed,
             onDeleteAll = bloc::onDeleteAllConfirmed,
+        )
+    }
+
+    if (state.showShareDialog) {
+        ShareListDialog(
+            collaborators = state.collaborators,
+            onDismiss = bloc::onShareListDismissed,
+            onInvite = { email, role -> bloc.onInviteCollaborator(email, role) },
+            onRemove = bloc::onRemoveCollaborator,
         )
     }
 }
@@ -249,41 +285,22 @@ private fun GroceryListSelectorSheet(
     onDeleteListClicked: (com.plusmobileapps.chefmate.grocery.data.GroceryListModel) -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState()
+    val myLists = state.lists.filter { !it.isShared }
+    val sharedLists = state.lists.filter { it.isShared }
+
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Text(
-            text = stringResource(Res.string.grocery_select_list),
+            text = stringResource(Res.string.grocery_my_lists),
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
-        state.lists.forEach { list ->
-            ListItem(
-                headlineContent = {
-                    Text(
-                        text = list.name,
-                        color =
-                            if (list.id == state.selectedList?.id) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurface
-                            },
-                    )
-                },
-                modifier = Modifier.clickable { onListSelected(list) },
-                trailingContent =
-                    if (state.lists.size > 1) {
-                        {
-                            IconButton(onClick = { onDeleteListClicked(list) }) {
-                                Icon(
-                                    Icons.Default.Delete,
-                                    contentDescription =
-                                        stringResource(Res.string.grocery_delete_list),
-                                    modifier = Modifier.size(18.dp),
-                                )
-                            }
-                        }
-                    } else {
-                        null
-                    },
+        myLists.forEach { list ->
+            GroceryListSelectorItem(
+                list = list,
+                isSelected = list.id == state.selectedList?.id,
+                canDelete = myLists.size > 1,
+                onListSelected = onListSelected,
+                onDeleteListClicked = onDeleteListClicked,
             )
         }
         HorizontalDivider()
@@ -298,6 +315,23 @@ private fun GroceryListSelectorSheet(
                 Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
             },
         )
+        if (sharedLists.isNotEmpty()) {
+            HorizontalDivider()
+            Text(
+                text = stringResource(Res.string.grocery_shared_with_you),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+            sharedLists.forEach { list ->
+                GroceryListSelectorItem(
+                    list = list,
+                    isSelected = list.id == state.selectedList?.id,
+                    canDelete = false,
+                    onListSelected = onListSelected,
+                    onDeleteListClicked = onDeleteListClicked,
+                )
+            }
+        }
         Spacer(modifier = Modifier.height(16.dp))
     }
 }
@@ -443,5 +477,136 @@ private fun GroceryListItem(
         IconButton(onClick = { onDeleteClick(item) }) {
             Icon(Icons.Default.Delete, stringResource(Res.string.grocery_delete_item))
         }
+    }
+}
+
+@Composable
+private fun GroceryListSelectorItem(
+    list: GroceryListModel,
+    isSelected: Boolean,
+    canDelete: Boolean,
+    onListSelected: (GroceryListModel) -> Unit,
+    onDeleteListClicked: (GroceryListModel) -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = list.name,
+                    color =
+                        if (isSelected) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurface
+                        },
+                )
+                if (list.isShared) {
+                    Text(
+                        text = stringResource(Res.string.grocery_shared_badge),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+            }
+        },
+        modifier = Modifier.clickable { onListSelected(list) },
+        trailingContent =
+            if (canDelete && list.role == ListRole.OWNER) {
+                {
+                    IconButton(onClick = { onDeleteListClicked(list) }) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = stringResource(Res.string.grocery_delete_list),
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
+            } else {
+                null
+            },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ShareListDialog(
+    collaborators: List<ListCollaborator>,
+    onDismiss: () -> Unit,
+    onInvite: (String, ListRole) -> Unit,
+    onRemove: (ListCollaborator) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    var inviteEmail by remember { mutableStateOf("") }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Text(
+            text = stringResource(Res.string.grocery_collaborators),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        )
+
+        collaborators.forEach { collaborator ->
+            ListItem(
+                headlineContent = { Text(collaborator.displayName ?: collaborator.email) },
+                supportingContent = {
+                    val roleText =
+                        when (collaborator.role) {
+                            ListRole.OWNER -> stringResource(Res.string.grocery_role_owner)
+                            ListRole.EDITOR -> stringResource(Res.string.grocery_role_editor)
+                            ListRole.VIEWER -> stringResource(Res.string.grocery_role_viewer)
+                        }
+                    val statusText =
+                        if (collaborator.status == CollaborationStatus.PENDING) " (pending)" else ""
+                    Text("$roleText$statusText")
+                },
+                trailingContent =
+                    if (collaborator.role != ListRole.OWNER) {
+                        {
+                            IconButton(onClick = { onRemove(collaborator) }) {
+                                Icon(
+                                    Icons.Default.PersonRemove,
+                                    contentDescription =
+                                        stringResource(Res.string.grocery_remove_collaborator),
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            }
+                        }
+                    } else {
+                        null
+                    },
+            )
+        }
+
+        HorizontalDivider()
+
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            OutlinedTextField(
+                value = inviteEmail,
+                onValueChange = { inviteEmail = it },
+                label = { Text(stringResource(Res.string.grocery_invite_hint)) },
+                singleLine = true,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(
+                onClick = {
+                    if (inviteEmail.isNotBlank()) {
+                        onInvite(inviteEmail, ListRole.EDITOR)
+                        inviteEmail = ""
+                    }
+                },
+                enabled = inviteEmail.isNotBlank(),
+            ) {
+                Icon(
+                    Icons.Default.PersonAdd,
+                    contentDescription = stringResource(Res.string.grocery_invite),
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
     }
 }

--- a/client/grocery/data/impl/build.gradle.kts
+++ b/client/grocery/data/impl/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             implementation(projects.client.auth.data.public)
             implementation(libs.supabase.client)
             implementation(libs.supabase.postgrest)
+            implementation(libs.supabase.realtime)
             implementation(libs.kotlinx.serialization.json)
         }
         jvmMain.dependencies { implementation(libs.ktor.client.cio) }

--- a/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
+++ b/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
@@ -5,18 +5,23 @@ import app.cash.sqldelight.coroutines.mapToList
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
 import com.plusmobileapps.chefmate.database.Grocery
+import com.plusmobileapps.chefmate.database.GroceryListMemberQueries
 import com.plusmobileapps.chefmate.database.GroceryListQueries
 import com.plusmobileapps.chefmate.database.GroceryQueries
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.di.IO
+import com.plusmobileapps.chefmate.grocery.data.CollaborationStatus
 import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
 import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
 import com.plusmobileapps.chefmate.grocery.data.IngredientParser
+import com.plusmobileapps.chefmate.grocery.data.ListCollaborator
+import com.plusmobileapps.chefmate.grocery.data.ListRole
 import com.plusmobileapps.chefmate.grocery.data.SyncStatus
 import com.plusmobileapps.chefmate.grocery.data.impl.remote.GroceryRemoteDataSource
 import com.plusmobileapps.chefmate.grocery.data.impl.remote.RemoteGroceryItem
 import com.plusmobileapps.chefmate.grocery.data.impl.remote.RemoteGroceryList
+import com.plusmobileapps.chefmate.grocery.data.impl.remote.RemoteGroceryListMember
 import com.plusmobileapps.chefmate.util.DateTimeUtil
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -45,6 +50,7 @@ import kotlinx.coroutines.withContext
 class GroceryRepositoryImpl(
     private val queries: GroceryQueries,
     private val listQueries: GroceryListQueries,
+    private val memberQueries: GroceryListMemberQueries,
     @IO private val ioContext: CoroutineContext,
     private val dateTimeUtil: DateTimeUtil,
     private val remoteDataSource: GroceryRemoteDataSource,
@@ -96,6 +102,8 @@ class GroceryRepositoryImpl(
                                 entity.remoteId != null -> SyncStatus.SYNCED
                                 else -> SyncStatus.NOT_SYNCED
                             },
+                        role = entity.role.toListRole(),
+                        isShared = entity.isShared,
                     )
                 }
             }
@@ -394,9 +402,10 @@ class GroceryRepositoryImpl(
         try {
             // --- Sync lists first ---
 
-            // Push unsynced lists
+            // Push unsynced owned lists only
             val unsyncedLists = withContext(ioContext) { listQueries.getUnsynced().executeAsList() }
             for (list in unsyncedLists) {
+                if (list.role != "owner") continue
                 try {
                     val remoteList =
                         remoteDataSource.createGroceryList(
@@ -408,9 +417,10 @@ class GroceryRepositoryImpl(
                 } catch (_: Exception) {}
             }
 
-            // Push dirty lists
+            // Push dirty owned lists only
             val dirtyLists = withContext(ioContext) { listQueries.getDirty().executeAsList() }
             for (list in dirtyLists) {
+                if (list.role != "owner") continue
                 try {
                     val remoteId = list.remoteId ?: continue
                     remoteDataSource.updateGroceryList(
@@ -420,17 +430,28 @@ class GroceryRepositoryImpl(
                 } catch (_: Exception) {}
             }
 
-            // Pull remote lists
-            val remoteLists = remoteDataSource.fetchGroceryLists(userId)
+            // Pull all accessible lists (RLS handles filtering)
+            val remoteLists = remoteDataSource.fetchAccessibleGroceryLists()
             withContext(ioContext) {
                 for (remoteList in remoteLists) {
                     val remoteId = remoteList.id ?: continue
+                    val isOwned = remoteList.ownerId == userId
+                    val role = if (isOwned) "owner" else "editor"
+                    val isShared = !isOwned
+
                     val existing = listQueries.getByRemoteId(remoteId).executeAsOneOrNull()
-                    if (existing != null) continue
+                    if (existing != null) {
+                        listQueries.updateOwnership(
+                            ownerId = remoteList.ownerId,
+                            role = role,
+                            isShared = isShared,
+                            id = existing.id,
+                        )
+                        continue
+                    }
 
                     val matchedByClientId =
                         remoteList.id.let { _ ->
-                            // Lists created locally have a clientId; check for match
                             val localLists = listQueries.getAll().executeAsList()
                             localLists.firstOrNull {
                                 it.clientId != null &&
@@ -440,15 +461,30 @@ class GroceryRepositoryImpl(
                         }
                     if (matchedByClientId != null) {
                         listQueries.updateRemoteId(remoteId = remoteId, id = matchedByClientId.id)
+                        listQueries.updateOwnership(
+                            ownerId = remoteList.ownerId,
+                            role = role,
+                            isShared = isShared,
+                            id = matchedByClientId.id,
+                        )
                     } else {
                         val newId = listQueries.transactionWithResult {
                             listQueries.create(name = remoteList.name, clientId = null)
                             listQueries.lastId().executeAsOne().MAX!!
                         }
                         listQueries.updateRemoteId(remoteId = remoteId, id = newId)
+                        listQueries.updateOwnership(
+                            ownerId = remoteList.ownerId,
+                            role = role,
+                            isShared = isShared,
+                            id = newId,
+                        )
                     }
                 }
             }
+
+            // Sync members for shared lists
+            syncListMembers(userId)
 
             // --- Sync items per list ---
             val allLists = withContext(ioContext) { listQueries.getAll().executeAsList() }
@@ -567,6 +603,155 @@ class GroceryRepositoryImpl(
     override suspend fun deletePurchasedGroceries(listId: Long) {
         withContext(ioContext) { queries.deleteCheckedByListId(listId) }
     }
+
+    override fun getListCollaborators(listId: Long): Flow<List<ListCollaborator>> =
+        memberQueries
+            .getByListId(listId)
+            .asFlow()
+            .mapToList(ioContext)
+            .map { members ->
+                members.map { member ->
+                    ListCollaborator(
+                        id = member.id,
+                        email = member.userEmail,
+                        displayName = member.displayName,
+                        role = member.role.toListRole(),
+                        status =
+                            when (member.status) {
+                                "accepted" -> CollaborationStatus.ACCEPTED
+                                "rejected" -> CollaborationStatus.REJECTED
+                                else -> CollaborationStatus.PENDING
+                            },
+                    )
+                }
+            }
+            .flowOn(ioContext)
+
+    override suspend fun inviteCollaborator(listId: Long, email: String, role: ListRole) {
+        val authState = authRepository.state.value
+        if (authState !is AuthState.Authenticated) return
+        val list =
+            withContext(ioContext) { listQueries.getById(listId).executeAsOneOrNull() } ?: return
+        val remoteListId = list.remoteId ?: return
+
+        val remoteMember =
+            remoteDataSource.inviteToList(
+                RemoteGroceryListMember(
+                    listId = remoteListId,
+                    invitedEmail = email,
+                    role = role.name.lowercase(),
+                    invitedBy = authState.user.userId,
+                )
+            )
+        withContext(ioContext) {
+            memberQueries.insert(
+                listLocalId = listId,
+                remoteId = remoteMember.id,
+                userId = remoteMember.userId,
+                userEmail = email,
+                role = role.name.lowercase(),
+                status = "pending",
+                displayName = null,
+            )
+        }
+    }
+
+    override suspend fun removeCollaborator(listId: Long, collaboratorId: Long) {
+        val member =
+            withContext(ioContext) {
+                memberQueries.getByListId(listId).executeAsList().firstOrNull {
+                    it.id == collaboratorId
+                }
+            } ?: return
+        member.remoteId?.let { remoteDataSource.removeFromList(it) }
+        withContext(ioContext) { memberQueries.deleteById(collaboratorId) }
+    }
+
+    override suspend fun acceptInvitation(listId: Long) {
+        val authState = authRepository.state.value
+        if (authState !is AuthState.Authenticated) return
+        val list =
+            withContext(ioContext) { listQueries.getById(listId).executeAsOneOrNull() } ?: return
+        val remoteListId = list.remoteId ?: return
+
+        val members = remoteDataSource.fetchListMembers(remoteListId)
+        val myMember = members.firstOrNull { it.userId == authState.user.userId }
+        myMember?.id?.let { remoteDataSource.respondToInvitation(it, accept = true) }
+    }
+
+    override suspend fun rejectInvitation(listId: Long) {
+        val authState = authRepository.state.value
+        if (authState !is AuthState.Authenticated) return
+        val list =
+            withContext(ioContext) { listQueries.getById(listId).executeAsOneOrNull() } ?: return
+        val remoteListId = list.remoteId ?: return
+
+        val members = remoteDataSource.fetchListMembers(remoteListId)
+        val myMember = members.firstOrNull { it.userId == authState.user.userId }
+        myMember?.id?.let { remoteDataSource.respondToInvitation(it, accept = false) }
+        withContext(ioContext) { listQueries.delete(listId) }
+    }
+
+    override fun getPendingInvitations(): Flow<List<GroceryListModel>> =
+        listQueries
+            .getAll()
+            .asFlow()
+            .mapToList(ioContext)
+            .map { lists ->
+                lists
+                    .filter { it.isShared && it.role != "owner" }
+                    .map { entity ->
+                        GroceryListModel(
+                            id = entity.id,
+                            name = entity.name,
+                            syncStatus = SyncStatus.SYNCED,
+                            role = entity.role.toListRole(),
+                            isShared = true,
+                        )
+                    }
+            }
+            .flowOn(ioContext)
+
+    private suspend fun syncListMembers(userId: String) {
+        val allLists = withContext(ioContext) { listQueries.getAll().executeAsList() }
+        for (list in allLists) {
+            val remoteListId = list.remoteId ?: continue
+            try {
+                val remoteMembers = remoteDataSource.fetchListMembers(remoteListId)
+                withContext(ioContext) {
+                    memberQueries.deleteByListId(list.id)
+                    for (member in remoteMembers) {
+                        memberQueries.insert(
+                            listLocalId = list.id,
+                            remoteId = member.id,
+                            userId = member.userId,
+                            userEmail = member.invitedEmail,
+                            role = member.role,
+                            status = member.status,
+                            displayName = null,
+                        )
+                    }
+                    // Determine role from members
+                    val myMember = remoteMembers.firstOrNull { it.userId == userId }
+                    if (myMember != null) {
+                        listQueries.updateOwnership(
+                            ownerId = list.ownerId,
+                            role = myMember.role,
+                            isShared = list.ownerId != userId,
+                            id = list.id,
+                        )
+                    }
+                }
+            } catch (_: Exception) {}
+        }
+    }
+
+    private fun String.toListRole(): ListRole =
+        when (this) {
+            "editor" -> ListRole.EDITOR
+            "viewer" -> ListRole.VIEWER
+            else -> ListRole.OWNER
+        }
 
     private fun fromEntity(entity: Grocery, syncing: Set<Long>): GroceryItem {
         val syncStatus =

--- a/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/remote/GroceryRemoteDataSource.kt
+++ b/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/remote/GroceryRemoteDataSource.kt
@@ -13,7 +13,17 @@ interface GroceryRemoteDataSource {
 
     suspend fun fetchGroceryLists(ownerId: String): List<RemoteGroceryList>
 
+    suspend fun fetchAccessibleGroceryLists(): List<RemoteGroceryList>
+
     suspend fun deleteGroceryList(remoteId: String)
 
     suspend fun updateGroceryList(list: RemoteGroceryList): RemoteGroceryList
+
+    suspend fun fetchListMembers(listId: String): List<RemoteGroceryListMember>
+
+    suspend fun inviteToList(member: RemoteGroceryListMember): RemoteGroceryListMember
+
+    suspend fun respondToInvitation(memberId: String, accept: Boolean)
+
+    suspend fun removeFromList(memberId: String)
 }

--- a/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/remote/RemoteGroceryListMember.kt
+++ b/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/remote/RemoteGroceryListMember.kt
@@ -1,0 +1,17 @@
+package com.plusmobileapps.chefmate.grocery.data.impl.remote
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RemoteGroceryListMember(
+    val id: String? = null,
+    @SerialName("list_id") val listId: String,
+    @SerialName("user_id") val userId: String? = null,
+    @SerialName("invited_email") val invitedEmail: String,
+    val role: String = "editor",
+    val status: String = "pending",
+    @SerialName("invited_by") val invitedBy: String? = null,
+    @SerialName("created_at") val createdAt: String? = null,
+    @SerialName("updated_at") val updatedAt: String? = null,
+)

--- a/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/remote/SupabaseGroceryRemoteDataSource.kt
+++ b/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/remote/SupabaseGroceryRemoteDataSource.kt
@@ -81,4 +81,31 @@ class SupabaseGroceryRemoteDataSource(private val supabaseClient: SupabaseClient
                 filter { eq("id", list.id!!) }
             }
             .decodeSingle<RemoteGroceryList>()
+
+    override suspend fun fetchAccessibleGroceryLists(): List<RemoteGroceryList> =
+        supabaseClient.from("grocery_lists").select().decodeList<RemoteGroceryList>()
+
+    override suspend fun fetchListMembers(listId: String): List<RemoteGroceryListMember> =
+        supabaseClient
+            .from("grocery_list_members")
+            .select { filter { eq("list_id", listId) } }
+            .decodeList<RemoteGroceryListMember>()
+
+    override suspend fun inviteToList(member: RemoteGroceryListMember): RemoteGroceryListMember =
+        supabaseClient
+            .from("grocery_list_members")
+            .insert(member) { select() }
+            .decodeSingle<RemoteGroceryListMember>()
+
+    override suspend fun respondToInvitation(memberId: String, accept: Boolean) {
+        supabaseClient.from("grocery_list_members").update(
+            mapOf("status" to if (accept) "accepted" else "rejected")
+        ) {
+            filter { eq("id", memberId) }
+        }
+    }
+
+    override suspend fun removeFromList(memberId: String) {
+        supabaseClient.from("grocery_list_members").delete { filter { eq("id", memberId) } }
+    }
 }

--- a/client/grocery/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/CollaborationModels.kt
+++ b/client/grocery/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/CollaborationModels.kt
@@ -1,0 +1,21 @@
+package com.plusmobileapps.chefmate.grocery.data
+
+enum class ListRole {
+    OWNER,
+    EDITOR,
+    VIEWER,
+}
+
+enum class CollaborationStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED,
+}
+
+data class ListCollaborator(
+    val id: Long,
+    val email: String,
+    val displayName: String?,
+    val role: ListRole,
+    val status: CollaborationStatus,
+)

--- a/client/grocery/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/GroceryListModel.kt
+++ b/client/grocery/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/GroceryListModel.kt
@@ -4,4 +4,6 @@ data class GroceryListModel(
     val id: Long,
     val name: String,
     val syncStatus: SyncStatus = SyncStatus.NOT_SYNCED,
+    val role: ListRole = ListRole.OWNER,
+    val isShared: Boolean = false,
 )

--- a/client/grocery/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/GroceryRepository.kt
+++ b/client/grocery/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/GroceryRepository.kt
@@ -43,4 +43,16 @@ interface GroceryRepository {
     suspend fun deletePurchasedGroceries(listId: Long)
 
     suspend fun clearLocalData()
+
+    fun getListCollaborators(listId: Long): Flow<List<ListCollaborator>>
+
+    suspend fun inviteCollaborator(listId: Long, email: String, role: ListRole = ListRole.EDITOR)
+
+    suspend fun removeCollaborator(listId: Long, collaboratorId: Long)
+
+    suspend fun acceptInvitation(listId: Long)
+
+    suspend fun rejectInvitation(listId: Long)
+
+    fun getPendingInvitations(): Flow<List<GroceryListModel>>
 }

--- a/client/grocery/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/testing/FakeGroceryRepository.kt
+++ b/client/grocery/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/testing/FakeGroceryRepository.kt
@@ -4,6 +4,8 @@ import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
 import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
 import com.plusmobileapps.chefmate.grocery.data.IngredientParser
+import com.plusmobileapps.chefmate.grocery.data.ListCollaborator
+import com.plusmobileapps.chefmate.grocery.data.ListRole
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -135,4 +137,18 @@ class FakeGroceryRepository : GroceryRepository {
         _lists.value = emptyList()
         itemListMap.clear()
     }
+
+    override fun getListCollaborators(listId: Long): Flow<List<ListCollaborator>> =
+        MutableStateFlow(emptyList())
+
+    override suspend fun inviteCollaborator(listId: Long, email: String, role: ListRole) {}
+
+    override suspend fun removeCollaborator(listId: Long, collaboratorId: Long) {}
+
+    override suspend fun acceptInvitation(listId: Long) {}
+
+    override suspend fun rejectInvitation(listId: Long) {}
+
+    override fun getPendingInvitations(): Flow<List<GroceryListModel>> =
+        MutableStateFlow(emptyList())
 }

--- a/client/recipe/data/impl/build.gradle.kts
+++ b/client/recipe/data/impl/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             implementation(projects.client.auth.data.public)
             implementation(libs.supabase.client)
             implementation(libs.supabase.postgrest)
+            implementation(libs.supabase.realtime)
             implementation(libs.kotlinx.serialization.json)
         }
         jvmMain.dependencies { implementation(libs.ktor.client.cio) }

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
@@ -8,10 +8,13 @@ import com.plusmobileapps.chefmate.database.RecipeQueries
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.di.IO
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.RecipeCollaborator
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import com.plusmobileapps.chefmate.recipe.data.RecipeRole
 import com.plusmobileapps.chefmate.recipe.data.SyncStatus
 import com.plusmobileapps.chefmate.recipe.data.impl.remote.RecipeRemoteDataSource
 import com.plusmobileapps.chefmate.recipe.data.impl.remote.RemoteRecipe
+import com.plusmobileapps.chefmate.recipe.data.impl.remote.RemoteRecipeShare
 import com.plusmobileapps.chefmate.util.DateTimeUtil
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -314,13 +317,27 @@ class RecipeRepositoryImpl(
                 } catch (_: Exception) {}
             }
 
-            // Pull remote recipes
-            val remoteRecipes = remoteDataSource.fetchAllRecipes(userId)
+            // Pull all accessible recipes (RLS handles filtering)
+            val remoteRecipes = remoteDataSource.fetchAccessibleRecipes()
             withContext(ioContext) {
                 for (remote in remoteRecipes) {
                     val remoteId = remote.id ?: continue
+                    val isOwned = remote.ownerId == userId
+                    val role = if (isOwned) "owner" else "viewer"
+                    val isShared = !isOwned
+
                     val existing = db.getByRemoteId(remoteId).executeAsOneOrNull()
-                    if (existing != null) continue
+                    if (existing != null) {
+                        db.updateOwnership(role = role, isShared = isShared, id = existing.id)
+                        if (remote.forkedFrom != null) {
+                            db.updateForkedFrom(
+                                forkedFromRemoteId = remote.forkedFrom,
+                                forkedFromTitle = null,
+                                id = existing.id,
+                            )
+                        }
+                        continue
+                    }
 
                     val matchedByClientId =
                         remote.clientId?.let { clientId ->
@@ -328,6 +345,11 @@ class RecipeRepositoryImpl(
                         }
                     if (matchedByClientId != null) {
                         db.updateRemoteId(remoteId = remoteId, id = matchedByClientId.id)
+                        db.updateOwnership(
+                            role = role,
+                            isShared = isShared,
+                            id = matchedByClientId.id,
+                        )
                     } else {
                         db.createWithRemoteId(
                             title = remote.title,
@@ -347,13 +369,123 @@ class RecipeRepositoryImpl(
                             updatedAt = remote.updatedAt ?: dateTimeUtil.now.toString(),
                             remoteId = remoteId,
                             clientId = remote.clientId,
-                            ownerId = userId,
+                            ownerId = remote.ownerId,
                         )
+                        val newId = db.lastInsertId().executeAsOne().MAX
+                        if (newId != null) {
+                            db.updateOwnership(role = role, isShared = isShared, id = newId)
+                            if (remote.forkedFrom != null) {
+                                db.updateForkedFrom(
+                                    forkedFromRemoteId = remote.forkedFrom,
+                                    forkedFromTitle = null,
+                                    id = newId,
+                                )
+                            }
+                        }
                     }
                 }
             }
         } catch (_: Exception) {}
     }
+
+    override fun getSharedRecipes(): Flow<List<Recipe>> =
+        db.getShared()
+            .asFlow()
+            .map { it.executeAsList() }
+            .map { recipes -> recipes.map { it.toRecipe() } }
+            .flowOn(ioContext)
+
+    override suspend fun shareRecipe(recipeId: Long, email: String, role: RecipeRole) {
+        val authState = authRepository.state.value
+        if (authState !is AuthState.Authenticated) return
+        val recipe = withContext(ioContext) { db.getById(recipeId).executeAsOneOrNull() } ?: return
+        val remoteRecipeId = recipe.remoteId ?: return
+
+        remoteDataSource.shareRecipe(
+            RemoteRecipeShare(
+                recipeId = remoteRecipeId,
+                invitedEmail = email,
+                role = role.name.lowercase(),
+                invitedBy = authState.user.userId,
+            )
+        )
+    }
+
+    override suspend fun forkRecipe(recipeId: Long): Recipe {
+        val original =
+            withContext(ioContext) { db.getById(recipeId).executeAsOneOrNull() }
+                ?: error("Recipe not found")
+        val forkedFromRemoteId = original.remoteId
+
+        val forked =
+            createRecipe(
+                Recipe(
+                    id = 0,
+                    title = original.title,
+                    description = original.description,
+                    ingredients = original.ingredients.orEmpty(),
+                    directions = original.directions.orEmpty(),
+                    imageUrl = original.imageUrl,
+                    sourceUrl = original.sourceUrl,
+                    servings = original.servings?.toInt(),
+                    prepTime = original.prepTime?.toInt(),
+                    cookTime = original.cookTime?.toInt(),
+                    totalTime = original.totalTime?.toInt(),
+                    calories = original.calories?.toInt(),
+                    starRating = original.starRating?.toInt(),
+                    isFavorite = false,
+                    createdAt = Instant.parse(dateTimeUtil.now.toString()),
+                    updatedAt = Instant.parse(dateTimeUtil.now.toString()),
+                    forkedFromRemoteId = forkedFromRemoteId,
+                    forkedFromTitle = original.title,
+                )
+            )
+
+        if (forkedFromRemoteId != null) {
+            withContext(ioContext) {
+                db.updateForkedFrom(
+                    forkedFromRemoteId = forkedFromRemoteId,
+                    forkedFromTitle = original.title,
+                    id = forked.id,
+                )
+            }
+        }
+
+        return forked
+    }
+
+    override suspend fun acceptRecipeShare(recipeId: Long) {
+        val authState = authRepository.state.value
+        if (authState !is AuthState.Authenticated) return
+        val recipe = withContext(ioContext) { db.getById(recipeId).executeAsOneOrNull() } ?: return
+        val remoteRecipeId = recipe.remoteId ?: return
+
+        val shares = remoteDataSource.fetchRecipeShares(remoteRecipeId)
+        val myShare = shares.firstOrNull { it.userId == authState.user.userId }
+        myShare?.id?.let { remoteDataSource.respondToRecipeShare(it, accept = true) }
+    }
+
+    override suspend fun rejectRecipeShare(recipeId: Long) {
+        val authState = authRepository.state.value
+        if (authState !is AuthState.Authenticated) return
+        val recipe = withContext(ioContext) { db.getById(recipeId).executeAsOneOrNull() } ?: return
+        val remoteRecipeId = recipe.remoteId ?: return
+
+        val shares = remoteDataSource.fetchRecipeShares(remoteRecipeId)
+        val myShare = shares.firstOrNull { it.userId == authState.user.userId }
+        myShare?.id?.let { remoteDataSource.respondToRecipeShare(it, accept = false) }
+        withContext(ioContext) { db.delete(recipeId) }
+    }
+
+    override fun getRecipeCollaborators(recipeId: Long): Flow<List<RecipeCollaborator>> =
+        MutableStateFlow(emptyList<RecipeCollaborator>())
+
+    private fun String.toRecipeRole(): RecipeRole =
+        when (this) {
+            "editor" -> RecipeRole.EDITOR
+            "viewer" -> RecipeRole.VIEWER
+            else -> RecipeRole.OWNER
+        }
 
     private fun DbRecipe.toRecipe(syncing: Set<Long> = emptySet()): Recipe {
         val syncStatus =
@@ -381,6 +513,10 @@ class RecipeRepositoryImpl(
             syncStatus = syncStatus,
             createdAt = Instant.parse(createdAt),
             updatedAt = Instant.parse(updatedAt),
+            forkedFromRemoteId = forkedFromRemoteId,
+            forkedFromTitle = forkedFromTitle,
+            role = role.toRecipeRole(),
+            isShared = isShared,
         )
     }
 }

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RecipeRemoteDataSource.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RecipeRemoteDataSource.kt
@@ -6,4 +6,14 @@ interface RecipeRemoteDataSource {
     suspend fun deleteRecipe(remoteId: String)
 
     suspend fun fetchAllRecipes(ownerId: String): List<RemoteRecipe>
+
+    suspend fun fetchAccessibleRecipes(): List<RemoteRecipe>
+
+    suspend fun fetchRecipeShares(recipeId: String): List<RemoteRecipeShare>
+
+    suspend fun shareRecipe(share: RemoteRecipeShare): RemoteRecipeShare
+
+    suspend fun respondToRecipeShare(shareId: String, accept: Boolean)
+
+    suspend fun removeRecipeShare(shareId: String)
 }

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RemoteRecipe.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RemoteRecipe.kt
@@ -23,4 +23,5 @@ data class RemoteRecipe(
     @SerialName("created_at") val createdAt: String? = null,
     @SerialName("updated_at") val updatedAt: String? = null,
     @SerialName("client_id") val clientId: String? = null,
+    @SerialName("forked_from") val forkedFrom: String? = null,
 )

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RemoteRecipeShare.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RemoteRecipeShare.kt
@@ -1,0 +1,16 @@
+package com.plusmobileapps.chefmate.recipe.data.impl.remote
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RemoteRecipeShare(
+    val id: String? = null,
+    @SerialName("recipe_id") val recipeId: String,
+    @SerialName("user_id") val userId: String? = null,
+    @SerialName("invited_email") val invitedEmail: String,
+    val role: String = "viewer",
+    val status: String = "pending",
+    @SerialName("invited_by") val invitedBy: String? = null,
+    @SerialName("created_at") val createdAt: String? = null,
+)

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipeRemoteDataSource.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipeRemoteDataSource.kt
@@ -33,4 +33,31 @@ class SupabaseRecipeRemoteDataSource(private val supabaseClient: SupabaseClient)
             .from("recipes")
             .select { filter { eq("owner_id", ownerId) } }
             .decodeList<RemoteRecipe>()
+
+    override suspend fun fetchAccessibleRecipes(): List<RemoteRecipe> =
+        supabaseClient.from("recipes").select().decodeList<RemoteRecipe>()
+
+    override suspend fun fetchRecipeShares(recipeId: String): List<RemoteRecipeShare> =
+        supabaseClient
+            .from("recipe_shares")
+            .select { filter { eq("recipe_id", recipeId) } }
+            .decodeList<RemoteRecipeShare>()
+
+    override suspend fun shareRecipe(share: RemoteRecipeShare): RemoteRecipeShare =
+        supabaseClient
+            .from("recipe_shares")
+            .insert(share) { select() }
+            .decodeSingle<RemoteRecipeShare>()
+
+    override suspend fun respondToRecipeShare(shareId: String, accept: Boolean) {
+        supabaseClient.from("recipe_shares").update(
+            mapOf("status" to if (accept) "accepted" else "rejected")
+        ) {
+            filter { eq("id", shareId) }
+        }
+    }
+
+    override suspend fun removeRecipeShare(shareId: String) {
+        supabaseClient.from("recipe_shares").delete { filter { eq("id", shareId) } }
+    }
 }

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/CollaborationModels.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/CollaborationModels.kt
@@ -1,0 +1,21 @@
+package com.plusmobileapps.chefmate.recipe.data
+
+enum class RecipeRole {
+    OWNER,
+    EDITOR,
+    VIEWER,
+}
+
+enum class RecipeCollaborationStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED,
+}
+
+data class RecipeCollaborator(
+    val id: Long,
+    val email: String,
+    val displayName: String?,
+    val role: RecipeRole,
+    val status: RecipeCollaborationStatus,
+)

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/Recipe.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/Recipe.kt
@@ -23,6 +23,10 @@ data class Recipe(
     val syncStatus: SyncStatus = SyncStatus.NOT_SYNCED,
     val createdAt: Instant,
     val updatedAt: Instant,
+    val forkedFromRemoteId: String? = null,
+    val forkedFromTitle: String? = null,
+    val role: RecipeRole = RecipeRole.OWNER,
+    val isShared: Boolean = false,
 ) {
     companion object {
         val Empty =
@@ -43,6 +47,10 @@ data class Recipe(
                 isFavorite = false,
                 createdAt = Instant.DISTANT_PAST,
                 updatedAt = Instant.DISTANT_PAST,
+                forkedFromRemoteId = null,
+                forkedFromTitle = null,
+                role = RecipeRole.OWNER,
+                isShared = false,
             )
     }
 }

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeRepository.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeRepository.kt
@@ -16,4 +16,16 @@ interface RecipeRepository {
     suspend fun clearLocalData()
 
     suspend fun syncAllUnsynced()
+
+    fun getSharedRecipes(): Flow<List<Recipe>>
+
+    suspend fun shareRecipe(recipeId: Long, email: String, role: RecipeRole = RecipeRole.VIEWER)
+
+    suspend fun forkRecipe(recipeId: Long): Recipe
+
+    suspend fun acceptRecipeShare(recipeId: Long)
+
+    suspend fun rejectRecipeShare(recipeId: Long)
+
+    fun getRecipeCollaborators(recipeId: Long): Flow<List<RecipeCollaborator>>
 }

--- a/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeRepository.kt
+++ b/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeRepository.kt
@@ -1,7 +1,9 @@
 package com.plusmobileapps.chefmate.recipe.data.testing
 
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.RecipeCollaborator
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import com.plusmobileapps.chefmate.recipe.data.RecipeRole
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -34,4 +36,18 @@ class FakeRecipeRepository(
     }
 
     override suspend fun syncAllUnsynced() {}
+
+    override fun getSharedRecipes(): Flow<List<Recipe>> = MutableStateFlow(emptyList())
+
+    override suspend fun shareRecipe(recipeId: Long, email: String, role: RecipeRole) {}
+
+    override suspend fun forkRecipe(recipeId: Long): Recipe =
+        recipes.value.first { it.id == recipeId }.copy(id = recipeId + 1000)
+
+    override suspend fun acceptRecipeShare(recipeId: Long) {}
+
+    override suspend fun rejectRecipeShare(recipeId: Long) {}
+
+    override fun getRecipeCollaborators(recipeId: Long): Flow<List<RecipeCollaborator>> =
+        MutableStateFlow(emptyList())
 }

--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -1,0 +1,207 @@
+# Collaboration Architecture
+
+This document describes the architecture for grocery list and recipe collaboration in Chef Mate.
+
+## Overview
+
+Collaboration allows users to share grocery lists and recipes with others via email invitations. Each shared resource has role-based access control (Owner, Editor, Viewer) enforced at both the UI and database levels via Supabase Row Level Security (RLS).
+
+```mermaid
+flowchart TB
+    subgraph Client["Client (KMP)"]
+        UI["UI Layer\nGroceryListScreen\nRecipe Screens"]
+        BLoC["BLoC / ViewModel\nGroceryListBloc\nGroceryListViewModel"]
+        Repo["Repository\nGroceryRepositoryImpl\nRecipeRepositoryImpl"]
+        Local["SQLDelight\nGroceryList, GroceryListMember\nRecipe"]
+        Remote["Remote Data Source\nSupabaseGroceryRemoteDataSource\nSupabaseRecipeRemoteDataSource"]
+    end
+
+    subgraph Supabase["Supabase"]
+        Auth["Auth\n(user identity)"]
+        DB["PostgreSQL\ngrocery_lists\ngrocery_items\ngrocery_list_members\nrecipes\nrecipe_shares"]
+        RLS["RLS Policies\n(access control)"]
+        RT["Realtime\n(live updates)"]
+    end
+
+    UI --> BLoC --> Repo
+    Repo --> Local
+    Repo --> Remote
+    Remote --> DB
+    DB --> RLS
+    DB --> RT
+    Auth --> RLS
+    RT -.-> Remote
+```
+
+## Roles
+
+| Role | Grocery Lists | Recipes |
+|------|--------------|---------|
+| **Owner** | Full control: rename, delete list, manage items, invite/remove collaborators | Full control: edit, delete, share |
+| **Editor** | Add, check, delete items. Cannot rename or delete the list | Edit recipe. Cannot delete |
+| **Viewer** | Read-only. Cannot add, check, or delete items | Read-only. Can fork (copy) to own account |
+
+## Data Model
+
+### Supabase Tables
+
+```mermaid
+erDiagram
+    grocery_lists {
+        uuid id PK
+        text name
+        uuid owner_id FK
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    grocery_items {
+        uuid id PK
+        uuid list_id FK
+        text name
+        boolean is_checked
+        text client_id
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    grocery_list_members {
+        uuid id PK
+        uuid list_id FK
+        uuid user_id FK
+        text invited_email
+        text role "owner | editor | viewer"
+        text status "pending | accepted | rejected"
+        uuid invited_by FK
+        timestamptz created_at
+    }
+
+    recipes {
+        uuid id PK
+        uuid owner_id FK
+        text title
+        uuid forked_from FK "nullable, self-reference"
+    }
+
+    recipe_shares {
+        uuid id PK
+        uuid recipe_id FK
+        uuid user_id FK
+        text invited_email
+        text role "owner | editor | viewer"
+        text status "pending | accepted | rejected"
+        uuid invited_by FK
+        timestamptz created_at
+    }
+
+    grocery_lists ||--o{ grocery_items : contains
+    grocery_lists ||--o{ grocery_list_members : has
+    recipes ||--o{ recipe_shares : has
+    recipes ||--o| recipes : "forked from"
+```
+
+### Local SQLDelight Schema
+
+The local database mirrors the remote collaboration state with these additions to existing tables:
+
+**GroceryList** (new columns):
+- `ownerId` - remote user ID of the list owner
+- `role` - current user's role (`owner`, `editor`, `viewer`)
+- `isShared` - whether this list was shared by another user
+
+**GroceryListMember** (new table): local cache of collaborators per list.
+
+**Recipe** (new columns):
+- `forkedFromRemoteId` - remote ID of the original recipe (if forked)
+- `forkedFromTitle` - title of the original recipe
+- `role` / `isShared` - same as grocery lists
+
+## Invitation Flow
+
+```mermaid
+sequenceDiagram
+    participant Owner as Owner (User A)
+    participant Supabase
+    participant Invitee as Invitee (User B)
+
+    Owner->>Supabase: INSERT into grocery_list_members<br/>(email, role=editor, status=pending)
+    Note over Supabase: RLS: only list owner can insert
+
+    Invitee->>Supabase: Sync (SELECT grocery_lists)
+    Note over Supabase: RLS returns lists where<br/>user is owner OR accepted member
+    Supabase-->>Invitee: Shared list appears after accept
+
+    Invitee->>Supabase: UPDATE grocery_list_members<br/>SET status = 'accepted'
+    Note over Supabase: RLS: invited user can update own row
+
+    Invitee->>Supabase: Add/edit grocery items
+    Note over Supabase: RLS: editor role allows<br/>INSERT/UPDATE/DELETE on items
+```
+
+For users who don't have an account yet, the `invited_email` is stored with `user_id = NULL`. A database trigger on `auth.users` INSERT automatically migrates pending invitations when the user signs up.
+
+## Sync Strategy
+
+The existing offline-first sync is extended for collaboration:
+
+1. **Push phase** (owned lists only):
+   - Push unsynced lists where `role = 'owner'`
+   - Push dirty lists where `role = 'owner'`
+   - Shared lists are never pushed as new creations
+
+2. **Pull phase** (all accessible lists):
+   - `fetchAccessibleGroceryLists()` uses a filter-less SELECT — RLS returns owned + shared lists
+   - Each pulled list is tagged locally with `ownerId`, `role`, and `isShared`
+   - Members are fetched and cached in `GroceryListMember` table
+
+3. **Item sync** (unchanged):
+   - Items sync per-list as before
+   - RLS handles authorization for shared list items
+
+## Recipe Forking
+
+When a viewer or editor copies a shared recipe:
+
+1. A new recipe is created in the user's account with identical content
+2. `forked_from` is set to the original recipe's remote ID
+3. The local record stores `forkedFromRemoteId` and `forkedFromTitle`
+4. The UI displays "Forked from: [original title]" on the recipe detail screen
+
+The fork is a full copy — changes to the original do not propagate.
+
+## RLS Policy Summary
+
+All access control is enforced server-side via Supabase RLS:
+
+| Table | SELECT | INSERT | UPDATE | DELETE |
+|-------|--------|--------|--------|--------|
+| `grocery_lists` | owner OR accepted member | owner only | owner OR editor member | owner only |
+| `grocery_items` | user has list access | owner OR editor | owner OR editor | owner OR editor |
+| `grocery_list_members` | list members + owner | list owner only | invited user OR owner | owner OR self (leave) |
+| `recipes` | owner OR accepted share | owner only | owner OR editor share | owner only |
+| `recipe_shares` | recipe members + owner | recipe owner only | invited user OR owner | owner OR self |
+
+## UI Components
+
+### Grocery List Screen
+
+- **Share button** (top app bar): visible only to list owners. Opens the collaborator management sheet.
+- **Collaborator sheet**: shows current members with role/status, email invite input field.
+- **List selector**: split into "My Lists" and "Shared with me" sections. Shared lists show a badge.
+- **Permission gating**: viewers don't see the add-item input or delete buttons.
+
+### Key Files
+
+| Concern | Path |
+|---------|------|
+| Supabase migration | `supabase/migrations/20260425_add_collaboration.sql` |
+| SQLDelight migration | `client/database/src/commonMain/sqldelight/migrations/4.sqm` |
+| Member queries | `client/database/src/commonMain/sqldelight/.../GroceryListMember.sq` |
+| Collaboration models | `client/grocery/data/public/.../CollaborationModels.kt` |
+| Remote member model | `client/grocery/data/impl/.../remote/RemoteGroceryListMember.kt` |
+| Repository (grocery) | `client/grocery/data/impl/.../GroceryRepositoryImpl.kt` |
+| Repository (recipe) | `client/recipe/data/impl/.../RecipeRepositoryImpl.kt` |
+| BLoC interface | `client/grocery/core/public/.../list/GroceryListBloc.kt` |
+| ViewModel | `client/grocery/core/impl/.../list/GroceryListViewModel.kt` |
+| UI screen | `client/grocery/core/public/.../list/GroceryListScreen.kt` |
+| DI bindings | `client/database/.../di/DatabaseComponent.kt` |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -109,6 +109,7 @@ sqldelight-dialect-sqlite335 = { group = "app.cash.sqldelight", name = "sqlite-3
 supabase-client = { module = "io.github.jan-tennert.supabase:supabase-kt", version.ref = "supabase" }
 supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
 supabase-postgrest = { module = "io.github.jan-tennert.supabase:postgrest-kt", version.ref = "supabase" }
+supabase-realtime = { module = "io.github.jan-tennert.supabase:realtime-kt", version.ref = "supabase" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 [plugins]

--- a/supabase/migrations/20260425_add_collaboration.sql
+++ b/supabase/migrations/20260425_add_collaboration.sql
@@ -1,0 +1,336 @@
+-- ============================================================
+-- Grocery List & Recipe Collaboration
+-- Run this migration in Supabase SQL Editor
+-- ============================================================
+
+-- 1. Grocery list members (sharing/collaboration)
+CREATE TABLE IF NOT EXISTS grocery_list_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  list_id UUID NOT NULL REFERENCES grocery_lists(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'editor' CHECK (role IN ('owner', 'editor', 'viewer')),
+  invited_by UUID REFERENCES auth.users(id),
+  invited_email TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'rejected')),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(list_id, invited_email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_glm_list_id ON grocery_list_members(list_id);
+CREATE INDEX IF NOT EXISTS idx_glm_user_id ON grocery_list_members(user_id);
+CREATE INDEX IF NOT EXISTS idx_glm_invited_email ON grocery_list_members(invited_email);
+
+-- 2. Recipe shares (sharing/collaboration)
+CREATE TABLE IF NOT EXISTS recipe_shares (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_id UUID NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'viewer' CHECK (role IN ('owner', 'editor', 'viewer')),
+  invited_by UUID REFERENCES auth.users(id),
+  invited_email TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'rejected')),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(recipe_id, invited_email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rs_recipe_id ON recipe_shares(recipe_id);
+CREATE INDEX IF NOT EXISTS idx_rs_user_id ON recipe_shares(user_id);
+CREATE INDEX IF NOT EXISTS idx_rs_invited_email ON recipe_shares(invited_email);
+
+-- 3. Add forked_from to recipes
+ALTER TABLE recipes ADD COLUMN IF NOT EXISTS forked_from UUID REFERENCES recipes(id) ON DELETE SET NULL;
+
+-- ============================================================
+-- Triggers
+-- ============================================================
+
+-- Auto-insert owner row into grocery_list_members on list creation
+CREATE OR REPLACE FUNCTION auto_add_grocery_list_owner()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO grocery_list_members (list_id, user_id, role, invited_email, status)
+  SELECT NEW.id, NEW.owner_id, 'owner',
+    COALESCE((SELECT email FROM auth.users WHERE id = NEW.owner_id), ''),
+    'accepted'
+  WHERE NEW.owner_id IS NOT NULL;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS trg_auto_add_grocery_list_owner ON grocery_lists;
+CREATE TRIGGER trg_auto_add_grocery_list_owner
+  AFTER INSERT ON grocery_lists
+  FOR EACH ROW EXECUTE FUNCTION auto_add_grocery_list_owner();
+
+-- Auto-insert owner row into recipe_shares on recipe creation
+CREATE OR REPLACE FUNCTION auto_add_recipe_owner()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO recipe_shares (recipe_id, user_id, role, invited_email, status)
+  SELECT NEW.id, NEW.owner_id, 'owner',
+    COALESCE((SELECT email FROM auth.users WHERE id = NEW.owner_id), ''),
+    'accepted'
+  WHERE NEW.owner_id IS NOT NULL;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS trg_auto_add_recipe_owner ON recipes;
+CREATE TRIGGER trg_auto_add_recipe_owner
+  AFTER INSERT ON recipes
+  FOR EACH ROW EXECUTE FUNCTION auto_add_recipe_owner();
+
+-- Migrate pending invitations when a new user signs up
+CREATE OR REPLACE FUNCTION migrate_pending_invitations()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Grocery list invitations
+  UPDATE grocery_list_members
+  SET user_id = NEW.id
+  WHERE invited_email = NEW.email AND user_id IS NULL;
+
+  -- Recipe share invitations
+  UPDATE recipe_shares
+  SET user_id = NEW.id
+  WHERE invited_email = NEW.email AND user_id IS NULL;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS trg_migrate_pending_invitations ON auth.users;
+CREATE TRIGGER trg_migrate_pending_invitations
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION migrate_pending_invitations();
+
+-- ============================================================
+-- RLS Policies
+-- ============================================================
+
+-- Enable RLS on new tables
+ALTER TABLE grocery_list_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE recipe_shares ENABLE ROW LEVEL SECURITY;
+
+-- === grocery_lists ===
+-- Drop existing policies if any to avoid conflicts
+DROP POLICY IF EXISTS "grocery_lists_select" ON grocery_lists;
+DROP POLICY IF EXISTS "grocery_lists_insert" ON grocery_lists;
+DROP POLICY IF EXISTS "grocery_lists_update" ON grocery_lists;
+DROP POLICY IF EXISTS "grocery_lists_delete" ON grocery_lists;
+
+CREATE POLICY "grocery_lists_select" ON grocery_lists FOR SELECT USING (
+  owner_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM grocery_list_members
+    WHERE grocery_list_members.list_id = grocery_lists.id
+      AND grocery_list_members.user_id = auth.uid()
+      AND grocery_list_members.status = 'accepted'
+  )
+);
+
+CREATE POLICY "grocery_lists_insert" ON grocery_lists FOR INSERT
+  WITH CHECK (owner_id = auth.uid());
+
+CREATE POLICY "grocery_lists_update" ON grocery_lists FOR UPDATE USING (
+  owner_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM grocery_list_members
+    WHERE grocery_list_members.list_id = grocery_lists.id
+      AND grocery_list_members.user_id = auth.uid()
+      AND grocery_list_members.role IN ('owner', 'editor')
+      AND grocery_list_members.status = 'accepted'
+  )
+);
+
+CREATE POLICY "grocery_lists_delete" ON grocery_lists FOR DELETE USING (
+  owner_id = auth.uid()
+);
+
+-- === grocery_items ===
+DROP POLICY IF EXISTS "grocery_items_select" ON grocery_items;
+DROP POLICY IF EXISTS "grocery_items_insert" ON grocery_items;
+DROP POLICY IF EXISTS "grocery_items_update" ON grocery_items;
+DROP POLICY IF EXISTS "grocery_items_delete" ON grocery_items;
+
+CREATE POLICY "grocery_items_select" ON grocery_items FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM grocery_lists
+    WHERE grocery_lists.id = grocery_items.list_id
+      AND (
+        grocery_lists.owner_id = auth.uid()
+        OR EXISTS (
+          SELECT 1 FROM grocery_list_members
+          WHERE grocery_list_members.list_id = grocery_lists.id
+            AND grocery_list_members.user_id = auth.uid()
+            AND grocery_list_members.status = 'accepted'
+        )
+      )
+  )
+);
+
+CREATE POLICY "grocery_items_insert" ON grocery_items FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM grocery_lists
+    WHERE grocery_lists.id = grocery_items.list_id
+      AND (
+        grocery_lists.owner_id = auth.uid()
+        OR EXISTS (
+          SELECT 1 FROM grocery_list_members
+          WHERE grocery_list_members.list_id = grocery_lists.id
+            AND grocery_list_members.user_id = auth.uid()
+            AND grocery_list_members.role IN ('owner', 'editor')
+            AND grocery_list_members.status = 'accepted'
+        )
+      )
+  )
+);
+
+CREATE POLICY "grocery_items_update" ON grocery_items FOR UPDATE USING (
+  EXISTS (
+    SELECT 1 FROM grocery_lists
+    WHERE grocery_lists.id = grocery_items.list_id
+      AND (
+        grocery_lists.owner_id = auth.uid()
+        OR EXISTS (
+          SELECT 1 FROM grocery_list_members
+          WHERE grocery_list_members.list_id = grocery_lists.id
+            AND grocery_list_members.user_id = auth.uid()
+            AND grocery_list_members.role IN ('owner', 'editor')
+            AND grocery_list_members.status = 'accepted'
+        )
+      )
+  )
+);
+
+CREATE POLICY "grocery_items_delete" ON grocery_items FOR DELETE USING (
+  EXISTS (
+    SELECT 1 FROM grocery_lists
+    WHERE grocery_lists.id = grocery_items.list_id
+      AND (
+        grocery_lists.owner_id = auth.uid()
+        OR EXISTS (
+          SELECT 1 FROM grocery_list_members
+          WHERE grocery_list_members.list_id = grocery_lists.id
+            AND grocery_list_members.user_id = auth.uid()
+            AND grocery_list_members.role IN ('owner', 'editor')
+            AND grocery_list_members.status = 'accepted'
+        )
+      )
+  )
+);
+
+-- === grocery_list_members ===
+CREATE POLICY "glm_select" ON grocery_list_members FOR SELECT USING (
+  user_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM grocery_lists
+    WHERE grocery_lists.id = grocery_list_members.list_id
+      AND grocery_lists.owner_id = auth.uid()
+  )
+);
+
+CREATE POLICY "glm_insert" ON grocery_list_members FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM grocery_lists
+    WHERE grocery_lists.id = grocery_list_members.list_id
+      AND grocery_lists.owner_id = auth.uid()
+  )
+);
+
+CREATE POLICY "glm_update" ON grocery_list_members FOR UPDATE USING (
+  -- Invited user can accept/reject
+  user_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM grocery_lists
+    WHERE grocery_lists.id = grocery_list_members.list_id
+      AND grocery_lists.owner_id = auth.uid()
+  )
+);
+
+CREATE POLICY "glm_delete" ON grocery_list_members FOR DELETE USING (
+  -- Owner can remove anyone, member can leave
+  user_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM grocery_lists
+    WHERE grocery_lists.id = grocery_list_members.list_id
+      AND grocery_lists.owner_id = auth.uid()
+  )
+);
+
+-- === recipes ===
+DROP POLICY IF EXISTS "recipes_select" ON recipes;
+DROP POLICY IF EXISTS "recipes_insert" ON recipes;
+DROP POLICY IF EXISTS "recipes_update" ON recipes;
+DROP POLICY IF EXISTS "recipes_delete" ON recipes;
+
+CREATE POLICY "recipes_select" ON recipes FOR SELECT USING (
+  owner_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM recipe_shares
+    WHERE recipe_shares.recipe_id = recipes.id
+      AND recipe_shares.user_id = auth.uid()
+      AND recipe_shares.status = 'accepted'
+  )
+);
+
+CREATE POLICY "recipes_insert" ON recipes FOR INSERT
+  WITH CHECK (owner_id = auth.uid());
+
+CREATE POLICY "recipes_update" ON recipes FOR UPDATE USING (
+  owner_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM recipe_shares
+    WHERE recipe_shares.recipe_id = recipes.id
+      AND recipe_shares.user_id = auth.uid()
+      AND recipe_shares.role IN ('owner', 'editor')
+      AND recipe_shares.status = 'accepted'
+  )
+);
+
+CREATE POLICY "recipes_delete" ON recipes FOR DELETE USING (
+  owner_id = auth.uid()
+);
+
+-- === recipe_shares ===
+CREATE POLICY "rs_select" ON recipe_shares FOR SELECT USING (
+  user_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM recipes
+    WHERE recipes.id = recipe_shares.recipe_id
+      AND recipes.owner_id = auth.uid()
+  )
+);
+
+CREATE POLICY "rs_insert" ON recipe_shares FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM recipes
+    WHERE recipes.id = recipe_shares.recipe_id
+      AND recipes.owner_id = auth.uid()
+  )
+);
+
+CREATE POLICY "rs_update" ON recipe_shares FOR UPDATE USING (
+  user_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM recipes
+    WHERE recipes.id = recipe_shares.recipe_id
+      AND recipes.owner_id = auth.uid()
+  )
+);
+
+CREATE POLICY "rs_delete" ON recipe_shares FOR DELETE USING (
+  user_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM recipes
+    WHERE recipes.id = recipe_shares.recipe_id
+      AND recipes.owner_id = auth.uid()
+  )
+);
+
+-- ============================================================
+-- Enable Realtime on tables for collaboration
+-- ============================================================
+ALTER PUBLICATION supabase_realtime ADD TABLE grocery_items;
+ALTER PUBLICATION supabase_realtime ADD TABLE grocery_list_members;
+ALTER PUBLICATION supabase_realtime ADD TABLE recipe_shares;


### PR DESCRIPTION
## Summary
- Adds collaboration support for grocery lists and recipes with owner/editor/viewer roles
- Email-based invitation system with pending/accept/reject workflow
- Supabase Realtime integration for live updates on shared lists
- RLS policies enforce access control — owners can delete, editors can modify, viewers are read-only
- Recipe fork ("Copy to My Recipes") with link back to original

## Changes

### Supabase (run `supabase/migrations/20260425_add_collaboration.sql` in SQL Editor)
- New `grocery_list_members` and `recipe_shares` tables
- `forked_from` column on `recipes`
- Auto-insert owner triggers, pending invitation migration trigger
- RLS policies for all tables

### Client
- **SQLDelight**: Migration 4.sqm, `GroceryListMember.sq`, ownership/role columns on `GroceryList` and `Recipe`
- **Domain models**: `ListRole`, `CollaborationStatus`, `ListCollaborator`, `RecipeRole`, `RecipeCollaborator`
- **Repository**: `inviteCollaborator`, `acceptInvitation`, `rejectInvitation`, `forkRecipe`, `shareRecipe`. Sync updated to fetch all RLS-accessible lists (not just owned)
- **BLoC/ViewModel**: Share dialog state, collaborator management, permission gating
- **UI**: Share button (owner only), collaborator bottom sheet with invite, split list selector (My Lists / Shared with me), viewer permission gating

### Dependencies
- Added `supabase-realtime` to `libs.versions.toml` and relevant modules
- Installed `Realtime` module in Supabase client configuration

## Test plan
- [ ] Run Supabase migration SQL in dashboard
- [ ] Verify RLS policies: non-member cannot access list, editor can add items, viewer cannot
- [ ] Create grocery list as User A, invite User B by email
- [ ] User B sees shared list in "Shared with me" section
- [ ] User B (editor) can add/check/delete items
- [ ] User B (viewer) cannot see add-item input
- [ ] Owner can remove collaborator from share dialog
- [ ] Share a recipe, fork it, verify forked recipe exists in user's recipes
- [ ] `./gradlew test` passes (server test failure is pre-existing)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)