### PR TITLE
feat: developer settings menu (debug-only env + test-user login)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ in your IDE’s toolbar or open the [/iosApp](./iosApp) directory in Xcode and r
 ```shell
 ./gradlew :server:run
 ```
+
+## Documentation
+
+- [Architecture overview](docs/architecture.md)
+- [Build configuration (Supabase + Bugsnag)](docs/buildconfig-setup.md)
+- [Developer settings (debug-only env switch + test-user login)](docs/developer-settings.md)
+- [Deployment (Android / iOS / Desktop)](docs/deployment.md)
+- [Deep linking setup](docs/DEEP_LINKING_SETUP.md)
+- [Email verification](docs/EMAIL_VERIFICATION_GUIDE.md)
+
 ---
 
 ## Libraries Used

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseModule.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseModule.kt
@@ -1,5 +1,7 @@
 package com.plusmobileapps.chefmate.auth.data.impl
 
+import com.plusmobileapps.chefmate.Environment
+import com.plusmobileapps.chefmate.EnvironmentProvider
 import com.plusmobileapps.chefmate.buildconfig.BuildConfig
 import com.plusmobileapps.chefmate.di.AppScope
 import dev.zacsweers.metro.ContributesTo
@@ -15,15 +17,25 @@ import io.github.jan.supabase.postgrest.Postgrest
 interface SupabaseModule {
     @SingleIn(AppScope::class)
     @Provides
-    fun provideSupabaseClient(): SupabaseClient =
-        createSupabaseClient(
-            supabaseUrl = BuildConfig.SUPABASE_URL,
-            supabaseKey = BuildConfig.SUPABASE_KEY,
-        ) {
+    fun provideSupabaseClient(environmentProvider: EnvironmentProvider): SupabaseClient {
+        // The client is bound to the env at first injection — switching env at runtime requires
+        // an app restart, which the dev-settings UI prompts for. FAKE falls back to PROD URL
+        // because we still need a valid client to construct; remote calls are gated by sign-in
+        // (the env switch signs the user out), so seeded FAKE data stays local until someone
+        // signs back in.
+        val (url, key) =
+            when (environmentProvider.environment.value) {
+                Environment.TESTING ->
+                    BuildConfig.SUPABASE_TESTING_URL to BuildConfig.SUPABASE_TESTING_KEY
+                Environment.PROD,
+                Environment.FAKE -> BuildConfig.SUPABASE_PROD_URL to BuildConfig.SUPABASE_PROD_KEY
+            }
+        return createSupabaseClient(supabaseUrl = url, supabaseKey = key) {
             install(Auth) {
                 scheme = "chefmate"
                 host = "auth"
             }
             install(Postgrest)
         }
+    }
 }

--- a/client/auth/usecase/impl/build.gradle.kts
+++ b/client/auth/usecase/impl/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins { alias(libs.plugins.kmpLibrary) }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.auth.usecase.public)
+            implementation(projects.client.shared)
+            implementation(projects.client.auth.data.public)
+            implementation(projects.client.grocery.data.public)
+            implementation(projects.client.meal.data.public)
+            implementation(projects.client.recipe.data.public)
+        }
+        commonTest.dependencies {
+            implementation(projects.client.auth.data.testing)
+            implementation(projects.client.grocery.data.testing)
+            implementation(projects.client.meal.data.testing)
+            implementation(projects.client.recipe.data.testing)
+        }
+    }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.auth.usecase.impl"
+    enableDi = true
+    enableTesting = true
+}

--- a/client/auth/usecase/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/SignOutUseCaseImpl.kt
+++ b/client/auth/usecase/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/SignOutUseCaseImpl.kt
@@ -1,0 +1,29 @@
+package com.plusmobileapps.chefmate.auth.usecase.impl
+
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
+import com.plusmobileapps.chefmate.meal.data.MealPlanRepository
+import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class SignOutUseCaseImpl(
+    private val authenticationRepository: AuthenticationRepository,
+    private val groceryRepository: GroceryRepository,
+    private val mealPlanRepository: MealPlanRepository,
+    private val recipeRepository: RecipeRepository,
+) : SignOutUseCase {
+    override suspend fun invoke() {
+        authenticationRepository.signOut()
+        mealPlanRepository.clearLocalData()
+        recipeRepository.clearLocalData()
+        groceryRepository.clearLocalData()
+        groceryRepository.ensureDefaultList()
+    }
+}

--- a/client/auth/usecase/public/build.gradle.kts
+++ b/client/auth/usecase/public/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins { alias(libs.plugins.kmpLibrary) }
+
+kotlin { sourceSets { commonMain.dependencies { implementation(libs.kotlin.coroutines.core) } } }
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.auth.usecase" }

--- a/client/auth/usecase/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/SignOutUseCase.kt
+++ b/client/auth/usecase/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/SignOutUseCase.kt
@@ -1,0 +1,5 @@
+package com.plusmobileapps.chefmate.auth.usecase
+
+fun interface SignOutUseCase {
+    suspend operator fun invoke()
+}

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -195,6 +195,7 @@ class BottomNavBlocImpl(
             SettingsBloc.Output.OpenSignIn -> OpenSignIn
             SettingsBloc.Output.OpenSignUp -> OpenSignUp
             SettingsBloc.Output.OpenAppSettings -> OpenAppSettings
+            SettingsBloc.Output.OpenDeveloperSettings -> BottomNavBloc.Output.OpenDeveloperSettings
             is SettingsBloc.Output.OpenUrl -> BottomNavBloc.Output.OpenUrl(output.url)
         }.let { this.output.onNext(it) }
     }

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -61,6 +61,8 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc {
 
         data object OpenAppSettings : Output()
 
+        data object OpenDeveloperSettings : Output()
+
         data class OpenUrl(val url: String) : Output()
 
         data class OpenMealPlanner(val props: MealPlannerRootBloc.Props) : Output()

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
             api(projects.client.auth.data.impl)
             api(projects.client.auth.data.public)
             api(projects.client.auth.ui.impl)
+            api(projects.client.auth.usecase.impl)
             api(projects.client.cook.impl)
             api(projects.client.cook.public)
             api(projects.client.grocery.data.impl)

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -96,6 +96,7 @@ kotlin {
             api(projects.client.recipe.core.impl)
             api(projects.client.util.impl)
             api(projects.client.settings.impl)
+            api(projects.client.developerSettings.impl)
             api(libs.kermit)
             implementation(libs.supabase.client)
             implementation(libs.supabase.auth)

--- a/client/database/core/src/androidMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.android.kt
+++ b/client/database/core/src/androidMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.android.kt
@@ -1,11 +1,23 @@
 package com.plusmobileapps.chefmate.client.database
 
 import android.content.Context
+import androidx.sqlite.db.SupportSQLiteDatabase
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.plusmobileapps.chefmate.database.Database
 
 actual class DriverFactory(private val context: Context) {
     actual fun createDriver(): SqlDriver =
-        AndroidSqliteDriver(schema = Database.Schema, context = context, name = "chefmate.db")
+        AndroidSqliteDriver(
+            schema = Database.Schema,
+            context = context,
+            name = "chefmate.db",
+            callback =
+                object : AndroidSqliteDriver.Callback(Database.Schema) {
+                    override fun onConfigure(db: SupportSQLiteDatabase) {
+                        super.onConfigure(db)
+                        db.setForeignKeyConstraintsEnabled(true)
+                    }
+                },
+        )
 }

--- a/client/database/core/src/iosMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.ios.kt
+++ b/client/database/core/src/iosMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.ios.kt
@@ -6,5 +6,13 @@ import com.plusmobileapps.chefmate.database.Database
 
 actual class DriverFactory {
     actual fun createDriver(): SqlDriver =
-        NativeSqliteDriver(schema = Database.Schema, name = "chefmate.db")
+        NativeSqliteDriver(
+            schema = Database.Schema,
+            name = "chefmate.db",
+            onConfiguration = { config ->
+                config.copy(
+                    extendedConfig = config.extendedConfig.copy(foreignKeyConstraints = true)
+                )
+            },
+        )
 }

--- a/client/database/core/src/jvmMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.jvm.kt
+++ b/client/database/core/src/jvmMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.jvm.kt
@@ -13,10 +13,11 @@ actual class DriverFactory {
         val dbFile = File(dbPath, "chefmate.db")
 
         return JdbcSqliteDriver(
-            url = "jdbc:sqlite:${dbFile.absolutePath}",
-            properties = Properties(),
-            schema = Database.Schema,
-        )
+                url = "jdbc:sqlite:${dbFile.absolutePath}",
+                properties = Properties(),
+                schema = Database.Schema,
+            )
+            .also { it.execute(null, "PRAGMA foreign_keys = ON", 0) }
     }
 
     private fun getAppDataDirectory(): File {

--- a/client/database/testing/src/androidMain/kotlin/com/plusmobileapps/chefmate/database/testing/TestDatabaseFactory.android.kt
+++ b/client/database/testing/src/androidMain/kotlin/com/plusmobileapps/chefmate/database/testing/TestDatabaseFactory.android.kt
@@ -6,5 +6,6 @@ import com.plusmobileapps.chefmate.database.Database
 actual fun createTestDatabase(): Database {
     val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     Database.Schema.create(driver)
+    driver.execute(null, "PRAGMA foreign_keys = ON", 0)
     return Database(driver)
 }

--- a/client/database/testing/src/iosMain/kotlin/com/plusmobileapps/chefmate/database/testing/TestDatabaseFactory.ios.kt
+++ b/client/database/testing/src/iosMain/kotlin/com/plusmobileapps/chefmate/database/testing/TestDatabaseFactory.ios.kt
@@ -5,5 +5,6 @@ import com.plusmobileapps.chefmate.database.Database
 
 actual fun createTestDatabase(): Database {
     val driver = inMemoryDriver(Database.Schema)
+    driver.execute(null, "PRAGMA foreign_keys = ON", 0)
     return Database(driver)
 }

--- a/client/database/testing/src/jvmMain/kotlin/com/plusmobileapps/chefmate/database/testing/TestDatabaseFactory.jvm.kt
+++ b/client/database/testing/src/jvmMain/kotlin/com/plusmobileapps/chefmate/database/testing/TestDatabaseFactory.jvm.kt
@@ -6,5 +6,6 @@ import com.plusmobileapps.chefmate.database.Database
 actual fun createTestDatabase(): Database {
     val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     Database.Schema.create(driver)
+    driver.execute(null, "PRAGMA foreign_keys = ON", 0)
     return Database(driver)
 }

--- a/client/developer-settings/impl/build.gradle.kts
+++ b/client/developer-settings/impl/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins { alias(libs.plugins.kmpLibrary) }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.developerSettings.public)
+            implementation(libs.arkivanov.decompose.core)
+            implementation(projects.client.shared)
+            implementation(projects.client.auth.data.public)
+            implementation(projects.client.grocery.data.public)
+            implementation(projects.client.recipe.data.public)
+        }
+        commonTest.dependencies {
+            implementation(projects.client.auth.data.testing)
+            implementation(projects.client.grocery.data.testing)
+            implementation(projects.client.recipe.data.testing)
+        }
+    }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.devsettings.impl"
+    enableDi = true
+    enableTesting = true
+}

