### PR TITLE
fix: shared element transition for recipe image + meal planner entry point (#70)

### DIFF
--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
@@ -80,6 +80,8 @@ import com.plusmobileapps.chefmate.meal.data.SyncStatus
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootScreen
 import com.plusmobileapps.chefmate.text.ResourceString
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.LocalIsActiveScreen
+import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
@@ -602,6 +604,8 @@ private fun MealItemCard(
     onDeleteClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val sharedTransitionScope = LocalSharedTransitionScope.current
+    val isActive = LocalIsActiveScreen.current
     Card(
         modifier =
             modifier
@@ -614,10 +618,20 @@ private fun MealItemCard(
             horizontalArrangement = spacedBy(ChefMateTheme.dimens.paddingNormal),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            val sharedElementModifier =
+                sharedTransitionScope?.let { sts ->
+                    with(sts) {
+                        Modifier.sharedElementWithCallerManagedVisibility(
+                            sharedContentState =
+                                rememberSharedContentState(key = "recipe_image_${meal.recipeId}"),
+                            visible = isActive,
+                        )
+                    }
+                } ?: Modifier
             RecipeImage(
                 imageUrl = meal.recipeImageUrl,
                 contentDescription = meal.recipeTitle,
-                modifier = Modifier.size(48.dp),
+                modifier = Modifier.size(48.dp).then(sharedElementModifier),
             )
             Text(
                 text = meal.recipeTitle,
@@ -643,6 +657,8 @@ private fun WeekMealItem(
     onDeleteClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val sharedTransitionScope = LocalSharedTransitionScope.current
+    val isActive = LocalIsActiveScreen.current
     Card(
         modifier =
             modifier
@@ -655,10 +671,20 @@ private fun WeekMealItem(
             horizontalArrangement = spacedBy(ChefMateTheme.dimens.paddingNormal),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            val sharedElementModifier =
+                sharedTransitionScope?.let { sts ->
+                    with(sts) {
+                        Modifier.sharedElementWithCallerManagedVisibility(
+                            sharedContentState =
+                                rememberSharedContentState(key = "recipe_image_${meal.recipeId}"),
+                            visible = isActive,
+                        )
+                    }
+                } ?: Modifier
             RecipeImage(
                 imageUrl = meal.recipeImageUrl,
                 contentDescription = meal.recipeTitle,
-                modifier = Modifier.size(40.dp),
+                modifier = Modifier.size(40.dp).then(sharedElementModifier),
             )
             Text(
                 text = meal.mealType.displayName(),

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -123,6 +123,8 @@ import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.LocalIsActiveScreen
+import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
@@ -550,10 +552,25 @@ private fun ColumnScope.RecipeDetailExpandedContent(
                     }
                 }
                 item(key = "image") {
+                    val sharedTransitionScope = LocalSharedTransitionScope.current
+                    val isActive = LocalIsActiveScreen.current
+                    val sharedElementModifier =
+                        sharedTransitionScope?.let { sts ->
+                            with(sts) {
+                                Modifier.sharedElementWithCallerManagedVisibility(
+                                    sharedContentState =
+                                        rememberSharedContentState(
+                                            key = "recipe_image_${recipe.id}"
+                                        ),
+                                    visible = isActive,
+                                )
+                            }
+                        } ?: Modifier
                     RecipeImage(
                         imageUrl = recipe.imageUrl,
                         contentDescription = recipe.title,
-                        modifier = Modifier.fillMaxWidth().height(180.dp),
+                        modifier =
+                            Modifier.fillMaxWidth().height(180.dp).then(sharedElementModifier),
                     )
                 }
                 recipe.starRating?.let { rating ->
@@ -834,11 +851,23 @@ private fun RecipeHeroSection(
     onSourceUrlClicked: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val sharedTransitionScope = LocalSharedTransitionScope.current
+    val isActive = LocalIsActiveScreen.current
     Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        val sharedElementModifier =
+            sharedTransitionScope?.let { sts ->
+                with(sts) {
+                    Modifier.sharedElementWithCallerManagedVisibility(
+                        sharedContentState =
+                            rememberSharedContentState(key = "recipe_image_${recipe.id}"),
+                        visible = isActive,
+                    )
+                }
+            } ?: Modifier
         RecipeImage(
             imageUrl = recipe.imageUrl,
             contentDescription = recipe.title,
-            modifier = Modifier.width(140.dp).height(140.dp),
+            modifier = Modifier.width(140.dp).height(140.dp).then(sharedElementModifier),
         )
         Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
             // Star Rating

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -90,6 +90,8 @@ import com.plusmobileapps.chefmate.recipe.data.SyncStatus
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.LocalIsActiveScreen
+import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
@@ -353,16 +355,28 @@ private fun RecipeGridItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val sharedTransitionScope = LocalSharedTransitionScope.current
+    val isActive = LocalIsActiveScreen.current
     Card(
         onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         colors =
             CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
     ) {
+        val sharedElementModifier =
+            sharedTransitionScope?.let { sts ->
+                with(sts) {
+                    Modifier.sharedElementWithCallerManagedVisibility(
+                        sharedContentState =
+                            rememberSharedContentState(key = "recipe_image_${recipe.id}"),
+                        visible = isActive,
+                    )
+                }
+            } ?: Modifier
         RecipeImage(
             imageUrl = recipe.imageUrl,
             contentDescription = recipe.title,
-            modifier = Modifier.fillMaxWidth().aspectRatio(1.2f),
+            modifier = Modifier.fillMaxWidth().aspectRatio(1.2f).then(sharedElementModifier),
         )
         Column(
             modifier = Modifier.padding(12.dp),
@@ -412,15 +426,27 @@ private fun RecipeListItemContent(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val sharedTransitionScope = LocalSharedTransitionScope.current
+    val isActive = LocalIsActiveScreen.current
     Row(
         modifier = modifier.fillMaxWidth().clickable(onClick = onClick).padding(16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        val sharedElementModifier =
+            sharedTransitionScope?.let { sts ->
+                with(sts) {
+                    Modifier.sharedElementWithCallerManagedVisibility(
+                        sharedContentState =
+                            rememberSharedContentState(key = "recipe_image_${recipe.id}"),
+                        visible = isActive,
+                    )
+                }
+            } ?: Modifier
         RecipeImage(
             imageUrl = recipe.imageUrl,
             contentDescription = recipe.title,
-            modifier = Modifier.size(80.dp),
+            modifier = Modifier.size(80.dp).then(sharedElementModifier),
         )
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Row(

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -2,8 +2,10 @@
 
 package com.plusmobileapps.chefmate.root
 
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.Dp
@@ -22,6 +24,8 @@ import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailScreen
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavigationScreen
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootScreen
 import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.ui.LocalIsActiveScreen
+import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -30,46 +34,60 @@ import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 fun RootScreen(rootBloc: RootBloc, modifier: Modifier = Modifier) {
     val state = rootBloc.state.subscribeAsState()
     ChefMateTheme {
-        Children(
-            modifier = modifier.fillMaxSize(),
-            stack = state.value,
-            animation =
-                predictiveBackAnimation(
-                    backHandler = rootBloc.backHandler,
-                    fallbackAnimation =
-                        stackAnimation { child, otherChild, _ ->
-                            if (
-                                child.instance is RootBloc.Child.Browser ||
-                                    otherChild.instance is RootBloc.Child.Browser
-                            ) {
-                                verticalSlide()
-                            } else {
-                                slide()
+        SharedTransitionLayout {
+            CompositionLocalProvider(LocalSharedTransitionScope provides this) {
+                Children(
+                    modifier = modifier.fillMaxSize(),
+                    stack = state.value,
+                    animation =
+                        predictiveBackAnimation(
+                            backHandler = rootBloc.backHandler,
+                            fallbackAnimation =
+                                stackAnimation { child, otherChild, _ ->
+                                    if (
+                                        child.instance is RootBloc.Child.Browser ||
+                                            otherChild.instance is RootBloc.Child.Browser
+                                    ) {
+                                        verticalSlide()
+                                    } else {
+                                        slide()
+                                    }
+                                },
+                            onBack = rootBloc::onBackClicked,
+                        ),
+                    content = {
+                        CompositionLocalProvider(
+                            LocalIsActiveScreen provides (it.key == state.value.active.key)
+                        ) {
+                            when (val child = it.instance) {
+                                is RootBloc.Child.BottomNavigation ->
+                                    BottomNavigationScreen(child.bloc)
+                                is RootBloc.Child.GroceryDetail -> GroceryDetailScreen(child.bloc)
+                                is RootBloc.Child.RecipeRoot -> RecipeRootScreen(child.bloc)
+                                is RootBloc.Child.Authentication -> AuthenticationScreen(child.bloc)
+                                is RootBloc.Child.Browser ->
+                                    PlusHeaderContainer(
+                                        modifier = Modifier.fillMaxSize(),
+                                        data =
+                                            PlusHeaderData.Modal(
+                                                title = FixedString(""),
+                                                onCloseClick = rootBloc::onBackClicked,
+                                            ),
+                                        scrollEnabled = false,
+                                        maxContentWidth = Dp.Unspecified,
+                                        content = {
+                                            BrowserScreen(
+                                                child.bloc,
+                                                modifier = Modifier.weight(1f),
+                                            )
+                                        },
+                                    )
                             }
-                        },
-                    onBack = rootBloc::onBackClicked,
-                ),
-            content = {
-                when (val child = it.instance) {
-                    is RootBloc.Child.BottomNavigation -> BottomNavigationScreen(child.bloc)
-                    is RootBloc.Child.GroceryDetail -> GroceryDetailScreen(child.bloc)
-                    is RootBloc.Child.RecipeRoot -> RecipeRootScreen(child.bloc)
-                    is RootBloc.Child.Authentication -> AuthenticationScreen(child.bloc)
-                    is RootBloc.Child.Browser ->
-                        PlusHeaderContainer(
-                            modifier = Modifier.fillMaxSize(),
-                            data =
-                                PlusHeaderData.Modal(
-                                    title = FixedString(""),
-                                    onCloseClick = rootBloc::onBackClicked,
-                                ),
-                            scrollEnabled = false,
-                            maxContentWidth = Dp.Unspecified,
-                            content = { BrowserScreen(child.bloc, modifier = Modifier.weight(1f)) },
-                        )
-                }
-            },
-        )
+                        }
+                    },
+                )
+            }
+        }
     }
 }
 

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/SharedTransitionScopes.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/SharedTransitionScopes.kt
@@ -1,0 +1,9 @@
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.runtime.compositionLocalOf
+
+val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { null }
+
+/** True when this screen is the topmost active child in the root navigation stack. */
+val LocalIsActiveScreen = compositionLocalOf { true }


### PR DESCRIPTION
## Summary

- **Fixes #70**: Adds a shared element transition for the recipe image when navigating from the recipe list (grid and list views) to the recipe detail screen.
- **Adjacent improvement**: Applies the same transition when navigating from the meal planner (day/week/month views) to the recipe detail screen.

### How it works

- `SharedTransitionLayout` is placed at the root of the app (`RootScreen`) and shared via `LocalSharedTransitionScope`.
- A `LocalIsActiveScreen` CompositionLocal (Boolean) is set per root-stack child — `true` for the topmost active child, `false` for outgoing children during animation.
- Recipe images in `RecipeListScreen`, `RecipeDetailScreen`, and `MealPlanScreen` use `Modifier.sharedElementWithCallerManagedVisibility(key = "recipe_image_<id>", visible = isActive)`. When the source screen transitions to inactive, the `SharedTransitionLayout` animates the image to its position on the destination screen.

## Test plan

- [ ] Navigate from recipe list (grid view) → recipe detail: image should animate smoothly between both positions
- [ ] Navigate from recipe list (list view) → recipe detail: same
- [ ] Navigate from meal planner (day/week/month) → recipe detail: same
- [ ] Back-navigate from recipe detail → list or meal planner: reverse animation
- [ ] Open a recipe that has no image: no crash, transition degrades gracefully
- [ ] Run `./gradlew :client:meal:core:impl:jvmTest :client:recipe:list:impl:jvmTest :client:recipe:core:impl:jvmTest` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)