### PR TITLE
feat(grocery): add recipe filter to sort/filter sheet

### DIFF
--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
@@ -41,6 +41,9 @@ class GroceryListBlocImpl(
                 groupedItems = it.groupedItems,
                 sort = it.sort,
                 filter = it.filter,
+                recipeFilter = it.recipeFilter,
+                availableRecipes = it.availableRecipes,
+                hasNoRecipeItems = it.hasNoRecipeItems,
                 isSyncing = it.isSyncing,
                 lists = it.lists,
                 selectedList = it.selectedList,
@@ -100,8 +103,12 @@ class GroceryListBlocImpl(
         viewModel.onDeleteListClicked(list)
     }
 
-    override fun onApplySortAndFilter(sort: GrocerySort, filter: GroceryFilter) {
-        viewModel.onApplySortAndFilter(sort, filter)
+    override fun onApplySortAndFilter(
+        sort: GrocerySort,
+        filter: GroceryFilter,
+        recipeFilter: String?,
+    ) {
+        viewModel.onApplySortAndFilter(sort, filter, recipeFilter)
     }
 
     override fun onDeleteClicked() {

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
@@ -4,6 +4,7 @@ package com.plusmobileapps.chefmate.grocery.core.impl.list
 
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryFilter
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryGroup
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GrocerySort
@@ -42,6 +43,7 @@ class GroceryListViewModel(
     private val selectedListId = MutableStateFlow<Long?>(null)
     private val _sort = MutableStateFlow(initialSort)
     private val _filter = MutableStateFlow(initialFilter)
+    private val _recipeFilter = MutableStateFlow<String?>(null)
 
     val state: StateFlow<State> = _state.asStateFlow()
 
@@ -80,37 +82,60 @@ class GroceryListViewModel(
                     },
                     _filter,
                     _sort,
-                ) { items, filter, sort ->
+                    _recipeFilter,
+                ) { items, filter, sort, recipeFilter ->
+                    val availableRecipes = items.mapNotNull { it.recipeName }.distinct().sorted()
+                    val hasNoRecipeItems = items.any { it.recipeName == null }
                     val filtered =
                         when (filter) {
                             GroceryFilter.ALL -> items
                             GroceryFilter.UNPURCHASED -> items.filter { !it.isChecked }
                             GroceryFilter.PURCHASED -> items.filter { it.isChecked }
                         }
-                    when (sort) {
-                        GrocerySort.AISLE ->
-                            filtered
-                                .groupBy { it.category }
-                                .entries
-                                .sortedBy { it.key.ordinal }
-                                .map { (category, categoryItems) ->
-                                    GroceryGroup(category = category, items = categoryItems)
-                                }
-                        GrocerySort.ALPHABETICAL ->
-                            listOf(
-                                    GroceryGroup(
-                                        category =
-                                            filtered.firstOrNull()?.category
-                                                ?: com.plusmobileapps.chefmate.grocery.data
-                                                    .GroceryCategory
-                                                    .OTHER,
-                                        items = filtered.sortedBy { it.displayName.lowercase() },
+                    val recipeFiltered =
+                        when (recipeFilter) {
+                            null -> filtered
+                            GroceryListBloc.NO_RECIPE_FILTER ->
+                                filtered.filter { it.recipeName == null }
+                            else -> filtered.filter { it.recipeName == recipeFilter }
+                        }
+                    val grouped =
+                        when (sort) {
+                            GrocerySort.AISLE ->
+                                recipeFiltered
+                                    .groupBy { it.category }
+                                    .entries
+                                    .sortedBy { it.key.ordinal }
+                                    .map { (category, categoryItems) ->
+                                        GroceryGroup(category = category, items = categoryItems)
+                                    }
+                            GrocerySort.ALPHABETICAL ->
+                                listOf(
+                                        GroceryGroup(
+                                            category =
+                                                recipeFiltered.firstOrNull()?.category
+                                                    ?: com.plusmobileapps.chefmate.grocery.data
+                                                        .GroceryCategory
+                                                        .OTHER,
+                                            items =
+                                                recipeFiltered.sortedBy {
+                                                    it.displayName.lowercase()
+                                                },
+                                        )
                                     )
-                                )
-                                .filter { it.items.isNotEmpty() }
+                                    .filter { it.items.isNotEmpty() }
+                        }
+                    Triple(grouped, availableRecipes, hasNoRecipeItems)
+                }
+                .collect { (grouped, availableRecipes, hasNoRecipeItems) ->
+                    _state.update {
+                        it.copy(
+                            groupedItems = grouped,
+                            availableRecipes = availableRecipes,
+                            hasNoRecipeItems = hasNoRecipeItems,
+                        )
                     }
                 }
-                .collect { grouped -> _state.update { it.copy(groupedItems = grouped) } }
         }
     }
 
@@ -179,12 +204,17 @@ class GroceryListViewModel(
         }
     }
 
-    fun onApplySortAndFilter(sort: GrocerySort, filter: GroceryFilter) {
+    fun onApplySortAndFilter(
+        sort: GrocerySort,
+        filter: GroceryFilter,
+        recipeFilter: String? = null,
+    ) {
         _sort.value = sort
         _filter.value = filter
+        _recipeFilter.value = recipeFilter
         sortPref = sort.name
         filterPref = filter.name
-        _state.update { it.copy(sort = sort, filter = filter) }
+        _state.update { it.copy(sort = sort, filter = filter, recipeFilter = recipeFilter) }
     }
 
     fun onDeleteClicked() {
@@ -219,6 +249,9 @@ class GroceryListViewModel(
         val groupedItems: List<GroceryGroup> = emptyList(),
         val sort: GrocerySort = GrocerySort.AISLE,
         val filter: GroceryFilter = GroceryFilter.ALL,
+        val recipeFilter: String? = null,
+        val availableRecipes: List<String> = emptyList(),
+        val hasNoRecipeItems: Boolean = false,
         val isSyncing: Boolean = false,
         val lists: List<GroceryListModel> = emptyList(),
         val selectedList: GroceryListModel? = null,

--- a/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
+++ b/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
@@ -74,7 +74,8 @@ class GroceryListBlocTest {
             awaitItem() shouldBe
                 GroceryListBloc.Model(
                     groupedItems =
-                        listOf(GroceryGroup(category = GroceryCategory.PRODUCE, items = items))
+                        listOf(GroceryGroup(category = GroceryCategory.PRODUCE, items = items)),
+                    hasNoRecipeItems = true,
                 )
         }
     }
@@ -165,6 +166,166 @@ class GroceryListBlocTest {
             result.filter shouldBe GroceryListBloc.GroceryFilter.UNPURCHASED
             result.groupedItems.flatMap { it.items }.size shouldBe 1
             result.groupedItems.flatMap { it.items }.first().displayName shouldBe "Bananas"
+        }
+    }
+
+    @Test
+    fun When_recipe_filter_applied_Then_only_items_from_that_recipe_shown() = runTest {
+        val items =
+            listOf(
+                GroceryItem(
+                    id = 1,
+                    name = "Flour",
+                    displayName = "Flour",
+                    category = GroceryCategory.BAKING,
+                    isChecked = false,
+                    recipeName = "Chocolate Cake",
+                ),
+                GroceryItem(
+                    id = 2,
+                    name = "Sugar",
+                    displayName = "Sugar",
+                    category = GroceryCategory.BAKING,
+                    isChecked = false,
+                    recipeName = "Chocolate Cake",
+                ),
+                GroceryItem(
+                    id = 3,
+                    name = "Chicken",
+                    displayName = "Chicken",
+                    category = GroceryCategory.MEAT,
+                    isChecked = false,
+                    recipeName = "Chicken Soup",
+                ),
+                GroceryItem(
+                    id = 4,
+                    name = "Salt",
+                    displayName = "Salt",
+                    category = GroceryCategory.SPICES,
+                    isChecked = false,
+                ),
+            )
+        groceries.emit(items)
+        bloc.onApplySortAndFilter(
+            GroceryListBloc.GrocerySort.AISLE,
+            GroceryListBloc.GroceryFilter.ALL,
+            recipeFilter = "Chocolate Cake",
+        )
+        bloc.state.test {
+            val result = awaitItem()
+            result.recipeFilter shouldBe "Chocolate Cake"
+            val allItems = result.groupedItems.flatMap { it.items }
+            allItems.size shouldBe 2
+            allItems.map { it.displayName } shouldBe listOf("Flour", "Sugar")
+        }
+    }
+
+    @Test
+    fun When_no_recipe_filter_applied_Then_only_items_without_recipe_shown() = runTest {
+        val items =
+            listOf(
+                GroceryItem(
+                    id = 1,
+                    name = "Flour",
+                    displayName = "Flour",
+                    category = GroceryCategory.BAKING,
+                    isChecked = false,
+                    recipeName = "Chocolate Cake",
+                ),
+                GroceryItem(
+                    id = 2,
+                    name = "Salt",
+                    displayName = "Salt",
+                    category = GroceryCategory.SPICES,
+                    isChecked = false,
+                ),
+            )
+        groceries.emit(items)
+        bloc.onApplySortAndFilter(
+            GroceryListBloc.GrocerySort.AISLE,
+            GroceryListBloc.GroceryFilter.ALL,
+            recipeFilter = GroceryListBloc.NO_RECIPE_FILTER,
+        )
+        bloc.state.test {
+            val result = awaitItem()
+            result.recipeFilter shouldBe GroceryListBloc.NO_RECIPE_FILTER
+            val allItems = result.groupedItems.flatMap { it.items }
+            allItems.size shouldBe 1
+            allItems.first().displayName shouldBe "Salt"
+        }
+    }
+
+    @Test
+    fun When_available_recipes_exist_Then_model_contains_sorted_recipe_names() = runTest {
+        bloc.state.test {
+            awaitItem() shouldBe GroceryListBloc.Model()
+            val items =
+                listOf(
+                    GroceryItem(
+                        id = 1,
+                        name = "Flour",
+                        category = GroceryCategory.BAKING,
+                        isChecked = false,
+                        recipeName = "Chocolate Cake",
+                    ),
+                    GroceryItem(
+                        id = 2,
+                        name = "Chicken",
+                        category = GroceryCategory.MEAT,
+                        isChecked = false,
+                        recipeName = "Chicken Soup",
+                    ),
+                    GroceryItem(
+                        id = 3,
+                        name = "Salt",
+                        category = GroceryCategory.SPICES,
+                        isChecked = false,
+                    ),
+                )
+            groceries.emit(items)
+            val result = awaitItem()
+            result.availableRecipes shouldBe listOf("Chicken Soup", "Chocolate Cake")
+            result.hasNoRecipeItems shouldBe true
+        }
+    }
+
+    @Test
+    fun When_clear_filters_applied_Then_recipe_filter_is_also_cleared() = runTest {
+        val items =
+            listOf(
+                GroceryItem(
+                    id = 1,
+                    name = "Flour",
+                    displayName = "Flour",
+                    category = GroceryCategory.BAKING,
+                    isChecked = false,
+                    recipeName = "Chocolate Cake",
+                ),
+                GroceryItem(
+                    id = 2,
+                    name = "Salt",
+                    displayName = "Salt",
+                    category = GroceryCategory.SPICES,
+                    isChecked = false,
+                ),
+            )
+        groceries.emit(items)
+        bloc.onApplySortAndFilter(
+            GroceryListBloc.GrocerySort.ALPHABETICAL,
+            GroceryListBloc.GroceryFilter.ALL,
+            recipeFilter = "Chocolate Cake",
+        )
+        bloc.onApplySortAndFilter(
+            GroceryListBloc.GrocerySort.AISLE,
+            GroceryListBloc.GroceryFilter.ALL,
+            recipeFilter = null,
+        )
+        bloc.state.test {
+            val result = awaitItem()
+            result.recipeFilter shouldBe null
+            result.sort shouldBe GroceryListBloc.GrocerySort.AISLE
+            result.filter shouldBe GroceryListBloc.GroceryFilter.ALL
+            result.groupedItems.flatMap { it.items }.size shouldBe 2
         }
     }
 

--- a/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
@@ -32,6 +32,9 @@
     <string name="grocery_sort_aisle">Aisle</string>
     <string name="grocery_sort_alphabetical">Alphabetical</string>
     <string name="grocery_filter_by">Filter by</string>
+    <string name="grocery_filter_by_recipe">By recipe</string>
+    <string name="grocery_filter_no_recipe">No Recipe</string>
+    <string name="grocery_clear_filters">Clear</string>
     <string name="grocery_apply">Apply</string>
     <string name="grocery_recipe_source">From: {recipe}</string>
     <string name="grocery_category_produce">Produce</string>

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
@@ -34,7 +34,7 @@ interface GroceryListBloc {
 
     fun onDeleteListClicked(list: GroceryListModel)
 
-    fun onApplySortAndFilter(sort: GrocerySort, filter: GroceryFilter)
+    fun onApplySortAndFilter(sort: GrocerySort, filter: GroceryFilter, recipeFilter: String? = null)
 
     fun onDeleteClicked()
 
@@ -65,6 +65,9 @@ interface GroceryListBloc {
         val groupedItems: List<GroceryGroup> = emptyList(),
         val sort: GrocerySort = GrocerySort.AISLE,
         val filter: GroceryFilter = GroceryFilter.ALL,
+        val recipeFilter: String? = null,
+        val availableRecipes: List<String> = emptyList(),
+        val hasNoRecipeItems: Boolean = false,
         val isSyncing: Boolean = false,
         val lists: List<GroceryListModel> = emptyList(),
         val selectedList: GroceryListModel? = null,
@@ -79,5 +82,9 @@ interface GroceryListBloc {
 
     fun interface Factory {
         fun create(context: BlocContext, output: Consumer<Output>): GroceryListBloc
+    }
+
+    companion object {
+        const val NO_RECIPE_FILTER = ""
     }
 }

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -270,7 +270,7 @@ private fun GrocerySortFilterBottomSheet(
         ) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var selectedSort by remember { mutableStateOf(currentSort) }
     var selectedFilter by remember { mutableStateOf(currentFilter) }
     var selectedRecipeFilter by remember { mutableStateOf(currentRecipeFilter) }

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -56,6 +56,7 @@ import chefmate.client.grocery.core.public.generated.resources.Res
 import chefmate.client.grocery.core.public.generated.resources.grocery_add_item
 import chefmate.client.grocery.core.public.generated.resources.grocery_apply
 import chefmate.client.grocery.core.public.generated.resources.grocery_cancel
+import chefmate.client.grocery.core.public.generated.resources.grocery_clear_filters
 import chefmate.client.grocery.core.public.generated.resources.grocery_create_list_cancel
 import chefmate.client.grocery.core.public.generated.resources.grocery_create_list_confirm
 import chefmate.client.grocery.core.public.generated.resources.grocery_create_list_hint
@@ -71,6 +72,8 @@ import chefmate.client.grocery.core.public.generated.resources.grocery_delete_pu
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_all
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_by
+import chefmate.client.grocery.core.public.generated.resources.grocery_filter_by_recipe
+import chefmate.client.grocery.core.public.generated.resources.grocery_filter_no_recipe
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_purchased
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_unpurchased
 import chefmate.client.grocery.core.public.generated.resources.grocery_list
@@ -98,7 +101,11 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
     var showSortFilterSheet by remember { mutableStateOf(false) }
     val hasActiveFilter = state.filter != GroceryListBloc.GroceryFilter.ALL
     val hasNonDefaultSort = state.sort != GroceryListBloc.GrocerySort.AISLE
-    val activeCount = (if (hasActiveFilter) 1 else 0) + (if (hasNonDefaultSort) 1 else 0)
+    val hasRecipeFilter = state.recipeFilter != null
+    val activeCount =
+        (if (hasActiveFilter) 1 else 0) +
+            (if (hasNonDefaultSort) 1 else 0) +
+            (if (hasRecipeFilter) 1 else 0)
 
     PlusNavContainer(
         modifier = modifier.fillMaxSize(),
@@ -210,8 +217,11 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
         GrocerySortFilterBottomSheet(
             currentSort = state.sort,
             currentFilter = state.filter,
-            onApply = { sort, filter ->
-                bloc.onApplySortAndFilter(sort, filter)
+            currentRecipeFilter = state.recipeFilter,
+            availableRecipes = state.availableRecipes,
+            hasNoRecipeItems = state.hasNoRecipeItems,
+            onApply = { sort, filter, recipeFilter ->
+                bloc.onApplySortAndFilter(sort, filter, recipeFilter)
                 showSortFilterSheet = false
             },
             onDismiss = { showSortFilterSheet = false },
@@ -249,22 +259,54 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
 private fun GrocerySortFilterBottomSheet(
     currentSort: GroceryListBloc.GrocerySort,
     currentFilter: GroceryListBloc.GroceryFilter,
-    onApply: (sort: GroceryListBloc.GrocerySort, filter: GroceryListBloc.GroceryFilter) -> Unit,
+    currentRecipeFilter: String?,
+    availableRecipes: List<String>,
+    hasNoRecipeItems: Boolean,
+    onApply:
+        (
+            sort: GroceryListBloc.GrocerySort,
+            filter: GroceryListBloc.GroceryFilter,
+            recipeFilter: String?,
+        ) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
     var selectedSort by remember { mutableStateOf(currentSort) }
     var selectedFilter by remember { mutableStateOf(currentFilter) }
+    var selectedRecipeFilter by remember { mutableStateOf(currentRecipeFilter) }
+
+    val showRecipeSection = availableRecipes.isNotEmpty() || hasNoRecipeItems
+    val hasActiveFilters =
+        selectedSort != GroceryListBloc.GrocerySort.AISLE ||
+            selectedFilter != GroceryListBloc.GroceryFilter.ALL ||
+            selectedRecipeFilter != null
 
     val dimens = ChefMateTheme.dimens
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
             modifier = Modifier.padding(horizontal = dimens.paddingNormal).navigationBarsPadding()
         ) {
-            Text(
-                text = stringResource(Res.string.grocery_sort_and_filter),
-                style = MaterialTheme.typography.titleLarge,
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(Res.string.grocery_sort_and_filter),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+                if (hasActiveFilters) {
+                    TextButton(
+                        onClick = {
+                            selectedSort = GroceryListBloc.GrocerySort.AISLE
+                            selectedFilter = GroceryListBloc.GroceryFilter.ALL
+                            selectedRecipeFilter = null
+                        }
+                    ) {
+                        Text(stringResource(Res.string.grocery_clear_filters))
+                    }
+                }
+            }
             Spacer(Modifier.height(dimens.paddingNormal))
 
             Text(
@@ -319,9 +361,46 @@ private fun GrocerySortFilterBottomSheet(
                     )
                 }
             }
+
+            if (showRecipeSection) {
+                Spacer(Modifier.height(dimens.paddingNormal))
+                Text(
+                    text = stringResource(Res.string.grocery_filter_by_recipe),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(dimens.paddingSmall))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(dimens.paddingSmall)) {
+                    availableRecipes.forEach { recipe ->
+                        FilterChip(
+                            selected = selectedRecipeFilter == recipe,
+                            onClick = {
+                                selectedRecipeFilter =
+                                    if (selectedRecipeFilter == recipe) null else recipe
+                            },
+                            label = { Text(recipe) },
+                        )
+                    }
+                    if (hasNoRecipeItems) {
+                        FilterChip(
+                            selected = selectedRecipeFilter == GroceryListBloc.NO_RECIPE_FILTER,
+                            onClick = {
+                                selectedRecipeFilter =
+                                    if (selectedRecipeFilter == GroceryListBloc.NO_RECIPE_FILTER) {
+                                        null
+                                    } else {
+                                        GroceryListBloc.NO_RECIPE_FILTER
+                                    }
+                            },
+                            label = { Text(stringResource(Res.string.grocery_filter_no_recipe)) },
+                        )
+                    }
+                }
+            }
+
             Spacer(Modifier.height(dimens.paddingNormal))
             Button(
-                onClick = { onApply(selectedSort, selectedFilter) },
+                onClick = { onApply(selectedSort, selectedFilter, selectedRecipeFilter) },
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(Res.string.grocery_apply))


### PR DESCRIPTION
## Summary
- Adds a **"By Recipe"** filter section to the grocery list sort/filter bottom sheet with chips for each recipe name present in the current list plus a **"No Recipe"** option for unlinked items
- Adds a **"Clear"** button in the sheet header that resets sort, filter, and recipe filter to defaults
- Recipe filter badge count is reflected in the app bar filter icon

## Test plan
- [x] Unit tests added for filtering by recipe name, filtering by "No Recipe", available recipes in model, and clearing filters
- [x] Verify bottom sheet shows "By Recipe" section only when items have recipe names
- [x] Verify selecting a recipe chip filters to only that recipe's items
- [x] Verify "No Recipe" chip shows items without a recipe
- [x] Verify "Clear" button resets all filters including recipe filter
- [x] Verify badge count includes recipe filter

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)