--- a/client/developer-settings/impl/build.gradle.kts
+++ b/client/developer-settings/impl/build.gradle.kts
@@ -7,16 +7,10 @@ kotlin {
             implementation(libs.arkivanov.decompose.core)
             implementation(projects.client.shared)
             implementation(projects.client.auth.data.public)
-            implementation(projects.client.grocery.data.public)
-            implementation(projects.client.meal.data.public)
+            implementation(projects.client.auth.usecase.public)
             implementation(projects.client.recipe.data.public)
         }
-        commonTest.dependencies {
-            implementation(projects.client.auth.data.testing)
-            implementation(projects.client.grocery.data.testing)
-            implementation(projects.client.meal.data.testing)
-            implementation(projects.client.recipe.data.testing)
-        }
+        commonTest.dependencies { implementation(projects.client.auth.data.testing) }
     }
 }
 

--- a/client/developer-settings/impl/build.gradle.kts
+++ b/client/developer-settings/impl/build.gradle.kts
@@ -8,11 +8,13 @@ kotlin {
             implementation(projects.client.shared)
             implementation(projects.client.auth.data.public)
             implementation(projects.client.grocery.data.public)
+            implementation(projects.client.meal.data.public)
             implementation(projects.client.recipe.data.public)
         }
         commonTest.dependencies {
             implementation(projects.client.auth.data.testing)
             implementation(projects.client.grocery.data.testing)
+            implementation(projects.client.meal.data.testing)
             implementation(projects.client.recipe.data.testing)
         }
     }

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperPreferencesImpl.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperPreferencesImpl.kt
@@ -1,0 +1,64 @@
+package com.plusmobileapps.chefmate.devsettings.impl
+
+import com.plusmobileapps.chefmate.Environment
+import com.plusmobileapps.chefmate.EnvironmentProvider
+import com.plusmobileapps.chefmate.devsettings.DEV_ENVIRONMENT_KEY
+import com.plusmobileapps.chefmate.devsettings.DEV_USER_INDEX_KEY
+import com.plusmobileapps.chefmate.devsettings.DeveloperPreferences
+import com.plusmobileapps.chefmate.di.AppScope
+import com.russhwolf.settings.Settings
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@Inject
+@SingleIn(AppScope::class)
+class DeveloperPreferencesImpl(private val settings: Settings) : DeveloperPreferences {
+
+    private val _environment =
+        MutableStateFlow(
+            settings.getStringOrNull(DEV_ENVIRONMENT_KEY)?.let { stored ->
+                Environment.entries.firstOrNull { it.name == stored }
+            } ?: Environment.PROD
+        )
+
+    override val environment: StateFlow<Environment> = _environment.asStateFlow()
+
+    private val _selectedUserIndex =
+        MutableStateFlow(
+            if (settings.hasKey(DEV_USER_INDEX_KEY)) {
+                settings.getInt(DEV_USER_INDEX_KEY, defaultValue = -1).takeIf { it >= 0 }
+            } else {
+                null
+            }
+        )
+
+    override val selectedUserIndex: StateFlow<Int?> = _selectedUserIndex.asStateFlow()
+
+    override fun setEnvironment(environment: Environment) {
+        settings.putString(DEV_ENVIRONMENT_KEY, environment.name)
+        _environment.value = environment
+    }
+
+    override fun setSelectedUserIndex(index: Int?) {
+        if (index == null) {
+            settings.remove(DEV_USER_INDEX_KEY)
+        } else {
+            settings.putInt(DEV_USER_INDEX_KEY, index)
+        }
+        _selectedUserIndex.value = index
+    }
+}
+
+@ContributesTo(AppScope::class)
+interface DeveloperPreferencesBindingModule {
+    @Provides
+    fun provideDeveloperPreferences(impl: DeveloperPreferencesImpl): DeveloperPreferences = impl
+
+    @Provides
+    fun provideEnvironmentProvider(impl: DeveloperPreferencesImpl): EnvironmentProvider = impl
+}

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsBlocImpl.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsBlocImpl.kt
@@ -67,6 +67,10 @@ class DeveloperSettingsBlocImpl(
     override fun onRestartPromptDismissed() {
         viewModel.dismissRestartPrompt()
     }
+
+    override fun onSignInErrorDismissed() {
+        viewModel.dismissSignInError()
+    }
 }
 
 @ContributesTo(AppScope::class)

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsBlocImpl.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsBlocImpl.kt
@@ -1,0 +1,80 @@
+package com.plusmobileapps.chefmate.devsettings.impl
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.Environment
+import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
+import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc.Output
+import com.plusmobileapps.chefmate.devsettings.TestUser
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.getViewModel
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides
+import kotlinx.coroutines.flow.StateFlow
+
+@AssistedInject
+class DeveloperSettingsBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<Output>,
+    viewModelFactory: Provider<DeveloperSettingsViewModel>,
+) : DeveloperSettingsBloc, BlocContext by context {
+
+    @AssistedFactory
+    fun interface ManagedFactory {
+        fun create(context: BlocContext, output: Consumer<Output>): DeveloperSettingsBlocImpl
+    }
+
+    private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
+
+    override val state: StateFlow<DeveloperSettingsBloc.Model> = viewModel.state
+
+    override fun onBack() {
+        output.onNext(Output.Back)
+    }
+
+    override fun onEnvironmentClicked() {
+        viewModel.showEnvironmentPicker()
+    }
+
+    override fun onEnvironmentSelected(environment: Environment) {
+        viewModel.changeEnvironment(environment)
+    }
+
+    override fun onEnvironmentPickerDismissed() {
+        viewModel.dismissEnvironmentPicker()
+    }
+
+    override fun onLoginAsUserClicked() {
+        viewModel.showUserPicker()
+    }
+
+    override fun onUserSelected(user: TestUser) {
+        viewModel.signInAsTestUser(user)
+    }
+
+    override fun onUserPickerDismissed() {
+        viewModel.dismissUserPicker()
+    }
+
+    override fun onSignOutTestUserClicked() {
+        viewModel.signOutTestUser()
+    }
+
+    override fun onRestartPromptDismissed() {
+        viewModel.dismissRestartPrompt()
+    }
+}
+
+@ContributesTo(AppScope::class)
+interface DeveloperSettingsBlocBindingModule {
+    @Provides
+    fun provideDeveloperSettingsBlocFactory(
+        factory: DeveloperSettingsBlocImpl.ManagedFactory
+    ): DeveloperSettingsBloc.Factory = DeveloperSettingsBloc.Factory { context, output ->
+        factory.create(context, output)
+    }
+}

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsViewModel.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsViewModel.kt
@@ -4,13 +4,11 @@ import com.plusmobileapps.chefmate.Environment
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
 import com.plusmobileapps.chefmate.devsettings.DeveloperPreferences
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.devsettings.TestUser
 import com.plusmobileapps.chefmate.di.Main
