### PR TITLE
ci(claude): add checkout step to Claude Code Action workflow

### DIFF
--- a/.github/workflows/claude-code-action.yml
+++ b/.github/workflows/claude-code-action.yml
@@ -24,6 +24,9 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Claude Code Action
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary
- Add `actions/checkout@v4` step to the Claude Code Action workflow so the runner has a working tree before the action runs.

## Why
Recent runs were failing with errors like:

```
Failed to compute SHA for client/.../MealPlanScreen.kt
  Command failed: git hash-object <file>
...
Action failed with error: Command failed: git fetch origin --depth=20 implement-issue-70
```

Both stem from the repo not being checked out — `git hash-object` and `git fetch` have nothing to operate on. Adding the standard checkout step resolves it.

## Test plan
- [x] Comment `@claude` on an issue or PR and confirm the workflow no longer errors at the SHA/fetch step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)