### PR TITLE
test(ui): add Compose Multiplatform UI test for recipe list → detail

### DIFF
--- a/.claude/skills/add-compose-multiplatform-test.md
+++ b/.claude/skills/add-compose-multiplatform-test.md
@@ -1,0 +1,439 @@
+# add-compose-multiplatform-test
+
+Add a Compose Multiplatform UI test that exercises a real BLoC tree end-to-end across JVM, iOS Simulator, and Android (instrumented) variants in `:client:composeApp`.
+
+## Required input
+
+Ask the user (if not provided):
+
+1. **What flow to test** — e.g. "tap recipe in list → recipe detail appears". Identify the user-visible entry point and the assertion target.
+2. **Which root to spin up** — almost always `RootBloc` (covers bottom-nav-hosted flows). Smaller scopes only make sense for screens not behind bottom nav.
+3. **Which remote sources need to be faked** — by default, fake everything that calls Supabase on the path being exercised. Each fake is one `@ContributesBinding(replaces = …)` class.
+
+## Architecture overview
+
+The test infra lives entirely in `:client:composeApp`'s test source sets. Module deps are already wired in `client/composeApp/build.gradle.kts`:
+
+| Source set | Purpose |
+|---|---|
+| `commonTest` | Test classes (`tests/`), test DI graph (`di/`), test doubles (`fakes/`), domain fixtures (`fixtures/`), and the entrypoint + scenario plumbing (`harness/`). All under `com.plusmobileapps.chefmate.<sub-package>` |
+| `jvmTest` | `di/JvmTestApplicationComponent` + `fakes/ProvideTestDatabase.jvm.kt` (actual) |
+| `iosTest` | `di/IosTestApplicationComponent` + `fakes/ProvideTestDatabase.ios.kt` (actual) |
+| `androidInstrumentedTest` | `di/AndroidTestApplicationComponent` + `fakes/ProvideTestDatabase.android.kt` (actual) |
+
+`commonTest` is routed into the Android **instrumented** variant (not unit test) via the source-set-tree split in `composeApp/build.gradle.kts`:
+
+```kotlin
+androidTarget {
+    compilerOptions {
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        unitTestVariant.sourceSetTree.set(KotlinSourceSetTree.unitTest)
+    }
+}
+```
+
+The unit-test variant gets its own (empty) `unitTest` tree, which keeps the common UI test class out of `testDebugUnitTest` (where Robolectric isn't initialised — see "Android: instrumented tests, not Robolectric" below).
+
+**One test class per scenario** lives in `commonTest` and runs unchanged across JVM, iOS Simulator, and Android instrumented. Per-platform variation is confined to `actual fun createTestApplicationComponent()` and `actual fun provideTestDatabase()`.
+
+## The pattern
+
+### 1. Test class in `commonTest`
+
+A single `@Test` class in `commonTest` runs on JVM, iOS Simulator, and Android (instrumented) unchanged. Seed data through `FakeDatabase` and `TestUserState` rather than calling `recipeQueries` directly. The test body uses domain `Recipe` models (from `TestRecipes`) and Robots (see "Robots" section below) for any node interaction. `runRootBlocTest` is the standard wrapper — it builds the test component, applies a default `TestUserState.Authenticated`, and renders `App` against a fresh root bloc.
+
+```kotlin
+// commonTest/.../RootNavigationUiTest.kt
+@OptIn(ExperimentalTestApi::class)
+class RootNavigationUiTest {
+
+    @Test
+    fun clicking_recipe_in_list_navigates_to_recipe_detail() = runRootBlocTest {
+        recipeList().clickRecipe(TestRecipes.fullyPopulated.title)
+        recipeDetail().awaitDisplayed().assertRecipeDisplayed(TestRecipes.fullyPopulated.title)
+    }
+}
+```
+
+`runRootBlocTest(userState, block)` lives in `commonTest/.../CreateRootBloc.kt`:
+
+```kotlin
+fun runRootBlocTest(
+    userState: TestUserState =
+        TestUserState.Authenticated(recipes = listOf(TestRecipes.fullyPopulated)),
+    block: suspend ComposeUiTest.(TestApplicationComponent) -> Unit,
+): TestResult = runComposeUiTest {
+    val app = createTestApplicationComponent()
+    app.applyUserState(userState)
+    setContent { App(rootBloc = app.createRootBloc()) }
+    block(app)
+}
+```
+
+Two things to know:
+
+- **Return `TestResult`** (not `Unit`). `runComposeUiTest` returns `kotlinx.coroutines.test.TestResult`; on JVM it's a `typealias` for `Unit`, but on K/N it's a Promise-like value that the test runner awaits. If your wrapper drops it, K/N tests exit before the suspending body completes.
+- **The component is passed to `block`** so a robot or assertion can reach back into the graph (e.g. flipping auth state mid-test via `app.testAuthenticationRepository.setState(...)`). If a test doesn't need it, ignore it: `runRootBlocTest { … }`.
+
+For tests that need different seeded state, override the parameter: `runRootBlocTest(TestUserState.NewUser) { app -> … }`.
+
+If a test ever needs setup that doesn't fit the wrapper (e.g. it needs to mutate the component *before* `setContent`), drop back to `runComposeUiTest { val app = createTestApplicationComponent(); … }` for that one test rather than expanding the wrapper. `createRootBloc()` is the underlying `TestApplicationComponent` extension that does the bloc wiring.
+
+### 2. `expect fun` + abstract base graph
+
+The graph exposes the **fake** types (not the queries) so the test can configure state via high-level helpers rather than writing raw SQL params.
+
+```kotlin
+// commonTest/.../TestApplicationComponent.kt
+interface TestApplicationComponent : ApplicationComponent {
+    val fakeDatabase: FakeDatabase
+    val testAuthenticationRepository: TestAuthenticationRepository
+}
+
+expect fun createTestApplicationComponent(): TestApplicationComponent
+```
+
+```kotlin
+// commonTest/.../BaseTestApplicationComponent.kt — extracted shared @Provides
+abstract class BaseTestApplicationComponent : TestApplicationComponent {
+    @Provides @SingleIn(AppScope::class)
+    fun providesFakeDatabase(): FakeDatabase = FakeDatabase()
+
+    @Provides fun providesDatabase(fakeDatabase: FakeDatabase): Database = fakeDatabase
+
+    @Provides fun providesRecipeQueries(db: Database): RecipeQueries = db.recipeQueries
+    @Provides fun providesGroceryQueries(db: Database): GroceryQueries = db.groceryQueries
+    // ... five more query bindings
+}
+```
+
+Metro's processor walks the class hierarchy across source sets, so the `@Provides` methods on the abstract base are picked up by the concrete `@DependencyGraph` in each platform. The `Database` binding is satisfied by the `FakeDatabase` instance, so any production code that injects `Database` or its queries gets the in-memory fake automatically.
+
+`DateTimeFormatterUtil` is bound in production by `client/util/impl/.../DateTimeFormatterComponent.kt` (a `@ContributesTo(AppScope::class)` interface), so the test graph picks it up automatically — no test-side `@Provides` needed.
+
+### 3. Per-platform graph (4 lines each)
+
+```kotlin
+// jvmTest/.../JvmTestApplicationComponent.kt
+@SingleIn(AppScope::class)
+@DependencyGraph(scope = AppScope::class, excludes = [DatabaseComponent::class])
+abstract class JvmTestApplicationComponent : BaseTestApplicationComponent()
+
+actual fun createTestApplicationComponent(): TestApplicationComponent =
+    createGraph<JvmTestApplicationComponent>()
+```
+
+```kotlin
+// iosTest/.../IosTestApplicationComponent.kt
+@SingleIn(AppScope::class)
+@DependencyGraph(scope = AppScope::class, excludes = [DatabaseComponent::class])
+abstract class IosTestApplicationComponent : BaseTestApplicationComponent()
+
+actual fun createTestApplicationComponent(): TestApplicationComponent =
+    createGraph<IosTestApplicationComponent>()
+```
+
+```kotlin
+// androidInstrumentedTest/.../AndroidTestApplicationComponent.kt
+@SingleIn(AppScope::class)
+@DependencyGraph(scope = AppScope::class, excludes = [DatabaseComponent::class])
+abstract class AndroidTestApplicationComponent : BaseTestApplicationComponent()
+
+actual fun createTestApplicationComponent(): TestApplicationComponent =
+    createGraph<AndroidTestApplicationComponent>()
+```
+
+`excludes = [DatabaseComponent::class]` is required because `DatabaseComponent` provides the production `Database` from `DriverFactory`, and we provide an in-memory one ourselves. Without the exclusion, Metro reports a duplicate binding.
+
+### 4. Fakes via `@ContributesBinding(replaces = …)`
+
+For each Supabase-touching production class on the test's code path:
+
+```kotlin
+// commonTest/.../FakeRecipeRemoteDataSource.kt
+@SingleIn(AppScope::class)
+@Inject
+@ContributesBinding(scope = AppScope::class, replaces = [SupabaseRecipeRemoteDataSource::class])
+class FakeRecipeRemoteDataSource : RecipeRemoteDataSource {
+    override suspend fun upsertRecipe(recipe: RemoteRecipe) = recipe
+    override suspend fun deleteRecipe(remoteId: String) = Unit
+    override suspend fun fetchAllRecipes(ownerId: String) = emptyList<RemoteRecipe>()
+}
+```
+
+For repositories that don't have a separate remote-source seam (e.g. `SupabaseAuthenticationRepository` calls `supabaseClient.auth.…` directly), replace at the repository level. Hold the underlying fake by reference so the test can flip auth state at runtime:
+
+```kotlin
+@SingleIn(AppScope::class)
+@Inject
+@ContributesBinding(scope = AppScope::class, replaces = [SupabaseAuthenticationRepository::class])
+class TestAuthenticationRepository(
+    private val fake: FakeAuthenticationRepository = FakeAuthenticationRepository(),
+) : AuthenticationRepository by fake {
+
+    fun setState(state: AuthState) = fake.setState(state)
+    fun setAuthenticated(user: ChefMateUser = FakeAuthenticationRepository.fakeUser()) =
+        fake.setAuthenticated(user)
+}
+```
+
+`FakeAuthenticationRepository` is `final`, so use `by` delegation rather than inheritance. Re-exposing `setState` / `setAuthenticated` on the test repo lets `applyUserState` flip auth state without needing to inject the fake separately.
+
+### 5. `FakeDatabase` — `Database` by class delegation
+
+The `Database` binding in DI is a `FakeDatabase` that wraps `provideTestDatabase()` via class delegation, plus high-level seed helpers that take domain `Recipe` models (no raw query args in tests).
+
+```kotlin
+// commonTest/.../FakeDatabase.kt
+class FakeDatabase(private val delegate: Database = provideTestDatabase()) : Database by delegate {
+    fun addRecipe(recipe: Recipe) {
+        recipeQueries.create(
+            title = recipe.title,
+            description = recipe.description,
+            ingredients = recipe.ingredients.takeIf { it.isNotEmpty() },
+            directions = recipe.directions.takeIf { it.isNotEmpty() },
+            // …
+            createdAt = recipe.createdAt.toString(),
+            updatedAt = recipe.updatedAt.toString(),
+            clientId = null,
+            ownerId = null,
+        )
+    }
+    fun addRecipes(recipes: Iterable<Recipe>) = recipes.forEach(::addRecipe)
+    fun addRecipes(vararg recipes: Recipe) = recipes.forEach(::addRecipe)
+    fun clearRecipes() = recipeQueries.deleteAll()
+}
+```
+
+The DB schema only requires `title`; the domain model also requires `ingredients` and `directions` to be non-null Strings (empty is valid). Pass empty strings for the title-only minimum; pass `null` to the SQL bind to leave the column NULL when the domain field is empty.
+
+#### `provideTestDatabase()` — per-platform driver
+
+`provideTestDatabase()` is an `expect fun` (commonTest) with a one-line `actual` per platform. JVM and iOS reuse the existing `client/database/testing` helper; Android needs `AndroidSqliteDriver` because `JdbcSqliteDriver` would try to load `libsqlitejdbc.so` and fail on a real device.
+
+```kotlin
+// commonTest/.../ProvideTestDatabase.kt
+expect fun provideTestDatabase(): Database
+
+// jvmTest/.../ProvideTestDatabase.jvm.kt
+actual fun provideTestDatabase(): Database = createTestDatabase()
+
+// iosTest/.../ProvideTestDatabase.ios.kt
+actual fun provideTestDatabase(): Database = createTestDatabase()
+
+// androidInstrumentedTest/.../ProvideTestDatabase.android.kt
+actual fun provideTestDatabase(): Database {
+    val driver = AndroidSqliteDriver(
+        schema = Database.Schema,
+        context = ApplicationProvider.getApplicationContext(),
+        name = null, // in-memory
+    )
+    return Database(driver)
+}
+```
+
+Add `libs.sqldelight.drivers.android` and `libs.androidx.test.core` (for `ApplicationProvider`) to `androidInstrumentedTest.dependencies` in `composeApp/build.gradle.kts`.
+
+### 6. `TestRecipes` — shared fixtures with field permutations
+
+```kotlin
+// commonTest/.../TestRecipes.kt
+object TestRecipes {
+    val fullyPopulated: Recipe = Recipe(/* all fields populated */)
+    val withoutDescriptionOrImage: Recipe = Recipe(/* description = null, imageUrl = null */)
+    val ingredientsAndDirectionsOnly: Recipe = Recipe(/* no metadata, no image, no rating */)
+    val titleOnly: Recipe = Recipe(/* title only — ingredients/directions empty Strings */)
+    val defaults: List<Recipe> = listOf(fullyPopulated, withoutDescriptionOrImage, ingredientsAndDirectionsOnly, titleOnly)
+}
+```
+
+The four permutations exercise the recipe-list rendering path for full → minimum field coverage. Tests that target one specific case use the named field directly; broader smoke tests use `TestRecipes.defaults`.
+
+### 7. `TestUserState` + `applyUserState` — high-level scenarios
+
+```kotlin
+// commonTest/.../TestUserState.kt
+sealed interface TestUserState {
+    data class Authenticated(val recipes: List<Recipe> = TestRecipes.defaults) : TestUserState
+    data object NewUser : TestUserState
+    data class UnauthenticatedWithRecipes(val recipes: List<Recipe> = TestRecipes.defaults) : TestUserState
+}
+
+fun TestApplicationComponent.applyUserState(state: TestUserState) {
+    when (state) {
+        is TestUserState.Authenticated -> {
+            testAuthenticationRepository.setAuthenticated()
+            fakeDatabase.addRecipes(state.recipes)
+        }
+        TestUserState.NewUser -> testAuthenticationRepository.setAuthenticated()
+        is TestUserState.UnauthenticatedWithRecipes -> fakeDatabase.addRecipes(state.recipes)
+    }
+}
+```
+
+`applyUserState` is the test's only setup call after building the component. Add new scenarios as new `TestUserState` arms; don't reach into `fakeDatabase` / `testAuthenticationRepository` from the test body unless the scenario truly is one-off.
+
+### 8. Robots — one module per screen
+
+UI tests interact with screens via Robot classes that live in a dedicated `impl-robots` module per screen. The robot owns the semantics-tree lookups and exposes a domain-level vocabulary (`clickRecipe(title)`, `awaitDisplayed()`, `assertRecipeDisplayed(title)`) so test bodies stay readable and shareable across scenarios.
+
+**Module layout** — `client/<feature>/<area>/impl-robots`, plain KMP library:
+
+```kotlin
+// client/recipe/list/impl-robots/build.gradle.kts
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+            api(compose.uiTest)
+            implementation(projects.client.recipe.list.public)
+        }
+    }
+}
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.recipe.list.robots" }
+```
+
+**Robot class** — takes `ComposeUiTest` in its constructor; an entry-point extension on `ComposeUiTest` is the only way tests construct it:
+
+```kotlin
+@file:OptIn(ExperimentalTestApi::class)
+
+class RecipeListRobot(private val test: ComposeUiTest) {
+
+    private val onScreen = hasAnyAncestor(hasTestTag(RecipeListTestTags.SCREEN))
+
+    fun assertRecipeIsDisplayed(title: String): RecipeListRobot = apply {
+        test.onNode(hasText(title) and onScreen).assertIsDisplayed()
+    }
+
+    fun clickRecipe(title: String): RecipeListRobot = apply {
+        test.onNode(hasText(title) and onScreen).assertIsDisplayed().performClick()
+    }
+}
+
+fun ComposeUiTest.recipeList(): RecipeListRobot = RecipeListRobot(this)
+```
+
+**Scope every lookup to the screen** via `hasAnyAncestor(hasTestTag(<Feature>TestTags.SCREEN))`. Without this, a recipe title rendered on the detail header satisfies `onNodeWithText(title)` from a list-robot call and the matcher silently picks the wrong node. The screen test tag itself is the one exception (asserted directly on the root container).
+
+**Wire each robot module into `composeApp/build.gradle.kts`** under `commonTest.dependencies`:
+
+```kotlin
+implementation(projects.client.recipe.core.implRobots)
+implementation(projects.client.recipe.list.implRobots)
+```
+
+### 9. Add a `testTag` to the screen root
+
+Robots find their screen via a stable, typed test-tag constant. Add `Modifier.testTag(<Feature>TestTags.SCREEN)` to the outer container of every screen a robot covers, with the constant defined in the screen's `:public` module so the screen and its robot can never disagree on the tag string.
+
+```kotlin
+// client/recipe/core/public/.../RecipeDetailTestTags.kt
+object RecipeDetailTestTags {
+    const val SCREEN: String = "recipe_detail_screen"
+}
+
+// in the screen composable
+Box(modifier = modifier.fillMaxSize().testTag(RecipeDetailTestTags.SCREEN)) { … }
+```
+
+Use semantic, screen-level tags (`recipe_detail_screen`, not `box_42`).
+
+## Android: instrumented tests, not Robolectric
+
+The `commonTest` `@Test` class can't run under Robolectric (`testDebugUnitTest`):
+
+1. **`runComposeUiTest` needs Robolectric** to stub `Build.FINGERPRINT` etc. Robolectric only initialises when JUnit4 sees `@RunWith(RobolectricTestRunner::class)` (or `@RunWith(AndroidJUnit4::class)`) **directly** on the test class. Meta-annotations don't work — `RunnerBuilder` calls `klass.getAnnotation(RunWith.class)`, which returns `null` for meta-annotated classes. And `@RunWith` can't live in `commonTest` because `org.junit.runner.RunWith` is JVM-only.
+2. Even with Robolectric initialised, `runComposeUiTest` internally calls `ActivityScenario.launch(ComponentActivity::class.java)`. Robolectric 4.12+ rejects this with `Unable to resolve activity … see robolectric/pull/4736`.
+
+**The right path is instrumented tests** — they run on a real emulator/device where the activity is registered with the real Android `PackageManager`, not a Robolectric shadow.
+
+```kotlin
+// composeApp/build.gradle.kts
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+            @OptIn(ExperimentalKotlinGradlePluginApi::class)
+            instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
+            @OptIn(ExperimentalKotlinGradlePluginApi::class)
+            unitTestVariant.sourceSetTree.set(KotlinSourceSetTree.unitTest)
+        }
+    }
+    // …
+}
+
+android {
+    defaultConfig {
+        // …
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+}
+
+sourceSets {
+    val androidInstrumentedTest by getting {
+        dependencies {
+            implementation(libs.sqldelight.drivers.android)
+            implementation(libs.androidx.test.core)
+        }
+    }
+}
+
+dependencies {
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4.android)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+}
+```
+
+`instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)` routes `commonTest` into the Android instrumented test APK, so the same `@Test` class runs unchanged on JVM, iOS Simulator, and Android. `unitTestVariant.sourceSetTree.set(KotlinSourceSetTree.unitTest)` then keeps the common UI test class out of `testDebugUnitTest` (where Robolectric isn't initialised) — without it, the task picks up the same class and NPEs on `Build.FINGERPRINT`. With both set, `testDebugUnitTest` is safe to run; it just doesn't see the common UI test.
+
+`androidInstrumentedTest` needs `sqldelight-drivers-android` (for `AndroidSqliteDriver` in `provideTestDatabase()`) and `androidx-test-core` (for `ApplicationProvider.getApplicationContext()`).
+
+CI runs `./gradlew :client:composeApp:connectedDebugAndroidTest` against an emulator — `reactivecircus/android-emulator-runner@v2` on a Linux runner with KVM.
+
+## Gotchas — do not skip
+
+1. **Instant string format** — `FakeDatabase.addRecipe` calls `recipe.createdAt.toString()`, which produces ISO-8601 with the required `Z` suffix when the input is a real `kotlin.time.Instant`. If you build a fixture by hand and pass a raw string for `createdAt`, it must end in `Z` — `RecipeRepositoryImpl.toRecipe` calls `Instant.parse` and throws `InstantFormatException` otherwise (the recipe list silently shows empty).
+2. **Don't override `SupabaseModule`** — leaving the real `createSupabaseClient()` in place is fine as long as every production caller on the test's code path is faked. The client is constructed lazily and never makes network calls if nothing invokes it.
+3. **iOS test linker** — `iosTarget.binaries.withType<TestExecutable> { linkerOpts.add("-lsqlite3") }` is required in `composeApp/build.gradle.kts` (the framework block already has `-lsqlite3`, but test executables are a separate binary). Without this, linking fails with `Undefined symbols: _sqlite3_*`.
+4. **JVM DB pollution** — never use the production `DriverFactory` in tests. The JVM driver writes to `~/Library/Application Support/Chef Mate/chefmate.db` (the developer's real desktop-app DB). Always exclude `DatabaseComponent` and provide `provideTestDatabase()` instead.
+5. **Settings on iOS** — `Settings()` on iOS is `NSUserDefaults`, which persists across simulator runs. With a single test it doesn't matter; once a second test exists, swap `SettingsComponent` for `MapSettings()` via the same `excludes = […]` mechanism.
+6. **`FakeAuthenticationRepository` is final** — you cannot subclass it. Use `by` delegation in `TestAuthenticationRepository`.
+7. **`expect fun createTestApplicationComponent()` must be top-level** — declaring it inside `TestApplicationComponent` won't compile because Metro's `createGraph<T>()` only works on the platform-specific concrete graph class.
+
+## Verification checklist
+
+Before reporting done:
+
+1. `./gradlew ktfmtFormat` — pre-commit hook runs this anyway.
+2. `./gradlew :client:composeApp:jvmTest --tests "*RootNavigationUiTest"` — fastest, run first.
+3. `./gradlew :client:composeApp:iosSimulatorArm64Test` — Apple Silicon Mac required.
+4. `./gradlew :client:composeApp:connectedDebugAndroidTest` — needs an emulator or attached device.
+
+## Reference implementation in this repo
+
+Test sources are split into semantic sub-packages — `tests/` for `@Test` classes, `di/` for the test graph, `fakes/` for production-binding replacements, `fixtures/` for sample domain data, `harness/` for the test entrypoint and scenario plumbing.
+
+- `client/composeApp/src/commonTest/.../tests/RootNavigationUiTest.kt` — single `@Test` class (runs on JVM, iOS Simulator, and Android instrumented)
+- `client/composeApp/src/commonTest/.../di/TestApplicationComponent.kt` — interface + `expect fun createTestApplicationComponent()`
+- `client/composeApp/src/commonTest/.../di/BaseTestApplicationComponent.kt` — abstract base with all shared `@Provides`
+- `client/composeApp/src/commonTest/.../harness/CreateRootBloc.kt` — `runRootBlocTest` wrapper + `TestApplicationComponent.createRootBloc()` primitive
+- `client/composeApp/src/commonTest/.../harness/TestUserState.kt` — sealed scenarios + `applyUserState` extension
+- `client/composeApp/src/commonTest/.../fakes/FakeDatabase.kt` — `Database by provideTestDatabase()` with `addRecipe` / `clearRecipes`
+- `client/composeApp/src/commonTest/.../fakes/ProvideTestDatabase.kt` — `expect fun` for the per-platform driver, with three `actual` files (`jvmTest/.../fakes/`, `iosTest/.../fakes/`, `androidInstrumentedTest/.../fakes/`)
+- `client/composeApp/src/commonTest/.../fakes/FakeRecipeRemoteDataSource.kt`, `fakes/TestAuthenticationRepository.kt` — fake bindings
+- `client/composeApp/src/commonTest/.../fixtures/TestRecipes.kt` — `Recipe` permutations (full → title-only)
+- `client/composeApp/src/{jvm,ios,androidInstrumented}Test/.../di/*TestApplicationComponent.kt` — per-platform graph + `actual fun`
+- `client/recipe/list/impl-robots/.../RecipeListRobot.kt` + `client/recipe/list/public/.../RecipeListTestTags.kt` — robot + test-tag pair
+- `client/recipe/core/impl-robots/.../RecipeDetailRobot.kt` + `client/recipe/core/.../detail/RecipeDetailTestTags.kt` — robot + test-tag pair
+- `client/util/impl/.../DateTimeFormatterComponent.kt` — production `@ContributesTo(AppScope)` binding picked up by the test graph
+- `client/composeApp/build.gradle.kts` — source-set-tree split (instrumented/unit), iOS test linker flag, robot-module wiring under `commonTest.dependencies`
+- `.github/workflows/compose-ui-tests.yml` — three-job CI workflow (jvm / android / ios) with `dorny/test-reporter` per platform

--- a/.github/workflows/compose-ui-tests.yml
+++ b/.github/workflows/compose-ui-tests.yml
@@ -1,0 +1,128 @@
+name: Compose UI tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: compose-ui-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  checks: write
+  contents: read
+
+jobs:
+  jvm:
+    name: JVM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew :client:composeApp:jvmTest --continue
+      - name: Publish JVM test report
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: Compose UI tests (JVM)
+          path: 'client/composeApp/build/test-results/jvmTest/TEST-*.xml'
+          reporter: java-junit
+          fail-on-error: false
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: compose-ui-test-jvm-report
+          path: client/composeApp/build/reports/tests/jvmTest/
+
+  android:
+    name: Android (instrumented)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-34-x86_64
+      - name: Create AVD and snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "AVD snapshot generated."
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew :client:composeApp:connectedDebugAndroidTest --continue
+      - name: Publish Android test report
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: Compose UI tests (Android)
+          path: 'client/composeApp/build/outputs/androidTest-results/connected/**/TEST-*.xml'
+          reporter: java-junit
+          fail-on-error: false
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: compose-ui-test-android-report
+          path: client/composeApp/build/reports/androidTests/connected/
+
+  ios:
+    name: iOS Simulator
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Cache Kotlin/Native compiler and toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-konan-
+      - run: ./gradlew :client:composeApp:iosSimulatorArm64Test --continue
+      - name: Publish iOS test report
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: Compose UI tests (iOS)
+          path: 'client/composeApp/build/test-results/iosSimulatorArm64Test/TEST-*.xml'
+          reporter: java-junit
+          fail-on-error: false
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: compose-ui-test-ios-report
+          path: client/composeApp/build/reports/tests/iosSimulatorArm64Test/

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -1,6 +1,8 @@
 import java.util.Properties
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
 fun osClassifier(): String {
     val osName = System.getProperty("os.name").lowercase()
@@ -9,10 +11,12 @@ fun osClassifier(): String {
         osName.contains("mac") || osName.contains("darwin") -> {
             if (osArch == "aarch64") "mac-aarch64" else "mac"
         }
+
         osName.contains("win") -> "win"
         osName.contains("linux") -> {
             if (osArch == "aarch64") "linux-aarch64" else "linux"
         }
+
         else -> error("Unsupported OS: $osName")
     }
 }
@@ -27,7 +31,20 @@ plugins {
 }
 
 kotlin {
-    androidTarget { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } }
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+
+            // commonTest is shared with the Android instrumented test variant
+            // (connectedDebugAndroidTest), not the unit test variant (testDebugUnitTest).
+            // unitTestVariant gets its own (empty) tree so commonTest UI tests don't get
+            // dragged into testDebugUnitTest, where Robolectric isn't initialised.
+            @OptIn(ExperimentalKotlinGradlePluginApi::class)
+            instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
+            @OptIn(ExperimentalKotlinGradlePluginApi::class)
+            unitTestVariant.sourceSetTree.set(KotlinSourceSetTree.unitTest)
+        }
+    }
 
     listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
         iosTarget.binaries.framework {
@@ -39,6 +56,11 @@ kotlin {
             export(libs.essenty.backhandler)
             export(projects.client.root.public)
             export(projects.client.shared)
+        }
+        iosTarget.binaries.withType(
+            org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable::class.java
+        ) {
+            linkerOpts.add("-lsqlite3")
         }
     }
 
@@ -101,7 +123,28 @@ kotlin {
             implementation(libs.bugsnag.kmp)
             implementation(libs.kermit.bugsnag)
         }
-        commonTest.dependencies { implementation(libs.kotlin.test) }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+            implementation(compose.uiTest)
+            implementation(projects.client.testing)
+            implementation(projects.client.database.testing)
+            implementation(projects.client.auth.data.testing)
+            implementation(projects.client.recipe.core.implRobots)
+            implementation(projects.client.recipe.list.implRobots)
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(compose.desktop.uiTestJUnit4)
+                implementation(compose.desktop.currentOs)
+            }
+        }
+        val androidInstrumentedTest by getting {
+            dependencies {
+                implementation(libs.sqldelight.drivers.android)
+                implementation(libs.androidx.test.core)
+            }
+        }
     }
 }
 
