### PR TITLE
fix(ios): resolve ShareExtension code signing conflict in CI

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,6 +48,7 @@ platform :ios do
       export_options: {
         provisioningProfiles: {
           "com.plusmobileapps.chefmate.ChefMate" => "match AppStore com.plusmobileapps.chefmate.ChefMate",
+          "com.plusmobileapps.chefmate.ChefMate.ShareExtension" => "match AppStore com.plusmobileapps.chefmate.ChefMate.ShareExtension",
         },
       },
     )

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,4 +1,4 @@
 git_url(ENV["MATCH_GIT_URL"] || "git@github.com:plusmobileapps/certificates.git")
 type("appstore")
-app_identifier("com.plusmobileapps.chefmate.ChefMate")
+app_identifier(["com.plusmobileapps.chefmate.ChefMate", "com.plusmobileapps.chefmate.ChefMate.ShareExtension"])
 username("andrew@plusmobileapps.com")

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -413,9 +413,10 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 50commi;
-				DEVELOPMENT_TEAM = Y89258SF5P;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y89258SF5P;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShareExtension/Info.plist;
@@ -430,6 +431,8 @@
 				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.plusmobileapps.chefmate.ChefMate.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.plusmobileapps.chefmate.ChefMate.ShareExtension";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;


### PR DESCRIPTION
## Summary
- **Matchfile**: Include `ShareExtension` bundle ID so `match` fetches its provisioning profile
- **Fastfile**: Add ShareExtension provisioning profile to `export_options`
- **pbxproj**: Switch ShareExtension Release config from automatic to manual signing with the correct match profile

Fixes the `ARCHIVE FAILED` error: _"ShareExtension has conflicting provisioning settings. ShareExtension is automatically signed for development, but a conflicting code signing identity Apple Distribution has been manually specified."_

## Test plan
- [x] Verify the ShareExtension App ID and provisioning profile exist in App Store Connect (match should create them if missing)
- [x] Re-run the iOS Release workflow and confirm archive succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)