### PR TITLE
feat(recipe): shared element transition for recipe image (list -> detail)

### DIFF
--- a/.claude/skills/add-shared-element-transition.md
+++ b/.claude/skills/add-shared-element-transition.md
@@ -1,0 +1,138 @@
+# add-shared-element-transition
+
+Add a Compose shared element transition between two screens in this Decompose-based KMP app.
+
+## Required input
+
+Ask the user (if not provided):
+
+1. **Source composable** — where the element is rendered before the transition (file, callsite).
+2. **Target composable** — where the element is rendered after (file, callsite).
+3. **What identifies the element** — typically a domain id (e.g. `recipe.id`, `groceryItem.id`) used to build the shared key.
+
+## Decide the integration point
+
+Find the lowest navigation BLoC whose `ChildStack` contains both source and target as descendants. That's where `SharedTransitionLayout` + `AnimatedContent` must live.
+
+- **Same `ChildStack` (siblings)** — e.g. `BrowserRootBloc`'s Landing/EditQuery/Browser. See `client/browser/public/.../BrowserRootScreen.kt` for the canonical example. Easy: replace its render with `SharedTransitionLayout { AnimatedContent { ... } }` and pass scopes as parameters.
+- **Different `ChildStack`s** — e.g. recipe list (under `BottomNavigation` child) → recipe detail (under `RecipeRoot` child). The integration point is `RootScreen.kt`. See it for the reference implementation. The deep child (list image) consumes the scope via `CompositionLocal`, not parameters.
+
+If integrating at `RootScreen` (or any layer that already uses Decompose's `Children` + `predictiveBackAnimation`), warn the user that **root-level predictive back gesture preview is lost** — `AnimatedContent` cannot drive a gesture-tracked animation. Predictive back inside descendant ChildStacks is unaffected.
+
+## The pattern
+
+### 1. CompositionLocals
+
+Already exist at `client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/SharedTransitionScopes.kt`:
+
+```kotlin
+val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { null }
+val LocalAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> { null }
+```
+
+Reuse — do not redefine.
+
+### 2. The navigation screen (integration point)
+
+```kotlin
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun SomeRootScreen(bloc: SomeRootBloc, modifier: Modifier = Modifier) {
+    val stack by bloc.routerState.subscribeAsState()
+    val saveableStateHolder = rememberSaveableStateHolder()
+    val previousKeys = remember { mutableSetOf<String>() }
+
+    DisposableEffect(stack) {
+        val currentKeys = stack.items.mapTo(HashSet()) { it.saveableKey() }
+        previousKeys.forEach { if (it !in currentKeys) saveableStateHolder.removeState(it) }
+        previousKeys.clear()
+        previousKeys.addAll(currentKeys)
+        onDispose {}
+    }
+
+    SharedTransitionLayout(modifier = modifier.fillMaxSize()) {
+        AnimatedContent(
+            targetState = stack.active,
+            contentKey = { it.key },
+            transitionSpec = { /* slide / fade — see RootScreen.kt for direction-aware spec */ },
+            label = "some-root",
+        ) { activeChild ->
+            CompositionLocalProvider(
+                LocalSharedTransitionScope provides this@SharedTransitionLayout,
+                LocalAnimatedVisibilityScope provides this,
+            ) {
+                saveableStateHolder.SaveableStateProvider(activeChild.saveableKey()) {
+                    when (val child = activeChild.instance) {
+                        // ... when branches per Child type
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun com.arkivanov.decompose.Child<*, *>.saveableKey(): String =
+    "${configuration::class.simpleName}_${key.hashCode()}"
+```
+
+### 3. The shared component
+
+Add an optional `sharedElementKey: String?` param. Read CompositionLocals; apply `Modifier.sharedElement` only when both key and scopes are non-null. Pattern (see `RecipeImage.kt`):
+
+```kotlin
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun MyComponent(/* existing params */, sharedElementKey: String? = null) {
+    val sharedScope = LocalSharedTransitionScope.current
+    val animatedScope = LocalAnimatedVisibilityScope.current
+    val sharedModifier =
+        if (sharedElementKey != null && sharedScope != null && animatedScope != null) {
+            with(sharedScope) {
+                Modifier.sharedElement(
+                    sharedContentState = rememberSharedContentState(key = sharedElementKey),
+                    animatedVisibilityScope = animatedScope,
+                )
+            }
+        } else Modifier
+
+    // Apply sharedModifier BEFORE clip / background — it must wrap the visual bounds.
+    Box(modifier = modifier.then(sharedModifier).clip(...)) { ... }
+}
+```
+
+### 4. Callsites
+
+Source and target both pass the same key, derived from the domain id:
+
+```kotlin
+MyComponent(..., sharedElementKey = "my-thing-${item.id}")
+```
+
+The key must be unique per logical element across the whole app. Prefix with the component/feature so keys from different shared transitions can't collide.
+
+## Gotchas — do not skip
+
+1. **Android Bundle crash on `SaveableStateProvider`** — Decompose's `Child.key` is the `Configuration` instance, which Android can't put in a `Bundle`. Always pass a `String`. Use the `saveableKey()` extension above.
+2. **Don't use `@InternalDecomposeApi`** — `keyHashString()` is internal. Define your own `saveableKey()` per the snippet above.
+3. **`contentKey = { it.key }` is fine** — `AnimatedContent.contentKey` only does equality comparison, no Bundle storage.
+4. **`SaveableStateHolder` retention** — Without the `DisposableEffect` cleanup, state for popped children leaks until process death. Always pair with the `previousKeys` tracker.
+5. **CompositionLocal default must be nullable** — `compositionLocalOf<SharedTransitionScope?> { null }`. Components must gracefully no-op when scopes are absent (so they still render correctly outside a `SharedTransitionLayout`, e.g. in previews).
+6. **`Modifier.sharedElement` placement** — apply it before any `clip` / `background` so the shared bounds match the visible bounds. If clip is applied first, the shared element animates the unclipped rect.
+7. **Replicating `slide()` / `verticalSlide()`** — Decompose's animator is direction-aware. In `transitionSpec`, infer direction from `stack.items.indexOfFirst { it.key == initialState.key }` vs `targetState.key`. If `initialIndex < 0` (popped), treat as back. See `RootScreen.kt` for the full spec.
+8. **Preview support** — `RecipeImage`-style components rendered in a `@Preview` won't have `LocalSharedTransitionScope` set; the null-check above handles this. Don't wrap previews in `SharedTransitionLayout` unless the preview is specifically for the transition.
+
+## Verification checklist
+
+Before reporting done:
+
+1. `./gradlew ktfmtFormat`
+2. `./gradlew :client:composeApp:compileKotlinJvm` — must pass.
+3. **Run on Android.** A passing JVM compile does not catch the Bundle crash on `SaveableStateProvider`. The bug appears at runtime on first navigation. If the user can't run it themselves, say so explicitly — don't claim success.
+4. Visually verify the morph: source → target should show the element growing/shrinking smoothly, not snapping.
+
+## Reference implementations in this repo
+
+- `client/browser/public/.../BrowserRootScreen.kt` — same-stack siblings, scopes via parameters.
+- `client/root/public/.../RootScreen.kt` — cross-stack via CompositionLocals, direction-aware slide, `saveableKey()`.
+- `client/ui/public/.../components/RecipeImage.kt` — opt-in `sharedElementKey` parameter pattern.
+- `client/ui/public/.../SharedTransitionScopes.kt` — CompositionLocals.

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -209,6 +209,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                     PlusHeaderData.Child(
                         title = state.recipe.title.asTextData(),
                         onBackClick = bloc::onBackClicked,
+                        titleSharedElementKey = "recipe-title-${state.recipe.id}",
                         trailingAccessory =
                             PlusHeaderData.TrailingAccessory.Custom {
                                 IconButton(onClick = bloc::onKeepScreenOnToggled) {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -613,6 +613,7 @@ private fun ColumnScope.RecipeDetailExpandedContent(
                         imageUrl = recipe.imageUrl,
                         contentDescription = recipe.title,
                         modifier = Modifier.fillMaxWidth().height(180.dp),
+                        sharedElementKey = "recipe-image-${recipe.id}",
                     )
                 }
                 recipe.starRating?.let { rating ->
@@ -898,6 +899,7 @@ private fun RecipeHeroSection(
             imageUrl = recipe.imageUrl,
             contentDescription = recipe.title,
             modifier = Modifier.width(140.dp).height(140.dp),
+            sharedElementKey = "recipe-image-${recipe.id}",
         )
         Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
             // Star Rating

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -558,6 +558,7 @@ private fun RecipeGridItem(
             imageUrl = recipe.imageUrl,
             contentDescription = recipe.title,
             modifier = Modifier.fillMaxWidth().aspectRatio(1.2f),
+            sharedElementKey = "recipe-image-${recipe.id}",
         )
         Column(
             modifier = Modifier.padding(12.dp),
@@ -617,6 +618,7 @@ private fun RecipeListItemContent(
             imageUrl = recipe.imageUrl,
             contentDescription = recipe.title,
             modifier = Modifier.size(80.dp),
+            sharedElementKey = "recipe-image-${recipe.id}",
         )
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Row(

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -116,6 +116,7 @@ import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
+import com.plusmobileapps.chefmate.ui.sharedBoundsBy
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -570,6 +571,7 @@ private fun RecipeGridItem(
                 minLines = 2,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.sharedBoundsBy("recipe-title-${recipe.id}"),
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -631,7 +633,7 @@ private fun RecipeListItemContent(
                     style = MaterialTheme.typography.titleMedium,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f).sharedBoundsBy("recipe-title-${recipe.id}"),
                 )
                 SyncStatusIcon(syncStatus = recipe.syncStatus)
                 if (recipe.isFavorite) {

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -117,6 +117,9 @@ import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.sharedBoundsBy
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -129,9 +132,15 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
     val listState = rememberLazyListState()
     val gridState = rememberLazyGridState()
 
-    LaunchedEffect(state.currentSort, state.activeFilters) {
-        listState.animateScrollToItem(0)
-        gridState.animateScrollToItem(0)
+    LaunchedEffect(Unit) {
+        bloc.state
+            .map { it.currentSort to it.activeFilters }
+            .distinctUntilChanged()
+            .drop(1)
+            .collect {
+                listState.animateScrollToItem(0)
+                gridState.animateScrollToItem(0)
+            }
     }
 
     PlusNavContainer(

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -1,20 +1,26 @@
-@file:OptIn(ExperimentalDecomposeApi::class)
+@file:OptIn(ExperimentalDecomposeApi::class, ExperimentalSharedTransitionApi::class)
 
 package com.plusmobileapps.chefmate.root
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.Dp
 import com.arkivanov.decompose.ExperimentalDecomposeApi
-import com.arkivanov.decompose.extensions.compose.stack.Children
-import com.arkivanov.decompose.extensions.compose.stack.animation.StackAnimator
-import com.arkivanov.decompose.extensions.compose.stack.animation.isFront
-import com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback.predictiveBackAnimation
-import com.arkivanov.decompose.extensions.compose.stack.animation.slide
-import com.arkivanov.decompose.extensions.compose.stack.animation.stackAnimation
-import com.arkivanov.decompose.extensions.compose.stack.animation.stackAnimator
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationScreen
 import com.plusmobileapps.chefmate.browser.BrowserRootScreen
@@ -24,70 +30,99 @@ import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootScreen
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootScreen
 import com.plusmobileapps.chefmate.settings.AppSettingsScreen
 import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.ui.LocalAnimatedVisibilityScope
+import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
 @Composable
 fun RootScreen(rootBloc: RootBloc, modifier: Modifier = Modifier) {
-    val state = rootBloc.state.subscribeAsState()
+    val stack by rootBloc.state.subscribeAsState()
+    val saveableStateHolder = rememberSaveableStateHolder()
+    val previousKeys = remember { mutableSetOf<String>() }
+
+    DisposableEffect(stack) {
+        val currentKeys = stack.items.mapTo(HashSet()) { it.saveableKey() }
+        previousKeys.forEach { key ->
+            if (key !in currentKeys) saveableStateHolder.removeState(key)
+        }
+        previousKeys.clear()
+        previousKeys.addAll(currentKeys)
+        onDispose {}
+    }
+
     ChefMateTheme {
-        Children(
-            modifier = modifier.fillMaxSize(),
-            stack = state.value,
-            animation =
-                predictiveBackAnimation(
-                    backHandler = rootBloc.backHandler,
-                    fallbackAnimation =
-                        stackAnimation { child, otherChild, _ ->
-                            if (
-                                child.instance is RootBloc.Child.Browser ||
-                                    otherChild.instance is RootBloc.Child.Browser ||
-                                    child.instance is RootBloc.Child.MealPlanner ||
-                                    otherChild.instance is RootBloc.Child.MealPlanner
-                            ) {
-                                verticalSlide()
-                            } else {
-                                slide()
-                            }
-                        },
-                    onBack = rootBloc::onBackClicked,
-                ),
-            content = {
-                when (val child = it.instance) {
-                    is RootBloc.Child.BottomNavigation -> BottomNavigationScreen(child.bloc)
-                    is RootBloc.Child.GroceryDetail -> GroceryDetailScreen(child.bloc)
-                    is RootBloc.Child.RecipeRoot -> RecipeRootScreen(child.bloc)
-                    is RootBloc.Child.Authentication -> AuthenticationScreen(child.bloc)
-                    is RootBloc.Child.Browser ->
-                        PlusHeaderContainer(
-                            modifier = Modifier.fillMaxSize(),
-                            data =
-                                PlusHeaderData.Modal(
-                                    title = FixedString(""),
-                                    onCloseClick = rootBloc::onBackClicked,
-                                ),
-                            scrollEnabled = false,
-                            maxContentWidth = Dp.Unspecified,
-                            content = {
-                                BrowserRootScreen(child.bloc, modifier = Modifier.weight(1f))
-                            },
-                        )
-                    is RootBloc.Child.MealPlanner -> MealPlannerRootScreen(child.bloc)
-                    is RootBloc.Child.AppSettings -> AppSettingsScreen(child.bloc)
+        SharedTransitionLayout(modifier = modifier.fillMaxSize()) {
+            AnimatedContent(
+                targetState = stack.active,
+                contentKey = { it.key },
+                transitionSpec = {
+                    val current = targetState.instance
+                    val previous = initialState.instance
+                    val isVertical =
+                        current is RootBloc.Child.Browser ||
+                            previous is RootBloc.Child.Browser ||
+                            current is RootBloc.Child.MealPlanner ||
+                            previous is RootBloc.Child.MealPlanner
+                    val items = stack.items
+                    val initialIndex = items.indexOfFirst { it.key == initialState.key }
+                    val targetIndex = items.indexOfFirst { it.key == targetState.key }
+                    val isForward = if (initialIndex < 0) false else targetIndex > initialIndex
+                    val spec = tween<androidx.compose.ui.unit.IntOffset>(durationMillis = 300)
+
+                    if (isVertical) {
+                        if (isForward) {
+                            slideInVertically(spec) { it } togetherWith
+                                slideOutVertically(spec) { 0 }
+                        } else {
+                            slideInVertically(spec) { 0 } togetherWith
+                                slideOutVertically(spec) { it }
+                        }
+                    } else {
+                        if (isForward) {
+                            slideInHorizontally(spec) { it } togetherWith
+                                slideOutHorizontally(spec) { -it / 4 }
+                        } else {
+                            slideInHorizontally(spec) { -it / 4 } togetherWith
+                                slideOutHorizontally(spec) { it }
+                        }
+                    }
+                },
+                label = "root-stack",
+            ) { activeChild ->
+                CompositionLocalProvider(
+                    LocalSharedTransitionScope provides this@SharedTransitionLayout,
+                    LocalAnimatedVisibilityScope provides this,
+                ) {
+                    saveableStateHolder.SaveableStateProvider(activeChild.saveableKey()) {
+                        RootChildContent(activeChild.instance, rootBloc::onBackClicked)
+                    }
                 }
-            },
-        )
+            }
+        }
     }
 }
 
-private fun verticalSlide(): StackAnimator = stackAnimator { factor, direction, content ->
-    content(Modifier.offsetYFactor(if (direction.isFront) factor else 0f))
-}
+private fun com.arkivanov.decompose.Child<*, *>.saveableKey(): String =
+    "${configuration::class.simpleName}_${key.hashCode()}"
 
-private fun Modifier.offsetYFactor(factor: Float): Modifier = layout { measurable, constraints ->
-    val placeable = measurable.measure(constraints)
-    layout(placeable.width, placeable.height) {
-        placeable.placeRelative(x = 0, y = (placeable.height.toFloat() * factor).toInt())
+@Composable
+private fun RootChildContent(child: RootBloc.Child, onBack: () -> Unit) {
+    when (child) {
+        is RootBloc.Child.BottomNavigation -> BottomNavigationScreen(child.bloc)
+        is RootBloc.Child.GroceryDetail -> GroceryDetailScreen(child.bloc)
+        is RootBloc.Child.RecipeRoot -> RecipeRootScreen(child.bloc)
+        is RootBloc.Child.Authentication -> AuthenticationScreen(child.bloc)
+        is RootBloc.Child.Browser ->
+            PlusHeaderContainer(
+                modifier = Modifier.fillMaxSize(),
+                data = PlusHeaderData.Modal(title = FixedString(""), onCloseClick = onBack),
+                scrollEnabled = false,
+                maxContentWidth = Dp.Unspecified,
+                content = { BrowserRootScreen(child.bloc, modifier = Modifier.weight(1f)) },
+            )
+        is RootBloc.Child.MealPlanner -> MealPlannerRootScreen(child.bloc)
+        is RootBloc.Child.AppSettings -> AppSettingsScreen(child.bloc)
     }
 }

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/SharedTransitionScopes.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/SharedTransitionScopes.kt
@@ -5,8 +5,47 @@ package com.plusmobileapps.chefmate.ui
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Modifier
 
 val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { null }
 
 val LocalAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> { null }
+
+/**
+ * Applies `Modifier.sharedElement` when [key] is non-null and both scopes are present. Use for
+ * visually identical content morphing between locations (e.g. an image).
+ */
+@Composable
+fun Modifier.sharedElementBy(key: String?): Modifier {
+    val sharedScope = LocalSharedTransitionScope.current
+    val animatedScope = LocalAnimatedVisibilityScope.current
+    return if (key != null && sharedScope != null && animatedScope != null) {
+        with(sharedScope) {
+            this@sharedElementBy.sharedElement(
+                sharedContentState = rememberSharedContentState(key = key),
+                animatedVisibilityScope = animatedScope,
+            )
+        }
+    } else this
+}
+
+/**
+ * Applies `Modifier.sharedBounds` when [key] is non-null and both scopes are present. Use when the
+ * source and target render differently (e.g. text at different styles) — bounds morph while content
+ * crossfades.
+ */
+@Composable
+fun Modifier.sharedBoundsBy(key: String?): Modifier {
+    val sharedScope = LocalSharedTransitionScope.current
+    val animatedScope = LocalAnimatedVisibilityScope.current
+    return if (key != null && sharedScope != null && animatedScope != null) {
+        with(sharedScope) {
+            this@sharedBoundsBy.sharedBounds(
+                sharedContentState = rememberSharedContentState(key = key),
+                animatedVisibilityScope = animatedScope,
+            )
+        }
+    } else this
+}

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/SharedTransitionScopes.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/SharedTransitionScopes.kt
@@ -1,0 +1,12 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class)
+
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.runtime.compositionLocalOf
+
+val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { null }
+
+val LocalAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> { null }

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import chefmate.client.ui.public.generated.resources.Res
 import chefmate.client.ui.public.generated.resources.back
 import chefmate.client.ui.public.generated.resources.close
+import com.plusmobileapps.chefmate.ui.sharedBoundsBy
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import org.jetbrains.compose.resources.stringResource
 
@@ -181,7 +182,12 @@ fun PlusHeader(
                     bottom = WindowInsets.statusBars.getBottom(density),
                 ),
         title = {
-            Text(text = data.title.localized(), color = ChefMateTheme.colorScheme.onBackground)
+            val titleKey = (data as? PlusHeaderData.Child)?.titleSharedElementKey
+            Text(
+                text = data.title.localized(),
+                color = ChefMateTheme.colorScheme.onBackground,
+                modifier = Modifier.sharedBoundsBy(titleKey),
+            )
         },
         navigationIcon =
             when (data) {

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderData.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderData.kt
@@ -24,6 +24,7 @@ sealed class PlusHeaderData {
         override val title: TextData,
         val onBackClick: () -> Unit,
         override val trailingAccessory: TrailingAccessory? = null,
+        val titleSharedElementKey: String? = null,
     ) : PlusHeaderData()
 
     data class Modal(

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/RecipeImage.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/RecipeImage.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class)
+
 package com.plusmobileapps.chefmate.ui.components
 
+import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
@@ -12,20 +15,42 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import coil3.compose.AsyncImage
+import com.plusmobileapps.chefmate.ui.LocalAnimatedVisibilityScope
+import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
 
 @Composable
-fun RecipeImage(imageUrl: String?, contentDescription: String?, modifier: Modifier = Modifier) {
+fun RecipeImage(
+    imageUrl: String?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    sharedElementKey: String? = null,
+) {
+    val sharedScope = LocalSharedTransitionScope.current
+    val animatedScope = LocalAnimatedVisibilityScope.current
+    val sharedModifier =
+        if (sharedElementKey != null && sharedScope != null && animatedScope != null) {
+            with(sharedScope) {
+                Modifier.sharedElement(
+                    sharedContentState = rememberSharedContentState(key = sharedElementKey),
+                    animatedVisibilityScope = animatedScope,
+                )
+            }
+        } else {
+            Modifier
+        }
+
     if (imageUrl != null) {
         AsyncImage(
             model = imageUrl,
             contentDescription = contentDescription,
-            modifier = modifier.clip(MaterialTheme.shapes.medium),
+            modifier = modifier.then(sharedModifier).clip(MaterialTheme.shapes.medium),
             contentScale = ContentScale.Crop,
         )
     } else {
         Box(
             modifier =
                 modifier
+                    .then(sharedModifier)
                     .clip(MaterialTheme.shapes.medium)
                     .background(MaterialTheme.colorScheme.surfaceVariant),
             contentAlignment = Alignment.Center,

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/RecipeImage.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/RecipeImage.kt
@@ -1,8 +1,5 @@
-@file:OptIn(ExperimentalSharedTransitionApi::class)
-
 package com.plusmobileapps.chefmate.ui.components
 
-import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
@@ -15,8 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import coil3.compose.AsyncImage
-import com.plusmobileapps.chefmate.ui.LocalAnimatedVisibilityScope
-import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
+import com.plusmobileapps.chefmate.ui.sharedElementBy
 
 @Composable
 fun RecipeImage(
@@ -25,19 +21,7 @@ fun RecipeImage(
     modifier: Modifier = Modifier,
     sharedElementKey: String? = null,
 ) {
-    val sharedScope = LocalSharedTransitionScope.current
-    val animatedScope = LocalAnimatedVisibilityScope.current
-    val sharedModifier =
-        if (sharedElementKey != null && sharedScope != null && animatedScope != null) {
-            with(sharedScope) {
-                Modifier.sharedElement(
-                    sharedContentState = rememberSharedContentState(key = sharedElementKey),
-                    animatedVisibilityScope = animatedScope,
-                )
-            }
-        } else {
-            Modifier
-        }
+    val sharedModifier = Modifier.sharedElementBy(sharedElementKey)
 
     if (imageUrl != null) {
         AsyncImage(


### PR DESCRIPTION
## Summary
- Wraps `RootScreen` in `SharedTransitionLayout` + `AnimatedContent` so the recipe image can morph across the `BottomNav` → `RecipeRoot` stack boundary (mirrors the pattern from #134's browser flow, but applied at the root level since list and detail live in different `ChildStack`s).
- Adds `LocalSharedTransitionScope` / `LocalAnimatedVisibilityScope` CompositionLocals so deep descendants (the list image inside `BottomNav` → Recipes tab) can opt into the shared element without prop-drilling.
- `RecipeImage` gains an optional `sharedElementKey: String?` parameter; list (grid + list view) and detail (compact hero + expanded metadata) all key on `recipe-image-${recipe.id}`.
- Adds an `add-shared-element-transition` skill at `.claude/skills/` capturing the pattern, gotchas, and reference files.

**Trade-off:** the root-level Decompose `predictiveBackAnimation` is replaced by direction-aware slide / verticalSlide in `transitionSpec`. Predictive back inside `BottomNav` and `RecipeRoot` is unaffected — only the gesture-tracked preview at the root stack level is gone, since `AnimatedContent` can't drive a gesture-following animation.

## Test plan
- [x] Open the app on Android — confirm no crash on launch (initial fix swapped Decompose's `Configuration` key for a `String` in `SaveableStateProvider`, which Android's `Bundle` requires).
- [x] Tap a recipe in the **list view** — image should morph smoothly into the detail hero, not snap.
- [x] Tap a recipe in the **grid view** — same.
- [x] Press back — image should morph back to the list/grid item position.
- [x] Switch between Recipes / Groceries / Meals / Browser tabs — slide animations should still feel correct.
- [x] Open the Browser modal and Meal Planner — vertical slide preserved.
- [x] iOS swipe-back from detail — back navigation should still work (only Android root-level predictive preview is affected).
- [x] Rotate device on detail screen — `SaveableStateHolder` should preserve list scroll position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)