### PR TITLE
chore(ios): skip App Store Connect encryption prompt

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary
- Sets `ITSAppUsesNonExemptEncryption` to `false` in [iosApp/iosApp/Info.plist](iosApp/iosApp/Info.plist) so App Store Connect no longer asks the export compliance question on every TestFlight / App Store build.
- The app only uses standard iOS-provided HTTPS/crypto, which is exempt. If we ever add custom/proprietary encryption this will need to flip to `true` and include the relevant compliance docs.

## Test plan
- [x] Upload a new build to TestFlight and confirm the export compliance prompt no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)