@@ -146,6 +189,7 @@ android {
         targetSdk = libs.versions.android.targetSdk.get().toInt()
         versionCode = 61
         versionName = "1.4.1"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
     buildTypes {
@@ -158,6 +202,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+}
+
+dependencies {
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4.android)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
 
 compose.desktop {

--- a/client/composeApp/src/androidInstrumentedTest/kotlin/com/plusmobileapps/chefmate/di/AndroidTestApplicationComponent.kt
+++ b/client/composeApp/src/androidInstrumentedTest/kotlin/com/plusmobileapps/chefmate/di/AndroidTestApplicationComponent.kt
@@ -1,0 +1,13 @@
+package com.plusmobileapps.chefmate.di
+
+import com.plusmobileapps.chefmate.client.database.di.DatabaseComponent
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.createGraph
+
+@SingleIn(AppScope::class)
+@DependencyGraph(scope = AppScope::class, excludes = [DatabaseComponent::class])
+abstract class AndroidTestApplicationComponent : BaseTestApplicationComponent()
+
+actual fun createTestApplicationComponent(): TestApplicationComponent =
+    createGraph<AndroidTestApplicationComponent>()

--- a/client/composeApp/src/androidInstrumentedTest/kotlin/com/plusmobileapps/chefmate/fakes/ProvideTestDatabase.android.kt
+++ b/client/composeApp/src/androidInstrumentedTest/kotlin/com/plusmobileapps/chefmate/fakes/ProvideTestDatabase.android.kt
@@ -1,0 +1,15 @@
+package com.plusmobileapps.chefmate.fakes
+
+import androidx.test.core.app.ApplicationProvider
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import com.plusmobileapps.chefmate.database.Database
+
+actual fun provideTestDatabase(): Database {
+    val driver =
+        AndroidSqliteDriver(
+            schema = Database.Schema,
+            context = ApplicationProvider.getApplicationContext(),
+            name = null, // in-memory
+        )
+    return Database(driver)
+}

--- a/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/di/AndroidApplicationComponent.kt
+++ b/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/di/AndroidApplicationComponent.kt
@@ -1,12 +1,8 @@
 package com.plusmobileapps.chefmate.di
 
 import android.content.Context
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.plusmobileapps.chefmate.ApplicationComponent
 import com.plusmobileapps.chefmate.client.database.DriverFactory
-import com.plusmobileapps.chefmate.util.DateTimeFormatterUtil
-import com.plusmobileapps.chefmate.util.DateTimeFormatterUtilImpl
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
@@ -20,9 +16,4 @@ abstract class AndroidApplicationComponent : ApplicationComponent {
     }
 
     @Provides fun driverFactory(context: Context): DriverFactory = DriverFactory(context = context)
-
-    @RequiresApi(Build.VERSION_CODES.O)
-    @Provides
-    @SingleIn(AppScope::class)
-    fun provideDateTimeFormatterUtil(): DateTimeFormatterUtil = DateTimeFormatterUtilImpl()
 }

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/di/BaseTestApplicationComponent.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/di/BaseTestApplicationComponent.kt
@@ -1,0 +1,39 @@
+package com.plusmobileapps.chefmate.di
+
+import com.plusmobileapps.chefmate.database.BrowserHistoryQueries
+import com.plusmobileapps.chefmate.database.CookingSessionQueries
+import com.plusmobileapps.chefmate.database.Database
+import com.plusmobileapps.chefmate.database.GroceryListQueries
+import com.plusmobileapps.chefmate.database.GroceryQueries
+import com.plusmobileapps.chefmate.database.MealPlanQueries
+import com.plusmobileapps.chefmate.database.RecipeQueries
+import com.plusmobileapps.chefmate.fakes.FakeDatabase
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+abstract class BaseTestApplicationComponent : TestApplicationComponent {
+
+    @Provides @SingleIn(AppScope::class) fun providesFakeDatabase(): FakeDatabase = FakeDatabase()
+
+    @Provides fun providesDatabase(fakeDatabase: FakeDatabase): Database = fakeDatabase
+
+    @Provides fun providesRecipeQueries(database: Database): RecipeQueries = database.recipeQueries
+
+    @Provides
+    fun providesGroceryQueries(database: Database): GroceryQueries = database.groceryQueries
+
+    @Provides
+    fun providesGroceryListQueries(database: Database): GroceryListQueries =
+        database.groceryListQueries
+
+    @Provides
+    fun providesMealPlanQueries(database: Database): MealPlanQueries = database.mealPlanQueries
+
+    @Provides
+    fun providesBrowserHistoryQueries(database: Database): BrowserHistoryQueries =
+        database.browserHistoryQueries
+
+    @Provides
+    fun providesCookingSessionQueries(database: Database): CookingSessionQueries =
+        database.cookingSessionQueries
+}

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/di/TestApplicationComponent.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/di/TestApplicationComponent.kt
@@ -1,0 +1,12 @@
+package com.plusmobileapps.chefmate.di
+
+import com.plusmobileapps.chefmate.ApplicationComponent
+import com.plusmobileapps.chefmate.fakes.FakeDatabase
+import com.plusmobileapps.chefmate.fakes.TestAuthenticationRepository
+
+interface TestApplicationComponent : ApplicationComponent {
+    val fakeDatabase: FakeDatabase
+    val testAuthenticationRepository: TestAuthenticationRepository
+}
+
+expect fun createTestApplicationComponent(): TestApplicationComponent

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/FakeDatabase.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/FakeDatabase.kt
@@ -1,0 +1,41 @@
+package com.plusmobileapps.chefmate.fakes
+
+import com.plusmobileapps.chefmate.database.Database
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+
+class FakeDatabase(private val delegate: Database = provideTestDatabase()) : Database by delegate {
+
+    fun addRecipe(recipe: Recipe) {
+        recipeQueries.create(
+            title = recipe.title,
+            description = recipe.description,
+            ingredients = recipe.ingredients.takeIf { it.isNotEmpty() },
+            directions = recipe.directions.takeIf { it.isNotEmpty() },
+            imageUrl = recipe.imageUrl,
+            sourceUrl = recipe.sourceUrl,
+            servings = recipe.servings?.toLong(),
+            prepTime = recipe.prepTime?.toLong(),
+            cookTime = recipe.cookTime?.toLong(),
+            totalTime = recipe.totalTime?.toLong(),
+            calories = recipe.calories?.toLong(),
+            starRating = recipe.starRating?.toLong(),
+            isFavorite = recipe.isFavorite,
+            createdAt = recipe.createdAt.toString(),
+            updatedAt = recipe.updatedAt.toString(),
+            clientId = null,
+            ownerId = null,
+        )
+    }
+
+    fun addRecipes(recipes: Iterable<Recipe>) {
+        recipes.forEach(::addRecipe)
+    }
+
+    fun addRecipes(vararg recipes: Recipe) {
+        recipes.forEach(::addRecipe)
+    }
+
+    fun clearRecipes() {
+        recipeQueries.deleteAll()
+    }
+}

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/FakeRecipeRemoteDataSource.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/FakeRecipeRemoteDataSource.kt
@@ -1,0 +1,20 @@
+package com.plusmobileapps.chefmate.fakes
+
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.recipe.data.impl.remote.RecipeRemoteDataSource
+import com.plusmobileapps.chefmate.recipe.data.impl.remote.RemoteRecipe
+import com.plusmobileapps.chefmate.recipe.data.impl.remote.SupabaseRecipeRemoteDataSource
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+@SingleIn(AppScope::class)
+@Inject
+@ContributesBinding(scope = AppScope::class, replaces = [SupabaseRecipeRemoteDataSource::class])
+class FakeRecipeRemoteDataSource : RecipeRemoteDataSource {
+    override suspend fun upsertRecipe(recipe: RemoteRecipe): RemoteRecipe = recipe
+
+    override suspend fun deleteRecipe(remoteId: String) = Unit
+
+    override suspend fun fetchAllRecipes(ownerId: String): List<RemoteRecipe> = emptyList()
+}

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/ProvideTestDatabase.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/ProvideTestDatabase.kt
@@ -1,0 +1,11 @@
+package com.plusmobileapps.chefmate.fakes
+
+import com.plusmobileapps.chefmate.database.Database
+
+/**
+ * Per-platform test database used by [FakeDatabase]. JVM and iOS delegate to the existing
+ * `createTestDatabase()` (JdbcSqliteDriver / NativeSqliteDriver). Android instrumented tests use
+ * `AndroidSqliteDriver` with the test app context, since `JdbcSqliteDriver` would try to load
+ * `libsqlitejdbc.so` and fail on a real device.
+ */
+expect fun provideTestDatabase(): Database

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/TestAuthenticationRepository.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/TestAuthenticationRepository.kt
@@ -1,0 +1,24 @@
+package com.plusmobileapps.chefmate.fakes
+
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.data.ChefMateUser
+import com.plusmobileapps.chefmate.auth.data.impl.SupabaseAuthenticationRepository
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+@SingleIn(AppScope::class)
+@Inject
+@ContributesBinding(scope = AppScope::class, replaces = [SupabaseAuthenticationRepository::class])
+class TestAuthenticationRepository(
+    private val fake: FakeAuthenticationRepository = FakeAuthenticationRepository()
+) : AuthenticationRepository by fake {
+
+    fun setState(state: AuthState) = fake.setState(state)
+
+    fun setAuthenticated(user: ChefMateUser = FakeAuthenticationRepository.fakeUser()) =
+        fake.setAuthenticated(user)
+}

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fixtures/TestRecipes.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fixtures/TestRecipes.kt
@@ -1,0 +1,116 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.plusmobileapps.chefmate.fixtures
+
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.SyncStatus
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Default recipe fixtures for UI tests, ranging from a fully populated recipe down to a title-only
+ * minimum. The DB schema only requires `title`; the domain model also requires `ingredients` and
+ * `directions` to be non-null Strings (empty is valid).
+ */
+object TestRecipes {
+
+    private val createdAt = Instant.parse("2026-01-01T00:00:00Z")
+
+    /** Every field populated. Mirrors a real recipe a power user would save. */
+    val fullyPopulated =
+        Recipe(
+            id = 1L,
+            title = "Pasta Carbonara",
+            description = "A classic Roman pasta with eggs, cheese, and cured pork.",
+            ingredients =
+                "200g spaghetti\n100g guanciale\n2 large eggs\n50g pecorino romano\n" +
+                    "Freshly cracked black pepper\nSalt",
+            directions =
+                "Bring a large pot of salted water to a boil and cook pasta until al dente.\n" +
+                    "Render the guanciale in a wide pan over medium heat until crisp.\n" +
+                    "Whisk eggs and pecorino in a bowl with plenty of black pepper.\n" +
+                    "Drain pasta and toss with guanciale, then add the egg mixture off the heat.",
+            imageUrl = "https://example.test/carbonara.jpg",
+            sourceUrl = "https://example.test/carbonara",
+            servings = 2,
+            prepTime = 10,
+            cookTime = 15,
+            totalTime = 25,
+            calories = 620,
+            starRating = 5,
+            isFavorite = true,
+            syncStatus = SyncStatus.SYNCED,
+            createdAt = createdAt,
+            updatedAt = createdAt,
+        )
+
+    /** Description and image dropped; metadata still present. */
+    val withoutDescriptionOrImage =
+        Recipe(
+            id = 2L,
+            title = "Lasagna",
+            description = null,
+            ingredients = "Lasagna sheets\nGround beef\nTomato sauce\nMozzarella",
+            directions = "Layer ingredients in a baking dish and bake at 375°F for 45 minutes.",
+            imageUrl = null,
+            sourceUrl = null,
+            servings = 6,
+            prepTime = 20,
+            cookTime = 45,
+            totalTime = 65,
+            calories = 480,
+            starRating = 4,
+            isFavorite = false,
+            syncStatus = SyncStatus.SYNCED,
+            createdAt = createdAt,
+            updatedAt = createdAt,
+        )
+
+    /** Only title + ingredients + directions; no metadata, no image, no rating. */
+    val ingredientsAndDirectionsOnly =
+        Recipe(
+            id = 3L,
+            title = "Toast",
+            description = null,
+            ingredients = "Bread\nButter",
+            directions = "Toast bread. Apply butter.",
+            imageUrl = null,
+            sourceUrl = null,
+            servings = null,
+            prepTime = null,
+            cookTime = null,
+            totalTime = null,
+            calories = null,
+            starRating = null,
+            isFavorite = false,
+            syncStatus = SyncStatus.NOT_SYNCED,
+            createdAt = createdAt,
+            updatedAt = createdAt,
+        )
+
+    /** Title only — the technical minimum the DB will accept. */
+    val titleOnly =
+        Recipe(
+            id = 4L,
+            title = "Mystery Dish",
+            description = null,
+            ingredients = "",
+            directions = "",
+            imageUrl = null,
+            sourceUrl = null,
+            servings = null,
+            prepTime = null,
+            cookTime = null,
+            totalTime = null,
+            calories = null,
+            starRating = null,
+            isFavorite = false,
+            syncStatus = SyncStatus.NOT_SYNCED,
+            createdAt = createdAt,
+            updatedAt = createdAt,
+        )
+
+    /** All four permutations from fully-populated to title-only. */
+    val defaults: List<Recipe> =
+        listOf(fullyPopulated, withoutDescriptionOrImage, ingredientsAndDirectionsOnly, titleOnly)
+}

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
@@ -1,0 +1,49 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package com.plusmobileapps.chefmate.harness
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.resume
+import com.plusmobileapps.chefmate.App
+import com.plusmobileapps.chefmate.DefaultBlocContext
+import com.plusmobileapps.chefmate.di.TestApplicationComponent
+import com.plusmobileapps.chefmate.di.createTestApplicationComponent
+import com.plusmobileapps.chefmate.fixtures.TestRecipes
+import com.plusmobileapps.chefmate.root.RootBloc
+import kotlinx.coroutines.test.TestResult
+
+/**
+ * Build a root BLoC tree for UI tests using production-default coroutine dispatchers (Main, IO,
+ * Default, Unconfined as set by [DefaultBlocContext]). The lifecycle is started in the resumed
+ * state so child blocs and view models initialise immediately. Returns a fully-wired [RootBloc]
+ * ready to be passed into `App(rootBloc = …)`.
+ */
+fun TestApplicationComponent.createRootBloc(
+    lifecycle: LifecycleRegistry = LifecycleRegistry().apply { resume() }
+): RootBloc =
+    rootBlocFactory.create(
+        DefaultBlocContext(componentContext = DefaultComponentContext(lifecycle = lifecycle))
+    )
+
+/**
+ * Wraps [runComposeUiTest] with the standard root-bloc setup: builds a [TestApplicationComponent],
+ * applies [userState], and renders `App` against a fresh [RootBloc]. The component is passed to
+ * [block] so robots/assertions can reach back into the graph (e.g. flipping auth state mid-test).
+ *
+ * Returns the [TestResult] from [runComposeUiTest] unchanged — required so K/N test runners await
+ * the suspending body before reporting the test as finished.
+ */
+fun runRootBlocTest(
+    userState: TestUserState =
+        TestUserState.Authenticated(recipes = listOf(TestRecipes.fullyPopulated)),
+    block: suspend ComposeUiTest.(TestApplicationComponent) -> Unit,
+): TestResult = runComposeUiTest {
+    val app = createTestApplicationComponent()
+    app.applyUserState(userState)
+    setContent { App(rootBloc = app.createRootBloc()) }
+    block(app)
+}

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/TestUserState.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/TestUserState.kt
@@ -1,0 +1,41 @@
+package com.plusmobileapps.chefmate.harness
+
+import com.plusmobileapps.chefmate.di.TestApplicationComponent
+import com.plusmobileapps.chefmate.fixtures.TestRecipes
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+
+/**
+ * High-level test scenarios composing the user's auth state with seeded recipes. Apply via
+ * [applyUserState] after building a [TestApplicationComponent].
+ */
+sealed interface TestUserState {
+
+    /** Signed-in user with recipes already in the local DB. Defaults to [TestRecipes.defaults]. */
+    data class Authenticated(val recipes: List<Recipe> = TestRecipes.defaults) : TestUserState
+
+    /** Signed-in user with no recipes yet. */
+    data object NewUser : TestUserState
+
+    /**
+     * Not signed in, but the local DB has recipes (mirrors a user who saved recipes offline before
+     * authenticating, or signed out without clearing local data).
+     */
+    data class UnauthenticatedWithRecipes(val recipes: List<Recipe> = TestRecipes.defaults) :
+        TestUserState
+}
+
+fun TestApplicationComponent.applyUserState(state: TestUserState) {
+    when (state) {
+        is TestUserState.Authenticated -> {
+            testAuthenticationRepository.setAuthenticated()
+            fakeDatabase.addRecipes(state.recipes)
+        }
+        TestUserState.NewUser -> {
+            testAuthenticationRepository.setAuthenticated()
+        }
+        is TestUserState.UnauthenticatedWithRecipes -> {
+            // FakeAuthenticationRepository defaults to AuthState.Unauthenticated; nothing to do.
+            fakeDatabase.addRecipes(state.recipes)
+        }
+    }
+}

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/RootNavigationUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/RootNavigationUiTest.kt
@@ -1,0 +1,18 @@
+package com.plusmobileapps.chefmate.tests
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.plusmobileapps.chefmate.fixtures.TestRecipes
+import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.recipe.core.robots.recipeDetail
+import com.plusmobileapps.chefmate.recipe.list.robots.recipeList
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class RootNavigationUiTest {
+
+    @Test
+    fun clicking_recipe_in_list_navigates_to_recipe_detail() = runRootBlocTest {
+        recipeList().clickRecipe(TestRecipes.fullyPopulated.title)
+        recipeDetail().awaitDisplayed().assertRecipeDisplayed(TestRecipes.fullyPopulated.title)
+    }
+}

--- a/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/di/IosApplicationComponent.kt
+++ b/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/di/IosApplicationComponent.kt
@@ -2,8 +2,6 @@ package com.plusmobileapps.chefmate.di
 
 import com.plusmobileapps.chefmate.ApplicationComponent
 import com.plusmobileapps.chefmate.client.database.DriverFactory
-import com.plusmobileapps.chefmate.util.DateTimeFormatterUtil
-import com.plusmobileapps.chefmate.util.DateTimeFormatterUtilImpl
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
@@ -18,8 +16,4 @@ abstract class IosApplicationComponent : ApplicationComponent {
     }
 
     @Provides fun driverFactory(): DriverFactory = DriverFactory()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    fun provideDateTimeFormatterUtil(): DateTimeFormatterUtil = DateTimeFormatterUtilImpl()
 }

