### PR TITLE
fix(serialization): add @Serializable to sealed class subclasses to fix recipe detail crash

### DIFF
--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
@@ -124,9 +124,9 @@ class RecipeRootBlocImpl(
 
     @Serializable
     sealed class Configuration {
-        data class Detail(val recipeId: Long) : Configuration()
+        @Serializable data class Detail(val recipeId: Long) : Configuration()
 
-        data class Edit(val recipeId: Long?) : Configuration()
+        @Serializable data class Edit(val recipeId: Long?) : Configuration()
     }
 }
 

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addmeal/MealPlannerRootBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addmeal/MealPlannerRootBloc.kt
@@ -25,9 +25,9 @@ interface MealPlannerRootBloc : BackHandlerOwner, BackClickBloc {
 
     @Serializable
     sealed class Props {
-        data class FromRecipeDetail(val recipeId: Long) : Props()
+        @Serializable data class FromRecipeDetail(val recipeId: Long) : Props()
 
-        data object FromMealPlanner : Props()
+        @Serializable data object FromMealPlanner : Props()
     }
 
     fun interface Factory {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/root/RecipeRootBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/root/RecipeRootBloc.kt
@@ -32,9 +32,9 @@ interface RecipeRootBloc : BackHandlerOwner, BackClickBloc {
 
     @Serializable
     sealed class Props {
-        data class Detail(val recipeId: Long) : Props()
+        @Serializable data class Detail(val recipeId: Long) : Props()
 
-        data object Create : Props()
+        @Serializable data object Create : Props()
     }
 
     fun interface Factory {


### PR DESCRIPTION
## Report

**Base:** `main` (10201dd)

**Diagnosis:** `RecipeRootBloc.Props`, `RecipeRootBlocImpl.Configuration`, and `MealPlannerRootBloc.Props` are sealed classes annotated with `@Serializable`, but their subclasses were missing individual `@Serializable` annotations. kotlinx.serialization requires every subclass in a polymorphic hierarchy to be individually annotated. When Decompose's state keeper (Essenty) tried to save the back-stack to a Bundle on Android (e.g., when the app was backgrounded with a recipe open), it called the JSON serializer on the `RecipeRoot` configuration, which holds a `RecipeRootBloc.Props`. The serializer couldn't find a registered serializer for `Props.Detail`, producing the crash in the issue.

**Fix:** Add `@Serializable` to each subclass of the three sealed classes:
- `RecipeRootBloc.Props.Detail` and `Props.Create`
- `RecipeRootBlocImpl.Configuration.Detail` and `Configuration.Edit`
- `MealPlannerRootBloc.Props.FromRecipeDetail` and `Props.FromMealPlanner`

**Files changed:**
- `client/recipe/core/public/…/recipe/core/root/RecipeRootBloc.kt`
- `client/recipe/core/impl/…/recipe/core/impl/root/RecipeRootBlocImpl.kt`
- `client/recipe/core/public/…/recipe/core/addmeal/MealPlannerRootBloc.kt`

**SHA:** facaa13

Closes #126

## Test plan
- [x] All existing `RecipeRootBlocImplTest` and `RootBlocTest` JVM tests pass (`./gradlew :client:recipe:core:impl:jvmTest :client:root:impl:jvmTest`)
- [ ] On device/emulator: open a recipe detail, background the app, return — no crash
- [ ] On device/emulator: start adding to meal planner, background the app, return — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)