### PR TITLE
ci: add Gradle and Konan caching to tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,13 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Cache Kotlin/Native compiler and toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-konan-
       - run: ./gradlew iosSimulatorArm64Test --continue
       - name: Publish test report
         uses: dorny/test-reporter@v2


### PR DESCRIPTION
## Summary

- `gradle/actions/setup-gradle@v4` was already in use (handles `~/.gradle/caches`, `~/.gradle/wrapper`, config cache, and build outputs automatically) — no change needed there.
- Added a manual `actions/cache@v4` step for `~/.konan` to the **`ios-tests`** job, which is the single biggest time sink on KMP CI: the Kotlin/Native LLVM toolchain (~1 GB) is downloaded fresh on every run without it.
- Cache key: `${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}` with a prefix-only restore key so partial hits still land.

## Why only the `ios-tests` job

The `jvm-android-tests` job runs on `ubuntu-latest` and only exercises JVM/Android targets — no Kotlin/Native compilation, so Konan caching has no effect there.

## Workflows touched

| Workflow | Changed | Reason |
|---|---|---|
| `.github/workflows/tests.yml` | ✅ | Primary target — `ios-tests` job on `macos-15` exercises `iosSimulatorArm64Test` |
| `.github/workflows/ios-release.yml` | ❌ intentionally skipped | Runs Fastlane `ios release` on `macos-15` and would also benefit, but the task scope was tests-workflow-first; release workflows are a separate change |
| `android-release.yml`, `build-release.yml`, `desktop-release.yml` | ❌ | JVM/Android or desktop-JVM targets — no Konan involved |

## Estimated impact

- **First run (cold):** same as today — Konan toolchain downloads as usual.
- **Subsequent runs (warm cache, same dependency lockset):** iOS job should be **3–5× faster** — skipping the ~1 GB Konan download/unpack is typically the dominant cost on a fresh `macos-15` runner.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)