--- a/client/composeApp/src/iosTest/kotlin/com/plusmobileapps/chefmate/di/IosTestApplicationComponent.kt
+++ b/client/composeApp/src/iosTest/kotlin/com/plusmobileapps/chefmate/di/IosTestApplicationComponent.kt
@@ -1,0 +1,13 @@
+package com.plusmobileapps.chefmate.di
+
+import com.plusmobileapps.chefmate.client.database.di.DatabaseComponent
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.createGraph
+
+@SingleIn(AppScope::class)
+@DependencyGraph(scope = AppScope::class, excludes = [DatabaseComponent::class])
+abstract class IosTestApplicationComponent : BaseTestApplicationComponent()
+
+actual fun createTestApplicationComponent(): TestApplicationComponent =
+    createGraph<IosTestApplicationComponent>()

--- a/client/composeApp/src/iosTest/kotlin/com/plusmobileapps/chefmate/fakes/ProvideTestDatabase.ios.kt
+++ b/client/composeApp/src/iosTest/kotlin/com/plusmobileapps/chefmate/fakes/ProvideTestDatabase.ios.kt
@@ -1,0 +1,6 @@
+package com.plusmobileapps.chefmate.fakes
+
+import com.plusmobileapps.chefmate.database.Database
+import com.plusmobileapps.chefmate.database.testing.createTestDatabase
+
+actual fun provideTestDatabase(): Database = createTestDatabase()

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/JvmApplicationComponent.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/JvmApplicationComponent.kt
@@ -2,8 +2,6 @@ package com.plusmobileapps.chefmate
 
 import com.plusmobileapps.chefmate.client.database.DriverFactory
 import com.plusmobileapps.chefmate.di.AppScope
