### PR TITLE
feat(sync): add pull-to-refresh to all tabs and fix meal planner sync

### DIFF
--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -185,46 +186,52 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
                 remember(state.groupedItems) {
                     state.groupedItems.flatMap { it.items }.associateBy { it.id }
                 }
-            GroceryGroupedList(
-                groups =
-                    state.groupedItems.map { group ->
-                        GroceryDisplayGroup(
-                            category = group.category,
-                            items =
-                                group.items.map { item ->
-                                    GroceryDisplayItem(
-                                        key = item.id,
-                                        displayName = item.displayName,
-                                        quantity = item.quantity,
-                                        isChecked = item.isChecked,
-                                        recipeName = item.recipeName,
-                                    )
-                                },
-                        )
+            PullToRefreshBox(
+                isRefreshing = state.isSyncing,
+                onRefresh = bloc::onSyncClicked,
+                modifier = Modifier.weight(1f),
+            ) {
+                GroceryGroupedList(
+                    groups =
+                        state.groupedItems.map { group ->
+                            GroceryDisplayGroup(
+                                category = group.category,
+                                items =
+                                    group.items.map { item ->
+                                        GroceryDisplayItem(
+                                            key = item.id,
+                                            displayName = item.displayName,
+                                            quantity = item.quantity,
+                                            isChecked = item.isChecked,
+                                            recipeName = item.recipeName,
+                                        )
+                                    },
+                            )
+                        },
+                    onItemClick = { key ->
+                        itemLookup[key as Long]?.let { bloc.onGroceryItemClicked(it) }
                     },
-                onItemClick = { key ->
-                    itemLookup[key as Long]?.let { bloc.onGroceryItemClicked(it) }
-                },
-                onCheckedChange = { key ->
-                    itemLookup[key as Long]?.let {
-                        bloc.onGroceryItemCheckedChange(it, !it.isChecked)
-                    }
-                },
-                modifier =
-                    Modifier.weight(1f).pointerInput(Unit) {
-                        detectTapGestures(onTap = { focusManager.clearFocus() })
+                    onCheckedChange = { key ->
+                        itemLookup[key as Long]?.let {
+                            bloc.onGroceryItemCheckedChange(it, !it.isChecked)
+                        }
                     },
-                showHeaders = state.sort == GroceryListBloc.GrocerySort.AISLE,
-                trailingContent = { displayItem ->
-                    val item = itemLookup[displayItem.key as Long]
-                    if (item != null) {
-                        GroceryItemTrailingContent(
-                            item = item,
-                            onDeleteClick = { bloc.onGroceryItemDelete(item) },
-                        )
-                    }
-                },
-            )
+                    modifier =
+                        Modifier.fillMaxSize().pointerInput(Unit) {
+                            detectTapGestures(onTap = { focusManager.clearFocus() })
+                        },
+                    showHeaders = state.sort == GroceryListBloc.GrocerySort.AISLE,
+                    trailingContent = { displayItem ->
+                        val item = itemLookup[displayItem.key as Long]
+                        if (item != null) {
+                            GroceryItemTrailingContent(
+                                item = item,
+                                onDeleteClick = { bloc.onGroceryItemDelete(item) },
+                            )
+                        }
+                    },
+                )
+            }
             GroceryListInput(
                 name = bloc.newGroceryItemName,
                 onNameChange = bloc::onNewGroceryItemNameChange,

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
@@ -37,6 +37,7 @@ class MealPlanBlocImpl(
         viewModel.state.mapState {
             MealPlanBloc.Model(
                 isLoading = it.isLoading,
+                isSyncing = it.isSyncing,
                 viewMode = it.viewMode,
                 dateLabel = FixedString(viewModel.getDateLabel()),
                 dayMeals =
@@ -95,6 +96,10 @@ class MealPlanBlocImpl(
 
     override fun onAddMealClicked() {
         output.onNext(Output.OpenMealPlanner(MealPlannerRootBloc.Props.FromMealPlanner))
+    }
+
+    override fun onSyncClicked() {
+        viewModel.onSyncClicked()
     }
 }
 

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanViewModel.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanViewModel.kt
@@ -100,6 +100,17 @@ class MealPlanViewModel(
         _state.update { it.copy(mealToDelete = null) }
     }
 
+    fun onSyncClicked() {
+        scope.launch {
+            _state.update { it.copy(isSyncing = true) }
+            try {
+                repository.syncAllUnsynced()
+            } finally {
+                _state.update { it.copy(isSyncing = false) }
+            }
+        }
+    }
+
     fun getDateLabel(): String {
         val current = _state.value
         return when (current.viewMode) {
@@ -191,6 +202,7 @@ class MealPlanViewModel(
 
     data class State(
         val isLoading: Boolean = true,
+        val isSyncing: Boolean = false,
         val viewMode: MealPlanBloc.ViewMode = MealPlanBloc.ViewMode.DAY,
         val currentDate: LocalDate = LocalDate(2000, 1, 1),
         val selectedMonthDay: LocalDate = LocalDate(2000, 1, 1),

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanBloc.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanBloc.kt
@@ -30,8 +30,11 @@ interface MealPlanBloc {
 
     fun onAddMealClicked()
 
+    fun onSyncClicked()
+
     data class Model(
         val isLoading: Boolean = true,
+        val isSyncing: Boolean = false,
         val viewMode: ViewMode = ViewMode.DAY,
         val dateLabel: TextData = FixedString(""),
         val dayMeals: DayMeals? = null,

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -117,34 +118,43 @@ fun MealPlanScreen(bloc: MealPlanBloc, modifier: Modifier = Modifier) {
                         onNext = bloc::onNextClicked,
                     )
 
-                    if (state.isLoading) {
-                        Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
-                            PlusLoadingIndicator()
-                        }
-                    } else {
-                        when (state.viewMode) {
-                            MealPlanBloc.ViewMode.DAY ->
-                                DayView(
-                                    dayMeals = state.dayMeals,
-                                    onMealClicked = bloc::onMealClicked,
-                                    onDeleteClicked = bloc::onDeleteMealClicked,
-                                    modifier = Modifier.weight(1f),
-                                )
-                            MealPlanBloc.ViewMode.WEEK ->
-                                WeekView(
-                                    weekMeals = state.weekMeals.orEmpty(),
-                                    onMealClicked = bloc::onMealClicked,
-                                    onDeleteClicked = bloc::onDeleteMealClicked,
-                                    modifier = Modifier.weight(1f),
-                                )
-                            MealPlanBloc.ViewMode.MONTH ->
-                                MonthView(
-                                    monthModel = state.monthModel,
-                                    onDaySelected = bloc::onMonthDaySelected,
-                                    onMealClicked = bloc::onMealClicked,
-                                    onDeleteClicked = bloc::onDeleteMealClicked,
-                                    modifier = Modifier.weight(1f),
-                                )
+                    PullToRefreshBox(
+                        isRefreshing = state.isSyncing,
+                        onRefresh = bloc::onSyncClicked,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        if (state.isLoading) {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                PlusLoadingIndicator()
+                            }
+                        } else {
+                            when (state.viewMode) {
+                                MealPlanBloc.ViewMode.DAY ->
+                                    DayView(
+                                        dayMeals = state.dayMeals,
+                                        onMealClicked = bloc::onMealClicked,
+                                        onDeleteClicked = bloc::onDeleteMealClicked,
+                                        modifier = Modifier.fillMaxSize(),
+                                    )
+                                MealPlanBloc.ViewMode.WEEK ->
+                                    WeekView(
+                                        weekMeals = state.weekMeals.orEmpty(),
+                                        onMealClicked = bloc::onMealClicked,
+                                        onDeleteClicked = bloc::onDeleteMealClicked,
+                                        modifier = Modifier.fillMaxSize(),
+                                    )
+                                MealPlanBloc.ViewMode.MONTH ->
+                                    MonthView(
+                                        monthModel = state.monthModel,
+                                        onDaySelected = bloc::onMonthDaySelected,
+                                        onMealClicked = bloc::onMealClicked,
+                                        onDeleteClicked = bloc::onDeleteMealClicked,
+                                        modifier = Modifier.fillMaxSize(),
+                                    )
+                            }
                         }
                     }
                 }

--- a/client/meal/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/impl/MealPlanRepositoryImpl.kt
+++ b/client/meal/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/impl/MealPlanRepositoryImpl.kt
@@ -101,6 +101,13 @@ class MealPlanRepositoryImpl(
         }
     }
 
+    override suspend fun syncAllUnsynced() {
+        val authState = authRepository.state.value
+        if (authState is AuthState.Authenticated) {
+            syncWithRemote(authState.user.userId)
+        }
+    }
+
     private fun pushAddToRemote(localId: Long) {
         val authState = authRepository.state.value
         if (authState !is AuthState.Authenticated) return

--- a/client/meal/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/MealPlanRepository.kt
+++ b/client/meal/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/MealPlanRepository.kt
@@ -10,4 +10,6 @@ interface MealPlanRepository {
     suspend fun addMeal(recipeId: Long, date: String, mealType: MealType)
 
     suspend fun removeMeal(id: Long)
+
+    suspend fun syncAllUnsynced()
 }

--- a/client/meal/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/testing/FakeMealPlanRepository.kt
+++ b/client/meal/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/testing/FakeMealPlanRepository.kt
@@ -37,4 +37,8 @@ class FakeMealPlanRepository : MealPlanRepository {
     override suspend fun removeMeal(id: Long) {
         _meals.update { items -> items.filter { it.id != id } }
     }
+
+    override suspend fun syncAllUnsynced() {
+        // No-op in fake
+    }
 }

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
@@ -38,6 +38,7 @@ class RecipeListBlocImpl(
         viewModel.state.mapState {
             RecipeListBloc.Model(
                 isLoading = it.isLoading,
+                isSyncing = it.isSyncing,
                 recipes = it.displayRecipes.map { recipe -> recipe.toRecipeListItem() },
                 totalRecipeCount = it.recipes.size,
                 currentSort = it.currentSort,
@@ -90,6 +91,10 @@ class RecipeListBlocImpl(
 
     override fun onBrowseRecipesClicked() {
         output.onNext(Output.OpenBrowser)
+    }
+
+    override fun onSyncClicked() {
+        viewModel.onSyncClicked()
     }
 
     private fun Recipe.toRecipeListItem(): RecipeListItem =

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
@@ -109,8 +109,20 @@ class RecipeListViewModel(
         _state.update { it.copy(searchQuery = query) }
     }
 
+    fun onSyncClicked() {
+        scope.launch {
+            _state.update { it.copy(isSyncing = true) }
+            try {
+                repository.syncAllUnsynced()
+            } finally {
+                _state.update { it.copy(isSyncing = false) }
+            }
+        }
+    }
+
     data class State(
         val isLoading: Boolean = true,
+        val isSyncing: Boolean = false,
         val recipes: List<Recipe> = emptyList(),
         val currentSort: RecipeSortOption = RecipeSortOption.RECENTLY_ADDED,
         val activeFilters: Set<RecipeFilterOption> = emptySet(),

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
@@ -29,10 +29,13 @@ interface RecipeListBloc {
 
     fun onBrowseRecipesClicked()
 
+    fun onSyncClicked()
+
     data class Model(
         val recipes: List<RecipeListItem> = emptyList(),
         val totalRecipeCount: Int = 0,
         val isLoading: Boolean = false,
+        val isSyncing: Boolean = false,
         val currentSort: RecipeSortOption = RecipeSortOption.RECENTLY_ADDED,
         val activeFilters: Set<RecipeFilterOption> = emptySet(),
         val isGridView: Boolean = false,

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -209,39 +210,45 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                     },
                 )
             }
-            when {
-                !state.isLoading && state.totalRecipeCount == 0 -> {
-                    NoRecipesEmptyState(
-                        onBrowseClicked = bloc::onBrowseRecipesClicked,
-                        onCreateClicked = bloc::onAddRecipeClicked,
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-                state.recipes.isEmpty() && state.isSearchActive -> {
-                    SearchEmptyState(modifier = Modifier.weight(1f))
-                }
-                state.recipes.isEmpty() && state.activeFilters.isNotEmpty() -> {
-                    FilterEmptyState(
-                        activeFilters = state.activeFilters,
-                        onClearFilters = bloc::onClearFilters,
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-                state.isGridView -> {
-                    RecipeGrid(
-                        modifier = Modifier.weight(1f),
-                        recipes = state.recipes,
-                        onRecipeClicked = bloc::onRecipeClicked,
-                        state = gridState,
-                    )
-                }
-                else -> {
-                    RecipeList(
-                        modifier = Modifier.weight(1f),
-                        recipes = state.recipes,
-                        onRecipeClicked = bloc::onRecipeClicked,
-                        state = listState,
-                    )
+            PullToRefreshBox(
+                isRefreshing = state.isSyncing,
+                onRefresh = bloc::onSyncClicked,
+                modifier = Modifier.weight(1f),
+            ) {
+                when {
+                    !state.isLoading && state.totalRecipeCount == 0 -> {
+                        NoRecipesEmptyState(
+                            onBrowseClicked = bloc::onBrowseRecipesClicked,
+                            onCreateClicked = bloc::onAddRecipeClicked,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                    state.recipes.isEmpty() && state.isSearchActive -> {
+                        SearchEmptyState(modifier = Modifier.fillMaxSize())
+                    }
+                    state.recipes.isEmpty() && state.activeFilters.isNotEmpty() -> {
+                        FilterEmptyState(
+                            activeFilters = state.activeFilters,
+                            onClearFilters = bloc::onClearFilters,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                    state.isGridView -> {
+                        RecipeGrid(
+                            modifier = Modifier.fillMaxSize(),
+                            recipes = state.recipes,
+                            onRecipeClicked = bloc::onRecipeClicked,
+                            state = gridState,
+                        )
+                    }
+                    else -> {
+                        RecipeList(
+                            modifier = Modifier.fillMaxSize(),
+                            recipes = state.recipes,
+                            onRecipeClicked = bloc::onRecipeClicked,
+                            state = listState,
+                        )
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Summary
- Adds pull-to-refresh (swipe down) to **recipe list**, **grocery list**, and **meal planner** screens using Material3 `PullToRefreshBox`
- Exposes `syncAllUnsynced()` on `MealPlanRepository` so meal plans can be manually synced — previously sync only triggered on auth state change, which meant meals added after initial login were never pushed to remote
- Wires up `onSyncClicked()` + `isSyncing` state through BLoC → ViewModel → Repository for recipes and meal planner (grocery already had this)

Closes #125

## Test plan
- [x] JVM desktop build compiles successfully
- [x] Existing tests pass (`meal:core:impl:test`, `recipe:list:impl:test`)
- [x] Verify pull-to-refresh gesture works on recipe list (syncs unsynced recipes)
- [x] Verify pull-to-refresh gesture works on grocery list (existing sync, now with gesture)
- [x] Verify pull-to-refresh gesture works on meal planner (syncs meal plans)
- [x] Verify meal planner meals sync to Supabase after pull-to-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)