### PR TITLE
fix(cook): stop double-padding cutout side in landscape (#155)

### DIFF
--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModePreviews.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModePreviews.kt
@@ -132,6 +132,28 @@ internal fun CookModeStackedLandscapeDarkPreview() {
     ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocStacked) }
 }
 
+// Tablet/large-phone landscape with the split body — mirrors the configuration in issue #155
+// where the body layouts must stay clear of horizontal insets without double-padding the
+// cutout side. (Screenshot rendering doesn't inject real display-cutout insets, so this
+// preview locks in the no-cutout baseline for the split landscape layout.)
+@Preview(showBackground = true, widthDp = 1000, heightDp = 460)
+@Composable
+internal fun CookModeSplitLandscapePreview() {
+    ChefMateTheme { CookModeScreen(bloc = previewCookBlocSplit) }
+}
+
+@Preview(showBackground = true, widthDp = 1000, heightDp = 460)
+@Composable
+internal fun CookModeSplitLandscapeDarkPreview() {
+    ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocSplit) }
+}
+
+@Preview(showBackground = true, widthDp = 1000, heightDp = 460)
+@Composable
+internal fun CookModeStackedLandscapeWidePreview() {
+    ChefMateTheme { CookModeScreen(bloc = previewCookBlocStacked) }
+}
+
 @Preview(showBackground = true, heightDp = 1100)
 @Composable
 internal fun CookModeLongTitlePreview() {

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeScreen.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeScreen.kt
@@ -196,7 +196,7 @@ private fun CookModeTabletLayout(
             floatingHeader = true,
             headerContainerAlpha = 0.85f,
             centerAlignTitle = true,
-            floatingHeaderTopReserve = false,
+            applyContentInsets = false,
             scrollEnabled = false,
             maxContentWidth = Dp.Unspecified,
         ) {
@@ -331,7 +331,7 @@ private fun CookModeMobileLayout(
                 floatingHeader = true,
                 headerContainerAlpha = 0.85f,
                 centerAlignTitle = true,
-                floatingHeaderTopReserve = false,
+                applyContentInsets = false,
                 scrollEnabled = false,
                 maxContentWidth = Dp.Unspecified,
             ) {

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
@@ -70,9 +70,11 @@ fun PlusHeaderContainer(
     floatingHeader: Boolean = false,
     headerContainerAlpha: Float = 1f,
     centerAlignTitle: Boolean = false,
-    // When true the container adds status-bar + app-bar top padding to the content so it clears
-    // the floating header. Pass false when the content manages its own top inset (e.g. Cook Mode).
-    floatingHeaderTopReserve: Boolean = true,
+    // When true the container reserves status-bar + app-bar space at the top *and* applies
+    // horizontal display-cutout padding to the content. Pass false when the content manages all
+    // its own insets (e.g. Cook Mode applies horizontal insets per body region) so the cutout
+    // side isn't padded twice.
+    applyContentInsets: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val scrollState = rememberScrollState()
@@ -80,7 +82,7 @@ fun PlusHeaderContainer(
 
     if (floatingHeader) {
         val topPadding =
-            if (floatingHeaderTopReserve) {
+            if (applyContentInsets) {
                 with(density) { WindowInsets.statusBars.getTop(density).toDp() } + 64.dp
             } else {
                 0.dp
@@ -97,6 +99,7 @@ fun PlusHeaderContainer(
                         scrollState = scrollState,
                         maxContentWidth = maxContentWidth,
                         topPadding = topPadding,
+                        applyHorizontalInsets = applyContentInsets,
                         content = content,
                     )
                     BottomBarBox(
@@ -144,6 +147,7 @@ fun PlusHeaderContainer(
                         scrollEnabled = scrollEnabled,
                         scrollState = scrollState,
                         maxContentWidth = maxContentWidth,
+                        applyHorizontalInsets = true,
                         content = content,
                     )
                     BottomBarBox(
@@ -203,24 +207,15 @@ private fun ScrollingContent(
     scrollState: ScrollState,
     maxContentWidth: Dp,
     topPadding: Dp = 0.dp,
+    applyHorizontalInsets: Boolean = true,
     content: @Composable (ColumnScope.() -> Unit),
 ) {
+    val baseModifier =
+        modifier.fillMaxHeight().widthIn(max = maxContentWidth).padding(top = topPadding)
+    val insetModifier =
+        if (applyHorizontalInsets) baseModifier.scaffoldContentInsetPadding() else baseModifier
     Column(
-        modifier =
-            if (scrollEnabled) {
-                modifier
-                    .fillMaxHeight()
-                    .widthIn(max = maxContentWidth)
-                    .padding(top = topPadding)
-                    .scaffoldContentInsetPadding()
-                    .verticalScroll(scrollState)
-            } else {
-                modifier
-                    .fillMaxHeight()
-                    .widthIn(max = maxContentWidth)
-                    .padding(top = topPadding)
-                    .scaffoldContentInsetPadding()
-            }
+        modifier = if (scrollEnabled) insetModifier.verticalScroll(scrollState) else insetModifier
     ) {
         content()
         if (scrollEnabled) {

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTest.kt
@@ -92,3 +92,35 @@ fun CookModeTabletLightScreenshot() {
 fun CookModeTabletDarkScreenshot() {
     ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocSplit) }
 }
+
+// ── Tablet/large phone landscape (1000 × 460 dp, EXPANDED width, compact height) ──
+// Regression coverage for issue #155: the split body must not double-pad horizontally
+// when the floating header container also handles insets. Screenshot rendering doesn't
+// inject real display-cutout insets, so these lock in the no-cutout baseline for the
+// landscape layouts that exhibited the bug.
+
+@PreviewTest
+@Preview(showBackground = true, widthDp = 1000, heightDp = 460)
+@Composable
+fun CookModeSplitLandscapeLightScreenshot() {
+    ChefMateTheme { CookModeScreen(bloc = previewCookBlocSplit) }
+}
+
+@PreviewTest
+@Preview(
+    showBackground = true,
+    widthDp = 1000,
+    heightDp = 460,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun CookModeSplitLandscapeDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) { CookModeScreen(bloc = previewCookBlocSplit) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, widthDp = 1000, heightDp = 460)
+@Composable
+fun CookModeStackedLandscapeWideScreenshot() {
+    ChefMateTheme { CookModeScreen(bloc = previewCookBlocStacked) }
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeSplitLandscapeDarkScreenshot_bcb1b394_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeSplitLandscapeDarkScreenshot_bcb1b394_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4198ef740e62d5ed43b17a46a890b09e82a6dbc93c9e486e5106cf91522f43ff
+size 127700

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeSplitLandscapeLightScreenshot_840002fb_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeSplitLandscapeLightScreenshot_840002fb_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f108af84477e26a617f9a735bfb13cb106bb23c2f52e9f0ad7db9888eb137c2b
+size 127621

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeStackedLandscapeWideScreenshot_840002fb_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeStackedLandscapeWideScreenshot_840002fb_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9d4c70ebd29e4d782272c5b5293fd23fcecb6814d4f2fe017d516247e847071
+size 114122


### PR DESCRIPTION
## Summary
- `PlusHeaderContainer` was unconditionally wrapping content with `scaffoldContentInsetPadding()` (cutout left/right), and Cook Mode's body layouts then added `systemBars ∪ displayCutout` start/end padding again via `bodyContentPadding` — so the cutout side got padded twice and looked visibly off in landscape (worse on whichever side the camera landed)
- Renamed `floatingHeaderTopReserve` → `applyContentInsets` so the same flag governs both the top reserve and the horizontal cutout wrapper; Cook Mode opts out (it manages all its own insets per body region)
- Adds tablet/wide-landscape screenshot previews + tests as no-cutout regression coverage for the split + stacked layouts that exhibited the bug

Closes #155

## Test plan
- [x] `./gradlew :client:ui:public:compileDebugKotlinAndroid :client:cook:public:compileDebugKotlinAndroid :client:ui:screenshot-test:compileDebugKotlin`
- [x] `./gradlew :client:ui:screenshot-test:updateDebugScreenshotTest` (3 new reference PNGs reviewed)
- [x] `./gradlew :client:ui:screenshot-test:validateDebugScreenshotTest` (existing screenshots unchanged)
- [x] `./gradlew :client:ui:public:ktfmtCheck :client:cook:public:ktfmtCheck :client:ui:screenshot-test:ktfmtCheck`
- [ ] Manual: rotate a Pixel device through both landscape orientations in Cook Mode and confirm the cutout side has a single inset, not double

## Notes
Compose preview rendering can't inject real `displayCutout` insets, so the new screenshot tests lock in the no-cutout baseline for the layouts that exhibited the bug rather than reproducing the cutout itself. Cutout-driven regressions still need to be caught by manual rotation testing on a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)