-import com.plusmobileapps.chefmate.util.DateTimeFormatterUtil
-import com.plusmobileapps.chefmate.util.DateTimeFormatterUtilImpl
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
@@ -12,8 +10,4 @@ import dev.zacsweers.metro.SingleIn
 @DependencyGraph(AppScope::class)
 abstract class JvmApplicationComponent : ApplicationComponent {
     @Provides fun providesDriverFactory(): DriverFactory = DriverFactory()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    fun provideDateTimeFormatterUtil(): DateTimeFormatterUtil = DateTimeFormatterUtilImpl()
 }

--- a/client/composeApp/src/jvmTest/kotlin/com/plusmobileapps/chefmate/di/JvmTestApplicationComponent.kt
+++ b/client/composeApp/src/jvmTest/kotlin/com/plusmobileapps/chefmate/di/JvmTestApplicationComponent.kt
@@ -1,0 +1,13 @@
+package com.plusmobileapps.chefmate.di
+
+import com.plusmobileapps.chefmate.client.database.di.DatabaseComponent
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.createGraph
+
+@SingleIn(AppScope::class)
+@DependencyGraph(scope = AppScope::class, excludes = [DatabaseComponent::class])
+abstract class JvmTestApplicationComponent : BaseTestApplicationComponent()
+
+actual fun createTestApplicationComponent(): TestApplicationComponent =
+    createGraph<JvmTestApplicationComponent>()

