### PR TITLE
feat: add keep-screen-on toggle to recipe detail app bar

### DIFF
--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -90,6 +90,7 @@ class RecipeDetailBlocImpl(
                 formattedTotalTime =
                     it.recipe.totalTime?.let { time -> timeFormatterUtil.formatMinutes(time) },
                 showGroceryAddedSnackbar = it.showGroceryAddedSnackbar,
+                keepScreenOn = it.keepScreenOn,
             )
         }
 
@@ -132,6 +133,10 @@ class RecipeDetailBlocImpl(
     override fun onViewGroceryListClicked() {
         viewModel.dismissGroceryAddedSnackbar()
         output.onNext(Output.OpenGroceryList)
+    }
+
+    override fun onKeepScreenOnToggled() {
+        viewModel.toggleKeepScreenOn()
     }
 
     override fun onGrocerySnackbarDismissed() {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -4,6 +4,8 @@ import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.boolean
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
@@ -23,11 +25,14 @@ class RecipeDetailViewModel(
     @Assisted private val recipeId: Long,
     @Main mainContext: CoroutineContext,
     private val repository: RecipeRepository,
+    settings: Settings,
 ) : ViewModel(mainContext) {
+
+    private var keepScreenOnPref by settings.boolean(KEY_KEEP_SCREEN_ON, defaultValue = true)
     private val _output = Channel<Output>(Channel.BUFFERED)
     val output: Flow<Output> = _output.receiveAsFlow()
 
-    private val _state = MutableStateFlow(State())
+    private val _state = MutableStateFlow(State(keepScreenOn = keepScreenOnPref))
     val state: StateFlow<State> = _state.asStateFlow()
 
     init {
@@ -76,12 +81,19 @@ class RecipeDetailViewModel(
         _state.update { it.copy(showGroceryAddedSnackbar = false) }
     }
 
+    fun toggleKeepScreenOn() {
+        val newValue = !_state.value.keepScreenOn
+        keepScreenOnPref = newValue
+        _state.update { it.copy(keepScreenOn = newValue) }
+    }
+
     data class State(
         val isLoading: Boolean = true,
         val isDeleting: Boolean = false,
         val showDeleteConfirmationDialog: Boolean = false,
         val recipe: Recipe = Recipe.Empty,
         val showGroceryAddedSnackbar: Boolean = false,
+        val keepScreenOn: Boolean = true,
     )
 
     sealed class Output {
@@ -91,5 +103,9 @@ class RecipeDetailViewModel(
     @AssistedFactory
     fun interface Factory {
         fun create(recipeId: Long): RecipeDetailViewModel
+    }
+
+    companion object {
+        private const val KEY_KEEP_SCREEN_ON = "recipe_detail_keep_screen_on"
     }
 }

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -40,6 +40,8 @@
 <string name="recipe_detail_share_url">Share recipe URL</string>
 <string name="recipe_detail_share_text">Share recipe text</string>
     <string name="recipe_detail_copied_to_clipboard">Copied to clipboard</string>
+    <string name="recipe_detail_keep_screen_on">Keep screen on</string>
+    <string name="recipe_detail_allow_screen_off">Allow screen to turn off</string>
 
     <!-- Add to Meal Plan -->
     <string name="recipe_detail_add_to_meal_plan">Add to meal plan</string>

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -36,6 +36,8 @@ interface RecipeDetailBloc : BackClickBloc {
 
     fun onViewGroceryListClicked()
 
+    fun onKeepScreenOnToggled()
+
     fun onGrocerySnackbarDismissed()
 
     data class Model(
@@ -49,6 +51,7 @@ interface RecipeDetailBloc : BackClickBloc {
         val formattedCookTime: TextData? = null,
         val formattedTotalTime: TextData? = null,
         val showGroceryAddedSnackbar: Boolean = false,
+        val keepScreenOn: Boolean = true,
     )
 
     sealed class Output {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
@@ -92,6 +94,7 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_groc
 import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_view
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_favorite
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_meal_plan
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_allow_screen_off
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_calories
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_time
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_copied_to_clipboard
@@ -109,6 +112,7 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_dire
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_edit
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_ingredients
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_kcal
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_keep_screen_on
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_prep_time
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_remove_favorite
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_servings
@@ -149,8 +153,10 @@ import org.jetbrains.compose.resources.stringResource
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
-    KeepScreenOn()
     val state by bloc.state.collectAsState()
+    if (state.keepScreenOn) {
+        KeepScreenOn()
+    }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val shareLauncher = rememberShareLauncher()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -204,6 +210,29 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                     PlusHeaderData.Child(
                         title = state.recipe.title.asTextData(),
                         onBackClick = bloc::onBackClicked,
+                        trailingAccessory =
+                            PlusHeaderData.TrailingAccessory.Custom {
+                                IconButton(onClick = bloc::onKeepScreenOnToggled) {
+                                    Icon(
+                                        imageVector =
+                                            if (state.keepScreenOn) {
+                                                Icons.Default.Visibility
+                                            } else {
+                                                Icons.Default.VisibilityOff
+                                            },
+                                        contentDescription =
+                                            if (state.keepScreenOn) {
+                                                stringResource(
+                                                    Res.string.recipe_detail_allow_screen_off
+                                                )
+                                            } else {
+                                                stringResource(
+                                                    Res.string.recipe_detail_keep_screen_on
+                                                )
+                                            },
+                                    )
+                                }
+                            },
                     ),
                 verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingNormal),
                 scrollEnabled = false,
@@ -1295,6 +1324,10 @@ private val previewBloc =
         }
 
         override fun onViewGroceryListClicked() {
+            TODO("Not yet implemented")
+        }
+
+        override fun onKeepScreenOnToggled() {
             TODO("Not yet implemented")
         }
 


### PR DESCRIPTION
Persists the preference across sessions using multiplatform-settings, defaults to on.