### PR TITLE
fix: convert meal planner modals to full-screen navigation

### DIFF
--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -183,6 +183,8 @@ class BottomNavBlocImpl(
         when (output) {
             is MealPlanBloc.Output.OpenRecipe ->
                 this.output.onNext(BottomNavBloc.Output.OpenRecipe(output.recipeId))
+            is MealPlanBloc.Output.OpenMealPlanner ->
+                this.output.onNext(BottomNavBloc.Output.OpenMealPlanner(output.props))
         }
     }
 

--- a/client/bottomnav/public/build.gradle.kts
+++ b/client/bottomnav/public/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
             api(projects.client.browser.public)
             api(projects.client.grocery.core.public)
             api(projects.client.meal.core.public)
+            api(projects.client.recipe.core.public)
             api(projects.client.recipe.list.public)
             api(projects.client.settings.public)
             implementation(projects.client.shared)

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -9,6 +9,7 @@ import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.browser.BrowserBloc
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
 import com.plusmobileapps.chefmate.meal.core.MealPlanBloc
+import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc
 import com.plusmobileapps.chefmate.settings.SettingsBloc
 import kotlinx.coroutines.flow.StateFlow
@@ -56,6 +57,8 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc {
         data object OpenSignUp : Output()
 
         data class OpenUrl(val url: String) : Output()
+
+        data class OpenMealPlanner(val props: MealPlannerRootBloc.Props) : Output()
     }
 
     fun interface Factory {

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
@@ -1,11 +1,5 @@
 package com.plusmobileapps.chefmate.meal.core.impl
 
-import com.arkivanov.decompose.router.slot.ChildSlot
-import com.arkivanov.decompose.router.slot.SlotNavigation
-import com.arkivanov.decompose.router.slot.activate
-import com.arkivanov.decompose.router.slot.childSlot
-import com.arkivanov.decompose.router.slot.dismiss
-import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
@@ -24,14 +18,12 @@ import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.datetime.LocalDate
-import kotlinx.serialization.Serializable
 
 @AssistedInject
 class MealPlanBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: Provider<MealPlanViewModel>,
-    private val mealPlannerRootFactory: MealPlannerRootBloc.Factory,
 ) : MealPlanBloc, BlocContext by context {
 
     @AssistedFactory
@@ -40,17 +32,6 @@ class MealPlanBlocImpl(
     }
 
     private val viewModel: MealPlanViewModel = instanceKeeper.getViewModel { viewModelFactory() }
-
-    private val sheetNavigation = SlotNavigation<SheetConfig>()
-    private val sheetRouter =
-        childSlot(
-            source = sheetNavigation,
-            serializer = SheetConfig.serializer(),
-            key = "MealPlanBloc_Sheet",
-            childFactory = ::createSheet,
-        )
-
-    override val childSlot: Value<ChildSlot<*, MealPlanBloc.Sheet>> = sheetRouter
 
     override val state: StateFlow<MealPlanBloc.Model> =
         viewModel.state.mapState {
@@ -113,33 +94,7 @@ class MealPlanBlocImpl(
     }
 
     override fun onAddMealClicked() {
-        sheetNavigation.activate(SheetConfig.AddMeal)
-    }
-
-    override fun onDismissSheet() {
-        sheetNavigation.dismiss()
-    }
-
-    private fun createSheet(config: SheetConfig, context: BlocContext): MealPlanBloc.Sheet =
-        when (config) {
-            SheetConfig.AddMeal ->
-                MealPlanBloc.Sheet.AddMeal(
-                    bloc =
-                        mealPlannerRootFactory.create(
-                            context = context,
-                            props = MealPlannerRootBloc.Props.FromMealPlanner,
-                            output = { rootOutput ->
-                                when (rootOutput) {
-                                    MealPlannerRootBloc.Output.Finished -> sheetNavigation.dismiss()
-                                }
-                            },
-                        )
-                )
-        }
-
-    @Serializable
-    sealed class SheetConfig {
-        @Serializable data object AddMeal : SheetConfig()
+        output.onNext(Output.OpenMealPlanner(MealPlannerRootBloc.Props.FromMealPlanner))
     }
 }
 

--- a/client/meal/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocTest.kt
+++ b/client/meal/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocTest.kt
@@ -8,7 +8,6 @@ import com.plusmobileapps.chefmate.meal.core.MealPlanBloc
 import com.plusmobileapps.chefmate.meal.data.MealPlanItem
 import com.plusmobileapps.chefmate.meal.data.MealPlanRepository
 import com.plusmobileapps.chefmate.meal.data.MealType
-import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
 import com.plusmobileapps.chefmate.text.FixedString
@@ -37,10 +36,6 @@ class MealPlanBlocTest {
         every { getMealsByDateRange("2026-04-13", "2026-04-19") } returns mealsFlow
     }
 
-    val mealPlannerRootFactory = MealPlannerRootBloc.Factory { _, _, _ ->
-        error("not used in test")
-    }
-
     val bloc =
         MealPlanBlocImpl(
             context = context,
@@ -52,7 +47,6 @@ class MealPlanBlocTest {
                     dateTimeUtil = dateTimeUtil,
                 )
             },
-            mealPlannerRootFactory = mealPlannerRootFactory,
         )
 
     @Test

