### PR TITLE
feat(grocery): extract shared GroceryGroupedList composable

### DIFF
--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryGroupedList.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryGroupedList.kt
@@ -1,0 +1,122 @@
+package com.plusmobileapps.chefmate.grocery.core.list
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckBox
+import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import chefmate.client.grocery.core.public.generated.resources.Res
+import chefmate.client.grocery.core.public.generated.resources.grocery_checked
+import chefmate.client.grocery.core.public.generated.resources.grocery_not_checked
+import com.plusmobileapps.chefmate.grocery.core.displayName
+import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
+import org.jetbrains.compose.resources.stringResource
+
+data class GroceryDisplayItem(
+    val key: Any,
+    val displayName: String,
+    val quantity: String? = null,
+    val isChecked: Boolean = false,
+)
+
+data class GroceryDisplayGroup(val category: GroceryCategory, val items: List<GroceryDisplayItem>)
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun GroceryGroupedList(
+    groups: List<GroceryDisplayGroup>,
+    onItemClick: (Any) -> Unit,
+    onCheckedChange: (Any) -> Unit,
+    modifier: Modifier = Modifier,
+    trailingContent: (@Composable (GroceryDisplayItem) -> Unit)? = null,
+    footer: (LazyListScope.() -> Unit)? = null,
+) {
+    LazyColumn(modifier = modifier.fillMaxSize()) {
+        groups.forEach { group ->
+            stickyHeader(key = "header_${group.category.name}") {
+                CategoryHeader(category = group.category)
+            }
+            items(group.items.size, key = { group.items[it].key }) { index ->
+                val item = group.items[index]
+                GroceryDisplayListItem(
+                    item = item,
+                    onCheckedChange = { onCheckedChange(item.key) },
+                    onClick = { onItemClick(item.key) },
+                    trailingContent = trailingContent,
+                    modifier = Modifier.animateItem(),
+                )
+            }
+        }
+        footer?.invoke(this)
+    }
+}
+
+@Composable
+internal fun CategoryHeader(category: GroceryCategory, modifier: Modifier = Modifier) {
+    Surface(color = MaterialTheme.colorScheme.surfaceVariant, modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = category.displayName().localized(),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        )
+    }
+}
+
+@Composable
+private fun GroceryDisplayListItem(
+    item: GroceryDisplayItem,
+    onCheckedChange: () -> Unit,
+    onClick: () -> Unit,
+    trailingContent: (@Composable (GroceryDisplayItem) -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth().clickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onCheckedChange) {
+            if (item.isChecked) {
+                Icon(
+                    Icons.Default.CheckBox,
+                    contentDescription = stringResource(Res.string.grocery_checked),
+                )
+            } else {
+                Icon(
+                    Icons.Default.CheckBoxOutlineBlank,
+                    contentDescription = stringResource(Res.string.grocery_not_checked),
+                )
+            }
+        }
+        Column(modifier = Modifier.weight(1f).padding(start = 8.dp)) {
+            Text(text = item.displayName, style = MaterialTheme.typography.bodyLarge)
+            val quantity = item.quantity
+            if (quantity != null) {
+                Text(
+                    text = quantity,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        if (trailingContent != null) {
+            trailingContent(item)
+        }
+    }
+}

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -1,8 +1,6 @@
 package com.plusmobileapps.chefmate.grocery.core.list
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -11,11 +9,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.CheckBox
-import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.FilterList
@@ -35,7 +30,6 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -54,7 +48,6 @@ import androidx.compose.ui.unit.dp
 import chefmate.client.grocery.core.public.generated.resources.Res
 import chefmate.client.grocery.core.public.generated.resources.grocery_add_item
 import chefmate.client.grocery.core.public.generated.resources.grocery_cancel
-import chefmate.client.grocery.core.public.generated.resources.grocery_checked
 import chefmate.client.grocery.core.public.generated.resources.grocery_create_list_cancel
 import chefmate.client.grocery.core.public.generated.resources.grocery_create_list_confirm
 import chefmate.client.grocery.core.public.generated.resources.grocery_create_list_hint
@@ -72,14 +65,11 @@ import chefmate.client.grocery.core.public.generated.resources.grocery_filter_al
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_purchased
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_unpurchased
 import chefmate.client.grocery.core.public.generated.resources.grocery_list
-import chefmate.client.grocery.core.public.generated.resources.grocery_not_checked
 import chefmate.client.grocery.core.public.generated.resources.grocery_select_list
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_all
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_not_synced
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_synced
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_syncing
-import com.plusmobileapps.chefmate.grocery.core.displayName
-import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
 import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.SyncStatus
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
@@ -87,7 +77,7 @@ import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import kotlinx.coroutines.flow.StateFlow
 import org.jetbrains.compose.resources.stringResource
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
@@ -133,23 +123,45 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
                     }
                 },
             )