--- a/client/composeApp/src/jvmTest/kotlin/com/plusmobileapps/chefmate/fakes/ProvideTestDatabase.jvm.kt
+++ b/client/composeApp/src/jvmTest/kotlin/com/plusmobileapps/chefmate/fakes/ProvideTestDatabase.jvm.kt
@@ -1,0 +1,6 @@
+package com.plusmobileapps.chefmate.fakes
+
+import com.plusmobileapps.chefmate.database.Database
+import com.plusmobileapps.chefmate.database.testing.createTestDatabase
+
+actual fun provideTestDatabase(): Database = createTestDatabase()

--- a/client/recipe/core/impl-robots/build.gradle.kts
+++ b/client/recipe/core/impl-robots/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)
+            implementation(projects.client.recipe.core.public)
+        }
+    }
+}
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.recipe.core.robots" }

--- a/client/recipe/core/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/robots/RecipeDetailRobot.kt
+++ b/client/recipe/core/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/robots/RecipeDetailRobot.kt
@@ -1,0 +1,32 @@
+package com.plusmobileapps.chefmate.recipe.core.robots
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailTestTags
+
+/**
+ * Robot for interacting with and asserting on the recipe detail screen. Lives next to
+ * `client/recipe/core/impl` so any test that exercises this screen can compose against the same
+ * domain-level vocabulary instead of hardcoding semantics-tree lookups.
+ *
+ * Construct via [recipeDetail] from inside a `runComposeUiTest { … }` block.
+ */
+@OptIn(ExperimentalTestApi::class)
+class RecipeDetailRobot(private val test: ComposeUiTest) {
+
+    private val onScreen = hasTestTag(RecipeDetailTestTags.SCREEN)
+
+    fun awaitDisplayed(): RecipeDetailRobot = apply { test.waitUntilExactlyOneExists(onScreen) }
+
+    fun assertRecipeDisplayed(recipeName: String): RecipeDetailRobot = apply {
+        test.onNode(hasText(recipeName) and hasAnyAncestor(onScreen)).assertIsDisplayed()
+    }
+}
+
+@OptIn(ExperimentalTestApi::class)
+fun ComposeUiTest.recipeDetail(): RecipeDetailRobot = RecipeDetailRobot(this)

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -94,6 +94,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -210,7 +211,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     var showOverflowMenu by remember { mutableStateOf(false) }
     var metadataCollapsed by rememberSaveable { mutableStateOf(false) }
 