--- a/client/meal/core/public/build.gradle.kts
+++ b/client/meal/core/public/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
             api(projects.client.shared)
             implementation(compose.components.resources)
             implementation(projects.client.meal.data.public)
-            implementation(projects.client.recipe.core.public)
+            api(projects.client.recipe.core.public)
             implementation(projects.client.ui.public)
             implementation(projects.client.text.public)
             implementation(libs.arkivanov.decompose.compose.extensions)

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanBloc.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanBloc.kt
@@ -1,7 +1,5 @@
 package com.plusmobileapps.chefmate.meal.core
 
-import com.arkivanov.decompose.router.slot.ChildSlot
-import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.meal.data.MealPlanItem
@@ -13,8 +11,6 @@ import kotlinx.datetime.LocalDate
 
 interface MealPlanBloc {
     val state: StateFlow<Model>
-
-    val childSlot: Value<ChildSlot<*, Sheet>>
 
     fun onViewModeSelected(mode: ViewMode)
 
@@ -33,8 +29,6 @@ interface MealPlanBloc {
     fun onMonthDaySelected(date: LocalDate)
 
     fun onAddMealClicked()
-
-    fun onDismissSheet()
 
     data class Model(
         val isLoading: Boolean = true,
@@ -68,12 +62,10 @@ interface MealPlanBloc {
         MONTH,
     }
 
-    sealed class Sheet {
-        data class AddMeal(val bloc: MealPlannerRootBloc) : Sheet()
-    }
-
     sealed class Output {
         data class OpenRecipe(val recipeId: Long) : Output()
+
+        data class OpenMealPlanner(val props: MealPlannerRootBloc.Props) : Output()
     }
 
     fun interface Factory {

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
@@ -11,13 +11,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -28,7 +26,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.CloudDone
 import androidx.compose.material.icons.outlined.CloudOff
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -36,19 +33,13 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
@@ -75,11 +66,9 @@ import chefmate.client.meal.core.public.generated.resources.meal_plan_sync_synce
 import chefmate.client.meal.core.public.generated.resources.meal_plan_sync_syncing
 import chefmate.client.meal.core.public.generated.resources.meal_plan_title
 import chefmate.client.meal.core.public.generated.resources.meal_plan_week
-import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.plusmobileapps.chefmate.meal.data.MealPlanItem
 import com.plusmobileapps.chefmate.meal.data.MealType
 import com.plusmobileapps.chefmate.meal.data.SyncStatus
-import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootScreen
 import com.plusmobileapps.chefmate.text.ResourceString
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
@@ -97,7 +86,6 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun MealPlanScreen(bloc: MealPlanBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     state.mealToDelete?.let {
         PlusDialog(
@@ -109,8 +97,6 @@ fun MealPlanScreen(bloc: MealPlanBloc, modifier: Modifier = Modifier) {
             onDismissRequest = bloc::onDeleteMealDismissed,
         )
     }
-
-    MealPlanSheet(bloc = bloc, sheetState = sheetState)
 
     Box(modifier = modifier.fillMaxSize()) {
         PlusNavContainer(
@@ -171,48 +157,6 @@ fun MealPlanScreen(bloc: MealPlanBloc, modifier: Modifier = Modifier) {
         ) {
             Icon(Icons.Default.Add, contentDescription = null)
             Text(stringResource(Res.string.meal_plan_add_meal))
-        }
-    }
-}
-
-@Composable
-private fun MealPlanSheet(bloc: MealPlanBloc, sheetState: androidx.compose.material3.SheetState) {
-    val slot = bloc.childSlot.subscribeAsState()
-    val child = slot.value.child?.instance
-
-    var sheetChild by remember { mutableStateOf(child) }
-    if (child != null) {
-        sheetChild = child
-    }
-
-    LaunchedEffect(child) {
-        if (child == null && sheetChild != null) {
-            sheetState.hide()
-            sheetChild = null
-        }
-    }
-
-    if (sheetChild != null) {
-        ModalBottomSheet(
-            onDismissRequest = {
-                when (sheetChild) {
-                    is MealPlanBloc.Sheet.AddMeal -> bloc.onDismissSheet()
-                    null -> {}
-                }
-            },
-            sheetState = sheetState,
-            contentWindowInsets = { WindowInsets(0, 0, 0, 0) },
-            dragHandle = {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Spacer(Modifier.statusBarsPadding())
-                    BottomSheetDefaults.DragHandle()
-                }
-            },
-        ) {
-            when (val current = sheetChild) {
-                is MealPlanBloc.Sheet.AddMeal -> MealPlannerRootScreen(current.bloc)
-                null -> {}
-            }
         }
     }
 }

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -235,6 +236,7 @@ private fun MonthView(
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingSmall),
+        contentPadding = PaddingValues(bottom = ChefMateTheme.dimens.fabClearance),
     ) {
         item(key = "month_calendar") {
             MonthCalendar(
@@ -444,6 +446,7 @@ private fun DayView(
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingSmall),
+        contentPadding = PaddingValues(bottom = ChefMateTheme.dimens.fabClearance),
     ) {
         if (dayMeals.breakfast.isNotEmpty()) {
             stickyHeader(key = "breakfast") {
@@ -511,6 +514,7 @@ private fun WeekView(
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingSmall),
+        contentPadding = PaddingValues(bottom = ChefMateTheme.dimens.fabClearance),
     ) {
         weekMeals.forEach { dayGroup ->
             if (dayGroup.meals.isNotEmpty()) {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -12,7 +12,6 @@ import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
-import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc.Output
 import com.plusmobileapps.chefmate.text.FixedString
@@ -36,7 +35,6 @@ class RecipeDetailBlocImpl(
     private val dateTimeUtil: DateTimeUtil,
     private val timeFormatterUtil: TimeFormatterUtil,
     private val addToGroceryList: AddRecipeToGroceryListBloc.Factory,
-    private val mealPlannerRootFactory: MealPlannerRootBloc.Factory,
 ) : RecipeDetailBloc, BlocContext by context {
     @AssistedFactory
     fun interface ManagedFactory {
@@ -119,7 +117,7 @@ class RecipeDetailBlocImpl(
     }
 
     override fun onAddToMealPlanClicked() {
-        sheetNavigation.activate(SheetConfig.AddToMealPlan(recipeId))
+        output.onNext(Output.OpenMealPlanner(recipeId))
     }
 
     override fun onSourceUrlClicked(url: String) {
@@ -167,26 +165,11 @@ class RecipeDetailBlocImpl(
                             },
                         )
                 )
-            is SheetConfig.AddToMealPlan ->
-                RecipeDetailBloc.Sheet.AddToMealPlan(
-                    bloc =
-                        mealPlannerRootFactory.create(
-                            context = context,
-                            props = MealPlannerRootBloc.Props.FromRecipeDetail(config.recipeId),
-                            output = { output ->
-                                when (output) {
-                                    MealPlannerRootBloc.Output.Finished -> sheetNavigation.dismiss()
-                                }
-                            },
-                        )
-                )
         }
 
     @Serializable
     sealed class SheetConfig {
         data class AddToGroceryList(val recipeId: Long) : SheetConfig()
-
-        data class AddToMealPlan(val recipeId: Long) : SheetConfig()
     }
 }
 

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
@@ -10,6 +10,7 @@ import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
@@ -110,6 +111,13 @@ class RecipeRootBlocImpl(
             }
             RecipeDetailBloc.Output.OpenGroceryList -> {
                 this.output.onNext(RecipeRootBloc.Output.OpenGroceryList)
+            }
+            is RecipeDetailBloc.Output.OpenMealPlanner -> {
+                this.output.onNext(
+                    RecipeRootBloc.Output.OpenMealPlanner(
+                        MealPlannerRootBloc.Props.FromRecipeDetail(output.recipeId)
+                    )
+                )
             }
         }
     }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addmeal/ChooseDateScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addmeal/ChooseDateScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -88,101 +89,124 @@ fun ChooseDateScreen(bloc: ChooseDateBloc, showAsChild: Boolean, modifier: Modif
             }
         },
     ) {
-        Row(
-            modifier =
-                Modifier.fillMaxWidth().padding(horizontal = ChefMateTheme.dimens.paddingSmall),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            IconButton(onClick = bloc::onPreviousMonth) {
-                Icon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, contentDescription = null)
-            }
-            Text(text = state.monthLabel, style = MaterialTheme.typography.titleMedium)
-            IconButton(onClick = bloc::onNextMonth) {
-                Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
-            }
-        }
-
-        if (state.selectedDate != null) {
-            Row(
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .padding(horizontal = ChefMateTheme.dimens.paddingNormal),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = state.formattedSelectedDate,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                TextButton(onClick = bloc::onTodayClicked) {
-                    Text(stringResource(Res.string.add_meal_plan_today))
-                }
-            }
-        }
-
-        MonthCalendar(
-            firstDayOfMonth = state.firstDayOfMonth,
-            selectedDate = state.selectedDate,
-            daysWithMeals = state.daysWithMeals,
+        ChooseDateContent(
+            state = state,
+            onPreviousMonth = bloc::onPreviousMonth,
+            onNextMonth = bloc::onNextMonth,
+            onTodayClicked = bloc::onTodayClicked,
             onDaySelected = bloc::onDaySelected,
-            modifier = Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal),
+            modifier = Modifier.fillMaxWidth().weight(1f),
         )
-
-        if (state.selectedDate != null) {
-            SelectedDayMeals(
-                meals = state.selectedDayMeals,
-                modifier = Modifier.fillMaxWidth().weight(1f),
-            )
-        }
     }
 }
 
 @Composable
-private fun SelectedDayMeals(meals: List<MealPlanItem>, modifier: Modifier = Modifier) {
-    if (meals.isEmpty()) {
-        Box(modifier = modifier, contentAlignment = Alignment.Center) {
-            Text(
-                text = stringResource(Res.string.add_meal_plan_no_meals),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+private fun ChooseDateContent(
+    state: ChooseDateBloc.Model,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit,
+    onTodayClicked: () -> Unit,
+    onDaySelected: (LocalDate) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = PaddingValues(bottom = ChefMateTheme.dimens.fabClearance),
+    ) {
+        item(key = "month_nav") {
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth().padding(horizontal = ChefMateTheme.dimens.paddingSmall),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onPreviousMonth) {
+                    Icon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, contentDescription = null)
+                }
+                Text(text = state.monthLabel, style = MaterialTheme.typography.titleMedium)
+                IconButton(onClick = onNextMonth) {
+                    Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+                }
+            }
+        }
+
+        if (state.selectedDate != null) {
+            item(key = "selected_date") {
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(horizontal = ChefMateTheme.dimens.paddingNormal),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = state.formattedSelectedDate,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    TextButton(onClick = onTodayClicked) {
+                        Text(stringResource(Res.string.add_meal_plan_today))
+                    }
+                }
+            }
+        }
+
+        item(key = "calendar") {
+            MonthCalendar(
+                firstDayOfMonth = state.firstDayOfMonth,
+                selectedDate = state.selectedDate,
+                daysWithMeals = state.daysWithMeals,
+                onDaySelected = onDaySelected,
+                modifier = Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal),
             )
         }
-    } else {
-        val breakfast = meals.filter { it.mealType == MealType.BREAKFAST }
-        val lunch = meals.filter { it.mealType == MealType.LUNCH }
-        val dinner = meals.filter { it.mealType == MealType.DINNER }
-        val snacks = meals.filter { it.mealType == MealType.SNACKS }
 
-        LazyColumn(
-            modifier = modifier.padding(horizontal = ChefMateTheme.dimens.paddingNormal),
-            verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingSmall),
-        ) {
-            if (breakfast.isNotEmpty()) {
-                stickyHeader(key = "breakfast") {
-                    MealSectionHeader(stringResource(Res.string.add_meal_plan_breakfast))
+        if (state.selectedDate != null) {
+            val meals = state.selectedDayMeals
+            if (meals.isEmpty()) {
+                item(key = "no_meals") {
+                    Box(
+                        modifier = Modifier.fillMaxWidth().height(120.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(Res.string.add_meal_plan_no_meals),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
-                items(breakfast, key = { it.id }) { meal -> MealRow(meal) }
-            }
-            if (lunch.isNotEmpty()) {
-                stickyHeader(key = "lunch") {
-                    MealSectionHeader(stringResource(Res.string.add_meal_plan_lunch))
+            } else {
+                val breakfast = meals.filter { it.mealType == MealType.BREAKFAST }
+                val lunch = meals.filter { it.mealType == MealType.LUNCH }
+                val dinner = meals.filter { it.mealType == MealType.DINNER }
+                val snacks = meals.filter { it.mealType == MealType.SNACKS }
+
+                if (breakfast.isNotEmpty()) {
+                    stickyHeader(key = "breakfast") {
+                        MealSectionHeader(stringResource(Res.string.add_meal_plan_breakfast))
+                    }
+                    items(breakfast, key = { it.id }) { meal -> MealRow(meal) }
                 }
-                items(lunch, key = { it.id }) { meal -> MealRow(meal) }
-            }
-            if (dinner.isNotEmpty()) {
-                stickyHeader(key = "dinner") {
-                    MealSectionHeader(stringResource(Res.string.add_meal_plan_dinner))
+                if (lunch.isNotEmpty()) {
+                    stickyHeader(key = "lunch") {
+                        MealSectionHeader(stringResource(Res.string.add_meal_plan_lunch))
+                    }
+                    items(lunch, key = { it.id }) { meal -> MealRow(meal) }
                 }
-                items(dinner, key = { it.id }) { meal -> MealRow(meal) }
-            }
-            if (snacks.isNotEmpty()) {
-                stickyHeader(key = "snacks") {
-                    MealSectionHeader(stringResource(Res.string.add_meal_plan_snacks))
+                if (dinner.isNotEmpty()) {
+                    stickyHeader(key = "dinner") {
+                        MealSectionHeader(stringResource(Res.string.add_meal_plan_dinner))
+                    }
+                    items(dinner, key = { it.id }) { meal -> MealRow(meal) }
                 }
-                items(snacks, key = { it.id }) { meal -> MealRow(meal) }
+                if (snacks.isNotEmpty()) {
+                    stickyHeader(key = "snacks") {
+                        MealSectionHeader(stringResource(Res.string.add_meal_plan_snacks))
+                    }
+                    items(snacks, key = { it.id }) { meal -> MealRow(meal) }
+                }
             }
         }
     }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -6,7 +6,6 @@ import com.plusmobileapps.chefmate.BackClickBloc
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
-import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.text.TextData
 import kotlinx.coroutines.flow.StateFlow
@@ -62,12 +61,12 @@ interface RecipeDetailBloc : BackClickBloc {
         data class OpenUrl(val url: String) : Output()
 
         data object OpenGroceryList : Output()
+
+        data class OpenMealPlanner(val recipeId: Long) : Output()
     }
 
     sealed class Sheet {
         data class AddToGroceryList(val bloc: AddRecipeToGroceryListBloc) : Sheet()
-
-        data class AddToMealPlan(val bloc: MealPlannerRootBloc) : Sheet()
     }
 
     interface Factory {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -128,7 +128,6 @@ import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListScreen
-import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootScreen
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
@@ -421,7 +420,6 @@ private fun RecipeDetailSheet(
             onDismissRequest = {
                 when (val current = sheetChild) {
                     is RecipeDetailBloc.Sheet.AddToGroceryList -> current.bloc.onBackClicked()
-                    is RecipeDetailBloc.Sheet.AddToMealPlan -> bloc.onDismissSheet()
                     null -> {}
                 }
             },
@@ -438,7 +436,6 @@ private fun RecipeDetailSheet(
             when (val current = sheetChild) {
                 is RecipeDetailBloc.Sheet.AddToGroceryList ->
                     AddRecipeToGroceryListScreen(current.bloc)
-                is RecipeDetailBloc.Sheet.AddToMealPlan -> MealPlannerRootScreen(current.bloc)
                 null -> {}
             }
         }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/root/RecipeRootBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/root/RecipeRootBloc.kt
@@ -6,6 +6,7 @@ import com.arkivanov.essenty.backhandler.BackHandlerOwner
 import com.plusmobileapps.chefmate.BackClickBloc
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc
 import kotlinx.serialization.Serializable
@@ -25,6 +26,8 @@ interface RecipeRootBloc : BackHandlerOwner, BackClickBloc {
         data class OpenUrl(val url: String) : Output()
 
         data object OpenGroceryList : Output()
+
+        data class OpenMealPlanner(val props: MealPlannerRootBloc.Props) : Output()
     }
 
     @Serializable

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -15,6 +15,7 @@ import com.plusmobileapps.chefmate.browser.BrowserBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc.Props.Detail
 import com.plusmobileapps.chefmate.root.RootBloc.Child.BottomNavigation
@@ -34,6 +35,7 @@ class RootBlocImpl(
     private val browserBlocFactory: BrowserBloc.Factory,
     private val groceryDetail: GroceryDetailBloc.Factory,
     private val recipeRoot: RecipeRootBloc.Factory,
+    private val mealPlannerRoot: MealPlannerRootBloc.Factory,
     private val authentication: AuthenticationBloc.Factory,
 ) : RootBloc, BlocContext by context {
 
@@ -118,6 +120,16 @@ class RootBlocImpl(
                                 bloc.onNavigate()
                             }
                 )
+
+            is Configuration.MealPlanner ->
+                RootBloc.Child.MealPlanner(
+                    bloc =
+                        mealPlannerRoot.create(
+                            context = context,
+                            props = config.props,
+                            output = ::handleMealPlannerOutput,
+                        )
+                )
         }
 
     private fun handleBottomNavOutput(output: BottomNavBloc.Output) {
@@ -149,6 +161,10 @@ class RootBlocImpl(
             is BottomNavBloc.Output.OpenUrl -> {
                 navigation.bringToFront(Configuration.Browser(output.url))
             }
+
+            is BottomNavBloc.Output.OpenMealPlanner -> {
+                navigation.bringToFront(Configuration.MealPlanner(output.props))
+            }
         }
     }
 
@@ -173,6 +189,15 @@ class RootBlocImpl(
                 bottomNavChild?.bloc?.onTabSelected(BottomNavBloc.Tab.GROCERIES)
                 navigation.bringToFront(Configuration.BottomNavigation)
             }
+            is RecipeRootBloc.Output.OpenMealPlanner -> {
+                navigation.bringToFront(Configuration.MealPlanner(output.props))
+            }
+        }
+    }
+
+    private fun handleMealPlannerOutput(output: MealPlannerRootBloc.Output) {
+        when (output) {
+            MealPlannerRootBloc.Output.Finished -> navigation.pop()
         }
     }
 
@@ -198,6 +223,8 @@ class RootBlocImpl(
         data class Authentication(val props: AuthenticationBloc.Props) : Configuration()
 
         @Serializable data class Browser(val url: String) : Configuration()
+
+        @Serializable data class MealPlanner(val props: MealPlannerRootBloc.Props) : Configuration()
     }
 }
 

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -7,6 +7,7 @@ import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.browser.BrowserBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import dev.mokkery.MockMode
@@ -49,6 +50,7 @@ class RootBlocTest {
                 detailOutput = output
                 mock()
             },
+            mealPlannerRoot = MealPlannerRootBloc.Factory { _, _, _ -> mock() },
             authentication = { context, props, output -> mock() },
         )
 

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -9,6 +9,7 @@ import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc
 import com.plusmobileapps.chefmate.browser.BrowserBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 
 interface RootBloc : BackHandlerOwner, BackClickBloc {
@@ -26,6 +27,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class Authentication(val bloc: AuthenticationBloc) : Child()
 
         data class Browser(val bloc: BrowserBloc) : Child()
+
+        data class MealPlanner(val bloc: MealPlannerRootBloc) : Child()
     }
 
     fun interface Factory {

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -20,6 +20,7 @@ import com.plusmobileapps.chefmate.auth.ui.AuthenticationScreen
 import com.plusmobileapps.chefmate.browser.BrowserScreen
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailScreen
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavigationScreen
+import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootScreen
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootScreen
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
@@ -40,7 +41,9 @@ fun RootScreen(rootBloc: RootBloc, modifier: Modifier = Modifier) {
                         stackAnimation { child, otherChild, _ ->
                             if (
                                 child.instance is RootBloc.Child.Browser ||
-                                    otherChild.instance is RootBloc.Child.Browser
+                                    otherChild.instance is RootBloc.Child.Browser ||
+                                    child.instance is RootBloc.Child.MealPlanner ||
+                                    otherChild.instance is RootBloc.Child.MealPlanner
                             ) {
                                 verticalSlide()
                             } else {
@@ -67,6 +70,7 @@ fun RootScreen(rootBloc: RootBloc, modifier: Modifier = Modifier) {
                             maxContentWidth = Dp.Unspecified,
                             content = { BrowserScreen(child.bloc, modifier = Modifier.weight(1f)) },
                         )
+                    is RootBloc.Child.MealPlanner -> MealPlannerRootScreen(child.bloc)
                 }
             },
         )

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/theme/AppDimensions.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/theme/AppDimensions.kt
@@ -11,6 +11,7 @@ data class AppDimensions(
     val paddingLarge: Dp = 24.dp,
     val paddingExtraLarge: Dp = 32.dp,
     val rowHeight: Dp = 56.dp,
+    val fabClearance: Dp = 88.dp,
 )
 
 internal val LocalDimensions = staticCompositionLocalOf { AppDimensions() }


### PR DESCRIPTION
## Summary
- Replaces `ModalBottomSheet` with root-level stack navigation for the meal planner flow, fixing the padding bug between the drag handle and top app bar (#102)
- Both entry points (Recipe Detail "Add to Meal Plan" and Meal Plan tab FAB) now push a full-screen `MealPlannerRootBloc` child with a vertical slide animation
- Removes slot navigation and sheet-related code from `MealPlanBlocImpl` and `RecipeDetailBlocImpl`, replacing with output-based navigation that bubbles up to `RootBlocImpl`

## Test plan
- [x] Open a recipe → tap "Add to Meal Plan" → verify it slides up full-screen with vertical animation
- [x] Press back → verify it slides back down
- [x] Go to Meal Plan tab → tap FAB "Add Meal" → verify full-screen vertical slide
- [x] Verify the "Add to Grocery List" sheet on recipe detail still works as a modal bottom sheet
- [x] Test on Android and iOS

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)