-            LazyColumn(modifier = Modifier.weight(1f)) {
-                state.groupedItems.forEach { group ->
-                    stickyHeader(key = "header_${group.category.name}") {
-                        CategoryHeader(category = group.category)
+            val itemLookup =
+                remember(state.groupedItems) {
+                    state.groupedItems.flatMap { it.items }.associateBy { it.id }
+                }
+            GroceryGroupedList(
+                groups =
+                    state.groupedItems.map { group ->
+                        GroceryDisplayGroup(
+                            category = group.category,
+                            items =
+                                group.items.map { item ->
+                                    GroceryDisplayItem(
+                                        key = item.id,
+                                        displayName = item.displayName,
+                                        quantity = item.quantity,
+                                        isChecked = item.isChecked,
+                                    )
+                                },
+                        )
+                    },
+                onItemClick = { key ->
+                    itemLookup[key as Long]?.let { bloc.onGroceryItemClicked(it) }
+                },
+                onCheckedChange = { key ->
+                    itemLookup[key as Long]?.let {
+                        bloc.onGroceryItemCheckedChange(it, !it.isChecked)
                     }
-                    items(group.items.size, key = { group.items[it].id }) { index ->
-                        val item = group.items[index]
-                        GroceryListItem(
+                },
+                modifier = Modifier.weight(1f),
+                trailingContent = { displayItem ->
+                    val item = itemLookup[displayItem.key as Long]
+                    if (item != null) {
+                        GroceryItemTrailingContent(
                             item = item,
-                            onCheckedChange = bloc::onGroceryItemCheckedChange,
-                            onDeleteClick = bloc::onGroceryItemDelete,
-                            onGroceryClick = bloc::onGroceryItemClicked,
-                            modifier = Modifier.animateItem(),
+                            onDeleteClick = { bloc.onGroceryItemDelete(item) },
                         )
                     }
-                }
-            }
+                },
+            )
             GroceryListInput(
                 name = bloc.newGroceryItemName,
                 onNameChange = bloc::onNewGroceryItemNameChange,
@@ -180,18 +192,6 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
             onDismiss = bloc::onDeleteDismissed,
             onDeletePurchased = bloc::onDeletePurchasedConfirmed,
             onDeleteAll = bloc::onDeleteAllConfirmed,
-        )
-    }
-}
-
-@Composable
-private fun CategoryHeader(category: GroceryCategory, modifier: Modifier = Modifier) {
-    Surface(color = MaterialTheme.colorScheme.surfaceVariant, modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = category.displayName().localized(),
-            style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
     }
 }
@@ -381,68 +381,32 @@ private fun GroceryListInput(
 }
 
 @Composable
-private fun GroceryListItem(
-    item: GroceryItem,
-    onCheckedChange: (GroceryItem, Boolean) -> Unit,
-    onDeleteClick: (GroceryItem) -> Unit,
-    onGroceryClick: (GroceryItem) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier.fillMaxWidth().clickable { onGroceryClick(item) },
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        IconButton(onClick = { onCheckedChange(item, !item.isChecked) }) {
-            if (item.isChecked) {
-                Icon(
-                    Icons.Default.CheckBox,
-                    contentDescription = stringResource(Res.string.grocery_checked),
-                )
-            } else {
-                Icon(
-                    Icons.Default.CheckBoxOutlineBlank,
-                    contentDescription = stringResource(Res.string.grocery_not_checked),
-                )
-            }
-        }
-        Column(modifier = Modifier.weight(1f).padding(start = 8.dp)) {
-            Text(text = item.displayName, style = MaterialTheme.typography.bodyLarge)
-            val quantity = item.quantity
-            if (quantity != null) {
-                Text(
-                    text = quantity,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
+private fun GroceryItemTrailingContent(item: GroceryItem, onDeleteClick: () -> Unit) {
+    val syncingDescription = stringResource(Res.string.grocery_sync_syncing)
+    when (item.syncStatus) {
+        SyncStatus.NOT_SYNCED ->
+            Icon(
+                imageVector = Icons.Outlined.CloudOff,
+                contentDescription = stringResource(Res.string.grocery_sync_not_synced),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        SyncStatus.SYNCING ->
+            CircularProgressIndicator(
+                modifier =
+                    Modifier.size(16.dp).semantics { contentDescription = syncingDescription },
+                strokeWidth = 2.dp,
+            )
+        SyncStatus.SYNCED ->
+            Icon(
+                imageVector = Icons.Outlined.CloudDone,
+                contentDescription = stringResource(Res.string.grocery_sync_synced),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+    }
 
-        val syncingDescription = stringResource(Res.string.grocery_sync_syncing)
-        when (item.syncStatus) {
-            SyncStatus.NOT_SYNCED ->
-                Icon(
-                    imageVector = Icons.Outlined.CloudOff,
-                    contentDescription = stringResource(Res.string.grocery_sync_not_synced),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(20.dp),
-                )
-            SyncStatus.SYNCING ->
-                CircularProgressIndicator(
-                    modifier =
-                        Modifier.size(16.dp).semantics { contentDescription = syncingDescription },
-                    strokeWidth = 2.dp,
-                )
-            SyncStatus.SYNCED ->
-                Icon(
-                    imageVector = Icons.Outlined.CloudDone,
-                    contentDescription = stringResource(Res.string.grocery_sync_synced),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(20.dp),
-                )
-        }
-
-        IconButton(onClick = { onDeleteClick(item) }) {
-            Icon(Icons.Default.Delete, stringResource(Res.string.grocery_delete_item))
-        }
+    IconButton(onClick = onDeleteClick) {
+        Icon(Icons.Default.Delete, stringResource(Res.string.grocery_delete_item))
     }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListViewModel.kt
@@ -126,8 +126,13 @@ class AddRecipeToGroceryListViewModel(
                     .filter { it.isNotBlank() }
                     .map { raw ->
                         val parsed = IngredientParser.parse(raw)
-                        ListItem(id = raw.hashCode(), name = raw, isSelected = true) to
-                            parsed.category
+                        ListItem(
+                            id = raw.hashCode(),
+                            name = raw,
+                            displayName = parsed.name,
+                            quantity = parsed.quantity,
+                            isSelected = true,
+                        ) to parsed.category
                     }
                     .groupBy { it.second }
                     .entries

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListBloc.kt
@@ -19,7 +19,13 @@ interface AddRecipeToGroceryListBloc : BackClickBloc {
 
     data class IngredientGroup(val category: GroceryCategory, val items: List<ListItem>)
 
-    data class ListItem(val id: Int, val name: String, val isSelected: Boolean)
+    data class ListItem(
+        val id: Int,
+        val name: String,
+        val displayName: String,
+        val quantity: String? = null,
+        val isSelected: Boolean,
+    )
 
     data class Model(
         val isLoading: Boolean,

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListScreen.kt
@@ -1,15 +1,9 @@
 package com.plusmobileapps.chefmate.recipe.core.addgrocery
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
@@ -18,7 +12,6 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -34,8 +27,9 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_groc
 import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_add
 import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_no_ingredients
 import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_select_list
-import com.plusmobileapps.chefmate.grocery.core.displayName
-import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryDisplayGroup
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryDisplayItem
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryGroupedList
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
@@ -44,7 +38,7 @@ import com.plusmobileapps.chefmate.ui.components.lastItemFloatingActionButtonSpa
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import org.jetbrains.compose.resources.stringResource
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddRecipeToGroceryListScreen(bloc: AddRecipeToGroceryListBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
@@ -91,10 +85,26 @@ fun AddRecipeToGroceryListScreen(bloc: AddRecipeToGroceryListBloc, modifier: Mod
                     selectedList = state.selectedGroceryList,
                     onListSelected = bloc::onGroceryListSelected,
                 )
-                GroupedIngredientsList(
-                    groups = state.groupedIngredients,
-                    onIngredientToggled = bloc::onIngredientToggled,
+                GroceryGroupedList(
+                    groups =
+                        state.groupedIngredients.map { group ->
+                            GroceryDisplayGroup(
+                                category = group.category,
+                                items =
+                                    group.items.map { item ->
+                                        GroceryDisplayItem(
+                                            key = item.id,
+                                            displayName = item.displayName,
+                                            quantity = item.quantity,
+                                            isChecked = item.isSelected,
+                                        )
+                                    },
+                            )
+                        },
+                    onItemClick = { key -> bloc.onIngredientToggled(key as Int) },
+                    onCheckedChange = { key -> bloc.onIngredientToggled(key as Int) },
                     modifier = Modifier.weight(1f),
+                    footer = { lastItemFloatingActionButtonSpacer() },
                 )
             }
         }
@@ -136,69 +146,5 @@ private fun GroceryListSelector(
                 )
             }
         }
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun GroupedIngredientsList(
-    groups: List<AddRecipeToGroceryListBloc.IngredientGroup>,
-    onIngredientToggled: (Int) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    LazyColumn(modifier = modifier.fillMaxSize()) {
-        groups.forEach { group ->
-            stickyHeader(key = "header_${group.category.name}") {
-                CategoryHeader(category = group.category)
-            }
-            items(group.items.size, key = { group.items[it].id }) { index ->
-                val ingredient = group.items[index]
-                IngredientListItem(
-                    ingredient = ingredient,
-                    onToggle = { onIngredientToggled(ingredient.id) },
-                )
-            }
-        }
-
-        lastItemFloatingActionButtonSpacer()
-    }
-}
-
-@Composable
-private fun CategoryHeader(category: GroceryCategory, modifier: Modifier = Modifier) {
-    Surface(color = MaterialTheme.colorScheme.surfaceVariant, modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = category.displayName().localized(),
-            style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-        )
-    }
-}
-
-@Composable
-private fun IngredientListItem(
-    ingredient: AddRecipeToGroceryListBloc.ListItem,
-    onToggle: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .clickable(onClick = onToggle)
-                .padding(
-                    horizontal = ChefMateTheme.dimens.paddingNormal,
-                    vertical = ChefMateTheme.dimens.paddingSmall,
-                ),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Checkbox(checked = ingredient.isSelected, onCheckedChange = { onToggle() })
-        Text(
-            text = ingredient.name,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.weight(1f),
-        )
     }
 }


### PR DESCRIPTION
## Summary
- Extracted the grocery list UI (LazyColumn with sticky category headers + item rows showing checkbox, name, and quantity) into a shared `GroceryGroupedList` composable in `grocery/core/public`
- Updated `AddRecipeToGroceryListScreen` to use the shared composable instead of its own `GroupedIngredientsList`/`IngredientListItem`
- Added `displayName` and `quantity` fields to `AddRecipeToGroceryListBloc.ListItem`, populated via `IngredientParser`, so the add-to-grocery screen displays parsed ingredient names and quantities matching the grocery list appearance

## Test plan
- [x] Verify grocery list screen renders items with checkbox, name, quantity, sync status, and delete button as before
- [x] Verify add-to-grocery screen now shows parsed ingredient name and quantity separately (matching grocery list style)
- [x] Verify toggling items works on both screens
- [x] Verify category sticky headers appear correctly on both screens
- [x] All client tests pass (`./gradlew test -x :server:test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)