### PR TITLE
build: auto-publish Android release to internal track

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,7 +10,7 @@ platform :android do
     supply(
       package_name: "com.plusmobileapps.chefmate",
       track: "internal",
-      release_status: "draft",
+      release_status: "completed",
       aab: "client/composeApp/build/outputs/bundle/release/composeApp-release.aab",
       json_key_data: ENV["SUPPLY_JSON_KEY_DATA"],
       skip_upload_metadata: true,


### PR DESCRIPTION
## Summary
- Change supply's `release_status` from `"draft"` to `"completed"` in `fastlane/Fastfile` so the Android release lane publishes straight to the Play Console internal testing track instead of leaving a draft for manual promotion.

## Why
Internal testers should pick up new builds automatically once the lane finishes, without an extra Play Console click each release. The track is still `internal`, so this only affects internal testers — promotion to closed/open/production tracks remains a separate manual step.

## Test plan
- [x] Next Android release lane run uploads the AAB to the internal track and the build appears as live (not draft) for internal testers in the Play Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)