### PR TITLE
fix(ui): cap PlusHeader title at two lines with ellipsis

### DIFF
--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModePreviews.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModePreviews.kt
@@ -70,6 +70,24 @@ val previewCookBlocLoading: CookModeBloc = cookBloc(CookModeBloc.Model(isLoading
 
 val previewCookBlocEmpty: CookModeBloc = cookBloc(CookModeBloc.Model(isLoading = false))
 
+// Recipe with an unusually long title — guards against the header growing past two lines and
+// breaking the sticky section header (issue #149).
+val previewCookBlocLongTitle: CookModeBloc =
+    cookBloc(
+        CookModeBloc.Model(
+            isLoading = false,
+            activeRecipe =
+                Recipe.Sample.copy(
+                    title =
+                        "Grandma's Authentic Sunday Slow-Simmered Pasta Carbonara with " +
+                            "Hand-Rolled Spaghetti and Crispy Guanciale"
+                ),
+            activeSessions = activeSessionsSample,
+            layoutMode = CookModeBloc.LayoutMode.Stacked,
+            keepScreenOn = true,
+        )
+    )
+
 @Preview(showBackground = true, heightDp = 1100)
 @Composable
 internal fun CookModeStackedPreview() {
@@ -112,4 +130,10 @@ internal fun CookModeStackedLandscapePreview() {
 @Composable
 internal fun CookModeStackedLandscapeDarkPreview() {
     ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocStacked) }
+}
+
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+internal fun CookModeLongTitlePreview() {
+    ChefMateTheme { CookModeScreen(bloc = previewCookBlocLongTitle) }
 }

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
@@ -258,6 +259,8 @@ fun PlusHeader(
         Text(
             text = data.title.localized(),
             color = ChefMateTheme.colorScheme.onBackground,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.sharedBoundsBy(titleKey),
         )
     }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTest.kt
@@ -7,6 +7,7 @@ import com.android.tools.screenshot.PreviewTest
 import com.plusmobileapps.chefmate.cook.CookModeScreen
 import com.plusmobileapps.chefmate.cook.previewCookBlocEmpty
 import com.plusmobileapps.chefmate.cook.previewCookBlocLoading
+import com.plusmobileapps.chefmate.cook.previewCookBlocLongTitle
 import com.plusmobileapps.chefmate.cook.previewCookBlocSplit
 import com.plusmobileapps.chefmate.cook.previewCookBlocStacked
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -21,11 +22,7 @@ fun CookModePhonePortraitLightScreenshot() {
 }
 
 @PreviewTest
-@Preview(
-    showBackground = true,
-    heightDp = 1100,
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
+@Preview(showBackground = true, heightDp = 1100, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun CookModePhonePortraitDarkScreenshot() {
     ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocStacked) }
@@ -43,6 +40,15 @@ fun CookModeLoadingScreenshot() {
 @Composable
 fun CookModeEmptyScreenshot() {
     ChefMateTheme { CookModeScreen(bloc = previewCookBlocEmpty) }
+}
+
+// Long-title regression for issue #149: header must ellipsis after two lines so the floating
+// app bar doesn't grow and overlap the sticky section header.
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun CookModeLongTitleScreenshot() {
+    ChefMateTheme { CookModeScreen(bloc = previewCookBlocLongTitle) }
 }
 
 // ── Phone landscape (580 × 360 dp, COMPACT width → mobile layout, compact height) ──

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeLongTitleScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeLongTitleScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5112b0a0d802fe77e9a3f2ddf16167dbebe257e6db1011a5d6b1b1c2e4cc767f
+size 143983


### PR DESCRIPTION
## Summary
- Apply `maxLines = 2` + `TextOverflow.Ellipsis` to the shared `PlusHeader` title so long recipe titles can't grow the app bar past two lines and break Cook Mode's sticky section header.
- Add a long-title preview Bloc and `CookModeLongTitleScreenshot` regression test (with reference PNG) so the behavior is locked in.

Fixes #149

## Test plan
- [x] `./gradlew ktfmtFormat`
- [x] `./gradlew :client:ui:screenshot-test:updateDebugScreenshotTest` — visually inspected the new `CookModeLongTitleScreenshot` reference PNG; title ellipsizes after 2 lines and the "Ingredients" sticky header sits cleanly below the floating app bar.
- [x] `./gradlew :client:ui:screenshot-test:validateDebugScreenshotTest` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)