-import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
-import com.plusmobileapps.chefmate.meal.data.MealPlanRepository
-import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import dev.zacsweers.metro.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,9 +26,7 @@ class DeveloperSettingsViewModel(
     private val preferences: DeveloperPreferences,
     private val testUserProvider: TestUserProvider,
     private val authenticationRepository: AuthenticationRepository,
-    private val groceryRepository: GroceryRepository,
-    private val recipeRepository: RecipeRepository,
-    private val mealPlanRepository: MealPlanRepository,
+    private val signOutUseCase: SignOutUseCase,
     private val fakeRecipeSeeder: FakeRecipeSeeder,
 ) : ViewModel(mainContext) {
 
@@ -89,8 +85,7 @@ class DeveloperSettingsViewModel(
         scope.launch {
             preferences.setEnvironment(environment)
             preferences.setSelectedUserIndex(null)
-            authenticationRepository.signOut()
-            wipeLocalData()
+            signOutUseCase()
             if (environment == Environment.FAKE) {
                 fakeRecipeSeeder.seed()
             }
@@ -116,16 +111,8 @@ class DeveloperSettingsViewModel(
 
     fun signOutTestUser() {
         scope.launch {
-            authenticationRepository.signOut()
             preferences.setSelectedUserIndex(null)
-            wipeLocalData()
+            signOutUseCase()
         }
-    }
-
-    private suspend fun wipeLocalData() {
-        mealPlanRepository.clearLocalData()
-        recipeRepository.clearLocalData()
-        groceryRepository.clearLocalData()
-        groceryRepository.ensureDefaultList()
     }
 }

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsViewModel.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsViewModel.kt
@@ -9,6 +9,7 @@ import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.devsettings.TestUser
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
+import com.plusmobileapps.chefmate.meal.data.MealPlanRepository
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import dev.zacsweers.metro.Inject
 import kotlin.coroutines.CoroutineContext
@@ -29,6 +30,7 @@ class DeveloperSettingsViewModel(
     private val authenticationRepository: AuthenticationRepository,
     private val groceryRepository: GroceryRepository,
     private val recipeRepository: RecipeRepository,
+    private val mealPlanRepository: MealPlanRepository,
     private val fakeRecipeSeeder: FakeRecipeSeeder,
 ) : ViewModel(mainContext) {
 
@@ -77,6 +79,10 @@ class DeveloperSettingsViewModel(
         _state.update { it.copy(showRestartPrompt = false) }
     }
 
+    fun dismissSignInError() {
+        _state.update { it.copy(signInError = null) }
+    }
+
     fun changeEnvironment(environment: Environment) {
         _state.update { it.copy(showEnvironmentPicker = false) }
         if (environment == _state.value.currentEnvironment) return
@@ -84,9 +90,7 @@ class DeveloperSettingsViewModel(
             preferences.setEnvironment(environment)
             preferences.setSelectedUserIndex(null)
             authenticationRepository.signOut()
-            recipeRepository.clearLocalData()
-            groceryRepository.clearLocalData()
-            groceryRepository.ensureDefaultList()
+            wipeLocalData()
             if (environment == Environment.FAKE) {
                 fakeRecipeSeeder.seed()
             }
@@ -95,13 +99,17 @@ class DeveloperSettingsViewModel(
     }
 
     fun signInAsTestUser(user: TestUser) {
-        _state.update { it.copy(showUserPicker = false) }
+        _state.update { it.copy(showUserPicker = false, signInError = null) }
         scope.launch {
             authenticationRepository.signOut()
             val result =
                 authenticationRepository.signInWithEmailAndPassword(user.email, user.password)
             if (result.isSuccess) {
                 preferences.setSelectedUserIndex(user.index)
+            } else {
+                val message =
+                    result.exceptionOrNull()?.message?.takeIf(String::isNotBlank).orEmpty()
+                _state.update { it.copy(signInError = message) }
             }
         }
     }
@@ -110,6 +118,14 @@ class DeveloperSettingsViewModel(
         scope.launch {
             authenticationRepository.signOut()
             preferences.setSelectedUserIndex(null)
+            wipeLocalData()
         }
+    }
+
+    private suspend fun wipeLocalData() {
+        mealPlanRepository.clearLocalData()
+        recipeRepository.clearLocalData()
+        groceryRepository.clearLocalData()
+        groceryRepository.ensureDefaultList()
     }
 }

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsViewModel.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsViewModel.kt
@@ -1,0 +1,115 @@
+package com.plusmobileapps.chefmate.devsettings.impl
+
+import com.plusmobileapps.chefmate.Environment
+import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.devsettings.DeveloperPreferences
+import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
+import com.plusmobileapps.chefmate.devsettings.TestUser
+import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
+import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import dev.zacsweers.metro.Inject
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@Inject
+class DeveloperSettingsViewModel(
+    @Main mainContext: CoroutineContext,
+    private val preferences: DeveloperPreferences,
+    private val testUserProvider: TestUserProvider,
+    private val authenticationRepository: AuthenticationRepository,
+    private val groceryRepository: GroceryRepository,
+    private val recipeRepository: RecipeRepository,
+    private val fakeRecipeSeeder: FakeRecipeSeeder,
+) : ViewModel(mainContext) {
+
+    private val _state =
+        MutableStateFlow(DeveloperSettingsBloc.Model(availableUsers = testUserProvider.users))
+    val state: StateFlow<DeveloperSettingsBloc.Model> = _state.asStateFlow()
+
+    init {
+        combine(
+                preferences.environment,
+                preferences.selectedUserIndex,
+                authenticationRepository.state,
+            ) { env, userIndex, authState ->
+                Triple(env, userIndex, authState)
+            }
+            .onEach { (env, userIndex, authState) ->
+                _state.update {
+                    it.copy(
+                        currentEnvironment = env,
+                        selectedUserIndex = userIndex,
+                        currentUserEmail = (authState as? AuthState.Authenticated)?.user?.userEmail,
+                        isAuthenticated = authState is AuthState.Authenticated,
+                    )
+                }
+            }
+            .launchIn(scope)
+    }
+
+    fun showEnvironmentPicker() {
+        _state.update { it.copy(showEnvironmentPicker = true) }
+    }
+
+    fun dismissEnvironmentPicker() {
+        _state.update { it.copy(showEnvironmentPicker = false) }
+    }
+
+    fun showUserPicker() {
+        _state.update { it.copy(showUserPicker = true) }
+    }
+
+    fun dismissUserPicker() {
+        _state.update { it.copy(showUserPicker = false) }
+    }
+
+    fun dismissRestartPrompt() {
+        _state.update { it.copy(showRestartPrompt = false) }
+    }
+
+    fun changeEnvironment(environment: Environment) {
+        _state.update { it.copy(showEnvironmentPicker = false) }
+        if (environment == _state.value.currentEnvironment) return
+        scope.launch {
+            preferences.setEnvironment(environment)
+            preferences.setSelectedUserIndex(null)
+            authenticationRepository.signOut()
+            recipeRepository.clearLocalData()
+            groceryRepository.clearLocalData()
+            groceryRepository.ensureDefaultList()
+            if (environment == Environment.FAKE) {
+                fakeRecipeSeeder.seed()
+            }
+            _state.update { it.copy(showRestartPrompt = true) }
+        }
+    }
+
+    fun signInAsTestUser(user: TestUser) {
+        _state.update { it.copy(showUserPicker = false) }
+        scope.launch {
+            authenticationRepository.signOut()
+            val result =
+                authenticationRepository.signInWithEmailAndPassword(user.email, user.password)
+            if (result.isSuccess) {
+                preferences.setSelectedUserIndex(user.index)
+            }
+        }
+    }
+
+    fun signOutTestUser() {
+        scope.launch {
+            authenticationRepository.signOut()
+            preferences.setSelectedUserIndex(null)
+        }
+    }
+}

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/FakeRecipeSeeder.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/FakeRecipeSeeder.kt
@@ -1,0 +1,15 @@
+package com.plusmobileapps.chefmate.devsettings.impl
+
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+@Inject
+@SingleIn(AppScope::class)
+class FakeRecipeSeeder(private val recipeRepository: RecipeRepository) {
+    suspend fun seed() {
+        Recipe.Samples.forEach { recipeRepository.createRecipe(it) }
+    }
+}

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/TestUserProvider.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/TestUserProvider.kt
@@ -1,0 +1,32 @@
+package com.plusmobileapps.chefmate.devsettings.impl
+
+import com.plusmobileapps.chefmate.buildconfig.BuildConfig
+import com.plusmobileapps.chefmate.devsettings.TestUser
+import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+@Inject
+@SingleIn(AppScope::class)
+class TestUserProvider {
+    val users: List<TestUser> = parse(BuildConfig.TEST_USERS)
+
+    companion object {
+        fun parse(serialized: String): List<TestUser> =
+            if (serialized.isBlank()) {
+                emptyList()
+            } else {
+                serialized
+                    .split(';')
+                    .filter { it.isNotBlank() }
+                    .mapIndexedNotNull { i, entry ->
+                        val parts = entry.split('|', limit = 2)
+                        if (parts.size != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+                            null
+                        } else {
+                            TestUser(index = i + 1, email = parts[0], password = parts[1])
+                        }
+                    }
+            }
+    }
+}

--- a/client/developer-settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/devsettings/impl/TestUserProviderTest.kt
+++ b/client/developer-settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/devsettings/impl/TestUserProviderTest.kt
@@ -1,0 +1,49 @@
+package com.plusmobileapps.chefmate.devsettings.impl
+
+import com.plusmobileapps.chefmate.devsettings.TestUser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestUserProviderTest {
+
+    @Test
+    fun `parse returns empty list for blank input`() {
+        assertEquals(emptyList(), TestUserProvider.parse(""))
+        assertEquals(emptyList(), TestUserProvider.parse("   "))
+    }
+
+    @Test
+    fun `parse handles single user`() {
+        val users = TestUserProvider.parse("alice@chefmate.test|hunter2")
+        assertEquals(listOf(TestUser(1, "alice@chefmate.test", "hunter2")), users)
+    }
+
+    @Test
+    fun `parse handles multiple users with sequential indexes`() {
+        val users =
+            TestUserProvider.parse(
+                "alice@chefmate.test|hunter2;bob@chefmate.test|hunter3;carol@chefmate.test|hunter4"
+            )
+        assertEquals(
+            listOf(
+                TestUser(1, "alice@chefmate.test", "hunter2"),
+                TestUser(2, "bob@chefmate.test", "hunter3"),
+                TestUser(3, "carol@chefmate.test", "hunter4"),
+            ),
+            users,
+        )
+    }
+
+    @Test
+    fun `parse skips malformed entries`() {
+        val users = TestUserProvider.parse("alice@chefmate.test|hunter2;malformed_no_pipe")
+        // Malformed entry filtered out; the only valid entry keeps its original positional index.
+        assertEquals(listOf(TestUser(1, "alice@chefmate.test", "hunter2")), users)
+    }
+
+    @Test
+    fun `parse skips empty trailing segment`() {
+        val users = TestUserProvider.parse("alice@chefmate.test|hunter2;")
+        assertEquals(listOf(TestUser(1, "alice@chefmate.test", "hunter2")), users)
+    }
+}

--- a/client/developer-settings/public/build.gradle.kts
+++ b/client/developer-settings/public/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.arkivanov.decompose.core)
+            api(projects.client.shared)
+            api(projects.client.text.public)
+            implementation(projects.client.ui.public)
+            implementation(compose.components.resources)
+        }
+    }
+}
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.devsettings" }

--- a/client/developer-settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/developer-settings/public/src/commonMain/composeResources/values/strings.xml
@@ -14,6 +14,5 @@
     <string name="dev_sign_out_test_user">Sign out</string>
     <string name="dev_restart_required_title">Restart required</string>
     <string name="dev_restart_required_message">Environment changed. Local data was wiped and you were signed out. Force-stop and reopen the app for the new environment to take effect.</string>
-    <string name="dev_restart_acknowledge">OK</string>
     <string name="dev_picker_dismiss">Cancel</string>
 </resources>

--- a/client/developer-settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/developer-settings/public/src/commonMain/composeResources/values/strings.xml
@@ -7,7 +7,9 @@
     <string name="dev_login_as_user">Login as test user</string>
     <string name="dev_user_label_format">User {index}: {email}</string>
     <string name="dev_no_test_users">No test users configured</string>
-    <string name="dev_no_test_users_message">Set CHEF_MATE_USER_1 / CHEF_MATE_USER_PASSWORD_1 (and optionally _2, _3, …) as Gradle env vars or local.properties keys, then rebuild.</string>
+    <string name="dev_no_test_users_message">Add chefmate.user.1 / chefmate.user.password.1 (and optionally .2, .3, …) to local.properties or ~/.gradle/gradle.properties, or export CHEF_MATE_USER_1 / CHEF_MATE_USER_PASSWORD_1, then rebuild.</string>
+    <string name="dev_sign_in_error_title">Sign-in failed</string>
+    <string name="dev_sign_in_error_unknown">Unable to sign in. Check the password in local.properties.</string>
     <string name="dev_signed_out">Not signed in</string>
     <string name="dev_sign_out_test_user">Sign out</string>
     <string name="dev_restart_required_title">Restart required</string>

--- a/client/developer-settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/developer-settings/public/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="developer_settings">Developer Settings</string>
+    <string name="dev_environment">Environment</string>
+    <string name="dev_env_prod">Production</string>
+    <string name="dev_env_testing">Testing</string>
+    <string name="dev_env_fake">Fake (local seed)</string>
+    <string name="dev_login_as_user">Login as test user</string>
+    <string name="dev_user_label_format">User {index}: {email}</string>
+    <string name="dev_no_test_users">No test users configured</string>
+    <string name="dev_no_test_users_message">Set CHEF_MATE_USER_1 / CHEF_MATE_USER_PASSWORD_1 (and optionally _2, _3, …) as Gradle env vars or local.properties keys, then rebuild.</string>
+    <string name="dev_signed_out">Not signed in</string>
+    <string name="dev_sign_out_test_user">Sign out</string>
+    <string name="dev_restart_required_title">Restart required</string>
+    <string name="dev_restart_required_message">Environment changed. Local data was wiped and you were signed out. Force-stop and reopen the app for the new environment to take effect.</string>
+    <string name="dev_restart_acknowledge">OK</string>
+    <string name="dev_picker_dismiss">Cancel</string>
+</resources>

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperPreferences.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperPreferences.kt
@@ -1,0 +1,18 @@
+package com.plusmobileapps.chefmate.devsettings
+
+import com.plusmobileapps.chefmate.Environment
+import com.plusmobileapps.chefmate.EnvironmentProvider
+import kotlinx.coroutines.flow.StateFlow
+
+const val DEV_ENVIRONMENT_KEY = "dev.environment"
+const val DEV_USER_INDEX_KEY = "dev.user_index"
+
+interface DeveloperPreferences : EnvironmentProvider {
+    override val environment: StateFlow<Environment>
+
+    val selectedUserIndex: StateFlow<Int?>
+
+    fun setEnvironment(environment: Environment)
+
+    fun setSelectedUserIndex(index: Int?)
+}

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsBloc.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsBloc.kt
@@ -26,6 +26,8 @@ interface DeveloperSettingsBloc {
 
     fun onRestartPromptDismissed()
 
+    fun onSignInErrorDismissed()
+
     data class Model(
         val currentEnvironment: Environment = Environment.PROD,
         val availableUsers: List<TestUser> = emptyList(),
@@ -35,6 +37,7 @@ interface DeveloperSettingsBloc {
         val showEnvironmentPicker: Boolean = false,
         val showUserPicker: Boolean = false,
         val showRestartPrompt: Boolean = false,
+        val signInError: String? = null,
     )
 
     sealed class Output {

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsBloc.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsBloc.kt
@@ -1,0 +1,47 @@
+package com.plusmobileapps.chefmate.devsettings
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.Environment
+import kotlinx.coroutines.flow.StateFlow
+
+interface DeveloperSettingsBloc {
+    val state: StateFlow<Model>
+
+    fun onBack()
+
+    fun onEnvironmentClicked()
+
+    fun onEnvironmentSelected(environment: Environment)
+
+    fun onEnvironmentPickerDismissed()
+
+    fun onLoginAsUserClicked()
+
+    fun onUserSelected(user: TestUser)
+
+    fun onUserPickerDismissed()
+
+    fun onSignOutTestUserClicked()
+
+    fun onRestartPromptDismissed()
+
+    data class Model(
+        val currentEnvironment: Environment = Environment.PROD,
+        val availableUsers: List<TestUser> = emptyList(),
+        val selectedUserIndex: Int? = null,
+        val currentUserEmail: String? = null,
+        val isAuthenticated: Boolean = false,
+        val showEnvironmentPicker: Boolean = false,
+        val showUserPicker: Boolean = false,
+        val showRestartPrompt: Boolean = false,
+    )
+
+    sealed class Output {
+        data object Back : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): DeveloperSettingsBloc
+    }
+}

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
@@ -37,6 +37,8 @@ import chefmate.client.developer_settings.public.generated.resources.dev_picker_
 import chefmate.client.developer_settings.public.generated.resources.dev_restart_acknowledge
 import chefmate.client.developer_settings.public.generated.resources.dev_restart_required_message
 import chefmate.client.developer_settings.public.generated.resources.dev_restart_required_title
+import chefmate.client.developer_settings.public.generated.resources.dev_sign_in_error_title
+import chefmate.client.developer_settings.public.generated.resources.dev_sign_in_error_unknown
 import chefmate.client.developer_settings.public.generated.resources.dev_sign_out_test_user
 import chefmate.client.developer_settings.public.generated.resources.dev_signed_out
 import chefmate.client.developer_settings.public.generated.resources.dev_user_label_format
@@ -79,6 +81,22 @@ fun DeveloperSettingsScreen(bloc: DeveloperSettingsBloc, modifier: Modifier = Mo
             text = { Text(Res.string.dev_restart_required_message.asTextData().localized()) },
             confirmButton = {
                 TextButton(onClick = bloc::onRestartPromptDismissed) {
+                    Text(Res.string.dev_restart_acknowledge.asTextData().localized())
+                }
+            },
+        )
+    }
+
+    state.signInError?.let { rawMessage ->
+        val message = rawMessage.ifBlank {
+            Res.string.dev_sign_in_error_unknown.asTextData().localized()
+        }
+        AlertDialog(
+            onDismissRequest = bloc::onSignInErrorDismissed,
+            title = { Text(Res.string.dev_sign_in_error_title.asTextData().localized()) },
+            text = { Text(message) },
+            confirmButton = {
+                TextButton(onClick = bloc::onSignInErrorDismissed) {
                     Text(Res.string.dev_restart_acknowledge.asTextData().localized())
                 }
             },
@@ -298,4 +316,6 @@ val previewDeveloperSettingsBloc =
         override fun onSignOutTestUserClicked() = Unit
 
         override fun onRestartPromptDismissed() = Unit
+
+        override fun onSignInErrorDismissed() = Unit
     }

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
@@ -1,0 +1,298 @@
+package com.plusmobileapps.chefmate.devsettings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import chefmate.client.developer_settings.public.generated.resources.Res
+import chefmate.client.developer_settings.public.generated.resources.dev_env_fake
+import chefmate.client.developer_settings.public.generated.resources.dev_env_prod
+import chefmate.client.developer_settings.public.generated.resources.dev_env_testing
+import chefmate.client.developer_settings.public.generated.resources.dev_environment
+import chefmate.client.developer_settings.public.generated.resources.dev_login_as_user
+import chefmate.client.developer_settings.public.generated.resources.dev_no_test_users
+import chefmate.client.developer_settings.public.generated.resources.dev_no_test_users_message
+import chefmate.client.developer_settings.public.generated.resources.dev_picker_dismiss
+import chefmate.client.developer_settings.public.generated.resources.dev_restart_acknowledge
+import chefmate.client.developer_settings.public.generated.resources.dev_restart_required_message
+import chefmate.client.developer_settings.public.generated.resources.dev_restart_required_title
+import chefmate.client.developer_settings.public.generated.resources.dev_sign_out_test_user
+import chefmate.client.developer_settings.public.generated.resources.dev_signed_out
+import chefmate.client.developer_settings.public.generated.resources.dev_user_label_format
+import chefmate.client.developer_settings.public.generated.resources.developer_settings
+import com.plusmobileapps.chefmate.Environment
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.PhraseModel
+import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+
+@Composable
+fun DeveloperSettingsScreen(bloc: DeveloperSettingsBloc, modifier: Modifier = Modifier) {
+    val state by bloc.state.collectAsState()
+
+    if (state.showEnvironmentPicker) {
+        EnvironmentPickerDialog(
+            current = state.currentEnvironment,
+            onSelected = bloc::onEnvironmentSelected,
+            onDismiss = bloc::onEnvironmentPickerDismissed,
+        )
+    }
+
+    if (state.showUserPicker) {
+        UserPickerDialog(
+            users = state.availableUsers,
+            selectedIndex = state.selectedUserIndex,
+            onSelected = bloc::onUserSelected,
+            onDismiss = bloc::onUserPickerDismissed,
+        )
+    }
+
+    if (state.showRestartPrompt) {
+        AlertDialog(
+            onDismissRequest = bloc::onRestartPromptDismissed,
+            title = { Text(Res.string.dev_restart_required_title.asTextData().localized()) },
+            text = { Text(Res.string.dev_restart_required_message.asTextData().localized()) },
+            confirmButton = {
+                TextButton(onClick = bloc::onRestartPromptDismissed) {
+                    Text(Res.string.dev_restart_acknowledge.asTextData().localized())
+                }
+            },
+        )
+    }
+
+    PlusNavContainer(
+        modifier = modifier,
+        data =
+            PlusHeaderData.Child(
+                title = Res.string.developer_settings.asTextData(),
+                onBackClick = bloc::onBack,
+            ),
+        content = {
+            DeveloperRow(
+                title = Res.string.dev_environment.asTextData(),
+                trailing = state.currentEnvironment.label(),
+                onClick = bloc::onEnvironmentClicked,
+            )
+            HorizontalDivider()
+            DeveloperRow(
+                title = Res.string.dev_login_as_user.asTextData(),
+                trailing =
+                    state.currentUserEmail?.let { FixedString(it) }
+                        ?: Res.string.dev_signed_out.asTextData(),
+                onClick = bloc::onLoginAsUserClicked,
+            )
+            if (state.isAuthenticated) {
+                HorizontalDivider()
+                DeveloperRow(
+                    title = Res.string.dev_sign_out_test_user.asTextData(),
+                    onClick = bloc::onSignOutTestUserClicked,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun DeveloperRow(
+    title: TextData,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    trailing: TextData? = null,
+) {
+    val description = title.localized()
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(ChefMateTheme.dimens.rowHeight)
+                .clickable { onClick() }
+                .padding(horizontal = ChefMateTheme.dimens.paddingNormal)
+                .semantics { contentDescription = description },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(title.localized(), style = ChefMateTheme.typography.titleMedium)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (trailing != null) {
+                Text(
+                    trailing.localized(),
+                    style = ChefMateTheme.typography.bodyMedium,
+                    color = ChefMateTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(Icons.Default.ChevronRight, contentDescription = null)
+        }
+    }
+}
+
+@Composable
+private fun EnvironmentPickerDialog(
+    current: Environment,
+    onSelected: (Environment) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(Res.string.dev_environment.asTextData().localized()) },
+        text = {
+            Column {
+                Environment.entries.forEach { env ->
+                    Row(
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .selectable(
+                                    selected = env == current,
+                                    onClick = { onSelected(env) },
+                                )
+                                .padding(vertical = ChefMateTheme.dimens.paddingSmall),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(selected = env == current, onClick = { onSelected(env) })
+                        Text(
+                            env.label().localized(),
+                            style = ChefMateTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(start = ChefMateTheme.dimens.paddingSmall),
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(Res.string.dev_picker_dismiss.asTextData().localized())
+            }
+        },
+    )
+}
+
+@Composable
+private fun UserPickerDialog(
+    users: List<TestUser>,
+    selectedIndex: Int?,
+    onSelected: (TestUser) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(Res.string.dev_login_as_user.asTextData().localized()) },
+        text = {
+            if (users.isEmpty()) {
+                Column {
+                    Text(
+                        Res.string.dev_no_test_users.asTextData().localized(),
+                        style = ChefMateTheme.typography.titleMedium,
+                    )
+                    Text(
+                        Res.string.dev_no_test_users_message.asTextData().localized(),
+                        style = ChefMateTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(top = ChefMateTheme.dimens.paddingSmall),
+                    )
+                }
+            } else {
+                Column {
+                    users.forEach { user ->
+                        Row(
+                            modifier =
+                                Modifier.fillMaxWidth()
+                                    .selectable(
+                                        selected = user.index == selectedIndex,
+                                        onClick = { onSelected(user) },
+                                    )
+                                    .padding(vertical = ChefMateTheme.dimens.paddingSmall),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                selected = user.index == selectedIndex,
+                                onClick = { onSelected(user) },
+                            )
+                            Text(
+                                user.label().localized(),
+                                style = ChefMateTheme.typography.bodyLarge,
+                                modifier =
+                                    Modifier.padding(start = ChefMateTheme.dimens.paddingSmall),
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(Res.string.dev_picker_dismiss.asTextData().localized())
+            }
+        },
+    )
+}
+
+private fun Environment.label(): TextData =
+    when (this) {
+        Environment.PROD -> Res.string.dev_env_prod.asTextData()
+        Environment.TESTING -> Res.string.dev_env_testing.asTextData()
+        Environment.FAKE -> Res.string.dev_env_fake.asTextData()
+    }
+
+private fun TestUser.label(): TextData =
+    PhraseModel(
+        resource = Res.string.dev_user_label_format,
+        "index" to FixedString(index.toString()),
+        "email" to FixedString(email),
+    )
+
+val previewDeveloperSettingsBloc =
+    object : DeveloperSettingsBloc {
+        override val state =
+            MutableStateFlow(
+                DeveloperSettingsBloc.Model(
+                    currentEnvironment = Environment.PROD,
+                    availableUsers =
+                        listOf(
+                            TestUser(1, "alice@chefmate.test", "password1"),
+                            TestUser(2, "bob@chefmate.test", "password2"),
+                        ),
+                    selectedUserIndex = 1,
+                    currentUserEmail = "alice@chefmate.test",
+                    isAuthenticated = true,
+                )
+            )
+
+        override fun onBack() = Unit
+
+        override fun onEnvironmentClicked() = Unit
+
+        override fun onEnvironmentSelected(environment: Environment) = Unit
+
+        override fun onEnvironmentPickerDismissed() = Unit
+
+        override fun onLoginAsUserClicked() = Unit
+
+        override fun onUserSelected(user: TestUser) = Unit
+
+        override fun onUserPickerDismissed() = Unit
+
+        override fun onSignOutTestUserClicked() = Unit
+
+        override fun onRestartPromptDismissed() = Unit
+    }

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
@@ -34,7 +34,6 @@ import chefmate.client.developer_settings.public.generated.resources.dev_login_a
 import chefmate.client.developer_settings.public.generated.resources.dev_no_test_users
 import chefmate.client.developer_settings.public.generated.resources.dev_no_test_users_message
 import chefmate.client.developer_settings.public.generated.resources.dev_picker_dismiss
-import chefmate.client.developer_settings.public.generated.resources.dev_restart_acknowledge
 import chefmate.client.developer_settings.public.generated.resources.dev_restart_required_message
 import chefmate.client.developer_settings.public.generated.resources.dev_restart_required_title
 import chefmate.client.developer_settings.public.generated.resources.dev_sign_in_error_title
@@ -48,6 +47,7 @@ import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -75,31 +75,23 @@ fun DeveloperSettingsScreen(bloc: DeveloperSettingsBloc, modifier: Modifier = Mo
     }
 
     if (state.showRestartPrompt) {
-        AlertDialog(
+        PlusDialog(
+            title = Res.string.dev_restart_required_title.asTextData(),
+            message = Res.string.dev_restart_required_message.asTextData(),
+            onConfirmClick = bloc::onRestartPromptDismissed,
             onDismissRequest = bloc::onRestartPromptDismissed,
-            title = { Text(Res.string.dev_restart_required_title.asTextData().localized()) },
-            text = { Text(Res.string.dev_restart_required_message.asTextData().localized()) },
-            confirmButton = {
-                TextButton(onClick = bloc::onRestartPromptDismissed) {
-                    Text(Res.string.dev_restart_acknowledge.asTextData().localized())
-                }
-            },
         )
     }
 
     state.signInError?.let { rawMessage ->
-        val message = rawMessage.ifBlank {
-            Res.string.dev_sign_in_error_unknown.asTextData().localized()
-        }
-        AlertDialog(
+        val message: TextData =
+            if (rawMessage.isBlank()) Res.string.dev_sign_in_error_unknown.asTextData()
+            else FixedString(rawMessage)
+        PlusDialog(
+            title = Res.string.dev_sign_in_error_title.asTextData(),
+            message = message,
+            onConfirmClick = bloc::onSignInErrorDismissed,
             onDismissRequest = bloc::onSignInErrorDismissed,
-            title = { Text(Res.string.dev_sign_in_error_title.asTextData().localized()) },
-            text = { Text(message) },
-            confirmButton = {
-                TextButton(onClick = bloc::onSignInErrorDismissed) {
-                    Text(Res.string.dev_restart_acknowledge.asTextData().localized())
-                }
-            },
         )
     }
 

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -14,6 +15,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -83,36 +85,37 @@ fun DeveloperSettingsScreen(bloc: DeveloperSettingsBloc, modifier: Modifier = Mo
         )
     }
 
-    PlusNavContainer(
-        modifier = modifier,
-        data =
-            PlusHeaderData.Child(
-                title = Res.string.developer_settings.asTextData(),
-                onBackClick = bloc::onBack,
-            ),
-        content = {
-            DeveloperRow(
-                title = Res.string.dev_environment.asTextData(),
-                trailing = state.currentEnvironment.label(),
-                onClick = bloc::onEnvironmentClicked,
-            )
-            HorizontalDivider()
-            DeveloperRow(
-                title = Res.string.dev_login_as_user.asTextData(),
-                trailing =
-                    state.currentUserEmail?.let { FixedString(it) }
-                        ?: Res.string.dev_signed_out.asTextData(),
-                onClick = bloc::onLoginAsUserClicked,
-            )
-            if (state.isAuthenticated) {
+    Surface(modifier = modifier.fillMaxSize(), color = ChefMateTheme.colorScheme.background) {
+        PlusNavContainer(
+            data =
+                PlusHeaderData.Child(
+                    title = Res.string.developer_settings.asTextData(),
+                    onBackClick = bloc::onBack,
+                ),
+            content = {
+                DeveloperRow(
+                    title = Res.string.dev_environment.asTextData(),
+                    trailing = state.currentEnvironment.label(),
+                    onClick = bloc::onEnvironmentClicked,
+                )
                 HorizontalDivider()
                 DeveloperRow(
-                    title = Res.string.dev_sign_out_test_user.asTextData(),
-                    onClick = bloc::onSignOutTestUserClicked,
+                    title = Res.string.dev_login_as_user.asTextData(),
+                    trailing =
+                        state.currentUserEmail?.let { FixedString(it) }
+                            ?: Res.string.dev_signed_out.asTextData(),
+                    onClick = bloc::onLoginAsUserClicked,
                 )
-            }
-        },
-    )
+                if (state.isAuthenticated) {
+                    HorizontalDivider()
+                    DeveloperRow(
+                        title = Res.string.dev_sign_out_test_user.asTextData(),
+                        onClick = bloc::onSignOutTestUserClicked,
+                    )
+                }
+            },
+        )
+    }
 }
 
 @Composable

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/TestUser.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/TestUser.kt
@@ -1,0 +1,5 @@
+package com.plusmobileapps.chefmate.devsettings
+
+data class TestUser(val index: Int, val email: String, val password: String) {
+    override fun toString(): String = "TestUser(index=$index, email=$email, password=***)"
+}

--- a/client/meal/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/impl/MealPlanRepositoryImpl.kt
+++ b/client/meal/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/impl/MealPlanRepositoryImpl.kt
@@ -108,6 +108,10 @@ class MealPlanRepositoryImpl(
         }
     }
 
+    override suspend fun clearLocalData() {
+        withContext(ioContext) { queries.deleteAll() }
+    }
+
     private fun pushAddToRemote(localId: Long) {
         val authState = authRepository.state.value
         if (authState !is AuthState.Authenticated) return

--- a/client/meal/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/MealPlanRepository.kt
+++ b/client/meal/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/MealPlanRepository.kt
@@ -12,4 +12,6 @@ interface MealPlanRepository {
     suspend fun removeMeal(id: Long)
 
     suspend fun syncAllUnsynced()
+
+    suspend fun clearLocalData()
 }

--- a/client/meal/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/testing/FakeMealPlanRepository.kt
+++ b/client/meal/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/testing/FakeMealPlanRepository.kt
@@ -41,4 +41,9 @@ class FakeMealPlanRepository : MealPlanRepository {
     override suspend fun syncAllUnsynced() {
         // No-op in fake
     }
+
+    override suspend fun clearLocalData() {
+        _meals.value = emptyList()
+        nextId = 1L
+    }
 }

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/Recipe.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/Recipe.kt
@@ -73,6 +73,72 @@ data class Recipe(
                 createdAt = Instant.DISTANT_PAST,
                 updatedAt = Instant.DISTANT_PAST,
             )
+
+        /** Variants of [Sample] for seeding the local DB in FAKE environment / dev contexts. */
+        val Samples: List<Recipe> =
+            listOf(
+                Sample,
+                Sample.copy(
+                    id = 2L,
+                    title = "Margherita Pizza",
+                    description = "Neapolitan-style pizza with tomato, mozzarella, and basil.",
+                    servings = 4,
+                    prepTime = 90,
+                    cookTime = 5,
+                    totalTime = 95,
+                    calories = 720,
+                    starRating = 4,
+                    isFavorite = false,
+                ),
+                Sample.copy(
+                    id = 3L,
+                    title = "Beef Tacos",
+                    description = "Quick weeknight tacos with seasoned ground beef.",
+                    servings = 4,
+                    prepTime = 10,
+                    cookTime = 15,
+                    totalTime = 25,
+                    calories = 540,
+                    starRating = 4,
+                    isFavorite = true,
+                ),
+                Sample.copy(
+                    id = 4L,
+                    title = "Caesar Salad",
+                    description = "Crisp romaine, parmesan, and a creamy anchovy dressing.",
+                    servings = 2,
+                    prepTime = 15,
+                    cookTime = 0,
+                    totalTime = 15,
+                    calories = 380,
+                    starRating = 3,
+                    isFavorite = false,
+                ),
+                Sample.copy(
+                    id = 5L,
+                    title = "Chocolate Chip Cookies",
+                    description = "Chewy cookies with pools of dark chocolate.",
+                    servings = 24,
+                    prepTime = 20,
+                    cookTime = 12,
+                    totalTime = 32,
+                    calories = 180,
+                    starRating = 5,
+                    isFavorite = true,
+                ),
+                Sample.copy(
+                    id = 6L,
+                    title = "Chicken Curry",
+                    description = "Aromatic curry with coconut milk and warm spices.",
+                    servings = 4,
+                    prepTime = 15,
+                    cookTime = 35,
+                    totalTime = 50,
+                    calories = 610,
+                    starRating = 4,
+                    isFavorite = false,
+                ),
+            )
     }
 }
 

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -13,6 +13,7 @@ import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc
 import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
+import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
@@ -42,6 +43,7 @@ class RootBlocImpl(
     private val authentication: AuthenticationBloc.Factory,
     private val appSettings: AppSettingsBloc.Factory,
     private val bottomNavOrder: BottomNavOrderBloc.Factory,
+    private val developerSettings: DeveloperSettingsBloc.Factory,
     private val cookMode: CookModeBloc.Factory,
 ) : RootBloc, BlocContext by context {
 
@@ -147,6 +149,15 @@ class RootBlocImpl(
                         )
                 )
 
+            Configuration.DeveloperSettings ->
+                RootBloc.Child.DeveloperSettings(
+                    bloc =
+                        developerSettings.create(
+                            context = context,
+                            output = ::handleDeveloperSettingsOutput,
+                        )
+                )
+
             is Configuration.CookMode ->
                 RootBloc.Child.CookMode(
                     bloc =
@@ -202,6 +213,10 @@ class RootBlocImpl(
                 navigation.bringToFront(Configuration.AppSettings)
             }
 
+            BottomNavBloc.Output.OpenDeveloperSettings -> {
+                navigation.bringToFront(Configuration.DeveloperSettings)
+            }
+
             is BottomNavBloc.Output.OpenCookMode -> {
                 navigation.bringToFront(Configuration.CookMode(output.recipeId))
             }
@@ -220,6 +235,12 @@ class RootBlocImpl(
     private fun handleBottomNavOrderOutput(output: BottomNavOrderBloc.Output) {
         when (output) {
             BottomNavOrderBloc.Output.Back -> navigation.pop()
+        }
+    }
+
+    private fun handleDeveloperSettingsOutput(output: DeveloperSettingsBloc.Output) {
+        when (output) {
+            DeveloperSettingsBloc.Output.Back -> navigation.pop()
         }
     }
 
@@ -293,6 +314,8 @@ class RootBlocImpl(
         @Serializable data object AppSettings : Configuration()
 
         @Serializable data object BottomNavOrder : Configuration()
+
+        @Serializable data object DeveloperSettings : Configuration()
 
         @Serializable data class CookMode(val recipeId: Long) : Configuration()
     }

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -67,6 +67,7 @@ class RootBlocTest {
                 bottomNavOrderOutput = output
                 mock()
             },
+            developerSettings = { _, _ -> mock() },
             cookMode = CookModeBloc.Factory { _, _, _ -> mock() },
         )
 

--- a/client/root/public/build.gradle.kts
+++ b/client/root/public/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
             api(projects.client.bottomnav.public)
             api(projects.client.browser.public)
             api(projects.client.cook.public)
+            api(projects.client.developerSettings.public)
             api(projects.client.grocery.core.public)
             api(projects.client.recipe.core.public)
             api(projects.client.auth.ui.public)

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -8,6 +8,7 @@ import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc
 import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
+import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
@@ -36,6 +37,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class AppSettings(val bloc: AppSettingsBloc) : Child()
 
         data class BottomNavOrder(val bloc: BottomNavOrderBloc) : Child()
+
+        data class DeveloperSettings(val bloc: DeveloperSettingsBloc) : Child()
 
         data class CookMode(val bloc: CookModeBloc) : Child()
     }

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -28,6 +28,7 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationScreen
 import com.plusmobileapps.chefmate.browser.BrowserRootScreen
 import com.plusmobileapps.chefmate.cook.CookModeScreen
+import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsScreen
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailScreen
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderScreen
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavigationScreen
@@ -155,6 +156,7 @@ private fun RootChildContent(child: RootBloc.Child, onBack: () -> Unit) {
         is RootBloc.Child.MealPlanner -> MealPlannerRootScreen(child.bloc)
         is RootBloc.Child.AppSettings -> AppSettingsScreen(child.bloc)
         is RootBloc.Child.BottomNavOrder -> BottomNavOrderScreen(child.bloc)
+        is RootBloc.Child.DeveloperSettings -> DeveloperSettingsScreen(child.bloc)
         is RootBloc.Child.CookMode -> CookModeScreen(child.bloc)
     }
 }

--- a/client/settings/impl/build.gradle.kts
+++ b/client/settings/impl/build.gradle.kts
@@ -7,15 +7,12 @@ kotlin {
             implementation(libs.arkivanov.decompose.core)
             implementation(projects.client.shared)
             implementation(projects.client.auth.data.public)
+            implementation(projects.client.auth.usecase.public)
             implementation(projects.client.browser.public)
-            implementation(projects.client.grocery.data.public)
-            implementation(projects.client.recipe.data.public)
         }
         commonTest.dependencies {
             implementation(projects.client.auth.data.testing)
             implementation(projects.client.browser.testing)
-            implementation(projects.client.grocery.data.testing)
-            implementation(projects.client.recipe.data.testing)
         }
     }
 }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -4,6 +4,7 @@ import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
+import com.plusmobileapps.chefmate.isDebugBuild
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.chefmate.settings.SettingsBloc
 import com.plusmobileapps.chefmate.settings.SettingsBloc.Output
@@ -41,6 +42,7 @@ class SettingsBlocImpl(
                         createEmailVerificationMessage(email)
                     },
                 showSignOutConfirmationDialog = it.showSignOutConfirmationDialog,
+                isDebugBuild = isDebugBuild,
             )
         }
 
@@ -70,6 +72,10 @@ class SettingsBlocImpl(
 
     override fun onAppSettingsClicked() {
         output.onNext(Output.OpenAppSettings)
+    }
+
+    override fun onDeveloperSettingsClicked() {
+        output.onNext(Output.OpenDeveloperSettings)
     }
 }
 

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
@@ -3,9 +3,8 @@ package com.plusmobileapps.chefmate.settings.impl
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
 import com.plusmobileapps.chefmate.di.Main
-import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
-import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import dev.zacsweers.metro.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,8 +19,7 @@ import kotlinx.coroutines.launch
 class SettingsViewModel(
     @Main mainContext: CoroutineContext,
     private val authenticationRepository: AuthenticationRepository,
-    private val groceryRepository: GroceryRepository,
-    private val recipeRepository: RecipeRepository,
+    private val signOutUseCase: SignOutUseCase,
 ) : ViewModel(mainContext) {
     private val _state = MutableStateFlow(State())
     val state: StateFlow<State> = _state.asStateFlow()
@@ -75,12 +73,7 @@ class SettingsViewModel(
 
     fun signOut() {
         _state.update { it.copy(showSignOutConfirmationDialog = false) }
-        scope.launch {
-            authenticationRepository.signOut()
-            groceryRepository.clearLocalData()
-            recipeRepository.clearLocalData()
-            groceryRepository.ensureDefaultList()
-        }
+        scope.launch { signOutUseCase() }
     }
 
     data class State(

--- a/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImplTest.kt
+++ b/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImplTest.kt
@@ -5,8 +5,7 @@ package com.plusmobileapps.chefmate.settings.impl
 
 import app.cash.turbine.test
 import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
-import com.plusmobileapps.chefmate.grocery.data.testing.FakeGroceryRepository
-import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
+import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
 import com.plusmobileapps.chefmate.settings.SettingsBloc
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
@@ -20,8 +19,7 @@ class SettingsBlocImplTest {
     private val context = TestBlocContext.create()
     private val output = TestConsumer<SettingsBloc.Output>()
     private val authRepository = FakeAuthenticationRepository()
-    private val groceryRepository = FakeGroceryRepository()
-    private val recipeRepository = FakeRecipeRepository()
+    private val signOutUseCase = SignOutUseCase { authRepository.signOut() }
 
     private val bloc by lazy {
         SettingsBlocImpl(
@@ -31,8 +29,7 @@ class SettingsBlocImplTest {
                 SettingsViewModel(
                     mainContext = context.mainContext,
                     authenticationRepository = authRepository,
-                    groceryRepository = groceryRepository,
-                    recipeRepository = recipeRepository,
+                    signOutUseCase = signOutUseCase,
                 )
             },
         )

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="app_settings_clear_history_dialog_cancel">Cancel</string>
     <string name="app_settings_navigation_section">Navigation</string>
     <string name="app_settings_bottom_nav_order">Bottom navigation order</string>
+    <string name="developer_settings">Developer Settings</string>
 </resources>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -22,11 +22,14 @@ interface SettingsBloc {
 
     fun onAppSettingsClicked()
 
+    fun onDeveloperSettingsClicked()
+
     data class Model(
         val isAuthenticated: Boolean = false,
         val greeting: TextData? = null,
         val verificationMessage: TextData? = null,
         val showSignOutConfirmationDialog: Boolean = false,
+        val isDebugBuild: Boolean = false,
     )
 
     sealed class Output {
@@ -35,6 +38,8 @@ interface SettingsBloc {
         data object OpenSignIn : Output()
 
         data object OpenAppSettings : Output()
+
+        data object OpenDeveloperSettings : Output()
 
         data class OpenUrl(val url: String) : Output()
     }

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import chefmate.client.settings.public.generated.resources.Res
 import chefmate.client.settings.public.generated.resources.about
+import chefmate.client.settings.public.generated.resources.developer_settings
 import chefmate.client.settings.public.generated.resources.greeting_authenticated
 import chefmate.client.settings.public.generated.resources.more
 import chefmate.client.settings.public.generated.resources.privacy_policy
@@ -107,6 +108,13 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
                 name = Res.string.about.asTextData(),
                 onClick = { bloc.onUrlClicked("https://chefmate.plusmobileapps.com/") },
             )
+            if (viewState.isDebugBuild) {
+                HorizontalDivider()
+                SettingsRow(
+                    name = Res.string.developer_settings.asTextData(),
+                    onClick = bloc::onDeveloperSettingsClicked,
+                )
+            }
         },
     )
     Column(modifier = modifier.fillMaxSize()) {
@@ -187,6 +195,8 @@ private val previewBlocUnauthenticated =
         override fun onUrlClicked(url: String) = Unit
 
         override fun onAppSettingsClicked() = Unit
+
+        override fun onDeveloperSettingsClicked() = Unit
     }
 
 private val previewBlocAuthenticated =
@@ -216,6 +226,8 @@ private val previewBlocAuthenticated =
         override fun onUrlClicked(url: String) = Unit
 
         override fun onAppSettingsClicked() = Unit
+
+        override fun onDeveloperSettingsClicked() = Unit
     }
 
 @Preview(showBackground = true)

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.BOOLEAN
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import java.util.Properties
 
@@ -45,8 +46,46 @@ val supabaseKey =
         ?: System.getenv("SUPABASE_KEY")
         ?: "your-anon-public-key"
 
+val supabaseTestingUrl =
+    localProperties.getProperty("supabase.testing.url")
+        ?: System.getenv("SUPABASE_TESTING_URL")
+        ?: supabaseUrl
+
+val supabaseTestingKey =
+    localProperties.getProperty("supabase.testing.key")
+        ?: System.getenv("SUPABASE_TESTING_KEY")
+        ?: supabaseKey
+
 val bugsnagApiKey =
     localProperties.getProperty("bugsnag.apiKey") ?: System.getenv("BUGSNAG_API_KEY") ?: ""
+
+// Collect test users from CHEF_MATE_USER_<n> / CHEF_MATE_USER_PASSWORD_<n> (or local.properties
+// chefmate.user.<n> / chefmate.user.password.<n>) by incrementing n until a pair is missing.
+// Serialize as "email1|password1;email2|password2".
+val testUsersSerialized = buildString {
+    var index = 1
+    while (true) {
+        val email =
+            localProperties.getProperty("chefmate.user.$index")
+                ?: System.getenv("CHEF_MATE_USER_$index")
+        val password =
+            localProperties.getProperty("chefmate.user.password.$index")
+                ?: System.getenv("CHEF_MATE_USER_PASSWORD_$index")
+        if (email.isNullOrBlank() || password.isNullOrBlank()) break
+        if (index > 1) append(';')
+        append(email).append('|').append(password)
+        index++
+    }
+}
+
+// Detect debug builds by inspecting requested Gradle task names. Defaults to debug when no
+// release-flavoured task is requested (e.g. during IDE sync), which is the safe choice for
+// developer-only UI gating.
+val isDebugBuildFlag: Boolean =
+    gradle.startParameter.taskNames.none { taskName ->
+        taskName.contains("Release", ignoreCase = true) ||
+            taskName.contains("bundleRelease", ignoreCase = true)
+    }
 
 buildkonfig {
     packageName = "com.plusmobileapps.chefmate.buildconfig"
@@ -56,6 +95,12 @@ buildkonfig {
     defaultConfigs {
         buildConfigField(STRING, "SUPABASE_URL", supabaseUrl)
         buildConfigField(STRING, "SUPABASE_KEY", supabaseKey)
+        buildConfigField(STRING, "SUPABASE_PROD_URL", supabaseUrl)
+        buildConfigField(STRING, "SUPABASE_PROD_KEY", supabaseKey)
+        buildConfigField(STRING, "SUPABASE_TESTING_URL", supabaseTestingUrl)
+        buildConfigField(STRING, "SUPABASE_TESTING_KEY", supabaseTestingKey)
         buildConfigField(STRING, "BUGSNAG_API_KEY", bugsnagApiKey)
+        buildConfigField(STRING, "TEST_USERS", testUsersSerialized)
+        buildConfigField(BOOLEAN, "IS_DEBUG", isDebugBuildFlag.toString())
     }
 }

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -59,17 +59,21 @@ val supabaseTestingKey =
 val bugsnagApiKey =
     localProperties.getProperty("bugsnag.apiKey") ?: System.getenv("BUGSNAG_API_KEY") ?: ""
 
-// Collect test users from CHEF_MATE_USER_<n> / CHEF_MATE_USER_PASSWORD_<n> (or local.properties
-// chefmate.user.<n> / chefmate.user.password.<n>) by incrementing n until a pair is missing.
+// Collect test users by incrementing n until a pair is missing. Looked up in order:
+// 1. local.properties at the project root (chefmate.user.<n> / chefmate.user.password.<n>)
+// 2. ~/.gradle/gradle.properties or any other Gradle property source (same keys)
+// 3. Environment variables (CHEF_MATE_USER_<n> / CHEF_MATE_USER_PASSWORD_<n>)
 // Serialize as "email1|password1;email2|password2".
 val testUsersSerialized = buildString {
     var index = 1
     while (true) {
         val email =
             localProperties.getProperty("chefmate.user.$index")
+                ?: (findProperty("chefmate.user.$index") as? String)
                 ?: System.getenv("CHEF_MATE_USER_$index")
         val password =
             localProperties.getProperty("chefmate.user.password.$index")
+                ?: (findProperty("chefmate.user.password.$index") as? String)
                 ?: System.getenv("CHEF_MATE_USER_PASSWORD_$index")
         if (email.isNullOrBlank() || password.isNullOrBlank()) break
         if (index > 1) append(';')

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/Build.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/Build.kt
@@ -1,0 +1,6 @@
+package com.plusmobileapps.chefmate
+
+import com.plusmobileapps.chefmate.buildconfig.BuildConfig
+
+val isDebugBuild: Boolean
+    get() = BuildConfig.IS_DEBUG

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/Environment.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/Environment.kt
@@ -1,0 +1,13 @@
+package com.plusmobileapps.chefmate
+
+import kotlinx.coroutines.flow.StateFlow
+
+enum class Environment {
+    PROD,
+    TESTING,
+    FAKE,
+}
+
+interface EnvironmentProvider {
+    val environment: StateFlow<Environment>
+}

--- a/docs/buildconfig-setup.md
+++ b/docs/buildconfig-setup.md
@@ -76,3 +76,7 @@ buildkonfig {
 - **Never commit `local.properties` with real credentials** - it's already in `.gitignore`
 - The anon/public key is safe to use in client-side code (it's meant to be public)
 - For sensitive operations, always use Row Level Security (RLS) in your Supabase database
+
+## Related
+
+- [developer-settings.md](developer-settings.md) — how to wire up the staging Supabase URL (`supabase.testing.*` / `SUPABASE_TESTING_*`) and pre-baked test users for the in-app developer menu.

--- a/docs/developer-settings.md
+++ b/docs/developer-settings.md
@@ -6,8 +6,9 @@ A debug-only screen reachable from the bottom of the **More** tab that lets you 
 
 | Setting | Effect |
 |---|---|
-| **Environment** | Switches between `PROD`, `TESTING`, and `FAKE`. Persisted via `multiplatform-settings`. Selecting a new env signs you out, wipes the local DB, seeds `Recipe.Samples` if `FAKE` is chosen, and prompts for an app restart so the Supabase client rebinds. |
-| **Login as test user** | Lists pre-baked users sourced from Gradle env vars / properties and signs in via the existing Supabase auth repo. Persists which user is selected so the screen can show "currently signed in as User N" across restarts. |
+| **Environment** | Switches between `PROD`, `TESTING`, and `FAKE`. Persisted via `multiplatform-settings`. Selecting a new env signs you out, wipes the local DB (recipes, grocery, meal plans), seeds `Recipe.Samples` if `FAKE` is chosen, and prompts for an app restart so the Supabase client rebinds. |
+| **Login as test user** | Lists pre-baked users sourced from Gradle env vars / properties and signs in via the existing Supabase auth repo. Persists which user is selected so the screen can show "currently signed in as User N" across restarts. If the credentials are wrong, an error dialog surfaces the Supabase error message. |
+| **Sign out** | Visible only when authenticated. Signs the test user out **and** wipes the local DB so the next user starts from a clean cache. |
 
 ## Configuring the environment URLs
 
@@ -33,19 +34,28 @@ If `supabase.testing.*` is not set, the build falls back to the PROD values, so 
 
 Users are detected by **incrementing `n`** (starting at 1) until a pair (email + password) is missing. Provide as many as you like.
 
+> **Heads-up on key naming:** `local.properties` and `gradle.properties` use **dotted lower-case keys** (`chefmate.user.1`, `chefmate.user.password.1`). The `CHEF_MATE_USER_1` / `CHEF_MATE_USER_PASSWORD_1` form is for **shell environment variables only** — putting that form in `local.properties` will silently do nothing because Java's `Properties` loader doesn't translate the underscored uppercase form into a dotted key.
+
 Lookup order per index, first match wins:
 
-1. `local.properties` (project root)
-2. Gradle properties (`~/.gradle/gradle.properties`, `-P` flags, etc.)
-3. Environment variables
+1. `local.properties` (project root) — key form `chefmate.user.<n>` / `chefmate.user.password.<n>`
+2. Gradle properties (`~/.gradle/gradle.properties`, `-P` flags, etc.) — same dotted key form
+3. Environment variables — uppercase form `CHEF_MATE_USER_<n>` / `CHEF_MATE_USER_PASSWORD_<n>`
 
-### `local.properties`
+### `local.properties` (recommended for local-only secrets, gitignored)
 
 ```properties
 chefmate.user.1=alice@chefmate.test
 chefmate.user.password.1=hunter2
 chefmate.user.2=bob@chefmate.test
 chefmate.user.password.2=hunter3
+```
+
+After editing `local.properties`, re-run the JVM/Android target so Gradle regenerates `BuildConfig.TEST_USERS`:
+
+```bash
+./gradlew :client:composeApp:run            # desktop
+./gradlew :client:composeApp:installDebug   # Android
 ```
 
 ### `~/.gradle/gradle.properties` (machine-wide, outside any repo)
@@ -55,7 +65,7 @@ chefmate.user.1=alice@chefmate.test
 chefmate.user.password.1=hunter2
 ```
 
-### Environment variables
+### Environment variables (CI / one-off shells)
 
 ```bash
 export CHEF_MATE_USER_1=alice@chefmate.test
@@ -93,4 +103,6 @@ The "Developer Settings" row only appears when `BuildConfig.IS_DEBUG` is `true`.
 3. Switch Environment → TESTING. Verify: signed out, recipe list empty, restart-required dialog. Force-stop + reopen, confirm sync now hits the testing URL.
 4. Switch Environment → FAKE. Verify several seeded recipes appear after the wipe.
 5. Tap "Login as test user" → User 1. Verify signed in; user persists across an app restart.
-6. Build a release APK. Confirm the row is absent.
+6. Tap "Login as test user" with a deliberately bad password (edit `local.properties`, rebuild). Verify an error dialog appears with the Supabase message.
+7. Tap "Sign out". Verify recipes / meal plan / grocery list are wiped locally.
+8. Build a release APK. Confirm the row is absent.

--- a/docs/developer-settings.md
+++ b/docs/developer-settings.md
@@ -1,0 +1,96 @@
+# Developer Settings
+
+A debug-only screen reachable from the bottom of the **More** tab that lets you switch the active backend environment and sign in as one of several pre-configured test users without typing credentials. Lives in the `client/developer-settings` module pair and is hidden from release builds via `BuildConfig.IS_DEBUG`.
+
+## What it does
+
+| Setting | Effect |
+|---|---|
+| **Environment** | Switches between `PROD`, `TESTING`, and `FAKE`. Persisted via `multiplatform-settings`. Selecting a new env signs you out, wipes the local DB, seeds `Recipe.Samples` if `FAKE` is chosen, and prompts for an app restart so the Supabase client rebinds. |
+| **Login as test user** | Lists pre-baked users sourced from Gradle env vars / properties and signs in via the existing Supabase auth repo. Persists which user is selected so the screen can show "currently signed in as User N" across restarts. |
+
+## Configuring the environment URLs
+
+The Supabase URL/key for **TESTING** is read at build time. PROD already has its values (see [buildconfig-setup.md](buildconfig-setup.md) for the existing `supabase.url` / `supabase.key`). FAKE re-uses PROD.
+
+### `local.properties`
+
+```properties
+supabase.testing.url=https://your-staging-project.supabase.co
+supabase.testing.key=your-staging-anon-public-key
+```
+
+### Environment variables
+
+```bash
+export SUPABASE_TESTING_URL=https://your-staging-project.supabase.co
+export SUPABASE_TESTING_KEY=your-staging-anon-public-key
+```
+
+If `supabase.testing.*` is not set, the build falls back to the PROD values, so `TESTING` will be a no-op until you provide them.
+
+## Configuring test users
+
+Users are detected by **incrementing `n`** (starting at 1) until a pair (email + password) is missing. Provide as many as you like.
+
+Lookup order per index, first match wins:
+
+1. `local.properties` (project root)
+2. Gradle properties (`~/.gradle/gradle.properties`, `-P` flags, etc.)
+3. Environment variables
+
+### `local.properties`
+
+```properties
+chefmate.user.1=alice@chefmate.test
+chefmate.user.password.1=hunter2
+chefmate.user.2=bob@chefmate.test
+chefmate.user.password.2=hunter3
+```
+
+### `~/.gradle/gradle.properties` (machine-wide, outside any repo)
+
+```properties
+chefmate.user.1=alice@chefmate.test
+chefmate.user.password.1=hunter2
+```
+
+### Environment variables
+
+```bash
+export CHEF_MATE_USER_1=alice@chefmate.test
+export CHEF_MATE_USER_PASSWORD_1=hunter2
+export CHEF_MATE_USER_2=bob@chefmate.test
+export CHEF_MATE_USER_PASSWORD_2=hunter3
+```
+
+### How it's plumbed
+
+The build script in `client/shared/build.gradle.kts` collects every contiguous user pair and serializes them as a single BuildKonfig string field (`TEST_USERS = "email1|password1;email2|password2"`). At runtime, `TestUserProvider` parses the string and exposes a `List<TestUser>` to the dev-settings ViewModel. **A gap (e.g. `_1` defined, `_2` missing, `_3` defined) stops collection at the first miss** — define users contiguously.
+
+## Debug-build gating
+
+The "Developer Settings" row only appears when `BuildConfig.IS_DEBUG` is `true`. The flag is derived at configuration time from `gradle.startParameter.taskNames`: any task containing `Release` flips it to `false`. This is a UI-gate, not a security boundary — the dev-settings code itself ships in every binary.
+
+| Build path | `IS_DEBUG` |
+|---|---|
+| `./gradlew :client:composeApp:installDebug` | `true` |
+| `./gradlew :client:composeApp:run` (desktop) | `true` |
+| `./gradlew :client:composeApp:bundleRelease` | `false` |
+| IDE sync (no tasks) | `true` |
+
+## Architecture notes
+
+- **`client/shared`** owns the `Environment` enum and the read-only `EnvironmentProvider` contract, so production code (e.g. `SupabaseModule`) doesn't depend on the dev-settings module.
+- **`client/developer-settings/public`** owns the `DeveloperSettingsBloc`, screen, and `DeveloperPreferences` interface (which extends `EnvironmentProvider`).
+- **`client/developer-settings/impl`** provides `DeveloperPreferencesImpl` (russhwolf-`Settings`-backed), `TestUserProvider` (parses the BuildKonfig string), `FakeRecipeSeeder` (inserts `Recipe.Samples`), and the BLoC + ViewModel that orchestrate env changes.
+- The Supabase client is `@SingleIn(AppScope::class)` and binds the URL/key at first injection. **Switching env requires an app restart** — the screen surfaces a dialog telling the user to do so.
+
+## Verification checklist
+
+1. Add at least one `chefmate.user.1` / `chefmate.user.password.1` and (optionally) `supabase.testing.*` to one of the lookup sources above.
+2. `./gradlew :client:composeApp:installDebug` — open the More tab, confirm "Developer Settings" appears at the bottom.
+3. Switch Environment → TESTING. Verify: signed out, recipe list empty, restart-required dialog. Force-stop + reopen, confirm sync now hits the testing URL.
+4. Switch Environment → FAKE. Verify several seeded recipes appear after the wipe.
+5. Tap "Login as test user" → User 1. Verify signed in; user persists across an app restart.
+6. Build a release APK. Confirm the row is absent.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -108,6 +108,10 @@ include(":client:settings:impl")
 
 include(":client:settings:public")
 
+include(":client:developer-settings:impl")
+
+include(":client:developer-settings:public")
+
 include(":client:shared")
 
 include(":client:testing")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,6 +42,10 @@ include(":client:auth:ui:impl")
 
 include(":client:auth:ui:public")
 
+include(":client:auth:usecase:impl")
+
+include(":client:auth:usecase:public")
+
 include(":client:browser:impl")
 
 include(":client:browser:public")


### PR DESCRIPTION
## Summary
- New debug-only **Developer Settings** screen reachable from the bottom of the **More** tab. Gated on `isDebugBuild` (BuildKonfig flag derived from Gradle task names) so the entry is hidden in release.
- **Environment** picker (PROD / TESTING / FAKE). Persists via `russhwolf/multiplatform-settings`. Switching env signs out, wipes the local DB, optionally seeds `Recipe.Samples` for FAKE, and prompts the user to restart so `SupabaseModule` rebinds with the new URL/key.
- **Login as test user** picker. Users are baked in at build time from `CHEF_MATE_USER_<n>` / `CHEF_MATE_USER_PASSWORD_<n>` env vars (or `chefmate.user.<n>` in `local.properties`), serialized into a single BuildKonfig string and parsed at runtime by `TestUserProvider`.
- New `client/developer-settings/{public,impl}` module pair following the `public/impl` + Decompose-BLoC + Metro-DI conventions.

### How env switching works
The Supabase client is `@SingleIn(AppScope::class)` and built once at first injection from the persisted env. Runtime swap would require refactoring every repo holding the client; instead, the dev-settings UI shows a "restart required" dialog after a switch. FAKE re-uses the PROD URL (a valid client must construct), but remote calls are gated by sign-in — and the env switch signs you out — so seeded FAKE data stays local until you log back in.

### Reviewable in 5 commits
1. `build(shared)` — `Environment` enum, `EnvironmentProvider`, `isDebugBuild`, new BuildKonfig fields.
2. `feat(recipe-data)` — `Recipe.Samples` (6 variants for seeding).
3. `feat(developer-settings)` — the new module (Bloc / ViewModel / Preferences / Seeder + unit test for the parser).
4. `feat(auth)` — `SupabaseModule` reads URL/key from `EnvironmentProvider`.
5. `feat(more-tab)` — wires the click chain: `SettingsBloc.OpenDeveloperSettings` → `BottomNavBloc` → `RootBlocImpl.Configuration.DeveloperSettings`.

## Test plan
- [x] Configure `local.properties` with `supabase.testing.url` / `supabase.testing.key` and at least `chefmate.user.1` / `chefmate.user.password.1` (and optionally `_2`, `_3`, …).
- [x] `./gradlew :client:composeApp:installDebug` — open the More tab, confirm "Developer Settings" appears at the bottom.
- [x] Tap Environment, switch to TESTING. Verify: signed out, local DB wiped, restart-required dialog. Force-stop + reopen, confirm sync now hits the testing URL.
- [x] Switch to FAKE. Verify 5–6 seeded recipes appear in the recipe list after the wipe.
- [x] Tap "Login as test user", select User 1. Verify signed in as that user; persisted user index survives an app restart.
- [x] Build a release APK (`./gradlew :client:composeApp:assembleRelease`). Confirm the "Developer Settings" row is absent.
- [x] `./gradlew :client:developer-settings:impl:test` — `TestUserProvider` parser tests pass.
- [x] `./gradlew ktfmtCheck && ./gradlew :client:composeApp:compileDebugKotlinAndroid` — no warnings/errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)