-    Box(modifier = modifier.fillMaxSize()) {
+    Box(modifier = modifier.fillMaxSize().testTag(RecipeDetailTestTags.SCREEN)) {
         PlusResponsiveContainer(modifier = Modifier.fillMaxSize()) { windowSizeClass ->
             val isCompact = windowSizeClass == WindowSizeClass.COMPACT
             val showToolbar = isCompact || !metadataCollapsed

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailTestTags.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailTestTags.kt
@@ -1,0 +1,9 @@
+package com.plusmobileapps.chefmate.recipe.core.detail
+
+/**
+ * Stable test tags applied to the recipe detail screen. Shared with `RecipeDetailRobot` so UI tests
+ * scope semantics-tree lookups to this screen.
+ */
+object RecipeDetailTestTags {
+    const val SCREEN: String = "recipe_detail_screen"
+}

--- a/client/recipe/list/impl-robots/build.gradle.kts
+++ b/client/recipe/list/impl-robots/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)
+            implementation(projects.client.recipe.list.public)
+        }
+    }
+}
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.recipe.list.robots" }

--- a/client/recipe/list/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/robots/RecipeListRobot.kt
+++ b/client/recipe/list/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/robots/RecipeListRobot.kt
@@ -1,0 +1,37 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package com.plusmobileapps.chefmate.recipe.list.robots
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.performClick
+import com.plusmobileapps.chefmate.recipe.list.RecipeListTestTags
+
+/**
+ * Robot for interacting with and asserting on the recipe list screen. Lives next to
+ * `client/recipe/list/impl` so any test that exercises this screen can compose against the same
+ * domain-level vocabulary instead of hardcoding semantics-tree lookups.
+ *
+ * Every node lookup is scoped to a descendant of [RecipeListTestTags.SCREEN] so a recipe title
+ * rendered elsewhere (e.g. on the recipe detail header) doesn't satisfy the matcher.
+ *
+ * Construct via [recipeList] from inside a `runComposeUiTest { … }` block.
+ */
+class RecipeListRobot(private val test: ComposeUiTest) {
+
+    private val onScreen = hasAnyAncestor(hasTestTag(RecipeListTestTags.SCREEN))
+
+    fun assertRecipeIsDisplayed(title: String): RecipeListRobot = apply {
+        test.onNode(hasText(title) and onScreen).assertIsDisplayed()
+    }
+
+    fun clickRecipe(title: String): RecipeListRobot = apply {
+        test.onNode(hasText(title) and onScreen).assertIsDisplayed().performClick()
+    }
+}
+
+fun ComposeUiTest.recipeList(): RecipeListRobot = RecipeListRobot(this)

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -83,6 +83,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -162,7 +163,7 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
             }
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
+    Box(modifier = modifier.fillMaxSize().testTag(RecipeListTestTags.SCREEN)) {
         PlusNavContainer(
             modifier = modifier.fillMaxSize(),
             data =

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListTestTags.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListTestTags.kt
@@ -1,0 +1,10 @@
+package com.plusmobileapps.chefmate.recipe.list
+
+/**
+ * Stable test tags applied to the recipe list screen. Shared with `RecipeListRobot` so UI tests can
+ * scope semantics-tree lookups to this screen and avoid colliding with identical text rendered
+ * elsewhere (e.g. a recipe title shown on the detail screen header).
+ */
+object RecipeListTestTags {
+    const val SCREEN: String = "recipe_list_screen"
+}

--- a/client/util/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/impl/DateTimeFormatterComponent.kt
+++ b/client/util/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/impl/DateTimeFormatterComponent.kt
@@ -1,0 +1,15 @@
+package com.plusmobileapps.chefmate.util.impl
+
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.util.DateTimeFormatterUtil
+import com.plusmobileapps.chefmate.util.DateTimeFormatterUtilImpl
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+@ContributesTo(AppScope::class)
+interface DateTimeFormatterComponent {
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideDateTimeFormatterUtil(): DateTimeFormatterUtil = DateTimeFormatterUtilImpl()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidx-appcompat = "1.7.1"
 androidx-core = "1.17.0"
 androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.5"
+androidx-test-core = "1.7.0"
 androidx-testExt = "1.3.0"
 bugsnag-kmp = "1.0.0"
 coil = "3.1.0"
@@ -16,6 +17,7 @@ buildkonfig = "0.17.1"
 composeHotReload = "1.0.0"
 composeMaterialExpressive = "1.10.0-alpha05"
 composeMultiplatform = "1.10.3"
+composeUi = "1.11.1"
 composeMaterialIcons = "1.7.3"
 coroutines = "1.10.2"
 kermit = "2.1.0"
@@ -54,6 +56,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 junit = { module = "junit:junit", version.ref = "junit" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
 androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
@@ -72,6 +75,9 @@ compose-material-icons-extended = { module = "org.jetbrains.compose.material:mat
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
+compose-uiTest = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "composeMultiplatform" }
+androidx-compose-ui-test-junit4-android = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "composeUi" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "composeUi" }
 essenty-lifecycle = { group = "com.arkivanov.essenty", name = "lifecycle", version.ref = "essenty" }
 essenty-backhandler = { group = "com.arkivanov.essenty", name = "back-handler", version.ref = "essenty" }
 essenty-lifecycle-coroutines = {group = "com.arkivanov.essenty", name = "lifecycle-coroutines", version.ref = "essenty" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -84,6 +84,8 @@ include(":client:meal:data:testing")
 
 include(":client:recipe:core:impl")
 
+include(":client:recipe:core:impl-robots")
+
 include(":client:recipe:core:public")
 
 include(":client:recipe:data:impl")
@@ -93,6 +95,8 @@ include(":client:recipe:data:public")
 include(":client:recipe:data:testing")
 
 include(":client:recipe:list:impl")
+
+include(":client:recipe:list:impl-robots")
 
 include(":client:recipe:list:public")
 


### PR DESCRIPTION
## Summary

Adds the project's first **Compose Multiplatform UI test**, exercising real navigation from the recipe list to the recipe detail through a fully wired `RootBloc`. Targets **JVM, Android (Robolectric — currently `@Ignore`d), and iOS Simulator**.

- **Test DI**: Per-platform `*TestApplicationComponent` Metro graphs that exclude `DatabaseComponent` and provide an in-memory `Database` via `createTestDatabase()` so `:client:composeApp:jvmTest` doesn't pollute the developer's real `chefmate.db`
- **Surgical mocks**: `FakeRecipeRemoteDataSource` and `TestAuthenticationRepository` use `@ContributesBinding(replaces = [Supabase…::class])` so `RecipeRepositoryImpl`'s sync and the auth repo's `sessionStatus.collect` never reach real Supabase
- **Test body** lives in `commonTest/RootNavigationUiTest.kt`; per-platform classes (`JvmRootNavigationUiTest`, `IosRootNavigationUiTest`, `AndroidRootNavigationUiTest`) call into it
- `Modifier.testTag("recipe_detail_screen")` on `RecipeDetailScreen`'s outer Box so the test can assert the detail handoff completed
- iOS test binary now links `-lsqlite3` so the in-memory native driver compiles

## Why Android is `@Ignore`d

Robolectric 4.12+ rejects Compose UI test's `ActivityScenario.launch(ComponentActivity)` with `Unable to resolve activity ... see robolectric/pull/4736`, even with the launcher intent-filter merged into the test manifest (verified via `build/intermediates/packaged_manifests/debugUnitTest/`). Tracking for re-enable when Compose UI ≥1.11 ships a workaround.

## Test plan

- [x] `./gradlew :client:composeApp:jvmTest` passes locally (~1.3s)
- [x] `./gradlew :client:composeApp:iosSimulatorArm64Test` passes locally (~5.5s)
- [x] `./gradlew :client:composeApp:testDebugUnitTest` passes (Android variant skipped via `@Ignore`)
- [ ] CI: a follow-up workflow runs all three with test reporting (next commit on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)