### PR TITLE
feat(settings): add sign out confirmation dialog

### DIFF
--- a/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
+++ b/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
@@ -2,6 +2,7 @@ package com.plusmobileapps.chefmate.auth.data.testing
 
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.data.ChefMateUser
 import com.plusmobileapps.chefmate.auth.data.SignUpResult
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,6 +13,10 @@ class FakeAuthenticationRepository : AuthenticationRepository {
 
     fun setState(state: AuthState) {
         _state.value = state
+    }
+
+    fun setAuthenticated(user: ChefMateUser = fakeUser()) {
+        _state.value = AuthState.Authenticated(user)
     }
 
     override suspend fun signInWithEmailAndPassword(email: String, password: String) =
@@ -25,4 +30,13 @@ class FakeAuthenticationRepository : AuthenticationRepository {
     }
 
     override suspend fun sendPasswordResetEmail(email: String) = Result.success(Unit)
+
+    companion object {
+        fun fakeUser() = ChefMateUser(
+            userId = "test-id",
+            userName = "Test User",
+            userEmail = "test@example.com",
+            userProfileImageUrl = null,
+        )
+    }
 }

--- a/client/settings/impl/build.gradle.kts
+++ b/client/settings/impl/build.gradle.kts
@@ -10,6 +10,11 @@ kotlin {
             implementation(projects.client.grocery.data.public)
             implementation(projects.client.recipe.data.public)
         }
+        commonTest.dependencies {
+            implementation(projects.client.auth.data.testing)
+            implementation(projects.client.grocery.data.testing)
+            implementation(projects.client.recipe.data.testing)
+        }
     }
 }
 

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -40,6 +40,7 @@ class SettingsBlocImpl(
                     it.emailAwaitingVerification?.let { email ->
                         createEmailVerificationMessage(email)
                     },
+                showSignOutConfirmationDialog = it.showSignOutConfirmationDialog,
             )
         }
 
