### PR TITLE
feat(grocery): animate grocery item removal

### DIFF
--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -145,6 +145,7 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
                             onCheckedChange = bloc::onGroceryItemCheckedChange,
                             onDeleteClick = bloc::onGroceryItemDelete,
                             onGroceryClick = bloc::onGroceryItemClicked,
+                            modifier = Modifier.animateItem(),
                         )
                     }
                 }


### PR DESCRIPTION
## Summary
- Adds `Modifier.animateItem()` to each `GroceryListItem` rendered inside the `LazyColumn` in `GroceryListScreen`
- When an item is deleted, Compose automatically plays a fade-out + slide exit animation before removing it from the list
- Items already had stable `key` values set (`group.items[it].id`), which is required for `animateItem()` to work correctly

Closes #97

## Test plan
- [x] Run the app and navigate to the grocery list
- [x] Delete an item — verify it animates out (fade + slide) instead of disappearing instantly
- [x] Add items and delete multiple — verify each animates independently
- [x] Existing `GroceryListBlocTest` still passes (`./gradlew :client:grocery:core:impl:jvmTest`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)