### PR TITLE
fix(grocery): allow dismissing keyboard on iOS grocery list

### DIFF
--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -2,13 +2,8 @@
 
 package com.plusmobileapps.chefmate.recipe.bottomnav
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -27,9 +22,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
 import chefmate.client.bottomnav.public.generated.resources.Res
 import chefmate.client.bottomnav.public.generated.resources.tab_browser
 import chefmate.client.bottomnav.public.generated.resources.tab_grocery
@@ -103,30 +95,11 @@ private fun TabletNavRailContent(bloc: BottomNavBloc, modifier: Modifier = Modif
 @Composable
 private fun MobileBottomNavContent(bloc: BottomNavBloc, modifier: Modifier = Modifier) {
     val state = bloc.state.collectAsState()
-    val density = LocalDensity.current
-    val imeBottom = WindowInsets.ime.getBottom(density)
-    val isImeVisible = imeBottom > 0
     Scaffold(
         modifier = modifier.fillMaxSize(),
-        contentWindowInsets = WindowInsets(0, 0, 0, 0),
-        bottomBar = {
-            if (!isImeVisible) {
-                PlusBottomBar(state = state.value, onClick = bloc::onTabSelected)
-            }
-        },
+        bottomBar = { PlusBottomBar(state = state.value, onClick = bloc::onTabSelected) },
     ) { paddingValues ->
-        val adjustedPadding =
-            if (isImeVisible) {
-                PaddingValues(
-                    start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
-                    top = paddingValues.calculateTopPadding(),
-                    end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
-                    bottom = 0.dp,
-                )
-            } else {
-                paddingValues
-            }
-        BottomNavContentContainer(modifier = Modifier.padding(adjustedPadding), bloc = bloc)
+        BottomNavContentContainer(modifier = Modifier.padding(paddingValues), bloc = bloc)
     }
 }
 

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -2,7 +2,10 @@
 
 package com.plusmobileapps.chefmate.recipe.bottomnav
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
@@ -25,6 +28,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import chefmate.client.bottomnav.public.generated.resources.Res
 import chefmate.client.bottomnav.public.generated.resources.tab_browser
 import chefmate.client.bottomnav.public.generated.resources.tab_grocery
@@ -103,13 +108,25 @@ private fun MobileBottomNavContent(bloc: BottomNavBloc, modifier: Modifier = Mod
     val isImeVisible = imeBottom > 0
     Scaffold(
         modifier = modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         bottomBar = {
             if (!isImeVisible) {
                 PlusBottomBar(state = state.value, onClick = bloc::onTabSelected)
             }
         },
     ) { paddingValues ->
-        BottomNavContentContainer(modifier = Modifier.padding(paddingValues), bloc = bloc)
+        val adjustedPadding =
+            if (isImeVisible) {
+                PaddingValues(
+                    start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
+                    top = paddingValues.calculateTopPadding(),
+                    end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                    bottom = 0.dp,
+                )
+            } else {
+                paddingValues
+            }
+        BottomNavContentContainer(modifier = Modifier.padding(adjustedPadding), bloc = bloc)
     }
 }
 

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -2,6 +2,7 @@
 
 package com.plusmobileapps.chefmate.recipe.bottomnav
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -102,14 +103,19 @@ private fun MobileBottomNavContent(bloc: BottomNavBloc, modifier: Modifier = Mod
     val isImeVisible = WindowInsets.ime.getBottom(density) > 0
     Scaffold(
         modifier = modifier.fillMaxSize(),
-        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         bottomBar = {
             if (!isImeVisible) {
                 PlusBottomBar(state = state.value, onClick = bloc::onTabSelected)
             }
         },
     ) { paddingValues ->
-        BottomNavContentContainer(modifier = Modifier.padding(paddingValues), bloc = bloc)
+        val contentPadding =
+            if (isImeVisible) {
+                PaddingValues(top = paddingValues.calculateTopPadding())
+            } else {
+                paddingValues
+            }
+        BottomNavContentContainer(modifier = Modifier.padding(contentPadding), bloc = bloc)
     }
 }
 

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -2,8 +2,10 @@
 
 package com.plusmobileapps.chefmate.recipe.bottomnav
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -22,6 +24,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import chefmate.client.bottomnav.public.generated.resources.Res
 import chefmate.client.bottomnav.public.generated.resources.tab_browser
 import chefmate.client.bottomnav.public.generated.resources.tab_grocery
@@ -95,9 +98,16 @@ private fun TabletNavRailContent(bloc: BottomNavBloc, modifier: Modifier = Modif
 @Composable
 private fun MobileBottomNavContent(bloc: BottomNavBloc, modifier: Modifier = Modifier) {
     val state = bloc.state.collectAsState()
+    val density = LocalDensity.current
+    val isImeVisible = WindowInsets.ime.getBottom(density) > 0
     Scaffold(
         modifier = modifier.fillMaxSize(),
-        bottomBar = { PlusBottomBar(state = state.value, onClick = bloc::onTabSelected) },
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        bottomBar = {
+            if (!isImeVisible) {
+                PlusBottomBar(state = state.value, onClick = bloc::onTabSelected)
+            }
+        },
     ) { paddingValues ->
         BottomNavContentContainer(modifier = Modifier.padding(paddingValues), bloc = bloc)
     }

--- a/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="grocery_filter_no_recipe">No Recipe</string>
     <string name="grocery_clear_filters">Clear</string>
     <string name="grocery_apply">Apply</string>
+    <string name="grocery_done">Done</string>
     <string name="grocery_recipe_source">From: {recipe}</string>
     <string name="grocery_category_produce">Produce</string>
     <string name="grocery_category_dairy">Dairy</string>

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -1,5 +1,10 @@
 package com.plusmobileapps.chefmate.grocery.core.list
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -52,6 +57,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -77,6 +83,7 @@ import chefmate.client.grocery.core.public.generated.resources.grocery_delete_it
 import chefmate.client.grocery.core.public.generated.resources.grocery_delete_items_title
 import chefmate.client.grocery.core.public.generated.resources.grocery_delete_list
 import chefmate.client.grocery.core.public.generated.resources.grocery_delete_purchased
+import chefmate.client.grocery.core.public.generated.resources.grocery_done
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_all
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_by
@@ -98,6 +105,7 @@ import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.SyncStatus
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
+import com.plusmobileapps.chefmate.ui.isIosPlatform
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.coroutines.flow.StateFlow
 import org.jetbrains.compose.resources.stringResource
@@ -548,32 +556,52 @@ private fun GroceryListInput(
 ) {
     val state = name.collectAsState()
     val keyboardController = LocalSoftwareKeyboardController.current
-    OutlinedTextField(
-        value = state.value,
-        onValueChange = onNameChange,
-        modifier = modifier.fillMaxWidth(),
-        singleLine = true,
-        keyboardOptions =
-            KeyboardOptions(
-                capitalization = KeyboardCapitalization.Sentences,
-                imeAction = ImeAction.Done,
-            ),
-        keyboardActions =
-            KeyboardActions(
-                onDone = {
-                    if (state.value.isNotBlank()) onAddClick()
+    val focusManager = LocalFocusManager.current
+    val isIos = isIosPlatform()
+    var isFocused by remember { mutableStateOf(false) }
+
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        OutlinedTextField(
+            value = state.value,
+            onValueChange = onNameChange,
+            modifier = Modifier.weight(1f).onFocusChanged { isFocused = it.isFocused },
+            singleLine = true,
+            keyboardOptions =
+                KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Sentences,
+                    imeAction = ImeAction.Done,
+                ),
+            keyboardActions =
+                KeyboardActions(
+                    onDone = {
+                        if (state.value.isNotBlank()) onAddClick()
+                        keyboardController?.hide()
+                    }
+                ),
+            trailingIcon = {
+                IconButton(onClick = onAddClick, enabled = state.value.isNotBlank()) {
+                    Icon(
+                        Icons.Default.Add,
+                        contentDescription = stringResource(Res.string.grocery_add_item),
+                    )
+                }
+            },
+        )
+        AnimatedVisibility(
+            visible = isIos && isFocused,
+            enter = fadeIn() + expandHorizontally(),
+            exit = fadeOut() + shrinkHorizontally(),
+        ) {
+            TextButton(
+                onClick = {
+                    focusManager.clearFocus()
                     keyboardController?.hide()
                 }
-            ),
-        trailingIcon = {
-            IconButton(onClick = onAddClick, enabled = state.value.isNotBlank()) {
-                Icon(
-                    Icons.Default.Add,
-                    contentDescription = stringResource(Res.string.grocery_add_item),
-                )
+            ) {
+                Text(stringResource(Res.string.grocery_done))
             }
-        },
-    )
+        }
+    }
 }
 
 @Composable

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.grocery.core.list
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -14,6 +15,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
@@ -49,8 +52,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import chefmate.client.grocery.core.public.generated.resources.Res
 import chefmate.client.grocery.core.public.generated.resources.grocery_add_item
@@ -106,6 +114,7 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
         (if (hasActiveFilter) 1 else 0) +
             (if (hasNonDefaultSort) 1 else 0) +
             (if (hasRecipeFilter) 1 else 0)
+    val focusManager = LocalFocusManager.current
 
     PlusNavContainer(
         modifier = modifier.fillMaxSize(),
@@ -193,7 +202,10 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
                         bloc.onGroceryItemCheckedChange(it, !it.isChecked)
                     }
                 },
-                modifier = Modifier.weight(1f),
+                modifier =
+                    Modifier.weight(1f).pointerInput(Unit) {
+                        detectTapGestures(onTap = { focusManager.clearFocus() })
+                    },
                 showHeaders = state.sort == GroceryListBloc.GrocerySort.AISLE,
                 trailingContent = { displayItem ->
                     val item = itemLookup[displayItem.key as Long]
@@ -535,10 +547,24 @@ private fun GroceryListInput(
     modifier: Modifier = Modifier,
 ) {
     val state = name.collectAsState()
+    val keyboardController = LocalSoftwareKeyboardController.current
     OutlinedTextField(
         value = state.value,
         onValueChange = onNameChange,
         modifier = modifier.fillMaxWidth(),
+        singleLine = true,
+        keyboardOptions =
+            KeyboardOptions(
+                capitalization = KeyboardCapitalization.Sentences,
+                imeAction = ImeAction.Done,
+            ),
+        keyboardActions =
+            KeyboardActions(
+                onDone = {
+                    if (state.value.isNotBlank()) onAddClick()
+                    keyboardController?.hide()
+                }
+            ),
         trailingIcon = {
             IconButton(onClick = onAddClick, enabled = state.value.isNotBlank()) {
                 Icon(

--- a/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.android.kt
+++ b/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.android.kt
@@ -1,0 +1,7 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable actual fun isIosPlatform(): Boolean = false

--- a/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.android.kt
+++ b/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.android.kt
@@ -2,6 +2,4 @@
 
 package com.plusmobileapps.chefmate.ui
 
-import androidx.compose.runtime.Composable
-
-@Composable actual fun isIosPlatform(): Boolean = false
+actual fun isIosPlatform(): Boolean = false

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.kt
@@ -1,6 +1,4 @@
 package com.plusmobileapps.chefmate.ui
 
-import androidx.compose.runtime.Composable
-
 /** Returns true when running on an iOS device. */
-@Composable expect fun isIosPlatform(): Boolean
+expect fun isIosPlatform(): Boolean

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.kt
@@ -1,0 +1,6 @@
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.runtime.Composable
+
+/** Returns true when running on an iOS device. */
+@Composable expect fun isIosPlatform(): Boolean

--- a/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.ios.kt
+++ b/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.ios.kt
@@ -2,6 +2,4 @@
 
 package com.plusmobileapps.chefmate.ui
 
-import androidx.compose.runtime.Composable
-
-@Composable actual fun isIosPlatform(): Boolean = true
+actual fun isIosPlatform(): Boolean = true

--- a/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.ios.kt
+++ b/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.ios.kt
@@ -1,0 +1,7 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable actual fun isIosPlatform(): Boolean = true

--- a/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.jvm.kt
+++ b/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.jvm.kt
@@ -1,0 +1,7 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable actual fun isIosPlatform(): Boolean = false

--- a/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.jvm.kt
+++ b/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.jvm.kt
@@ -2,6 +2,4 @@
 
 package com.plusmobileapps.chefmate.ui
 
-import androidx.compose.runtime.Composable
-
-@Composable actual fun isIosPlatform(): Boolean = false
+actual fun isIosPlatform(): Boolean = false


### PR DESCRIPTION
## Summary
- Adds `ImeAction.Done` + a `KeyboardActions { onDone }` handler on the grocery list input — tapping the iOS keyboard's "Done" key now adds the item (if non-blank) and dismisses the keyboard.
- Adds tap-outside-to-dismiss on the grocery list area via `pointerInput { detectTapGestures }` + `LocalFocusManager.clearFocus()`, matching iOS muscle memory.
- Sets `singleLine = true` and `KeyboardCapitalization.Sentences` on the input while we're in there.

The pattern mirrors the existing keyboard handling in `AuthenticationScreen.kt` (`LocalSoftwareKeyboardController` + `ImeAction`).

Closes #121.

## Test plan
- [x] iOS sim: tap grocery input → keyboard appears → tap "Done" → keyboard dismisses, item is added when non-blank
- [x] iOS sim: tap input → tap empty list area → keyboard dismisses
- [x] iOS sim: trailing "+" icon still adds items in rapid succession (keyboard stays open intentionally)
- [x] Android regression: IME action and trailing icon both still add items
- [x] `./gradlew :client:grocery:core:impl:test` ✅ already passing locally
- [x] `./gradlew ktfmtCheck` ✅ already passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)