### PR TITLE
fix(ui): prevent modal bottom sheets from rendering above the status bar

### DIFF
--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -27,6 +28,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.CloudDone
 import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -200,6 +202,12 @@ private fun MealPlanSheet(bloc: MealPlanBloc, sheetState: androidx.compose.mater
             },
             sheetState = sheetState,
             contentWindowInsets = { WindowInsets(0, 0, 0, 0) },
+            dragHandle = {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Spacer(Modifier.statusBarsPadding())
+                    BottomSheetDefaults.DragHandle()
+                }
+            },
         ) {
             when (val current = sheetChild) {
                 is MealPlanBloc.Sheet.AddMeal -> MealPlannerRootScreen(current.bloc)

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
@@ -42,6 +43,7 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -372,6 +374,12 @@ private fun RecipeDetailSheet(
             },
             sheetState = sheetState,
             contentWindowInsets = { WindowInsets(0, 0, 0, 0) },
+            dragHandle = {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Spacer(Modifier.statusBarsPadding())
+                    BottomSheetDefaults.DragHandle()
+                }
+            },
         ) {
             when (val current = sheetChild) {
                 is RecipeDetailBloc.Sheet.AddToGroceryList ->


### PR DESCRIPTION
## Summary

- `MealPlanSheet` and `RecipeDetailSheet` used `contentWindowInsets = { WindowInsets(0, 0, 0, 0) }` to avoid double-padding from the embedded BLoC screens, but this removed the top boundary, allowing the sheet to expand above the status bar in edge-to-edge mode
- Added a custom `dragHandle` with `statusBarsPadding()` to both sheets so the drag handle (and all content below it) renders below the status bar, while the sheet surface correctly fills behind the transparent status bar area

Closes #95

## Test plan

- Open the Meal Plan screen and tap "Add Meal" — the sheet should expand with the drag handle visible **below** the status bar
- Open a Recipe Detail and tap "Add to Grocery List" or "Add to Meal Plan" — same behavior
- Verify no visual regression on the Grocery List selector sheet (uses default insets, unaffected)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)