### PR TITLE
feat: keep screen on while recipe detail is open

### DIFF
--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -137,6 +137,7 @@ import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import com.plusmobileapps.chefmate.util.KeepScreenOn
 import com.plusmobileapps.chefmate.util.rememberShareLauncher
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -148,6 +149,7 @@ import org.jetbrains.compose.resources.stringResource
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
+    KeepScreenOn()
     val state by bloc.state.collectAsState()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val shareLauncher = rememberShareLauncher()

--- a/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/KeepScreenOn.android.kt
+++ b/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/KeepScreenOn.android.kt
@@ -1,0 +1,16 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalView
+
+@Composable
+actual fun KeepScreenOn() {
+    val view = LocalView.current
+    DisposableEffect(view) {
+        view.keepScreenOn = true
+        onDispose { view.keepScreenOn = false }
+    }
+}

--- a/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/KeepScreenOn.kt
+++ b/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/KeepScreenOn.kt
@@ -1,0 +1,6 @@
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+
+/** Keeps the device screen on while this composable is in composition. Cleans up on dispose. */
+@Composable expect fun KeepScreenOn()

--- a/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/KeepScreenOn.ios.kt
+++ b/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/KeepScreenOn.ios.kt
@@ -1,0 +1,15 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import platform.UIKit.UIApplication
+
+@Composable
+actual fun KeepScreenOn() {
+    DisposableEffect(Unit) {
+        UIApplication.sharedApplication.idleTimerDisabled = true
+        onDispose { UIApplication.sharedApplication.idleTimerDisabled = false }
+    }
+}

--- a/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/KeepScreenOn.jvm.kt
+++ b/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/KeepScreenOn.jvm.kt
@@ -1,0 +1,10 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun KeepScreenOn() {
+    // TODO: implement if desktop needs to prevent sleep while recipe detail is open
+}


### PR DESCRIPTION
## Summary

- When the recipe detail screen is open, the device display stays on so it doesn't sleep while you're cooking.
- Adds a reusable `KeepScreenOn()` `@Composable` in `client/util/public` using `expect`/`actual` — follows the same pattern as the existing `rememberShareLauncher` in that module.
- `KeepScreenOn()` is called at the top of `RecipeDetailScreen`, so it is active for the entire time the screen is composed and automatically cleans up when navigating away.

## Per-platform implementations

| Platform | Implementation |
|---|---|
| **Android** | `view.keepScreenOn = true` via `LocalView.current`; reset to `false` on dispose. |
| **iOS** | `UIApplication.sharedApplication.idleTimerDisabled = true`; reset to `false` on dispose. |
| **JVM Desktop** | No-op (desktop apps don't trigger system sleep while the app is active); marked with a `// TODO` comment if this needs revisiting. |

## Flag cleanup on dispose

Both Android and iOS implementations use `DisposableEffect` — the flag/property is cleared in `onDispose {}`, so navigating back to the recipe list or any other screen restores normal idle-timer behaviour. The screen-on state does not leak.

## Testing

Compiled all targets (Android, iOS arm64, iOS simulator arm64, JVM) — no new errors or warnings introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)