### PR TITLE
fix(ci): use macos-26-arm64 runner for iOS release

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: macos-15
+    runs-on: macos-26-arm64
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- App Store Connect rejected the upload because the app was built with the iOS 18.5 SDK (Xcode on `macos-15`)
- Apple now requires all iOS/iPadOS apps to be built with the **iOS 26 SDK (Xcode 26) or later**
- Switches the runner from `macos-15` to `macos-26-arm64` to provide the required Xcode 26 toolchain

## Test plan

- [ ] Trigger the iOS Release workflow after merging and verify the upload to App Store Connect succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)