@@ -52,7 +53,15 @@ class SettingsBlocImpl(
     }
 
     override fun onSignOutClicked() {
+        viewModel.showSignOutConfirmationDialog()
+    }
+
+    override fun onSignOutConfirmed() {
         viewModel.signOut()
+    }
+
+    override fun onSignOutDismissed() {
+        viewModel.dismissSignOutConfirmationDialog()
     }
 
     override fun onUrlClicked(url: String) {

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @Inject
@@ -64,7 +65,16 @@ class SettingsViewModel(
             .launchIn(scope)
     }
 
+    fun showSignOutConfirmationDialog() {
+        _state.update { it.copy(showSignOutConfirmationDialog = true) }
+    }
+
+    fun dismissSignOutConfirmationDialog() {
+        _state.update { it.copy(showSignOutConfirmationDialog = false) }
+    }
+
     fun signOut() {
+        _state.update { it.copy(showSignOutConfirmationDialog = false) }
         scope.launch {
             authenticationRepository.signOut()
             groceryRepository.clearLocalData()
@@ -77,5 +87,6 @@ class SettingsViewModel(
         val isAuthenticated: Boolean = false,
         val userName: String? = null,
         val emailAwaitingVerification: String? = null,
+        val showSignOutConfirmationDialog: Boolean = false,
     )
 }

--- a/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImplTest.kt
+++ b/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImplTest.kt
@@ -4,8 +4,6 @@
 package com.plusmobileapps.chefmate.settings.impl
 
 import app.cash.turbine.test
-import com.plusmobileapps.chefmate.auth.data.AuthState
-import com.plusmobileapps.chefmate.auth.data.ChefMateUser
 import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
 import com.plusmobileapps.chefmate.grocery.data.testing.FakeGroceryRepository
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
@@ -42,7 +40,7 @@ class SettingsBlocImplTest {
 
     @Test
     fun When_sign_out_clicked_Then_confirmation_dialog_is_shown() = runTest {
-        authRepository.setState(AuthState.Authenticated(fakeUser()))
+        authRepository.setAuthenticated()
 
         bloc.state.test {
             awaitItem() // initial authenticated state
@@ -55,7 +53,7 @@ class SettingsBlocImplTest {
 
     @Test
     fun When_sign_out_dismissed_Then_confirmation_dialog_is_hidden() = runTest {
-        authRepository.setState(AuthState.Authenticated(fakeUser()))
+        authRepository.setAuthenticated()
 
         bloc.state.test {
             awaitItem()
@@ -70,7 +68,7 @@ class SettingsBlocImplTest {
 
     @Test
     fun When_sign_out_confirmed_Then_user_is_signed_out() = runTest {
-        authRepository.setState(AuthState.Authenticated(fakeUser()))
+        authRepository.setAuthenticated()
         bloc.onSignOutClicked()
         bloc.onSignOutConfirmed()
 
@@ -80,7 +78,7 @@ class SettingsBlocImplTest {
 
     @Test
     fun When_sign_out_confirmed_Then_dialog_is_hidden() = runTest {
-        authRepository.setState(AuthState.Authenticated(fakeUser()))
+        authRepository.setAuthenticated()
 
         bloc.state.test {
             awaitItem()
@@ -117,16 +115,9 @@ class SettingsBlocImplTest {
         bloc.state.test {
             awaitItem().isAuthenticated shouldBe false
 
-            authRepository.setState(AuthState.Authenticated(fakeUser()))
+            authRepository.setAuthenticated()
             awaitItem().isAuthenticated shouldBe true
         }
     }
 
-    private fun fakeUser() =
-        ChefMateUser(
-            userId = "test-id",
-            userName = "Test User",
-            userEmail = "test@example.com",
-            userProfileImageUrl = null,
-        )
 }

--- a/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImplTest.kt
+++ b/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImplTest.kt
@@ -1,0 +1,132 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.plusmobileapps.chefmate.settings.impl
+
+import app.cash.turbine.test
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.ChefMateUser
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.grocery.data.testing.FakeGroceryRepository
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
+import com.plusmobileapps.chefmate.settings.SettingsBloc
+import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.plusmobileapps.chefmate.testing.TestConsumer
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+
+class SettingsBlocImplTest {
+
+    private val context = TestBlocContext.create()
+    private val output = TestConsumer<SettingsBloc.Output>()
+    private val authRepository = FakeAuthenticationRepository()
+    private val groceryRepository = FakeGroceryRepository()
+    private val recipeRepository = FakeRecipeRepository()
+
+    private val bloc by lazy {
+        SettingsBlocImpl(
+            context = context,
+            output = output,
+            viewModelFactory = {
+                SettingsViewModel(
+                    mainContext = context.mainContext,
+                    authenticationRepository = authRepository,
+                    groceryRepository = groceryRepository,
+                    recipeRepository = recipeRepository,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun When_sign_out_clicked_Then_confirmation_dialog_is_shown() = runTest {
+        authRepository.setState(AuthState.Authenticated(fakeUser()))
+
+        bloc.state.test {
+            awaitItem() // initial authenticated state
+
+            bloc.onSignOutClicked()
+
+            awaitItem().showSignOutConfirmationDialog shouldBe true
+        }
+    }
+
+    @Test
+    fun When_sign_out_dismissed_Then_confirmation_dialog_is_hidden() = runTest {
+        authRepository.setState(AuthState.Authenticated(fakeUser()))
+
+        bloc.state.test {
+            awaitItem()
+
+            bloc.onSignOutClicked()
+            awaitItem().showSignOutConfirmationDialog shouldBe true
+
+            bloc.onSignOutDismissed()
+            awaitItem().showSignOutConfirmationDialog shouldBe false
+        }
+    }
+
+    @Test
+    fun When_sign_out_confirmed_Then_user_is_signed_out() = runTest {
+        authRepository.setState(AuthState.Authenticated(fakeUser()))
+        bloc.onSignOutClicked()
+        bloc.onSignOutConfirmed()
+
+        bloc.state.value.isAuthenticated shouldBe false
+        bloc.state.value.showSignOutConfirmationDialog shouldBe false
+    }
+
+    @Test
+    fun When_sign_out_confirmed_Then_dialog_is_hidden() = runTest {
+        authRepository.setState(AuthState.Authenticated(fakeUser()))
+
+        bloc.state.test {
+            awaitItem()
+            bloc.onSignOutClicked()
+            awaitItem()
+
+            bloc.onSignOutConfirmed()
+            awaitItem().showSignOutConfirmationDialog shouldBe false
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun When_sign_in_clicked_Then_OpenSignIn_output_emitted() {
+        bloc.onSignInClicked()
+        output.lastValue shouldBe SettingsBloc.Output.OpenSignIn
+    }
+
+    @Test
+    fun When_sign_up_clicked_Then_OpenSignUp_output_emitted() {
+        bloc.onSignUpClicked()
+        output.lastValue shouldBe SettingsBloc.Output.OpenSignUp
+    }
+
+    @Test
+    fun When_url_clicked_Then_OpenUrl_output_emitted() {
+        val url = "https://example.com"
+        bloc.onUrlClicked(url)
+        output.lastValue shouldBe SettingsBloc.Output.OpenUrl(url)
+    }
+
+    @Test
+    fun When_authenticated_Then_state_reflects_authenticated() = runTest {
+        bloc.state.test {
+            awaitItem().isAuthenticated shouldBe false
+
+            authRepository.setState(AuthState.Authenticated(fakeUser()))
+            awaitItem().isAuthenticated shouldBe true
+        }
+    }
+
+    private fun fakeUser() =
+        ChefMateUser(
+            userId = "test-id",
+            userName = "Test User",
+            userEmail = "test@example.com",
+            userProfileImageUrl = null,
+        )
+}

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -8,4 +8,8 @@
     <string name="sign_up">Sign Up</string>
     <string name="greeting_authenticated">Hello {name}!</string>
     <string name="email_verification_required">Please check your email ({email}) to verify your account before signing in.</string>
+    <string name="sign_out_confirmation_title">Sign Out</string>
+    <string name="sign_out_confirmation_message">Are you sure you want to sign out?</string>
+    <string name="sign_out_confirmation_confirm">Sign Out</string>
+    <string name="sign_out_confirmation_cancel">Cancel</string>
 </resources>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -14,12 +14,17 @@ interface SettingsBloc {
 
     fun onSignOutClicked()
 
+    fun onSignOutConfirmed()
+
+    fun onSignOutDismissed()
+
     fun onUrlClicked(url: String)
 
     data class Model(
         val isAuthenticated: Boolean = false,
         val greeting: TextData? = null,
         val verificationMessage: TextData? = null,
+        val showSignOutConfirmationDialog: Boolean = false,
     )
 
     sealed class Output {

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
@@ -35,10 +35,15 @@ import chefmate.client.settings.public.generated.resources.more
 import chefmate.client.settings.public.generated.resources.privacy_policy
 import chefmate.client.settings.public.generated.resources.sign_in
 import chefmate.client.settings.public.generated.resources.sign_out
+import chefmate.client.settings.public.generated.resources.sign_out_confirmation_cancel
+import chefmate.client.settings.public.generated.resources.sign_out_confirmation_confirm
+import chefmate.client.settings.public.generated.resources.sign_out_confirmation_message
+import chefmate.client.settings.public.generated.resources.sign_out_confirmation_title
 import chefmate.client.settings.public.generated.resources.sign_up
 import chefmate.client.settings.public.generated.resources.terms_of_use
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -46,6 +51,17 @@ import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 @Composable
 fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
     val viewState by bloc.state.collectAsState()
+
+    if (viewState.showSignOutConfirmationDialog) {
+        PlusDialog(
+            title = Res.string.sign_out_confirmation_title.asTextData(),
+            message = Res.string.sign_out_confirmation_message.asTextData(),
+            confirmButtonText = Res.string.sign_out_confirmation_confirm.asTextData(),
+            dismissButtonText = Res.string.sign_out_confirmation_cancel.asTextData(),
+            onConfirmClick = bloc::onSignOutConfirmed,
+            onDismissRequest = bloc::onSignOutDismissed,
+        )
+    }
 
     PlusNavContainer(
         data = PlusHeaderData.Parent(title = Res.string.more.asTextData()),
@@ -158,6 +174,10 @@ private val previewBlocUnauthenticated =
 
         override fun onSignOutClicked() = Unit
 
+        override fun onSignOutConfirmed() = Unit
+
+        override fun onSignOutDismissed() = Unit
+
         override fun onUrlClicked(url: String) = Unit
     }
 
@@ -180,6 +200,10 @@ private val previewBlocAuthenticated =
         override fun onSignUpClicked() = Unit
 
         override fun onSignOutClicked() = Unit
+
+        override fun onSignOutConfirmed() = Unit
+
+        override fun onSignOutDismissed() = Unit
 
         override fun onUrlClicked(url: String) = Unit
     }


### PR DESCRIPTION
## Summary

- Added a confirmation dialog when the user taps **Sign Out** on the More/Settings tab, preventing accidental sign-outs
- `onSignOutClicked` now shows the dialog instead of immediately signing out; new `onSignOutConfirmed` / `onSignOutDismissed` handlers complete or cancel the flow
- Added `SettingsBlocImplTest` covering show, dismiss, and confirm scenarios (8 tests)

## Changes

- **`SettingsBloc`** — added `onSignOutConfirmed()`, `onSignOutDismissed()`, and `showSignOutConfirmationDialog: Boolean` to `Model`
- **`SettingsBlocImpl`** — wires the new methods to the ViewModel; `onSignOutClicked` shows the dialog instead of signing out directly
- **`SettingsViewModel`** — adds `showSignOutConfirmationDialog` state and `showSignOutConfirmationDialog()` / `dismissSignOutConfirmationDialog()` methods; `signOut()` resets the flag before performing sign-out
- **`SettingsScreen`** — renders a `PlusDialog` when `showSignOutConfirmationDialog` is true
- **`strings.xml`** — adds four localized strings for the dialog title, message, confirm, and cancel buttons
- **`build.gradle.kts`** — adds auth/grocery/recipe testing fakes to `commonTest` dependencies

## Test plan

- [x] Tap Sign Out on the More tab → confirmation dialog appears
- [x] Tap Cancel → dialog dismissed, user remains signed in
- [x] Tap Sign Out in the dialog → user is signed out and local data is cleared
- [x] Run `./gradlew :client:settings:impl:test` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)