### PR TITLE
Cook Mode polish: keep screen on, overflow menu, floating header, animation fixes

### DIFF
--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -2,6 +2,7 @@
 
 package com.plusmobileapps.chefmate.recipe.bottomnav
 
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -26,6 +27,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import chefmate.client.bottomnav.public.generated.resources.Res
 import chefmate.client.bottomnav.public.generated.resources.tab_browser
 import chefmate.client.bottomnav.public.generated.resources.tab_grocery
@@ -52,28 +54,43 @@ import com.plusmobileapps.chefmate.settings.SettingsScreen
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.NavRailItem
 import com.plusmobileapps.chefmate.ui.components.PlusNavRailHeaderContainer
-import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
-import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.fadeScalePredictiveBackAnimatable
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
+private enum class NavigationLayout {
+    BOTTOM,
+    SIDE_COMPACT,
+    SIDE_EXPANDED,
+}
+
 @Composable
 fun BottomNavigationScreen(bloc: BottomNavBloc) {
-    PlusResponsiveContainer { windowSize ->
-        when (windowSize) {
-            WindowSizeClass.COMPACT ->
+    BoxWithConstraints {
+        val layout =
+            when {
+                maxWidth < 600.dp -> NavigationLayout.BOTTOM
+                maxHeight < 480.dp -> NavigationLayout.SIDE_COMPACT
+                else -> NavigationLayout.SIDE_EXPANDED
+            }
+        when (layout) {
+            NavigationLayout.BOTTOM ->
                 MobileBottomNavContent(modifier = Modifier.imePadding(), bloc = bloc)
-            WindowSizeClass.MEDIUM,
-            WindowSizeClass.EXPANDED ->
-                TabletNavRailContent(modifier = Modifier.imePadding(), bloc = bloc)
+            NavigationLayout.SIDE_COMPACT ->
+                SideNavContent(modifier = Modifier.imePadding(), bloc = bloc, expandedItems = false)
+            NavigationLayout.SIDE_EXPANDED ->
+                SideNavContent(modifier = Modifier.imePadding(), bloc = bloc, expandedItems = true)
         }
     }
 }
 
 @Composable
-private fun TabletNavRailContent(bloc: BottomNavBloc, modifier: Modifier = Modifier) {
+private fun SideNavContent(
+    bloc: BottomNavBloc,
+    expandedItems: Boolean,
+    modifier: Modifier = Modifier,
+) {
     val state = bloc.state.collectAsState()
 
     val navRailItems =
@@ -92,6 +109,7 @@ private fun TabletNavRailContent(bloc: BottomNavBloc, modifier: Modifier = Modif
     PlusNavRailHeaderContainer(
         modifier = modifier.fillMaxSize(),
         navRail = navRailItems,
+        expandedItems = expandedItems,
         content = { BottomNavContentContainer(modifier = Modifier.padding(it), bloc = bloc) },
     )
 }

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeBlocImpl.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeBlocImpl.kt
@@ -54,6 +54,7 @@ class CookModeBlocImpl(
                         )
                     },
                 layoutMode = vm.layoutMode,
+                keepScreenOn = vm.keepScreenOn,
             )
         }
 
@@ -67,6 +68,10 @@ class CookModeBlocImpl(
 
     override fun onLayoutToggled() {
         viewModel.toggleLayout()
+    }
+
+    override fun onKeepScreenOnToggled() {
+        viewModel.toggleKeepScreenOn()
     }
 
     override fun onBackClicked() {

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModel.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModel.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.cook.impl
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.cook.data.CookingSessionRepository
+import com.plusmobileapps.chefmate.di.KeepScreenOnRepository
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
@@ -26,6 +27,7 @@ class CookModeViewModel(
     private val recipeRepository: RecipeRepository,
     private val sessionRepository: CookingSessionRepository,
     settings: Settings,
+    private val keepScreenOnRepository: KeepScreenOnRepository,
 ) : ViewModel(mainContext) {
 
     private var splitLayoutPref by settings.boolean(KEY_LAYOUT_SPLIT, defaultValue = false)
@@ -35,7 +37,8 @@ class CookModeViewModel(
             State(
                 layoutMode =
                     if (splitLayoutPref) CookModeBloc.LayoutMode.Split
-                    else CookModeBloc.LayoutMode.Stacked
+                    else CookModeBloc.LayoutMode.Stacked,
+                keepScreenOn = keepScreenOnRepository.keepScreenOn.value,
             )
         )
     val state: StateFlow<State> = _state.asStateFlow()
@@ -63,6 +66,11 @@ class CookModeViewModel(
                     }
                 }
         }
+        scope.launch {
+            keepScreenOnRepository.keepScreenOn.collect { keepScreenOn ->
+                _state.update { it.copy(keepScreenOn = keepScreenOn) }
+            }
+        }
     }
 
     fun selectRecipe(recipeId: Long) {
@@ -80,11 +88,16 @@ class CookModeViewModel(
         _state.update { it.copy(layoutMode = next) }
     }
 
+    fun toggleKeepScreenOn() {
+        keepScreenOnRepository.toggle()
+    }
+
     data class State(
         val isLoading: Boolean = true,
         val cookingRecipes: List<Recipe> = emptyList(),
         val activeRecipeId: Long? = null,
         val layoutMode: CookModeBloc.LayoutMode = CookModeBloc.LayoutMode.Stacked,
+        val keepScreenOn: Boolean = true,
     )
 
     @AssistedFactory

--- a/client/cook/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/cook/public/src/commonMain/composeResources/values/strings.xml
@@ -8,6 +8,8 @@
     <string name="cook_mode_no_active_recipe">No recipe selected</string>
     <string name="cook_mode_layout_stacked">Show as single list</string>
     <string name="cook_mode_layout_split">Show ingredients and directions side by side</string>
+    <string name="cook_mode_keep_screen_on">Keep screen on</string>
+    <string name="cook_mode_allow_screen_off">Allow screen to turn off</string>
     <string name="whats_cooking_title">What’s Cooking</string>
     <string name="whats_cooking_select">Select recipes</string>
     <string name="whats_cooking_cancel_select">Cancel selection</string>

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeBloc.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeBloc.kt
@@ -21,6 +21,8 @@ interface CookModeBloc : BackClickBloc {
 
     fun onLayoutToggled()
 
+    fun onKeepScreenOnToggled()
+
     enum class LayoutMode {
         Stacked,
         Split,
@@ -31,6 +33,7 @@ interface CookModeBloc : BackClickBloc {
         val activeRecipe: Recipe? = null,
         val activeSessions: List<Chip> = emptyList(),
         val layoutMode: LayoutMode = LayoutMode.Stacked,
+        val keepScreenOn: Boolean = true,
     ) {
         data class Chip(val recipeId: Long, val title: String, val isActive: Boolean)
     }

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModePreviews.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModePreviews.kt
@@ -41,6 +41,8 @@ private fun cookBloc(model: CookModeBloc.Model): CookModeBloc =
 
         override fun onLayoutToggled() = Unit
 
+        override fun onKeepScreenOnToggled() = Unit
+
         override fun onBackClicked() = Unit
     }
 
@@ -57,6 +59,7 @@ val previewCookBlocStacked: CookModeBloc =
             activeRecipe = Recipe.Sample,
             activeSessions = activeSessionsSample,
             layoutMode = CookModeBloc.LayoutMode.Stacked,
+            keepScreenOn = true,
         )
     )
 

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeScreen.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -99,7 +100,6 @@ import chefmate.client.cook.public.generated.resources.cook_mode_no_active_recip
 import chefmate.client.cook.public.generated.resources.cook_mode_whats_cooking
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.ui.KeepScreenOn
-import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.coroutines.launch
@@ -112,11 +112,23 @@ fun CookModeScreen(bloc: CookModeBloc, modifier: Modifier = Modifier) {
         KeepScreenOn()
     }
     Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-        PlusResponsiveContainer(modifier = Modifier.fillMaxSize()) { windowSizeClass ->
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val windowSizeClass =
+                when {
+                    maxWidth < 600.dp -> WindowSizeClass.COMPACT
+                    maxWidth < 840.dp -> WindowSizeClass.MEDIUM
+                    else -> WindowSizeClass.EXPANDED
+                }
+            val isCompactHeight = maxHeight < 480.dp
             if (windowSizeClass == WindowSizeClass.COMPACT) {
                 CookModeMobileLayout(bloc = bloc, state = state, windowSizeClass = windowSizeClass)
             } else {
-                CookModeTabletLayout(bloc = bloc, state = state, windowSizeClass = windowSizeClass)
+                CookModeTabletLayout(
+                    bloc = bloc,
+                    state = state,
+                    windowSizeClass = windowSizeClass,
+                    isCompactHeight = isCompactHeight,
+                )
             }
         }
     }
@@ -127,6 +139,7 @@ private fun CookModeTabletLayout(
     bloc: CookModeBloc,
     state: CookModeBloc.Model,
     windowSizeClass: WindowSizeClass,
+    isCompactHeight: Boolean,
 ) {
     var showWhatsCooking by remember { mutableStateOf(false) }
 
@@ -136,7 +149,7 @@ private fun CookModeTabletLayout(
             recipe = state.activeRecipe,
             layoutMode = state.layoutMode,
             windowSizeClass = windowSizeClass,
-            bottomReserve = BottomBarReserve,
+            bottomReserve = if (isCompactHeight) 0.dp else BottomBarReserve,
             modifier = Modifier.fillMaxSize(),
         )
         CookModeAppBar(
@@ -146,14 +159,17 @@ private fun CookModeTabletLayout(
             onLayoutToggle = bloc::onLayoutToggled,
             onKeepScreenOnToggle = bloc::onKeepScreenOnToggled,
             onCloseClicked = bloc::onCloseClicked,
+            onWhatsCookingClicked = if (isCompactHeight) ({ showWhatsCooking = true }) else null,
             modifier = Modifier.align(Alignment.TopCenter),
         )
-        CookModeBottomBar(
-            chips = state.activeSessions,
-            onWhatsCookingClicked = { showWhatsCooking = true },
-            onChipClicked = bloc::onRecipeChipClicked,
-            modifier = Modifier.align(Alignment.BottomCenter),
-        )
+        if (!isCompactHeight) {
+            CookModeBottomBar(
+                chips = state.activeSessions,
+                onWhatsCookingClicked = { showWhatsCooking = true },
+                onChipClicked = bloc::onRecipeChipClicked,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
+        }
     }
 
     if (showWhatsCooking) {
@@ -281,6 +297,7 @@ private fun CookModeAppBar(
     onLayoutToggle: () -> Unit,
     onKeepScreenOnToggle: () -> Unit,
     onCloseClicked: () -> Unit,
+    onWhatsCookingClicked: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     CenterAlignedTopAppBar(
@@ -299,6 +316,14 @@ private fun CookModeAppBar(
             }
         },
         actions = {
+            if (onWhatsCookingClicked != null) {
+                IconButton(onClick = onWhatsCookingClicked) {
+                    Icon(
+                        imageVector = Icons.Default.Restaurant,
+                        contentDescription = stringResource(Res.string.cook_mode_whats_cooking),
+                    )
+                }
+            }
             IconButton(onClick = onKeepScreenOnToggle) {
                 Icon(
                     imageVector =

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeScreen.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeScreen.kt
@@ -35,13 +35,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.ViewAgenda
 import androidx.compose.material.icons.filled.ViewWeek
@@ -50,7 +50,6 @@ import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.BottomSheetScaffold
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -65,12 +64,12 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -81,6 +80,8 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
@@ -89,7 +90,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import chefmate.client.cook.public.generated.resources.Res
 import chefmate.client.cook.public.generated.resources.cook_mode_allow_screen_off
-import chefmate.client.cook.public.generated.resources.cook_mode_close
 import chefmate.client.cook.public.generated.resources.cook_mode_directions
 import chefmate.client.cook.public.generated.resources.cook_mode_ingredients
 import chefmate.client.cook.public.generated.resources.cook_mode_keep_screen_on
@@ -99,7 +99,10 @@ import chefmate.client.cook.public.generated.resources.cook_mode_loading
 import chefmate.client.cook.public.generated.resources.cook_mode_no_active_recipe
 import chefmate.client.cook.public.generated.resources.cook_mode_whats_cooking
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.ui.KeepScreenOn
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.coroutines.launch
@@ -144,24 +147,68 @@ private fun CookModeTabletLayout(
     var showWhatsCooking by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        CookModeBody(
-            isLoading = state.isLoading,
-            recipe = state.activeRecipe,
-            layoutMode = state.layoutMode,
-            windowSizeClass = windowSizeClass,
-            bottomReserve = if (isCompactHeight) 0.dp else BottomBarReserve,
+        PlusHeaderContainer(
+            data =
+                PlusHeaderData.Modal(
+                    title = FixedString(state.activeRecipe?.title.orEmpty()),
+                    onCloseClick = bloc::onCloseClicked,
+                    trailingAccessory =
+                        PlusHeaderData.TrailingAccessory.Custom {
+                            if (isCompactHeight) {
+                                IconButton(onClick = { showWhatsCooking = true }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Restaurant,
+                                        contentDescription =
+                                            stringResource(Res.string.cook_mode_whats_cooking),
+                                    )
+                                }
+                            }
+                            IconButton(onClick = bloc::onKeepScreenOnToggled) {
+                                Icon(
+                                    imageVector =
+                                        if (state.keepScreenOn) Icons.Default.Visibility
+                                        else Icons.Default.VisibilityOff,
+                                    contentDescription =
+                                        stringResource(
+                                            if (state.keepScreenOn)
+                                                Res.string.cook_mode_allow_screen_off
+                                            else Res.string.cook_mode_keep_screen_on
+                                        ),
+                                )
+                            }
+                            IconButton(onClick = bloc::onLayoutToggled) {
+                                Icon(
+                                    imageVector =
+                                        if (state.layoutMode == CookModeBloc.LayoutMode.Stacked)
+                                            Icons.Default.ViewWeek
+                                        else Icons.Default.ViewAgenda,
+                                    contentDescription =
+                                        stringResource(
+                                            if (state.layoutMode == CookModeBloc.LayoutMode.Stacked)
+                                                Res.string.cook_mode_layout_split
+                                            else Res.string.cook_mode_layout_stacked
+                                        ),
+                                )
+                            }
+                        },
+                ),
             modifier = Modifier.fillMaxSize(),
-        )
-        CookModeAppBar(
-            title = state.activeRecipe?.title.orEmpty(),
-            layoutMode = state.layoutMode,
-            keepScreenOn = state.keepScreenOn,
-            onLayoutToggle = bloc::onLayoutToggled,
-            onKeepScreenOnToggle = bloc::onKeepScreenOnToggled,
-            onCloseClicked = bloc::onCloseClicked,
-            onWhatsCookingClicked = if (isCompactHeight) ({ showWhatsCooking = true }) else null,
-            modifier = Modifier.align(Alignment.TopCenter),
-        )
+            floatingHeader = true,
+            headerContainerAlpha = 0.85f,
+            centerAlignTitle = true,
+            floatingHeaderTopReserve = false,
+            scrollEnabled = false,
+            maxContentWidth = Dp.Unspecified,
+        ) {
+            CookModeBody(
+                isLoading = state.isLoading,
+                recipe = state.activeRecipe,
+                layoutMode = state.layoutMode,
+                windowSizeClass = windowSizeClass,
+                bottomReserve = if (isCompactHeight) 0.dp else BottomBarReserve,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
         if (!isCompactHeight) {
             CookModeBottomBar(
                 chips = state.activeSessions,
@@ -241,23 +288,62 @@ private fun CookModeMobileLayout(
         Box(
             modifier = Modifier.fillMaxSize().padding(bottom = bodyPadding.calculateBottomPadding())
         ) {
-            CookModeBody(
-                isLoading = state.isLoading,
-                recipe = state.activeRecipe,
-                layoutMode = state.layoutMode,
-                windowSizeClass = windowSizeClass,
-                bottomReserve = 0.dp,
+            PlusHeaderContainer(
+                data =
+                    PlusHeaderData.Modal(
+                        title = FixedString(state.activeRecipe?.title.orEmpty()),
+                        onCloseClick = bloc::onCloseClicked,
+                        trailingAccessory =
+                            PlusHeaderData.TrailingAccessory.Custom {
+                                IconButton(onClick = bloc::onKeepScreenOnToggled) {
+                                    Icon(
+                                        imageVector =
+                                            if (state.keepScreenOn) Icons.Default.Visibility
+                                            else Icons.Default.VisibilityOff,
+                                        contentDescription =
+                                            stringResource(
+                                                if (state.keepScreenOn)
+                                                    Res.string.cook_mode_allow_screen_off
+                                                else Res.string.cook_mode_keep_screen_on
+                                            ),
+                                    )
+                                }
+                                IconButton(onClick = bloc::onLayoutToggled) {
+                                    Icon(
+                                        imageVector =
+                                            if (state.layoutMode == CookModeBloc.LayoutMode.Stacked)
+                                                Icons.Default.ViewWeek
+                                            else Icons.Default.ViewAgenda,
+                                        contentDescription =
+                                            stringResource(
+                                                if (
+                                                    state.layoutMode ==
+                                                        CookModeBloc.LayoutMode.Stacked
+                                                )
+                                                    Res.string.cook_mode_layout_split
+                                                else Res.string.cook_mode_layout_stacked
+                                            ),
+                                    )
+                                }
+                            },
+                    ),
                 modifier = Modifier.fillMaxSize(),
-            )
-            CookModeAppBar(
-                title = state.activeRecipe?.title.orEmpty(),
-                layoutMode = state.layoutMode,
-                keepScreenOn = state.keepScreenOn,
-                onLayoutToggle = bloc::onLayoutToggled,
-                onKeepScreenOnToggle = bloc::onKeepScreenOnToggled,
-                onCloseClicked = bloc::onCloseClicked,
-                modifier = Modifier.align(Alignment.TopCenter),
-            )
+                floatingHeader = true,
+                headerContainerAlpha = 0.85f,
+                centerAlignTitle = true,
+                floatingHeaderTopReserve = false,
+                scrollEnabled = false,
+                maxContentWidth = Dp.Unspecified,
+            ) {
+                CookModeBody(
+                    isLoading = state.isLoading,
+                    recipe = state.activeRecipe,
+                    layoutMode = state.layoutMode,
+                    windowSizeClass = windowSizeClass,
+                    bottomReserve = 0.dp,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
         }
     }
 }
@@ -287,75 +373,6 @@ private fun CookingPeekRow(
             modifier = Modifier.weight(1f),
         )
     }
-}
-
-@Composable
-private fun CookModeAppBar(
-    title: String,
-    layoutMode: CookModeBloc.LayoutMode,
-    keepScreenOn: Boolean,
-    onLayoutToggle: () -> Unit,
-    onKeepScreenOnToggle: () -> Unit,
-    onCloseClicked: () -> Unit,
-    onWhatsCookingClicked: (() -> Unit)? = null,
-    modifier: Modifier = Modifier,
-) {
-    CenterAlignedTopAppBar(
-        modifier = modifier.fillMaxWidth(),
-        windowInsets =
-            WindowInsets.systemBars
-                .union(WindowInsets.displayCutout)
-                .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
-        title = { Text(text = title, maxLines = 1) },
-        navigationIcon = {
-            IconButton(onClick = onCloseClicked) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(Res.string.cook_mode_close),
-                )
-            }
-        },
-        actions = {
-            if (onWhatsCookingClicked != null) {
-                IconButton(onClick = onWhatsCookingClicked) {
-                    Icon(
-                        imageVector = Icons.Default.Restaurant,
-                        contentDescription = stringResource(Res.string.cook_mode_whats_cooking),
-                    )
-                }
-            }
-            IconButton(onClick = onKeepScreenOnToggle) {
-                Icon(
-                    imageVector =
-                        if (keepScreenOn) Icons.Default.Visibility else Icons.Default.VisibilityOff,
-                    contentDescription =
-                        stringResource(
-                            if (keepScreenOn) Res.string.cook_mode_allow_screen_off
-                            else Res.string.cook_mode_keep_screen_on
-                        ),
-                )
-            }
-            IconButton(onClick = onLayoutToggle) {
-                Icon(
-                    imageVector =
-                        if (layoutMode == CookModeBloc.LayoutMode.Stacked) Icons.Default.ViewWeek
-                        else Icons.Default.ViewAgenda,
-                    contentDescription =
-                        stringResource(
-                            if (layoutMode == CookModeBloc.LayoutMode.Stacked) {
-                                Res.string.cook_mode_layout_split
-                            } else {
-                                Res.string.cook_mode_layout_stacked
-                            }
-                        ),
-                )
-            }
-        },
-        colors =
-            TopAppBarDefaults.centerAlignedTopAppBarColors(
-                containerColor = MaterialTheme.colorScheme.background.copy(alpha = 0.85f)
-            ),
-    )
 }
 
 @Composable
@@ -487,37 +504,72 @@ private fun StackedLayout(
     val padding = ChefMateTheme.dimens.paddingNormal
     val contentPadding = bodyContentPadding(bottomReserve)
     val layoutDir = LocalLayoutDirection.current
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding =
-            PaddingValues(
-                start = contentPadding.calculateStartPadding(layoutDir) + padding,
-                end = contentPadding.calculateEndPadding(layoutDir) + padding,
-                top = contentPadding.calculateTopPadding(),
-                bottom = contentPadding.calculateBottomPadding(),
-            ),
-        verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingExtraSmall),
-    ) {
-        stickyHeader(key = "ingredients_header") {
-            CookSectionHeader(stringResource(Res.string.cook_mode_ingredients))
+    val lazyListState = rememberLazyListState()
+
+    val ingredientsTitle = stringResource(Res.string.cook_mode_ingredients)
+    val directionsTitle = stringResource(Res.string.cook_mode_directions)
+
+    // List layout (no sticky headers):
+    //   indices 0..N-1     → ingredient items
+    //   index  N           → directions section header (regular item, scrolls normally)
+    //   indices N+1..      → direction items
+    // Switch to "Directions" label when the directions header or a direction item is first visible.
+    val currentSectionTitle by
+        remember(ingredientLines.size) {
+            derivedStateOf {
+                if (lazyListState.firstVisibleItemIndex < ingredientLines.size) ingredientsTitle
+                else directionsTitle
+            }
         }
-        itemsIndexed(ingredientLines, key = { i, _ -> "ingredient_$i" }) { index, line ->
-            IngredientRow(
-                text = line,
-                crossedOut = crossedOut[index],
-                onClick = { crossedOut[index] = !crossedOut[index] },
-            )
+
+    // Measure the overlay header height so contentPadding reserves the same space below the
+    // app bar. Starts at 0 on the first frame then stabilises immediately.
+    var overlayHeaderHeightPx by remember { mutableStateOf(0) }
+    val density = LocalDensity.current
+
+    Box(Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            state = lazyListState,
+            contentPadding =
+                PaddingValues(
+                    start = contentPadding.calculateStartPadding(layoutDir) + padding,
+                    end = contentPadding.calculateEndPadding(layoutDir) + padding,
+                    top =
+                        contentPadding.calculateTopPadding() +
+                            with(density) { overlayHeaderHeightPx.toDp() },
+                    bottom = contentPadding.calculateBottomPadding(),
+                ),
+            verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingExtraSmall),
+        ) {
+            itemsIndexed(ingredientLines, key = { i, _ -> "ingredient_$i" }) { index, line ->
+                IngredientRow(
+                    text = line,
+                    crossedOut = crossedOut[index],
+                    onClick = { crossedOut[index] = !crossedOut[index] },
+                )
+            }
+            // Directions header as a regular scrollable item — acts as a visual section divider.
+            item(key = "directions_header") { CookSectionHeader(directionsTitle) }
+            itemsIndexed(directionParagraphs, key = { i, _ -> "direction_$i" }) { index, paragraph
+                ->
+                DirectionRow(
+                    text = paragraph,
+                    highlighted = highlightedIndex == index,
+                    onClick = { onDirectionToggled(index) },
+                )
+            }
         }
-        stickyHeader(key = "directions_header") {
-            CookSectionHeader(stringResource(Res.string.cook_mode_directions))
-        }
-        itemsIndexed(directionParagraphs, key = { i, _ -> "direction_$i" }) { index, paragraph ->
-            DirectionRow(
-                text = paragraph,
-                highlighted = highlightedIndex == index,
-                onClick = { onDirectionToggled(index) },
-            )
-        }
+
+        // Overlay sticky header pinned to the bottom edge of the floating app bar.
+        // Items scroll freely through/behind the transparent app bar; only this header is anchored.
+        CookSectionHeader(
+            title = currentSectionTitle,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(top = contentPadding.calculateTopPadding())
+                    .onSizeChanged { overlayHeaderHeightPx = it.height },
+        )
     }
 }
 
@@ -687,9 +739,9 @@ private fun VerticalDragHandle(onDrag: (Float) -> Unit) {
 }
 
 @Composable
-private fun CookSectionHeader(title: String) {
+private fun CookSectionHeader(title: String, modifier: Modifier = Modifier) {
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 2.dp,
     ) {

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeScreen.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeScreen.kt
@@ -44,6 +44,8 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.ViewAgenda
 import androidx.compose.material.icons.filled.ViewWeek
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.BottomSheetScaffold
@@ -85,15 +87,18 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import chefmate.client.cook.public.generated.resources.Res
+import chefmate.client.cook.public.generated.resources.cook_mode_allow_screen_off
 import chefmate.client.cook.public.generated.resources.cook_mode_close
 import chefmate.client.cook.public.generated.resources.cook_mode_directions
 import chefmate.client.cook.public.generated.resources.cook_mode_ingredients
+import chefmate.client.cook.public.generated.resources.cook_mode_keep_screen_on
 import chefmate.client.cook.public.generated.resources.cook_mode_layout_split
 import chefmate.client.cook.public.generated.resources.cook_mode_layout_stacked
 import chefmate.client.cook.public.generated.resources.cook_mode_loading
 import chefmate.client.cook.public.generated.resources.cook_mode_no_active_recipe
 import chefmate.client.cook.public.generated.resources.cook_mode_whats_cooking
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.ui.KeepScreenOn
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -103,6 +108,9 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun CookModeScreen(bloc: CookModeBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
+    if (state.keepScreenOn) {
+        KeepScreenOn()
+    }
     Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         PlusResponsiveContainer(modifier = Modifier.fillMaxSize()) { windowSizeClass ->
             if (windowSizeClass == WindowSizeClass.COMPACT) {
@@ -134,7 +142,9 @@ private fun CookModeTabletLayout(
         CookModeAppBar(
             title = state.activeRecipe?.title.orEmpty(),
             layoutMode = state.layoutMode,
+            keepScreenOn = state.keepScreenOn,
             onLayoutToggle = bloc::onLayoutToggled,
+            onKeepScreenOnToggle = bloc::onKeepScreenOnToggled,
             onCloseClicked = bloc::onCloseClicked,
             modifier = Modifier.align(Alignment.TopCenter),
         )
@@ -226,7 +236,9 @@ private fun CookModeMobileLayout(
             CookModeAppBar(
                 title = state.activeRecipe?.title.orEmpty(),
                 layoutMode = state.layoutMode,
+                keepScreenOn = state.keepScreenOn,
                 onLayoutToggle = bloc::onLayoutToggled,
+                onKeepScreenOnToggle = bloc::onKeepScreenOnToggled,
                 onCloseClicked = bloc::onCloseClicked,
                 modifier = Modifier.align(Alignment.TopCenter),
             )
@@ -265,7 +277,9 @@ private fun CookingPeekRow(
 private fun CookModeAppBar(
     title: String,
     layoutMode: CookModeBloc.LayoutMode,
+    keepScreenOn: Boolean,
     onLayoutToggle: () -> Unit,
+    onKeepScreenOnToggle: () -> Unit,
     onCloseClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -285,6 +299,17 @@ private fun CookModeAppBar(
             }
         },
         actions = {
+            IconButton(onClick = onKeepScreenOnToggle) {
+                Icon(
+                    imageVector =
+                        if (keepScreenOn) Icons.Default.Visibility else Icons.Default.VisibilityOff,
+                    contentDescription =
+                        stringResource(
+                            if (keepScreenOn) Res.string.cook_mode_allow_screen_off
+                            else Res.string.cook_mode_keep_screen_on
+                        ),
+                )
+            }
             IconButton(onClick = onLayoutToggle) {
                 Icon(
                     imageVector =

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -1,11 +1,10 @@
 package com.plusmobileapps.chefmate.recipe.core.impl.detail
 
 import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.di.KeepScreenOnRepository
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
-import com.russhwolf.settings.Settings
-import com.russhwolf.settings.boolean
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
@@ -25,18 +24,23 @@ class RecipeDetailViewModel(
     @Assisted private val recipeId: Long,
     @Main mainContext: CoroutineContext,
     private val repository: RecipeRepository,
-    settings: Settings,
+    private val keepScreenOnRepository: KeepScreenOnRepository,
 ) : ViewModel(mainContext) {
 
-    private var keepScreenOnPref by settings.boolean(KEY_KEEP_SCREEN_ON, defaultValue = true)
     private val _output = Channel<Output>(Channel.BUFFERED)
     val output: Flow<Output> = _output.receiveAsFlow()
 
-    private val _state = MutableStateFlow(State(keepScreenOn = keepScreenOnPref))
+    private val _state =
+        MutableStateFlow(State(keepScreenOn = keepScreenOnRepository.keepScreenOn.value))
     val state: StateFlow<State> = _state.asStateFlow()
 
     init {
         scope.launch { observeRecipe() }
+        scope.launch {
+            keepScreenOnRepository.keepScreenOn.collect { keepScreenOn ->
+                _state.update { it.copy(keepScreenOn = keepScreenOn) }
+            }
+        }
     }
 
     private suspend fun observeRecipe() {
@@ -82,9 +86,7 @@ class RecipeDetailViewModel(
     }
 
     fun toggleKeepScreenOn() {
-        val newValue = !_state.value.keepScreenOn
-        keepScreenOnPref = newValue
-        _state.update { it.copy(keepScreenOn = newValue) }
+        keepScreenOnRepository.toggle()
     }
 
     data class State(
@@ -103,9 +105,5 @@ class RecipeDetailViewModel(
     @AssistedFactory
     fun interface Factory {
         fun create(recipeId: Long): RecipeDetailViewModel
-    }
-
-    companion object {
-        private const val KEY_KEEP_SCREEN_ON = "recipe_detail_keep_screen_on"
     }
 }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SoupKitchen
@@ -127,7 +128,6 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_keep
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_prep_time
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_remove_favorite
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_servings
-import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_text
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_url
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_source
@@ -144,6 +144,7 @@ import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.KeepScreenOn
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
@@ -151,7 +152,6 @@ import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
-import com.plusmobileapps.chefmate.util.KeepScreenOn
 import com.plusmobileapps.chefmate.util.rememberShareLauncher
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -207,7 +207,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     // Add to Grocery List Bottom Sheet
     RecipeDetailSheet(bloc = bloc, sheetState = sheetState)
 
-    var showShareMenu by remember { mutableStateOf(false) }
+    var showOverflowMenu by remember { mutableStateOf(false) }
     var metadataCollapsed by rememberSaveable { mutableStateOf(false) }
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -242,6 +242,100 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                                 )
                                             },
                                     )
+                                }
+                                Box {
+                                    IconButton(onClick = { showOverflowMenu = true }) {
+                                        Icon(
+                                            imageVector = Icons.Default.MoreVert,
+                                            contentDescription =
+                                                stringResource(Res.string.recipe_detail_edit),
+                                        )
+                                    }
+                                    DropdownMenu(
+                                        expanded = showOverflowMenu,
+                                        onDismissRequest = { showOverflowMenu = false },
+                                    ) {
+                                        DropdownMenuItem(
+                                            text = {
+                                                Text(stringResource(Res.string.recipe_detail_edit))
+                                            },
+                                            leadingIcon = {
+                                                Icon(Icons.Default.Edit, contentDescription = null)
+                                            },
+                                            onClick = {
+                                                showOverflowMenu = false
+                                                bloc.onEditClicked()
+                                            },
+                                        )
+                                        state.recipe.sourceUrl?.let { url ->
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Text(
+                                                        stringResource(
+                                                            Res.string.recipe_detail_share_url
+                                                        )
+                                                    )
+                                                },
+                                                leadingIcon = {
+                                                    Icon(
+                                                        Icons.Default.Share,
+                                                        contentDescription = null,
+                                                    )
+                                                },
+                                                onClick = {
+                                                    showOverflowMenu = false
+                                                    if (shareLauncher(url)) {
+                                                        scope.launch {
+                                                            snackbarHostState.showSnackbar(
+                                                                copiedMessage
+                                                            )
+                                                        }
+                                                    }
+                                                },
+                                            )
+                                        }
+                                        DropdownMenuItem(
+                                            text = {
+                                                Text(
+                                                    stringResource(
+                                                        Res.string.recipe_detail_share_text
+                                                    )
+                                                )
+                                            },
+                                            leadingIcon = {
+                                                Icon(Icons.Default.Share, contentDescription = null)
+                                            },
+                                            onClick = {
+                                                showOverflowMenu = false
+                                                if (
+                                                    shareLauncher(formatRecipeAsText(state.recipe))
+                                                ) {
+                                                    scope.launch {
+                                                        snackbarHostState.showSnackbar(
+                                                            copiedMessage
+                                                        )
+                                                    }
+                                                }
+                                            },
+                                        )
+                                        DropdownMenuItem(
+                                            text = {
+                                                Text(
+                                                    stringResource(Res.string.recipe_detail_delete)
+                                                )
+                                            },
+                                            leadingIcon = {
+                                                Icon(
+                                                    Icons.Default.Delete,
+                                                    contentDescription = null,
+                                                )
+                                            },
+                                            onClick = {
+                                                showOverflowMenu = false
+                                                bloc.onDeleteClicked()
+                                            },
+                                        )
+                                    }
                                 }
                             },
                     ),
@@ -300,76 +394,6 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                             stringResource(
                                                 Res.string.recipe_detail_add_to_meal_plan
                                             ),
-                                    )
-                                }
-                                IconButton(onClick = { bloc.onEditClicked() }) {
-                                    Icon(
-                                        imageVector = Icons.Default.Edit,
-                                        contentDescription =
-                                            stringResource(Res.string.recipe_detail_edit),
-                                    )
-                                }
-                                Box {
-                                    IconButton(onClick = { showShareMenu = true }) {
-                                        Icon(
-                                            imageVector = Icons.Default.Share,
-                                            contentDescription =
-                                                stringResource(Res.string.recipe_detail_share),
-                                        )
-                                    }
-                                    DropdownMenu(
-                                        expanded = showShareMenu,
-                                        onDismissRequest = { showShareMenu = false },
-                                    ) {
-                                        state.recipe.sourceUrl?.let { url ->
-                                            DropdownMenuItem(
-                                                text = {
-                                                    Text(
-                                                        stringResource(
-                                                            Res.string.recipe_detail_share_url
-                                                        )
-                                                    )
-                                                },
-                                                onClick = {
-                                                    showShareMenu = false
-                                                    if (shareLauncher(url)) {
-                                                        scope.launch {
-                                                            snackbarHostState.showSnackbar(
-                                                                copiedMessage
-                                                            )
-                                                        }
-                                                    }
-                                                },
-                                            )
-                                        }
-                                        DropdownMenuItem(
-                                            text = {
-                                                Text(
-                                                    stringResource(
-                                                        Res.string.recipe_detail_share_text
-                                                    )
-                                                )
-                                            },
-                                            onClick = {
-                                                showShareMenu = false
-                                                if (
-                                                    shareLauncher(formatRecipeAsText(state.recipe))
-                                                ) {
-                                                    scope.launch {
-                                                        snackbarHostState.showSnackbar(
-                                                            copiedMessage
-                                                        )
-                                                    }
-                                                }
-                                            },
-                                        )
-                                    }
-                                }
-                                IconButton(onClick = { bloc.onDeleteClicked() }) {
-                                    Icon(
-                                        imageVector = Icons.Default.Delete,
-                                        contentDescription =
-                                            stringResource(Res.string.recipe_detail_delete),
                                     )
                                 }
                             }

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -3,9 +3,12 @@
 package com.plusmobileapps.chefmate.root
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
@@ -77,14 +80,26 @@ fun RootScreen(rootBloc: RootBloc, modifier: Modifier = Modifier) {
                     val targetIndex = items.indexOfFirst { it.key == targetState.key }
                     val isForward = if (initialIndex < 0) false else targetIndex > initialIndex
                     val spec = tween<androidx.compose.ui.unit.IntOffset>(durationMillis = 300)
+                    val floatSpec = tween<Float>(durationMillis = 300)
 
                     if (isVertical) {
                         if (isForward) {
-                            slideInVertically(spec) { it } togetherWith
-                                slideOutVertically(spec) { 0 }
+                            // Modal slides up over the background. The background must stay alive
+                            // (via fadeOut) for the full duration so it's visible behind the
+                            // incoming screen; z-index puts the modal on top.
+                            ContentTransform(
+                                targetContentEnter = slideInVertically(spec) { it },
+                                initialContentExit = fadeOut(floatSpec),
+                                targetContentZIndex = 1f,
+                            )
                         } else {
-                            slideInVertically(spec) { 0 } togetherWith
-                                slideOutVertically(spec) { it }
+                            // Modal slides back down. The background should sit underneath while
+                            // the modal exits; negative z-index keeps the modal on top.
+                            ContentTransform(
+                                targetContentEnter = EnterTransition.None,
+                                initialContentExit = slideOutVertically(spec) { it },
+                                targetContentZIndex = -1f,
+                            )
                         }
                     } else {
                         if (isForward) {
@@ -98,9 +113,16 @@ fun RootScreen(rootBloc: RootBloc, modifier: Modifier = Modifier) {
                 },
                 label = "root-stack",
             ) { activeChild ->
+                // Only BottomNavigation and RecipeRoot participate in shared element transitions
+                // (recipe image/title morph). All other screens get a null AnimatedVisibilityScope
+                // so SharedTransitionLayout never intercepts their enter/exit timing.
+                val isSharedTransitionParticipant =
+                    activeChild.instance is RootBloc.Child.BottomNavigation ||
+                        activeChild.instance is RootBloc.Child.RecipeRoot
                 CompositionLocalProvider(
                     LocalSharedTransitionScope provides this@SharedTransitionLayout,
-                    LocalAnimatedVisibilityScope provides this,
+                    LocalAnimatedVisibilityScope provides
+                        if (isSharedTransitionParticipant) this else null,
                 ) {
                     saveableStateHolder.SaveableStateProvider(activeChild.saveableKey()) {
                         RootChildContent(activeChild.instance, rootBloc::onBackClicked)

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/KeepScreenOnRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/KeepScreenOnRepository.kt
@@ -1,0 +1,28 @@
+package com.plusmobileapps.chefmate.di
+
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.boolean
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@Inject
+@SingleIn(AppScope::class)
+class KeepScreenOnRepository(settings: Settings) {
+    private var pref by settings.boolean(KEY, defaultValue = true)
+
+    private val _keepScreenOn = MutableStateFlow(pref)
+    val keepScreenOn: StateFlow<Boolean> = _keepScreenOn.asStateFlow()
+
+    fun toggle() {
+        val newValue = !_keepScreenOn.value
+        pref = newValue
+        _keepScreenOn.value = newValue
+    }
+
+    companion object {
+        private const val KEY = "recipe_detail_keep_screen_on"
+    }
+}

--- a/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/KeepScreenOn.android.kt
+++ b/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/KeepScreenOn.android.kt
@@ -1,6 +1,6 @@
 @file:Suppress("ktlint:standard:filename")
 
-package com.plusmobileapps.chefmate.util
+package com.plusmobileapps.chefmate.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/KeepScreenOn.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/KeepScreenOn.kt
@@ -1,4 +1,4 @@
-package com.plusmobileapps.chefmate.util
+package com.plusmobileapps.chefmate.ui
 
 import androidx.compose.runtime.Composable
 

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
@@ -11,15 +11,18 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.systemGestures
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.rememberScrollState
@@ -27,6 +30,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
@@ -34,6 +38,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.BottomCenter
@@ -61,40 +66,96 @@ fun PlusHeaderContainer(
     snackbarHost: @Composable () -> Unit = {},
     floatingActionButton: @Composable () -> Unit = {},
     floatingToolbar: (@Composable () -> Unit)? = null,
+    floatingHeader: Boolean = false,
+    headerContainerAlpha: Float = 1f,
+    centerAlignTitle: Boolean = false,
+    // When true the container adds status-bar + app-bar top padding to the content so it clears
+    // the floating header. Pass false when the content manages its own top inset (e.g. Cook Mode).
+    floatingHeaderTopReserve: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val scrollState = rememberScrollState()
     val density = LocalDensity.current
 
-    Column(
-        modifier = modifier.fillMaxSize().background(ChefMateTheme.colorScheme.background),
-        verticalArrangement = verticalArrangement,
-        horizontalAlignment = horizontalAlignment,
-    ) {
-        if (data !is PlusHeaderData.None) {
-            PlusHeader(data = data)
+    if (floatingHeader) {
+        val topPadding =
+            if (floatingHeaderTopReserve) {
+                with(density) { WindowInsets.statusBars.getTop(density).toDp() } + 64.dp
+            } else {
+                0.dp
+            }
+        Box(modifier = modifier.fillMaxSize().background(ChefMateTheme.colorScheme.background)) {
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = ChefMateTheme.colorScheme.background,
+                contentColor = ChefMateTheme.colorScheme.onBackground,
+            ) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    ScrollingContent(
+                        scrollEnabled = scrollEnabled,
+                        scrollState = scrollState,
+                        maxContentWidth = maxContentWidth,
+                        topPadding = topPadding,
+                        content = content,
+                    )
+                    BottomBarBox(
+                        density = density,
+                        floatingActionButton = floatingActionButton,
+                        snackbarHost = snackbarHost,
+                    )
+                    floatingToolbar?.let {
+                        Box(modifier = Modifier.align(BottomCenter).floatingToolbarPadding()) {
+                            it()
+                        }
+                    }
+                }
+            }
+            if (data !is PlusHeaderData.None) {
+                PlusHeader(
+                    data = data,
+                    containerAlpha = headerContainerAlpha,
+                    centerAlign = centerAlignTitle,
+                    windowInsets =
+                        WindowInsets.systemBars
+                            .union(WindowInsets.displayCutout)
+                            .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
+                    modifier = Modifier.align(Alignment.TopCenter),
+                )
+            }
         }
-
-        Surface(
-            modifier = Modifier.weight(1f),
-            color = ChefMateTheme.colorScheme.background,
-            contentColor = ChefMateTheme.colorScheme.onBackground,
+    } else {
+        Column(
+            modifier = modifier.fillMaxSize().background(ChefMateTheme.colorScheme.background),
+            verticalArrangement = verticalArrangement,
+            horizontalAlignment = horizontalAlignment,
         ) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                ScrollingContent(
-                    scrollEnabled = scrollEnabled,
-                    scrollState = scrollState,
-                    maxContentWidth = maxContentWidth,
-                    content = content,
-                )
-                BottomBarBox(
-                    density = density,
-                    floatingActionButton = floatingActionButton,
-                    snackbarHost = snackbarHost,
-                )
+            if (data !is PlusHeaderData.None) {
+                PlusHeader(data = data)
+            }
 
-                floatingToolbar?.let {
-                    Box(modifier = Modifier.align(BottomCenter).floatingToolbarPadding()) { it() }
+            Surface(
+                modifier = Modifier.weight(1f),
+                color = ChefMateTheme.colorScheme.background,
+                contentColor = ChefMateTheme.colorScheme.onBackground,
+            ) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    ScrollingContent(
+                        scrollEnabled = scrollEnabled,
+                        scrollState = scrollState,
+                        maxContentWidth = maxContentWidth,
+                        content = content,
+                    )
+                    BottomBarBox(
+                        density = density,
+                        floatingActionButton = floatingActionButton,
+                        snackbarHost = snackbarHost,
+                    )
+
+                    floatingToolbar?.let {
+                        Box(modifier = Modifier.align(BottomCenter).floatingToolbarPadding()) {
+                            it()
+                        }
+                    }
                 }
             }
         }
@@ -140,6 +201,7 @@ private fun ScrollingContent(
     scrollEnabled: Boolean,
     scrollState: ScrollState,
     maxContentWidth: Dp,
+    topPadding: Dp = 0.dp,
     content: @Composable (ColumnScope.() -> Unit),
 ) {
     Column(
@@ -148,12 +210,14 @@ private fun ScrollingContent(
                 modifier
                     .fillMaxHeight()
                     .widthIn(max = maxContentWidth)
+                    .padding(top = topPadding)
                     .scaffoldContentInsetPadding()
                     .verticalScroll(scrollState)
             } else {
                 modifier
                     .fillMaxHeight()
                     .widthIn(max = maxContentWidth)
+                    .padding(top = topPadding)
                     .scaffoldContentInsetPadding()
             }
     ) {
@@ -168,83 +232,104 @@ private fun ScrollingContent(
 fun PlusHeader(
     data: PlusHeaderData,
     windowInsets: WindowInsets? = null,
+    containerAlpha: Float = 1f,
+    centerAlign: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val density = LocalDensity.current
-    TopAppBar(
-        modifier = modifier,
-        windowInsets =
-            windowInsets
-                ?: WindowInsets(
-                    left = WindowInsets.displayCutout.getLeft(density, LayoutDirection.Ltr),
-                    right = WindowInsets.displayCutout.getRight(density, LayoutDirection.Ltr),
-                    top = WindowInsets.statusBars.getTop(density),
-                    bottom = WindowInsets.statusBars.getBottom(density),
-                ),
-        title = {
-            val titleKey = (data as? PlusHeaderData.Child)?.titleSharedElementKey
-            Text(
-                text = data.title.localized(),
-                color = ChefMateTheme.colorScheme.onBackground,
-                modifier = Modifier.sharedBoundsBy(titleKey),
+    val resolvedInsets =
+        windowInsets
+            ?: WindowInsets(
+                left = WindowInsets.displayCutout.getLeft(density, LayoutDirection.Ltr),
+                right = WindowInsets.displayCutout.getRight(density, LayoutDirection.Ltr),
+                top = WindowInsets.statusBars.getTop(density),
+                bottom = WindowInsets.statusBars.getBottom(density),
             )
-        },
-        navigationIcon =
-            when (data) {
-                is PlusHeaderData.Child -> {
-                    {
-                        PlusIconButton(
-                            modifier = Modifier.padding(end = ChefMateTheme.dimens.paddingSmall),
-                            icon = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(Res.string.back),
-                            onClick = data.onBackClick,
-                        )
-                    }
+    val colors =
+        if (containerAlpha < 1f) {
+            TopAppBarDefaults.topAppBarColors(
+                containerColor = ChefMateTheme.colorScheme.background.copy(alpha = containerAlpha)
+            )
+        } else {
+            TopAppBarDefaults.topAppBarColors()
+        }
+    val title: @Composable () -> Unit = {
+        val titleKey = (data as? PlusHeaderData.Child)?.titleSharedElementKey
+        Text(
+            text = data.title.localized(),
+            color = ChefMateTheme.colorScheme.onBackground,
+            modifier = Modifier.sharedBoundsBy(titleKey),
+        )
+    }
+    val navigationIcon: @Composable () -> Unit =
+        when (data) {
+            is PlusHeaderData.Child -> {
+                {
+                    PlusIconButton(
+                        modifier = Modifier.padding(end = ChefMateTheme.dimens.paddingSmall),
+                        icon = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(Res.string.back),
+                        onClick = data.onBackClick,
+                    )
                 }
-
-                is PlusHeaderData.Modal -> {
-                    {
-                        PlusIconButton(
-                            icon = Icons.Default.Close,
-                            contentDescription = stringResource(Res.string.close),
-                            onClick = data.onCloseClick,
-                        )
-                    }
+            }
+            is PlusHeaderData.Modal -> {
+                {
+                    PlusIconButton(
+                        icon = Icons.Default.Close,
+                        contentDescription = stringResource(Res.string.close),
+                        onClick = data.onCloseClick,
+                    )
                 }
-
-                is PlusHeaderData.Parent -> {
-                    {}
-                }
-                PlusHeaderData.None -> {
-                    {}
-                }
-            },
-        actions = {
-            when (val trailingAccessory = data.trailingAccessory) {
-                is PlusHeaderData.TrailingAccessory.Button -> {
-                    PlusButton(text = trailingAccessory.text, onClick = trailingAccessory.onClick)
-                }
-
-                is PlusHeaderData.TrailingAccessory.Custom -> trailingAccessory.content(this)
-                null -> Unit
-                is PlusHeaderData.TrailingAccessory.Icon -> {
-                    if (trailingAccessory.onClick != null) {
-                        IconButton(onClick = trailingAccessory.onClick) {
-                            Icon(
-                                trailingAccessory.icon,
-                                contentDescription = trailingAccessory.contentDesc.localized(),
-                                tint = ChefMateTheme.colorScheme.onBackground,
-                            )
-                        }
-                    } else {
+            }
+            is PlusHeaderData.Parent,
+            PlusHeaderData.None -> {
+                {}
+            }
+        }
+    val actions: @Composable androidx.compose.foundation.layout.RowScope.() -> Unit = {
+        when (val trailingAccessory = data.trailingAccessory) {
+            is PlusHeaderData.TrailingAccessory.Button -> {
+                PlusButton(text = trailingAccessory.text, onClick = trailingAccessory.onClick)
+            }
+            is PlusHeaderData.TrailingAccessory.Custom -> trailingAccessory.content(this)
+            null -> Unit
+            is PlusHeaderData.TrailingAccessory.Icon -> {
+                if (trailingAccessory.onClick != null) {
+                    IconButton(onClick = trailingAccessory.onClick) {
                         Icon(
                             trailingAccessory.icon,
                             contentDescription = trailingAccessory.contentDesc.localized(),
                             tint = ChefMateTheme.colorScheme.onBackground,
                         )
                     }
+                } else {
+                    Icon(
+                        trailingAccessory.icon,
+                        contentDescription = trailingAccessory.contentDesc.localized(),
+                        tint = ChefMateTheme.colorScheme.onBackground,
+                    )
                 }
             }
-        },
-    )
+        }
+    }
+    if (centerAlign) {
+        CenterAlignedTopAppBar(
+            modifier = modifier,
+            windowInsets = resolvedInsets,
+            title = title,
+            navigationIcon = navigationIcon,
+            actions = actions,
+            colors = colors,
+        )
+    } else {
+        TopAppBar(
+            modifier = modifier,
+            windowInsets = resolvedInsets,
+            title = title,
+            navigationIcon = navigationIcon,
+            actions = actions,
+            colors = colors,
+        )
+    }
 }

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusNavRailContainer.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusNavRailContainer.kt
@@ -43,70 +43,62 @@ data class NavRailItem(
 fun PlusNavRailHeaderContainer(
     modifier: Modifier = Modifier,
     navRail: List<NavRailItem>,
+    expandedItems: Boolean = false,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     val density = LocalDensity.current
 
-    PlusResponsiveContainer(modifier = modifier.fillMaxSize()) { windowSize ->
-        Row(modifier = modifier.fillMaxSize()) {
-            NavigationRail(
-                modifier = Modifier.fillMaxHeight(),
-                windowInsets =
-                    WindowInsets(
-                        left = WindowInsets.displayCutout.getLeft(density, LayoutDirection.Ltr),
-                        right = 0,
-                        top = WindowInsets.statusBars.getTop(density),
-                        bottom = WindowInsets.systemGestures.getBottom(density),
-                    ),
-                content = {
-                    when (windowSize) {
-                        WindowSizeClass.COMPACT,
-                        WindowSizeClass.MEDIUM -> {
-                            navRail.forEach { item ->
-                                NavigationRailItem(
-                                    selected = item.selected,
-                                    onClick = item.onClick,
-                                    icon = { item.icon() },
-                                    label = { item.label.localized() },
-                                )
-                            }
-                        }
-
-                        WindowSizeClass.EXPANDED -> {
-                            navRail.forEach { item ->
-                                PlusExpandedNavRailItem(
-                                    selected = item.selected,
-                                    onClick = item.onClick,
-                                    icon = { item.icon() },
-                                    label = { Text(item.label.localized()) },
-                                )
-                            }
-                        }
-                    }
-                },
-                containerColor = ChefMateTheme.colorScheme.surfaceContainer,
-                contentColor = ChefMateTheme.colorScheme.onSurface,
-            )
-
-            Box(modifier = Modifier.weight(1f)) {
-                val paddingValues: PaddingValues =
-                    with(density) {
-                        PaddingValues.Absolute(
-                            right =
-                                WindowInsets.displayCutout
-                                    .getRight(density, LayoutDirection.Ltr)
-                                    .toDp(),
-                            top = WindowInsets.statusBars.getTop(density).toDp(),
-                            bottom = WindowInsets.navigationBars.getBottom(density).toDp(),
+    Row(modifier = modifier.fillMaxSize()) {
+        NavigationRail(
+            modifier = Modifier.fillMaxHeight(),
+            windowInsets =
+                WindowInsets(
+                    left = WindowInsets.displayCutout.getLeft(density, LayoutDirection.Ltr),
+                    right = 0,
+                    top = WindowInsets.statusBars.getTop(density),
+                    bottom = WindowInsets.systemGestures.getBottom(density),
+                ),
+            content = {
+                navRail.forEach { item ->
+                    if (expandedItems) {
+                        PlusExpandedNavRailItem(
+                            selected = item.selected,
+                            onClick = item.onClick,
+                            icon = { item.icon() },
+                            label = { Text(item.label.localized()) },
+                        )
+                    } else {
+                        NavigationRailItem(
+                            selected = item.selected,
+                            onClick = item.onClick,
+                            icon = { item.icon() },
+                            label = { Text(item.label.localized()) },
                         )
                     }
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = ChefMateTheme.colorScheme.background,
-                    contentColor = ChefMateTheme.colorScheme.onBackground,
-                ) {
-                    content(paddingValues)
                 }
+            },
+            containerColor = ChefMateTheme.colorScheme.surfaceContainer,
+            contentColor = ChefMateTheme.colorScheme.onSurface,
+        )
+
+        Box(modifier = Modifier.weight(1f)) {
+            val paddingValues: PaddingValues =
+                with(density) {
+                    PaddingValues.Absolute(
+                        right =
+                            WindowInsets.displayCutout
+                                .getRight(density, LayoutDirection.Ltr)
+                                .toDp(),
+                        top = WindowInsets.statusBars.getTop(density).toDp(),
+                        bottom = WindowInsets.navigationBars.getBottom(density).toDp(),
+                    )
+                }
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = ChefMateTheme.colorScheme.background,
+                contentColor = ChefMateTheme.colorScheme.onBackground,
+            ) {
+                content(paddingValues)
             }
         }
     }

--- a/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/KeepScreenOn.ios.kt
+++ b/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/KeepScreenOn.ios.kt
@@ -1,6 +1,6 @@
 @file:Suppress("ktlint:standard:filename")
 
-package com.plusmobileapps.chefmate.util
+package com.plusmobileapps.chefmate.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect

--- a/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/KeepScreenOn.jvm.kt
+++ b/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/KeepScreenOn.jvm.kt
@@ -1,6 +1,6 @@
 @file:Suppress("ktlint:standard:filename")
 
-package com.plusmobileapps.chefmate.util
+package com.plusmobileapps.chefmate.ui
 
 import androidx.compose.runtime.Composable
 

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTest.kt
@@ -11,18 +11,24 @@ import com.plusmobileapps.chefmate.cook.previewCookBlocSplit
 import com.plusmobileapps.chefmate.cook.previewCookBlocStacked
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
+// ── Phone portrait (360 × 1100 dp, COMPACT width → mobile layout) ──────────
+
 @PreviewTest
 @Preview(showBackground = true, heightDp = 1100)
 @Composable
-fun CookModeStackedScreenshot() {
+fun CookModePhonePortraitLightScreenshot() {
     ChefMateTheme { CookModeScreen(bloc = previewCookBlocStacked) }
 }
 
 @PreviewTest
-@Preview(showBackground = true, heightDp = 1100, widthDp = 800)
+@Preview(
+    showBackground = true,
+    heightDp = 1100,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
-fun CookModeSplitScreenshot() {
-    ChefMateTheme { CookModeScreen(bloc = previewCookBlocSplit) }
+fun CookModePhonePortraitDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocStacked) }
 }
 
 @PreviewTest
@@ -39,31 +45,12 @@ fun CookModeEmptyScreenshot() {
     ChefMateTheme { CookModeScreen(bloc = previewCookBlocEmpty) }
 }
 
-@PreviewTest
-@Preview(showBackground = true, heightDp = 1100, uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Composable
-fun CookModeStackedDarkScreenshot() {
-    ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocStacked) }
-}
+// ── Phone landscape (580 × 360 dp, COMPACT width → mobile layout, compact height) ──
 
-@PreviewTest
-@Preview(
-    showBackground = true,
-    heightDp = 1100,
-    widthDp = 800,
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
-@Composable
-fun CookModeSplitDarkScreenshot() {
-    ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocSplit) }
-}
-
-// Mobile landscape: widthDp stays under 600dp so the responsive container picks the
-// COMPACT (mobile) shell with the bottom-sheet peek row, in landscape orientation.
 @PreviewTest
 @Preview(showBackground = true, widthDp = 580, heightDp = 360)
 @Composable
-fun CookModeStackedLandscapeScreenshot() {
+fun CookModePhoneLandscapeLightScreenshot() {
     ChefMateTheme { CookModeScreen(bloc = previewCookBlocStacked) }
 }
 
@@ -75,6 +62,27 @@ fun CookModeStackedLandscapeScreenshot() {
     uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
-fun CookModeStackedLandscapeDarkScreenshot() {
+fun CookModePhoneLandscapeDarkScreenshot() {
     ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocStacked) }
+}
+
+// ── Tablet (800 × 1100 dp, MEDIUM width → tablet layout with split body) ───
+
+@PreviewTest
+@Preview(showBackground = true, widthDp = 800, heightDp = 1100)
+@Composable
+fun CookModeTabletLightScreenshot() {
+    ChefMateTheme { CookModeScreen(bloc = previewCookBlocSplit) }
+}
+
+@PreviewTest
+@Preview(
+    showBackground = true,
+    widthDp = 800,
+    heightDp = 1100,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun CookModeTabletDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocSplit) }
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeEmptyScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeEmptyScreenshot_73588fdf_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e9937a47bc4390fa1edf12998f80769a7adbc92db50638b04c5a29e817a818f
-size 33138
+oid sha256:f3c0060326c8181667a6da8c57c07c8919e77172afbfbf4028e7c9c1cbf4e87e
+size 36287

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeLoadingScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeLoadingScreenshot_73588fdf_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cfee509cc3323104664f6b60986e21ebd00fe12f186061d4529271aa3e5ceae0
-size 33941
+oid sha256:5180bfc5121d3479ad280e5b6410655c45079d6bff4b1512920d4ec8b96d28bc
+size 37100

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModePhoneLandscapeDarkScreenshot_e70ad3b5_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModePhoneLandscapeDarkScreenshot_e70ad3b5_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07cf5e78e8849877ed2e1bbbb58b4113c98fa294db573d16a9197eea7d79f725
+size 48141

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModePhoneLandscapeLightScreenshot_67927584_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModePhoneLandscapeLightScreenshot_67927584_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f03bf6208d9c10412f901514d8ca7a825f6b4c4cf4349c74d54dc94bda876aa
+size 48615

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModePhonePortraitDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModePhonePortraitDarkScreenshot_805fa67c_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ed50697d457b281e7038569b19ff7e1891db11806d36d33f86d61c7e4eef559
+size 130251

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModePhonePortraitLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModePhonePortraitLightScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13fa6f1d93b8dd0493275cec38af96261c6fcc4cd331ed69e0b387e08bc57ae9
+size 130160

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeSplitDarkScreenshot_8c4b9ab3_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeSplitDarkScreenshot_8c4b9ab3_0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0cd1283c5efb403dba17ac34b01b20e06d9ab19d23edb7aff2d43a2eed37e81c
-size 153478

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeSplitScreenshot_e0dd41dc_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeSplitScreenshot_e0dd41dc_0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7aaf624b7922d26e878c8b138bc487f67eeffd89fd97cfdb4d46eb38eadfe1c9
-size 153432

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeStackedDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeStackedDarkScreenshot_805fa67c_0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a066880326956e3222a6ab9b34b9546ab67c40db55184297b2e253180904277a
-size 134460

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeStackedLandscapeDarkScreenshot_e70ad3b5_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeStackedLandscapeDarkScreenshot_e70ad3b5_0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d464d7de82b0a1166e9eae31e2a29ade098024ac2d8c611103a15cb91f3b0c8
-size 51248

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeStackedLandscapeScreenshot_67927584_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeStackedLandscapeScreenshot_67927584_0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b037b7766508d7a2313fbaafd7c6710eb4dd9b95e049d36109a5380d7fc8aedd
-size 51974

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeStackedScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeStackedScreenshot_73588fdf_0.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ac2fa327dcf67ef7e761dd313d4f296b40e8ab8fecb2f89bf8e1b5ed4cd331f
-size 134845

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeTabletDarkScreenshot_8c4b9ab3_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeTabletDarkScreenshot_8c4b9ab3_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47c503dec3ed4c10702bd83ca3e2af67f92b9d3f09e0f93b6aa9775671b89a87
+size 156988

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeTabletLightScreenshot_e0dd41dc_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeTabletLightScreenshot_e0dd41dc_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82aed11ebecad3707b20d5b139dc59d8d805e6506d05730f150aae5078522921
+size 156836


### PR DESCRIPTION
## Summary

- **Keep screen on toggle in Cook Mode app bar** — shared reactive setting (`KeepScreenOnRepository`) so toggling in Cook Mode or Recipe Detail immediately reflects on both screens
- **Recipe Detail overflow menu** — Edit, Share, and Delete moved from the floating toolbar into a three-dot (`MoreVert`) dropdown in the header's trailing area; floating toolbar now shows only grocery/favorite/meal plan/cook actions
- **Smooth vertical slide animations for Browser and Cook Mode** — fixed `RootScreen` transition spec: push uses `slideInVertically + fadeOut` with z-index 1, pop uses `EnterTransition.None + slideOutVertically` with z-index -1 so modals no longer snap in/out
- **Floating translucent header in `PlusHeaderContainer`** — added `floatingHeader`, `headerContainerAlpha`, `centerAlignTitle`, and `floatingHeaderTopReserve` params so any screen can opt into the translucent overlay pattern; Cook Mode migrated to use the shared design component
- **Sticky section headers below the app bar in Cook Mode** — replaced `LazyColumn stickyHeader` (pinned at y=0, behind the transparent toolbar) with a `Box` overlay header anchored at the bottom edge of the app bar; list items still scroll freely through the translucent app bar

## Test plan

- [ ] Recipe Detail: Edit/Share/Delete appear in three-dot overflow menu; grocery/favorite/meal plan buttons remain in floating toolbar
- [ ] Cook Mode: Visibility toggle in app bar persists; toggling keep-screen-on in Cook Mode reflects on Recipe Detail (and vice versa)
- [ ] Cook Mode → dismiss: slides down smoothly; Browser → dismiss: slides down smoothly (no snap)
- [ ] Cook Mode app bar is translucent (content visible behind it when scrolled) and title is center-aligned
- [ ] Stacked layout: section header ("Ingredients"/"Directions") stays pinned below the app bar; list items scroll freely through the transparent toolbar
- [ ] All existing screens using `PlusHeaderContainer` look unchanged (params default to previous behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)