### PR TITLE
feat(recipe): upload recipe photos via Supabase Storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 For iOS, open `/iosApp` in Xcode or use the IDE run configuration.
 
+## Git workflow
+
+- **Never `git push` without an explicit request from the user in the current message.** "Commit it" / "save this" / "go ahead" authorize a commit but not a push. The push is always a separate, user-requested action.
+- **Never bundle `git push` into the same Bash invocation as `git add` / `git commit`.** Run the commit on its own and stop. The user will issue a separate "push" instruction when they're ready.
+
 ## Architecture
 
 This is a Kotlin Multiplatform app targeting Android, iOS, Desktop (JVM), Web (WASM), and a Ktor server. All new code must be Kotlin.
@@ -87,6 +92,8 @@ Call `.localized()` inside Composables to resolve to a `String`. Expose `text` m
 ### Localized Strings
 
 Add strings at `client/<module>/src/commonMain/composeResources/values/strings.xml`. Rebuild to generate accessors. Import the `compose` plugin and `compose.components.resources` dependency in the module's `build.gradle.kts`.
+
+**Apostrophes and quotes.** Use the typographic curly glyphs (`’`, `‘`, `“`, `”`) directly in `strings.xml` — not ASCII straight quotes (`'`, `"`). The codebase convention is curly throughout (e.g., `auth_switch_to_sign_up: "Don’t have an account?"`), and curly glyphs don't need the XML backslash escape that ASCII apostrophes require (`You\'re` → `You’re`).
 
 ### Dependency Injection
 

--- a/client/auth/data/impl/build.gradle.kts
+++ b/client/auth/data/impl/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
             implementation(libs.supabase.client)
             implementation(libs.supabase.auth)
             implementation(libs.supabase.postgrest)
+            implementation(libs.supabase.storage)
         }
         jvmMain.dependencies { implementation(libs.ktor.client.cio) }
         androidMain.dependencies { implementation(libs.ktor.client.cio) }

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
@@ -1,5 +1,6 @@
 package com.plusmobileapps.chefmate.auth.data.impl
 
+import co.touchlab.kermit.Logger
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
 import com.plusmobileapps.chefmate.auth.data.ChefMateUser
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.jsonPrimitive
 
 @Inject
 @SingleIn(AppScope::class)
@@ -37,7 +39,12 @@ class SupabaseAuthenticationRepository(
     override val state: StateFlow<AuthState> = _state.asStateFlow()
 
     init {
-        // Listen to auth state changes
+        // Listen to auth state changes. Whenever we land in NotAuthenticated (fresh install,
+        // explicit sign-out, expired refresh token, ...) bootstrap an anonymous Supabase session
+        // so every user always has an auth.uid() — that's what lets photo uploads, recipe upserts,
+        // and the per-user RLS policies work uniformly without a separate "signed-out" code path.
+        // The auth-anon-not-allowed state below stays Unauthenticated; the UI can decide what to
+        // show in the rare case where the bootstrap can't complete (e.g. cold-start while offline).
         scope.launch {
             supabaseClient.auth.sessionStatus.collect { sessionStatus ->
                 when (sessionStatus) {
@@ -46,7 +53,9 @@ class SupabaseAuthenticationRepository(
                         user?.let { _state.value = AuthState.Authenticated(it.toChefMateUser()) }
                     }
                     is SessionStatus.NotAuthenticated -> {
-                        _state.value = AuthState.Unauthenticated
+                        if (_state.value !is AuthState.AwaitingEmailVerification) {
+                            ensureAnonymousSession()
+                        }
                     }
                     is SessionStatus.Initializing,
                     is SessionStatus.RefreshFailure -> {
@@ -54,6 +63,16 @@ class SupabaseAuthenticationRepository(
                     }
                 }
             }
+        }
+    }
+
+    private suspend fun ensureAnonymousSession() {
+        try {
+            supabaseClient.auth.signInAnonymously()
+            // sessionStatus collector above will flip us into Authenticated.
+        } catch (t: Throwable) {
+            Logger.w(throwable = t, tag = TAG) { "Anonymous sign-in failed" }
+            _state.value = AuthState.Unauthenticated
         }
     }
 
@@ -73,6 +92,19 @@ class SupabaseAuthenticationRepository(
         password: String,
     ): Result<SignUpResult> {
         return try {
+            // If we're currently signed in anonymously, upgrade the existing account in-place via
+            // updateUser{} so the auth.uid() — and therefore every recipe/photo already attached
+            // to it — is preserved. Supabase still sends a confirmation email; the JWT loses
+            // is_anonymous after the user confirms.
+            if (supabaseClient.auth.currentUserOrNull()?.isAnonymousUser() == true) {
+                supabaseClient.auth.updateUser {
+                    this.email = email
+                    this.password = password
+                }
+                _state.value = AuthState.AwaitingEmailVerification(email)
+                return Result.success(SignUpResult.AwaitingEmailVerification)
+            }
+
             val result =
                 supabaseClient.auth.signUpWith(Email) {
                     this.email = email
@@ -170,5 +202,13 @@ class SupabaseAuthenticationRepository(
             userProfileImageUrl =
                 userMetadata?.get("avatar_url")?.toString()
                     ?: userMetadata?.get("picture")?.toString(),
+            isAnonymous = isAnonymousUser(),
         )
+
+    private fun UserInfo.isAnonymousUser(): Boolean =
+        appMetadata?.get("is_anonymous")?.jsonPrimitive?.content == "true"
+
+    private companion object {
+        const val TAG = "SupabaseAuthenticationRepository"
+    }
 }

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
@@ -19,11 +19,16 @@ import io.github.jan.supabase.auth.providers.builtin.OTP
 import io.github.jan.supabase.auth.status.SessionStatus
 import io.github.jan.supabase.auth.user.UserInfo
 import kotlin.coroutines.CoroutineContext
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 @Inject
@@ -50,7 +55,11 @@ class SupabaseAuthenticationRepository(
                 when (sessionStatus) {
                     is SessionStatus.Authenticated -> {
                         val user = sessionStatus.session.user
-                        user?.let { _state.value = AuthState.Authenticated(it.toChefMateUser()) }
+                        val isAnon = isAnonymousJwt(sessionStatus.session.accessToken)
+                        user?.let {
+                            _state.value =
+                                AuthState.Authenticated(it.toChefMateUser(isAnonymous = isAnon))
+                        }
                     }
                     is SessionStatus.NotAuthenticated -> {
                         if (_state.value !is AuthState.AwaitingEmailVerification) {
@@ -96,7 +105,8 @@ class SupabaseAuthenticationRepository(
             // updateUser{} so the auth.uid() — and therefore every recipe/photo already attached
             // to it — is preserved. Supabase still sends a confirmation email; the JWT loses
             // is_anonymous after the user confirms.
-            if (supabaseClient.auth.currentUserOrNull()?.isAnonymousUser() == true) {
+            val currentSession = supabaseClient.auth.currentSessionOrNull()
+            if (currentSession != null && isAnonymousJwt(currentSession.accessToken)) {
                 supabaseClient.auth.updateUser {
                     this.email = email
                     this.password = password
@@ -190,7 +200,7 @@ class SupabaseAuthenticationRepository(
             Result.failure(e)
         }
 
-    private fun UserInfo.toChefMateUser(): ChefMateUser =
+    private fun UserInfo.toChefMateUser(isAnonymous: Boolean): ChefMateUser =
         ChefMateUser(
             userId = id,
             userName =
@@ -202,16 +212,30 @@ class SupabaseAuthenticationRepository(
             userProfileImageUrl =
                 userMetadata?.get("avatar_url")?.toString()
                     ?: userMetadata?.get("picture")?.toString(),
-            isAnonymous = isAnonymousUser(),
+            isAnonymous = isAnonymous,
         )
 
-    private fun UserInfo.isAnonymousUser(): Boolean {
-        // The JWT claim `is_anonymous` lives at the top level, but supabase-kt 3.2.6's UserInfo
-        // doesn't deserialize that field. What *is* available is appMetadata.provider, which
-        // Supabase sets to "anonymous" for anon sign-ins (alongside identities being empty).
-        val provider = appMetadata?.get("provider")?.jsonPrimitive?.content
-        if (provider == "anonymous") return true
-        return identities?.any { it.provider == "anonymous" } == true
+    /**
+     * Reads the `is_anonymous` claim from the JWT payload directly. supabase-kt 3.2.6's UserInfo
+     * doesn't deserialize that top-level claim into a property, and `appMetadata.provider` is
+     * `null` (not `"anonymous"`) in current Supabase versions — JWT inspection is the only reliable
+     * signal.
+     */
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun isAnonymousJwt(accessToken: String): Boolean {
+        val payload = accessToken.split(".").getOrNull(1) ?: return false
+        return try {
+            // JWT uses base64url without padding; pad to a multiple of 4 before decoding.
+            val padded = payload + "=".repeat((4 - payload.length % 4) % 4)
+            val decoded = Base64.UrlSafe.decode(padded).decodeToString()
+            Json.parseToJsonElement(decoded)
+                .jsonObject["is_anonymous"]
+                ?.jsonPrimitive
+                ?.booleanOrNull == true
+        } catch (t: Throwable) {
+            Logger.w(throwable = t, tag = TAG) { "Failed to decode JWT for is_anonymous check" }
+            false
+        }
     }
 
     private companion object {

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
@@ -205,8 +205,14 @@ class SupabaseAuthenticationRepository(
             isAnonymous = isAnonymousUser(),
         )
 
-    private fun UserInfo.isAnonymousUser(): Boolean =
-        appMetadata?.get("is_anonymous")?.jsonPrimitive?.content == "true"
+    private fun UserInfo.isAnonymousUser(): Boolean {
+        // The JWT claim `is_anonymous` lives at the top level, but supabase-kt 3.2.6's UserInfo
+        // doesn't deserialize that field. What *is* available is appMetadata.provider, which
+        // Supabase sets to "anonymous" for anon sign-ins (alongside identities being empty).
+        val provider = appMetadata?.get("provider")?.jsonPrimitive?.content
+        if (provider == "anonymous") return true
+        return identities?.any { it.provider == "anonymous" } == true
+    }
 
     private companion object {
         const val TAG = "SupabaseAuthenticationRepository"

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseModule.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseModule.kt
@@ -11,6 +11,7 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.storage.Storage
 
 @SingleIn(AppScope::class)
 @ContributesTo(AppScope::class)
@@ -33,6 +34,7 @@ interface SupabaseModule {
         return createSupabaseClient(supabaseUrl = url, supabaseKey = key) {
             install(Auth)
             install(Postgrest)
+            install(Storage)
         }
     }
 }

--- a/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/ChefMateUser.kt
+++ b/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/ChefMateUser.kt
@@ -5,4 +5,5 @@ data class ChefMateUser(
     val userName: String,
     val userEmail: String,
     val userProfileImageUrl: String?,
+    val isAnonymous: Boolean = false,
 )

--- a/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
+++ b/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
@@ -33,6 +33,19 @@ class FakeAuthenticationRepository : AuthenticationRepository {
         _state.value = AuthState.Authenticated(user)
     }
 
+    fun setAnonymous(userId: String = "anon-test-id") {
+        _state.value =
+            AuthState.Authenticated(
+                ChefMateUser(
+                    userId = userId,
+                    userName = "Guest",
+                    userEmail = "",
+                    userProfileImageUrl = null,
+                    isAnonymous = true,
+                )
+            )
+    }
+
     override suspend fun signInWithEmailAndPassword(email: String, password: String): Result<Unit> =
         signInResult
 

--- a/client/auth/ui/impl/build.gradle.kts
+++ b/client/auth/ui/impl/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.client.auth.data.public)
             implementation(projects.client.auth.ui.public)
+            implementation(projects.client.auth.usecase.public)
             implementation(projects.client.util.public)
             implementation(libs.arkivanov.decompose.core)
             implementation(projects.client.shared)

--- a/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationBlocImpl.kt
+++ b/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationBlocImpl.kt
@@ -39,6 +39,7 @@ class AuthenticationBlocImpl(
                 errorMessage = it.errorMessage,
                 emailError = it.emailError,
                 confirmPasswordError = it.confirmPasswordError,
+                pendingGuestDataDiscard = it.pendingGuestDataDiscard,
             )
         }
 
@@ -101,5 +102,13 @@ class AuthenticationBlocImpl(
 
     override fun onDismissError() {
         viewModel.onDismissError()
+    }
+
+    override fun onDiscardGuestDataConfirmed() {
+        viewModel.onDiscardGuestDataConfirmed()
+    }
+
+    override fun onDiscardGuestDataCancelled() {
+        viewModel.onDiscardGuestDataCancelled()
     }
 }

--- a/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationViewModel.kt
+++ b/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationViewModel.kt
@@ -23,6 +23,8 @@ import com.plusmobileapps.chefmate.auth.data.SignUpResult
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc.Model.Mode.SignIn
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc.Model.Mode.SignUp
+import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc.Model.PendingGuestDataDiscard
+import com.plusmobileapps.chefmate.auth.usecase.SignInUseCase
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
@@ -44,6 +46,7 @@ class AuthenticationViewModel(
     @Assisted initialProps: AuthenticationBloc.Props,
     @Main mainContext: CoroutineContext,
     private val authRepository: AuthenticationRepository,
+    private val signInUseCase: SignInUseCase,
     private val emailUtil: EmailUtil,
 ) : ViewModel(mainContext) {
     private val _state =
@@ -142,25 +145,54 @@ class AuthenticationViewModel(
             return
         }
 
-        _state.value = _state.value.copy(isLoading = true, errorMessage = null, emailError = null)
-
+        // If the user is currently anonymous with guest data on this device, sign-in will
+        // discard it (their anon recipes get orphaned on the server, cleaned up by the
+        // periodic sweep). Gate behind an explicit confirmation so they don't lose recipes
+        // they didn't realize were "guest".
         scope.launch {
-            val result = authRepository.signInWithEmailAndPassword(email, password)
-            result.fold(
-                onSuccess = {
-                    _state.value = _state.value.copy(isLoading = false)
-                    output.send(Output.AuthenticationSuccess)
-                },
-                onFailure = { e ->
-                    Logger.e("Authentication failed", e)
-                    _state.value =
-                        _state.value.copy(
-                            isLoading = false,
-                            errorMessage = getSignInErrorMessage(e),
-                        )
-                },
-            )
+            val guestRecipeCount = signInUseCase.guestRecipesToDiscard()
+            if (guestRecipeCount > 0) {
+                _state.value =
+                    _state.value.copy(
+                        errorMessage = null,
+                        emailError = null,
+                        pendingGuestDataDiscard = PendingGuestDataDiscard(guestRecipeCount),
+                    )
+                return@launch
+            }
+            performSignIn(email, password)
         }
+    }
+
+    fun onDiscardGuestDataConfirmed() {
+        if (_state.value.pendingGuestDataDiscard == null) return
+        scope.launch { performSignIn(_email.value, _password.value) }
+    }
+
+    fun onDiscardGuestDataCancelled() {
+        _state.value = _state.value.copy(pendingGuestDataDiscard = null)
+    }
+
+    private suspend fun performSignIn(email: String, password: String) {
+        _state.value =
+            _state.value.copy(
+                isLoading = true,
+                errorMessage = null,
+                emailError = null,
+                pendingGuestDataDiscard = null,
+            )
+        val result = signInUseCase(email, password)
+        result.fold(
+            onSuccess = {
+                _state.value = _state.value.copy(isLoading = false)
+                output.send(Output.AuthenticationSuccess)
+            },
+            onFailure = { e ->
+                Logger.e("Authentication failed", e)
+                _state.value =
+                    _state.value.copy(isLoading = false, errorMessage = getSignInErrorMessage(e))
+            },
+        )
     }
 
     private fun signUp() {
@@ -373,6 +405,7 @@ class AuthenticationViewModel(
         val errorMessage: TextData? = null,
         val emailError: TextData? = null,
         val confirmPasswordError: TextData? = null,
+        val pendingGuestDataDiscard: PendingGuestDataDiscard? = null,
     )
 
     sealed class Output {

--- a/client/auth/ui/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/auth/ui/public/src/commonMain/composeResources/values/strings.xml
@@ -40,4 +40,11 @@
     <!-- Legal links -->
     <string name="auth_privacy_policy">Privacy Policy</string>
     <string name="auth_terms_of_use">Terms of Use</string>
+
+    <!-- Discard-guest-data confirmation -->
+    <string name="auth_discard_guest_title">Discard guest recipes?</string>
+    <string name="auth_discard_guest_message_one">You have 1 recipe saved as a guest. Signing in will delete it from this device.</string>
+    <string name="auth_discard_guest_message_other">You have {count} recipes saved as a guest. Signing in will delete them from this device.</string>
+    <string name="auth_discard_guest_confirm">Sign in anyway</string>
+    <string name="auth_discard_guest_cancel">Cancel</string>
 </resources>

--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationBloc.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationBloc.kt
@@ -31,17 +31,31 @@ interface AuthenticationBloc : BackClickBloc {
 
     fun onDismissError()
 
+    /** User confirmed the "you'll lose your guest recipes" dialog; proceed with sign-in. */
+    fun onDiscardGuestDataConfirmed()
+
+    /** User cancelled the "you'll lose your guest recipes" dialog; do nothing. */
+    fun onDiscardGuestDataCancelled()
+
     data class Model(
         val mode: Mode = Mode.SignIn,
         val isLoading: Boolean = false,
         val errorMessage: TextData? = null,
         val emailError: TextData? = null,
         val confirmPasswordError: TextData? = null,
+        /**
+         * When non-null, the user submitted Sign-In while currently anonymous and with guest
+         * recipes on this device. UI shows a confirmation dialog; sign-in is gated on
+         * [onDiscardGuestDataConfirmed].
+         */
+        val pendingGuestDataDiscard: PendingGuestDataDiscard? = null,
     ) {
         enum class Mode {
             SignIn,
             SignUp,
         }
+
+        data class PendingGuestDataDiscard(val guestRecipeCount: Int)
     }
 
     sealed class Output {

--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
@@ -51,6 +51,11 @@ import chefmate.client.auth.ui.public.generated.resources.auth_button_forgot_pas
 import chefmate.client.auth.ui.public.generated.resources.auth_button_okay
 import chefmate.client.auth.ui.public.generated.resources.auth_button_sign_in
 import chefmate.client.auth.ui.public.generated.resources.auth_button_sign_up
+import chefmate.client.auth.ui.public.generated.resources.auth_discard_guest_cancel
+import chefmate.client.auth.ui.public.generated.resources.auth_discard_guest_confirm
+import chefmate.client.auth.ui.public.generated.resources.auth_discard_guest_message_one
+import chefmate.client.auth.ui.public.generated.resources.auth_discard_guest_message_other
+import chefmate.client.auth.ui.public.generated.resources.auth_discard_guest_title
 import chefmate.client.auth.ui.public.generated.resources.auth_label_confirm_password
 import chefmate.client.auth.ui.public.generated.resources.auth_label_email
 import chefmate.client.auth.ui.public.generated.resources.auth_label_password
@@ -63,6 +68,8 @@ import chefmate.client.auth.ui.public.generated.resources.auth_screen_title_sign
 import chefmate.client.auth.ui.public.generated.resources.auth_switch_to_sign_in
 import chefmate.client.auth.ui.public.generated.resources.auth_switch_to_sign_up
 import chefmate.client.auth.ui.public.generated.resources.auth_terms_of_use
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.ResourceString
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
@@ -108,6 +115,13 @@ fun AuthenticationScreen(bloc: AuthenticationBloc, modifier: Modifier = Modifier
                     onDismissError = bloc::onDismissError,
                     onUrlClicked = bloc::onUrlClicked,
                 )
+                model.pendingGuestDataDiscard?.let { pending ->
+                    DiscardGuestDataDialog(
+                        guestRecipeCount = pending.guestRecipeCount,
+                        onConfirm = bloc::onDiscardGuestDataConfirmed,
+                        onCancel = bloc::onDiscardGuestDataCancelled,
+                    )
+                }
                 if (model.isLoading) {
                     PlusLoadingDialog(
                         message =
@@ -276,6 +290,38 @@ private fun AuthenticationBody(
 
         Spacer(modifier = Modifier.height(120.dp))
     }
+}
+
+@Composable
+private fun DiscardGuestDataDialog(
+    guestRecipeCount: Int,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val message: TextData =
+        if (guestRecipeCount == 1) {
+            ResourceString(Res.string.auth_discard_guest_message_one)
+        } else {
+            PhraseModel(
+                Res.string.auth_discard_guest_message_other,
+                "count" to FixedString(guestRecipeCount.toString()),
+            )
+        }
+    AlertDialog(
+        onDismissRequest = onCancel,
+        title = { Text(stringResource(Res.string.auth_discard_guest_title)) },
+        text = { Text(message.localized()) },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text(stringResource(Res.string.auth_discard_guest_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onCancel) {
+                Text(stringResource(Res.string.auth_discard_guest_cancel))
+            }
+        },
+    )
 }
 
 @Composable

--- a/client/auth/usecase/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/SignInUseCaseImpl.kt
+++ b/client/auth/usecase/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/SignInUseCaseImpl.kt
@@ -1,0 +1,41 @@
+package com.plusmobileapps.chefmate.auth.usecase.impl
+
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.SignInUseCase
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
+import com.plusmobileapps.chefmate.meal.data.MealPlanRepository
+import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.first
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class SignInUseCaseImpl(
+    private val authenticationRepository: AuthenticationRepository,
+    private val groceryRepository: GroceryRepository,
+    private val mealPlanRepository: MealPlanRepository,
+    private val recipeRepository: RecipeRepository,
+) : SignInUseCase {
+
+    override suspend fun guestRecipesToDiscard(): Int {
+        val authState = authenticationRepository.state.value as? AuthState.Authenticated ?: return 0
+        if (!authState.user.isAnonymous) return 0
+        return recipeRepository.getRecipes().first().size
+    }
+
+    override suspend fun invoke(email: String, password: String): Result<Unit> {
+        // Wipe before swapping sessions so the post-sign-in sync starts from a clean local DB
+        // rather than a mix of anon-owned rows (with stale remoteIds the new uid can't touch)
+        // and the real account's pull. Mirrors the order in SignOutUseCaseImpl.
+        mealPlanRepository.clearLocalData()
+        recipeRepository.clearLocalData()
+        groceryRepository.clearLocalData()
+        groceryRepository.ensureDefaultList()
+        return authenticationRepository.signInWithEmailAndPassword(email, password)
+    }
+}

--- a/client/auth/usecase/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/SignInUseCase.kt
+++ b/client/auth/usecase/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/SignInUseCase.kt
@@ -1,0 +1,20 @@
+package com.plusmobileapps.chefmate.auth.usecase
+
+interface SignInUseCase {
+    /**
+     * Number of locally-saved guest recipes that would be discarded by a sign-in. Returns 0 when
+     * the current session isn't anonymous (a real-user sign-in shouldn't have guest data anyway —
+     * this is the gate the UI uses to decide whether to show a "you'll lose X recipes" dialog).
+     */
+    suspend fun guestRecipesToDiscard(): Int
+
+    /**
+     * Wipes all local guest data (recipes, meal plans, grocery lists) and then signs in to the
+     * existing account. The post-sign-in sync repopulates from the real account's cloud data.
+     *
+     * The wipe happens before the sign-in attempt, so a failed sign-in leaves the user as
+     * anon-empty; their (still-on-server) anon recipes will re-sync the next time the auth state
+     * changes — typically when they successfully sign in.
+     */
+    suspend operator fun invoke(email: String, password: String): Result<Unit>
+}

--- a/client/recipe/core/impl/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/impl/src/commonMain/composeResources/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="create_recipe">Create Recipe</string>
     <string name="edit_recipe">Edit Recipe</string>
+    <string name="edit_recipe_upload_failed">Failed to upload photo. Please try again.</string>
 </resources>

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeBlocImpl.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.recipe.core.impl.edit
 import chefmate.client.recipe.core.impl.generated.resources.Res
 import chefmate.client.recipe.core.impl.generated.resources.create_recipe
 import chefmate.client.recipe.core.impl.generated.resources.edit_recipe
+import chefmate.client.recipe.core.impl.generated.resources.edit_recipe_upload_failed
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
@@ -49,7 +50,10 @@ class EditRecipeBlocImpl(
                     },
                 isLoading = it.isLoading,
                 isSaving = it.isSaving,
+                isUploadingPhoto = it.isUploadingPhoto,
                 showDiscardChangesDialog = it.showDiscardChangesDialog,
+                uploadError =
+                    it.uploadError?.let { ResourceString(Res.string.edit_recipe_upload_failed) },
             )
         }
     override val title: StateFlow<String> = viewModel.title
@@ -170,6 +174,14 @@ class EditRecipeBlocImpl(
 
     override fun onSaveClicked() {
         viewModel.save()
+    }
+
+    override fun onPhotoPicked(bytes: ByteArray, fileExtension: String) {
+        viewModel.uploadPhoto(bytes = bytes, fileExtension = fileExtension)
+    }
+
+    override fun onUploadErrorDismissed() {
+        viewModel.dismissUploadError()
     }
 
     override fun onBackClicked() {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeBlocImpl.kt
@@ -50,7 +50,6 @@ class EditRecipeBlocImpl(
                     },
                 isLoading = it.isLoading,
                 isSaving = it.isSaving,
-                isUploadingPhoto = it.isUploadingPhoto,
                 showDiscardChangesDialog = it.showDiscardChangesDialog,
                 uploadError =
                     it.uploadError?.let { ResourceString(Res.string.edit_recipe_upload_failed) },
@@ -71,6 +70,7 @@ class EditRecipeBlocImpl(
     override val categories: StateFlow<Set<Category>> = viewModel.categories
     override val availableUserCategories: StateFlow<List<Category>> =
         viewModel.availableUserCategories
+    override val pendingPhotoBytes: StateFlow<ByteArray?> = viewModel.pendingPhotoBytes
 
     init {
         scope.launch {
@@ -177,7 +177,7 @@ class EditRecipeBlocImpl(
     }
 
     override fun onPhotoPicked(bytes: ByteArray, fileExtension: String) {
-        viewModel.uploadPhoto(bytes = bytes, fileExtension = fileExtension)
+        viewModel.setPendingPhoto(bytes = bytes, fileExtension = fileExtension)
     }
 
     override fun onUploadErrorDismissed() {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModel.kt
@@ -2,6 +2,7 @@
 
 package com.plusmobileapps.chefmate.recipe.core.impl.edit
 
+import co.touchlab.kermit.Logger
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
@@ -9,6 +10,7 @@ import com.plusmobileapps.chefmate.recipe.data.Category
 import com.plusmobileapps.chefmate.recipe.data.CategoryRepository
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.RecipePhotoStorage
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
@@ -35,6 +37,7 @@ class EditRecipeViewModel(
     @Main mainContext: CoroutineContext,
     private val repository: RecipeRepository,
     private val categoryRepository: CategoryRepository,
+    private val photoStorage: RecipePhotoStorage,
 ) : ViewModel(mainContext) {
     private val _output = Channel<Output>(Channel.BUFFERED)
     val output: Flow<Output> = _output.receiveAsFlow()
@@ -250,6 +253,25 @@ class EditRecipeViewModel(
         _state.update { it.copy(showDiscardChangesDialog = false) }
     }
 
+    fun uploadPhoto(bytes: ByteArray, fileExtension: String) {
+        if (_state.value.isUploadingPhoto) return
+        _state.update { it.copy(isUploadingPhoto = true, uploadError = null) }
+        scope.launch {
+            try {
+                val url = photoStorage.uploadPhoto(bytes = bytes, fileExtension = fileExtension)
+                _imageUrl.value = url
+                _state.update { it.copy(isUploadingPhoto = false) }
+            } catch (t: Throwable) {
+                Logger.e(throwable = t, tag = "EditRecipeViewModel") { "Failed to upload photo" }
+                _state.update { it.copy(isUploadingPhoto = false, uploadError = t) }
+            }
+        }
+    }
+
+    fun dismissUploadError() {
+        _state.update { it.copy(uploadError = null) }
+    }
+
     fun save() {
         val originalRecipe = _state.value.recipe
         val currentRecipe = currentRecipe()
@@ -353,8 +375,10 @@ class EditRecipeViewModel(
     data class State(
         val isLoading: Boolean = false,
         val isSaving: Boolean = false,
+        val isUploadingPhoto: Boolean = false,
         val showDiscardChangesDialog: Boolean = false,
         val recipe: Recipe? = null,
+        val uploadError: Throwable? = null,
     )
 
     sealed class Output {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModel.kt
@@ -94,6 +94,10 @@ class EditRecipeViewModel(
     // UI stuck on a spinner).
     private val _isCreatingCategory = MutableStateFlow(false)
 
+    private val _pendingPhotoBytes = MutableStateFlow<ByteArray?>(null)
+    val pendingPhotoBytes: StateFlow<ByteArray?> = _pendingPhotoBytes.asStateFlow()
+    private var pendingPhotoExtension: String? = null
+
     init {
         when {
             recipeId != null -> {
@@ -253,19 +257,10 @@ class EditRecipeViewModel(
         _state.update { it.copy(showDiscardChangesDialog = false) }
     }
 
-    fun uploadPhoto(bytes: ByteArray, fileExtension: String) {
-        if (_state.value.isUploadingPhoto) return
-        _state.update { it.copy(isUploadingPhoto = true, uploadError = null) }
-        scope.launch {
-            try {
-                val url = photoStorage.uploadPhoto(bytes = bytes, fileExtension = fileExtension)
-                _imageUrl.value = url
-                _state.update { it.copy(isUploadingPhoto = false) }
-            } catch (t: Throwable) {
-                Logger.e(throwable = t, tag = "EditRecipeViewModel") { "Failed to upload photo" }
-                _state.update { it.copy(isUploadingPhoto = false, uploadError = t) }
-            }
-        }
+    fun setPendingPhoto(bytes: ByteArray, fileExtension: String) {
+        _pendingPhotoBytes.value = bytes
+        pendingPhotoExtension = fileExtension
+        _state.update { it.copy(uploadError = null) }
     }
 
     fun dismissUploadError() {
@@ -273,10 +268,28 @@ class EditRecipeViewModel(
     }
 
     fun save() {
-        val originalRecipe = _state.value.recipe
-        val currentRecipe = currentRecipe()
-        _state.update { it.copy(isLoading = true) }
+        if (_state.value.isSaving) return
+        _state.update { it.copy(isSaving = true, uploadError = null) }
         scope.launch {
+            val pendingBytes = _pendingPhotoBytes.value
+            val pendingExt = pendingPhotoExtension
+            if (pendingBytes != null && pendingExt != null) {
+                try {
+                    val url =
+                        photoStorage.uploadPhoto(bytes = pendingBytes, fileExtension = pendingExt)
+                    _imageUrl.value = url
+                    _pendingPhotoBytes.value = null
+                    pendingPhotoExtension = null
+                } catch (t: Throwable) {
+                    Logger.e(throwable = t, tag = "EditRecipeViewModel") {
+                        "Failed to upload photo"
+                    }
+                    _state.update { it.copy(isSaving = false, uploadError = t) }
+                    return@launch
+                }
+            }
+            val originalRecipe = _state.value.recipe
+            val currentRecipe = currentRecipe()
             val savedRecipe =
                 if (originalRecipe != null) {
                     repository.updateRecipe(currentRecipe)
@@ -317,8 +330,9 @@ class EditRecipeViewModel(
     private fun shouldShowDiscardChangesDialog(
         originalRecipe: Recipe?,
         currentRecipe: Recipe,
-    ): Boolean =
-        when {
+    ): Boolean {
+        if (_pendingPhotoBytes.value != null) return true
+        return when {
             originalRecipe != null -> originalRecipe.isDirty()
             else ->
                 currentRecipe.title.isNotBlank() ||
@@ -335,6 +349,7 @@ class EditRecipeViewModel(
                     currentRecipe.starRating != null ||
                     currentRecipe.categories.isNotEmpty()
         }
+    }
 
     private fun Recipe.isDirty(): Boolean =
         title != _title.value ||
@@ -375,7 +390,6 @@ class EditRecipeViewModel(
     data class State(
         val isLoading: Boolean = false,
         val isSaving: Boolean = false,
-        val isUploadingPhoto: Boolean = false,
         val showDiscardChangesDialog: Boolean = false,
         val recipe: Recipe? = null,
         val uploadError: Throwable? = null,

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModelTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModelTest.kt
@@ -410,33 +410,61 @@ class EditRecipeViewModelTest {
     }
 
     @Test
-    fun When_photo_uploaded_Then_image_url_is_updated() = runTest {
-        photoStorage.nextResult = { "https://cdn.example.com/photo.jpg" }
+    fun When_photo_picked_Then_bytes_are_held_and_no_upload_happens() {
         val vm = createViewModel()
 
-        vm.uploadPhoto(bytes = byteArrayOf(1, 2, 3), fileExtension = "jpg")
+        vm.setPendingPhoto(bytes = byteArrayOf(1, 2, 3), fileExtension = "jpg")
 
-        vm.imageUrl.value shouldBe "https://cdn.example.com/photo.jpg"
-        vm.state.value.isUploadingPhoto shouldBe false
-        vm.state.value.uploadError shouldBe null
-        photoStorage.uploads.size shouldBe 1
-        photoStorage.uploads.first().fileExtension shouldBe "jpg"
+        vm.pendingPhotoBytes.value?.toList() shouldBe listOf<Byte>(1, 2, 3)
+        vm.imageUrl.value shouldBe ""
+        photoStorage.uploads.size shouldBe 0
     }
 
     @Test
-    fun When_photo_upload_fails_Then_error_is_surfaced_and_url_is_unchanged() = runTest {
+    fun When_save_with_pending_photo_Then_photo_is_uploaded_before_recipe_save() = runTest {
+        photoStorage.nextResult = { "https://cdn.example.com/photo.jpg" }
+        val vm = createViewModel()
+        vm.updateTitle("With photo")
+        vm.setPendingPhoto(bytes = byteArrayOf(7, 7, 7), fileExtension = "png")
+
+        vm.save()
+        val output = vm.output.first()
+
+        output.shouldBeFinished()
+        photoStorage.uploads.size shouldBe 1
+        photoStorage.uploads.first().fileExtension shouldBe "png"
+        recipes.value.single().imageUrl shouldBe "https://cdn.example.com/photo.jpg"
+        vm.pendingPhotoBytes.value shouldBe null
+        vm.state.value.uploadError shouldBe null
+    }
+
+    @Test
+    fun When_save_upload_fails_Then_recipe_is_not_saved_and_error_is_surfaced() = runTest {
         val failure = RuntimeException("network down")
         photoStorage.nextResult = { throw failure }
         val vm = createViewModel()
+        vm.updateTitle("Will not save")
+        vm.setPendingPhoto(bytes = byteArrayOf(0), fileExtension = "jpg")
 
-        vm.uploadPhoto(bytes = byteArrayOf(0), fileExtension = "png")
+        vm.save()
 
-        vm.imageUrl.value shouldBe ""
-        vm.state.value.isUploadingPhoto shouldBe false
+        recipes.value shouldBe emptyList()
+        vm.state.value.isSaving shouldBe false
         vm.state.value.uploadError shouldBe failure
+        vm.pendingPhotoBytes.value?.toList() shouldBe listOf<Byte>(0)
 
         vm.dismissUploadError()
         vm.state.value.uploadError shouldBe null
+    }
+
+    @Test
+    fun When_only_photo_changed_Then_close_prompts_discard_dialog() {
+        val vm = createViewModel()
+        vm.setPendingPhoto(bytes = byteArrayOf(9), fileExtension = "jpg")
+
+        vm.tryToClose()
+
+        vm.state.value.showDiscardChangesDialog shouldBe true
     }
 
     private fun EditRecipeViewModel.Output.shouldBeFinished() {

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModelTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModelTest.kt
@@ -8,6 +8,7 @@ import com.plusmobileapps.chefmate.recipe.data.Category
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeCategoryRepository
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipePhotoStorage
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
@@ -24,6 +25,7 @@ class EditRecipeViewModelTest {
     private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
     private val repository = FakeRecipeRepository(recipes)
     private val categoryRepository = FakeCategoryRepository()
+    private val photoStorage = FakeRecipePhotoStorage()
     private val mainContext = UnconfinedTestDispatcher()
 
     private fun createViewModel(
@@ -36,6 +38,7 @@ class EditRecipeViewModelTest {
             mainContext = mainContext,
             repository = repository,
             categoryRepository = categoryRepository,
+            photoStorage = photoStorage,
         )
 
     @Test
@@ -404,6 +407,36 @@ class EditRecipeViewModelTest {
         vm.output.first().shouldBeFinished()
 
         recipes.value.first().categories shouldBe emptySet()
+    }
+
+    @Test
+    fun When_photo_uploaded_Then_image_url_is_updated() = runTest {
+        photoStorage.nextResult = { "https://cdn.example.com/photo.jpg" }
+        val vm = createViewModel()
+
+        vm.uploadPhoto(bytes = byteArrayOf(1, 2, 3), fileExtension = "jpg")
+
+        vm.imageUrl.value shouldBe "https://cdn.example.com/photo.jpg"
+        vm.state.value.isUploadingPhoto shouldBe false
+        vm.state.value.uploadError shouldBe null
+        photoStorage.uploads.size shouldBe 1
+        photoStorage.uploads.first().fileExtension shouldBe "jpg"
+    }
+
+    @Test
+    fun When_photo_upload_fails_Then_error_is_surfaced_and_url_is_unchanged() = runTest {
+        val failure = RuntimeException("network down")
+        photoStorage.nextResult = { throw failure }
+        val vm = createViewModel()
+
+        vm.uploadPhoto(bytes = byteArrayOf(0), fileExtension = "png")
+
+        vm.imageUrl.value shouldBe ""
+        vm.state.value.isUploadingPhoto shouldBe false
+        vm.state.value.uploadError shouldBe failure
+
+        vm.dismissUploadError()
+        vm.state.value.uploadError shouldBe null
     }
 
     private fun EditRecipeViewModel.Output.shouldBeFinished() {

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -71,6 +71,9 @@
     <string name="edit_recipe_field_image_url_placeholder">Enter image URL</string>
     <string name="edit_recipe_upload_photo">Upload photo</string>
     <string name="edit_recipe_upload_photo_dismiss">OK</string>
+    <string name="edit_recipe_crop_title">Crop photo</string>
+    <string name="edit_recipe_crop_cancel">Cancel</string>
+    <string name="edit_recipe_crop_confirm">Crop</string>
     <string name="edit_recipe_field_source_url">Source URL</string>
     <string name="edit_recipe_field_source_url_placeholder">Enter source URL</string>
     <string name="edit_recipe_field_servings">Servings</string>

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -69,6 +69,8 @@
     <string name="edit_recipe_field_description_placeholder">Enter recipe description</string>
     <string name="edit_recipe_field_image_url">Image URL</string>
     <string name="edit_recipe_field_image_url_placeholder">Enter image URL</string>
+    <string name="edit_recipe_upload_photo">Upload photo</string>
+    <string name="edit_recipe_upload_photo_dismiss">OK</string>
     <string name="edit_recipe_field_source_url">Source URL</string>
     <string name="edit_recipe_field_source_url_placeholder">Enter source URL</string>
     <string name="edit_recipe_field_servings">Servings</string>

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/CropPhotoOverlay.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/CropPhotoOverlay.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import chefmate.client.recipe.core.public.generated.resources.Res
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_crop_cancel
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_crop_confirm
@@ -60,112 +62,128 @@ fun CropPhotoOverlay(
     var userScale by remember(bitmap) { mutableStateOf(1f) }
     var userOffset by remember(bitmap) { mutableStateOf(Offset.Zero) }
 
-    BoxWithConstraints(
-        modifier = modifier.fillMaxSize().background(Color.Black),
-        contentAlignment = Alignment.Center,
+    Dialog(
+        onDismissRequest = { if (!isProcessing) onCancel() },
+        properties =
+            DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = false,
+            ),
     ) {
-        val frameSidePx = (min(constraints.maxWidth, constraints.maxHeight) * 0.85f).toInt()
-        val baseScale =
-            max(frameSidePx.toFloat() / imgW.toFloat(), frameSidePx.toFloat() / imgH.toFloat())
-        val effectiveScale = baseScale * userScale
+        BoxWithConstraints(
+            modifier = modifier.fillMaxSize().background(Color.Black),
+            contentAlignment = Alignment.Center,
+        ) {
+            val frameSidePx = (min(constraints.maxWidth, constraints.maxHeight) * 0.85f).toInt()
+            val baseScale =
+                max(frameSidePx.toFloat() / imgW.toFloat(), frameSidePx.toFloat() / imgH.toFloat())
+            val effectiveScale = baseScale * userScale
 
-        Canvas(
-            modifier =
-                Modifier.fillMaxSize().pointerInput(bitmap) {
-                    detectTransformGestures { _, pan, zoom, _ ->
-                        val nextScale = (userScale * zoom).coerceIn(1f, MAX_USER_ZOOM)
-                        val nextEffective = baseScale * nextScale
-                        val nextRenderedW = imgW * nextEffective
-                        val nextRenderedH = imgH * nextEffective
-                        val nextMaxX = max(0f, (nextRenderedW - frameSidePx) / 2f)
-                        val nextMaxY = max(0f, (nextRenderedH - frameSidePx) / 2f)
-                        userScale = nextScale
-                        userOffset =
-                            Offset(
-                                (userOffset.x + pan.x).coerceIn(-nextMaxX, nextMaxX),
-                                (userOffset.y + pan.y).coerceIn(-nextMaxY, nextMaxY),
-                            )
+            Canvas(
+                modifier =
+                    Modifier.fillMaxSize().pointerInput(bitmap) {
+                        detectTransformGestures { _, pan, zoom, _ ->
+                            val nextScale = (userScale * zoom).coerceIn(1f, MAX_USER_ZOOM)
+                            val nextEffective = baseScale * nextScale
+                            val nextRenderedW = imgW * nextEffective
+                            val nextRenderedH = imgH * nextEffective
+                            val nextMaxX = max(0f, (nextRenderedW - frameSidePx) / 2f)
+                            val nextMaxY = max(0f, (nextRenderedH - frameSidePx) / 2f)
+                            userScale = nextScale
+                            userOffset =
+                                Offset(
+                                    (userOffset.x + pan.x).coerceIn(-nextMaxX, nextMaxX),
+                                    (userOffset.y + pan.y).coerceIn(-nextMaxY, nextMaxY),
+                                )
+                        }
                     }
-                }
-        ) {
-            val canvasCenter = Offset(size.width / 2f, size.height / 2f)
-            val renderedW = imgW * effectiveScale
-            val renderedH = imgH * effectiveScale
-            val imageTopLeft = canvasCenter + userOffset - Offset(renderedW / 2f, renderedH / 2f)
-            drawImage(
-                image = bitmap,
-                srcOffset = IntOffset.Zero,
-                srcSize = IntSize(imgW, imgH),
-                dstOffset = IntOffset(imageTopLeft.x.toInt(), imageTopLeft.y.toInt()),
-                dstSize = IntSize(renderedW.toInt(), renderedH.toInt()),
-            )
-
-            val frameSizeF = frameSidePx.toFloat()
-            val frameTopLeft = canvasCenter - Offset(frameSizeF / 2f, frameSizeF / 2f)
-            val dim = Color.Black.copy(alpha = 0.55f)
-            drawRect(dim, Offset.Zero, Size(size.width, frameTopLeft.y))
-            drawRect(
-                dim,
-                Offset(0f, frameTopLeft.y + frameSizeF),
-                Size(size.width, size.height - (frameTopLeft.y + frameSizeF)),
-            )
-            drawRect(dim, Offset(0f, frameTopLeft.y), Size(frameTopLeft.x, frameSizeF))
-            drawRect(
-                dim,
-                Offset(frameTopLeft.x + frameSizeF, frameTopLeft.y),
-                Size(size.width - (frameTopLeft.x + frameSizeF), frameSizeF),
-            )
-            drawRect(
-                color = Color.White,
-                topLeft = frameTopLeft,
-                size = Size(frameSizeF, frameSizeF),
-                style = Stroke(width = 2.dp.toPx()),
-            )
-        }
-
-        Text(
-            text = stringResource(Res.string.edit_recipe_crop_title),
-            color = Color.White,
-            style = MaterialTheme.typography.titleMedium,
-            modifier =
-                Modifier.align(Alignment.TopCenter)
-                    .windowInsetsPadding(WindowInsets.safeDrawing)
-                    .padding(ChefMateTheme.dimens.paddingNormal),
-        )
-
-        Row(
-            modifier =
-                Modifier.align(Alignment.BottomCenter)
-                    .fillMaxWidth()
-                    .windowInsetsPadding(WindowInsets.safeDrawing)
-                    .padding(ChefMateTheme.dimens.paddingNormal),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            TextButton(onClick = onCancel, enabled = !isProcessing) {
-                Text(text = stringResource(Res.string.edit_recipe_crop_cancel), color = Color.White)
-            }
-            Button(
-                enabled = !isProcessing,
-                onClick = {
-                    val srcSizeF = frameSidePx.toFloat() / effectiveScale
-                    val srcSizeInt = srcSizeF.toInt().coerceIn(1, min(imgW, imgH))
-                    val srcCenterX = imgW / 2f - userOffset.x / effectiveScale
-                    val srcCenterY = imgH / 2f - userOffset.y / effectiveScale
-                    val srcX = (srcCenterX - srcSizeInt / 2f).toInt().coerceIn(0, imgW - srcSizeInt)
-                    val srcY = (srcCenterY - srcSizeInt / 2f).toInt().coerceIn(0, imgH - srcSizeInt)
-                    onConfirm(srcX, srcY, srcSizeInt)
-                },
             ) {
-                if (isProcessing) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(16.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
+                val canvasCenter = Offset(size.width / 2f, size.height / 2f)
+                val renderedW = imgW * effectiveScale
+                val renderedH = imgH * effectiveScale
+                val imageTopLeft =
+                    canvasCenter + userOffset - Offset(renderedW / 2f, renderedH / 2f)
+                drawImage(
+                    image = bitmap,
+                    srcOffset = IntOffset.Zero,
+                    srcSize = IntSize(imgW, imgH),
+                    dstOffset = IntOffset(imageTopLeft.x.toInt(), imageTopLeft.y.toInt()),
+                    dstSize = IntSize(renderedW.toInt(), renderedH.toInt()),
+                )
+
+                val frameSizeF = frameSidePx.toFloat()
+                val frameTopLeft = canvasCenter - Offset(frameSizeF / 2f, frameSizeF / 2f)
+                val dim = Color.Black.copy(alpha = 0.55f)
+                drawRect(dim, Offset.Zero, Size(size.width, frameTopLeft.y))
+                drawRect(
+                    dim,
+                    Offset(0f, frameTopLeft.y + frameSizeF),
+                    Size(size.width, size.height - (frameTopLeft.y + frameSizeF)),
+                )
+                drawRect(dim, Offset(0f, frameTopLeft.y), Size(frameTopLeft.x, frameSizeF))
+                drawRect(
+                    dim,
+                    Offset(frameTopLeft.x + frameSizeF, frameTopLeft.y),
+                    Size(size.width - (frameTopLeft.x + frameSizeF), frameSizeF),
+                )
+                drawRect(
+                    color = Color.White,
+                    topLeft = frameTopLeft,
+                    size = Size(frameSizeF, frameSizeF),
+                    style = Stroke(width = 2.dp.toPx()),
+                )
+            }
+
+            Text(
+                text = stringResource(Res.string.edit_recipe_crop_title),
+                color = Color.White,
+                style = MaterialTheme.typography.titleMedium,
+                modifier =
+                    Modifier.align(Alignment.TopCenter)
+                        .windowInsetsPadding(WindowInsets.safeDrawing)
+                        .padding(ChefMateTheme.dimens.paddingNormal),
+            )
+
+            Row(
+                modifier =
+                    Modifier.align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .windowInsetsPadding(WindowInsets.safeDrawing)
+                        .padding(ChefMateTheme.dimens.paddingNormal),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                TextButton(onClick = onCancel, enabled = !isProcessing) {
+                    Text(
+                        text = stringResource(Res.string.edit_recipe_crop_cancel),
+                        color = Color.White,
                     )
-                    Spacer(Modifier.width(ChefMateTheme.dimens.paddingSmall))
                 }
-                Text(stringResource(Res.string.edit_recipe_crop_confirm))
+                Button(
+                    enabled = !isProcessing,
+                    onClick = {
+                        val srcSizeF = frameSidePx.toFloat() / effectiveScale
+                        val srcSizeInt = srcSizeF.toInt().coerceIn(1, min(imgW, imgH))
+                        val srcCenterX = imgW / 2f - userOffset.x / effectiveScale
+                        val srcCenterY = imgH / 2f - userOffset.y / effectiveScale
+                        val srcX =
+                            (srcCenterX - srcSizeInt / 2f).toInt().coerceIn(0, imgW - srcSizeInt)
+                        val srcY =
+                            (srcCenterY - srcSizeInt / 2f).toInt().coerceIn(0, imgH - srcSizeInt)
+                        onConfirm(srcX, srcY, srcSizeInt)
+                    },
+                ) {
+                    if (isProcessing) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                        Spacer(Modifier.width(ChefMateTheme.dimens.paddingSmall))
+                    }
+                    Text(stringResource(Res.string.edit_recipe_crop_confirm))
+                }
             }
         }
     }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/CropPhotoOverlay.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/CropPhotoOverlay.kt
@@ -1,0 +1,172 @@
+package com.plusmobileapps.chefmate.recipe.core.edit
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import chefmate.client.recipe.core.public.generated.resources.Res
+import chefmate.client.recipe.core.public.generated.resources.edit_recipe_crop_cancel
+import chefmate.client.recipe.core.public.generated.resources.edit_recipe_crop_confirm
+import chefmate.client.recipe.core.public.generated.resources.edit_recipe_crop_title
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlin.math.max
+import kotlin.math.min
+import org.jetbrains.compose.resources.stringResource
+
+private const val MAX_USER_ZOOM = 4f
+
+@Composable
+fun CropPhotoOverlay(
+    bitmap: ImageBitmap,
+    isProcessing: Boolean,
+    onCancel: () -> Unit,
+    onConfirm: (srcX: Int, srcY: Int, srcSize: Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val imgW = bitmap.width
+    val imgH = bitmap.height
+    var userScale by remember(bitmap) { mutableStateOf(1f) }
+    var userOffset by remember(bitmap) { mutableStateOf(Offset.Zero) }
+
+    BoxWithConstraints(
+        modifier = modifier.fillMaxSize().background(Color.Black),
+        contentAlignment = Alignment.Center,
+    ) {
+        val frameSidePx = (min(constraints.maxWidth, constraints.maxHeight) * 0.85f).toInt()
+        val baseScale =
+            max(frameSidePx.toFloat() / imgW.toFloat(), frameSidePx.toFloat() / imgH.toFloat())
+        val effectiveScale = baseScale * userScale
+
+        Canvas(
+            modifier =
+                Modifier.fillMaxSize().pointerInput(bitmap) {
+                    detectTransformGestures { _, pan, zoom, _ ->
+                        val nextScale = (userScale * zoom).coerceIn(1f, MAX_USER_ZOOM)
+                        val nextEffective = baseScale * nextScale
+                        val nextRenderedW = imgW * nextEffective
+                        val nextRenderedH = imgH * nextEffective
+                        val nextMaxX = max(0f, (nextRenderedW - frameSidePx) / 2f)
+                        val nextMaxY = max(0f, (nextRenderedH - frameSidePx) / 2f)
+                        userScale = nextScale
+                        userOffset =
+                            Offset(
+                                (userOffset.x + pan.x).coerceIn(-nextMaxX, nextMaxX),
+                                (userOffset.y + pan.y).coerceIn(-nextMaxY, nextMaxY),
+                            )
+                    }
+                }
+        ) {
+            val canvasCenter = Offset(size.width / 2f, size.height / 2f)
+            val renderedW = imgW * effectiveScale
+            val renderedH = imgH * effectiveScale
+            val imageTopLeft = canvasCenter + userOffset - Offset(renderedW / 2f, renderedH / 2f)
+            drawImage(
+                image = bitmap,
+                srcOffset = IntOffset.Zero,
+                srcSize = IntSize(imgW, imgH),
+                dstOffset = IntOffset(imageTopLeft.x.toInt(), imageTopLeft.y.toInt()),
+                dstSize = IntSize(renderedW.toInt(), renderedH.toInt()),
+            )
+
+            val frameSizeF = frameSidePx.toFloat()
+            val frameTopLeft = canvasCenter - Offset(frameSizeF / 2f, frameSizeF / 2f)
+            val dim = Color.Black.copy(alpha = 0.55f)
+            drawRect(dim, Offset.Zero, Size(size.width, frameTopLeft.y))
+            drawRect(
+                dim,
+                Offset(0f, frameTopLeft.y + frameSizeF),
+                Size(size.width, size.height - (frameTopLeft.y + frameSizeF)),
+            )
+            drawRect(dim, Offset(0f, frameTopLeft.y), Size(frameTopLeft.x, frameSizeF))
+            drawRect(
+                dim,
+                Offset(frameTopLeft.x + frameSizeF, frameTopLeft.y),
+                Size(size.width - (frameTopLeft.x + frameSizeF), frameSizeF),
+            )
+            drawRect(
+                color = Color.White,
+                topLeft = frameTopLeft,
+                size = Size(frameSizeF, frameSizeF),
+                style = Stroke(width = 2.dp.toPx()),
+            )
+        }
+
+        Text(
+            text = stringResource(Res.string.edit_recipe_crop_title),
+            color = Color.White,
+            style = MaterialTheme.typography.titleMedium,
+            modifier =
+                Modifier.align(Alignment.TopCenter)
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
+                    .padding(ChefMateTheme.dimens.paddingNormal),
+        )
+
+        Row(
+            modifier =
+                Modifier.align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
+                    .padding(ChefMateTheme.dimens.paddingNormal),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            TextButton(onClick = onCancel, enabled = !isProcessing) {
+                Text(text = stringResource(Res.string.edit_recipe_crop_cancel), color = Color.White)
+            }
+            Button(
+                enabled = !isProcessing,
+                onClick = {
+                    val srcSizeF = frameSidePx.toFloat() / effectiveScale
+                    val srcSizeInt = srcSizeF.toInt().coerceIn(1, min(imgW, imgH))
+                    val srcCenterX = imgW / 2f - userOffset.x / effectiveScale
+                    val srcCenterY = imgH / 2f - userOffset.y / effectiveScale
+                    val srcX = (srcCenterX - srcSizeInt / 2f).toInt().coerceIn(0, imgW - srcSizeInt)
+                    val srcY = (srcCenterY - srcSizeInt / 2f).toInt().coerceIn(0, imgH - srcSizeInt)
+                    onConfirm(srcX, srcY, srcSizeInt)
+                },
+            ) {
+                if (isProcessing) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                    Spacer(Modifier.width(ChefMateTheme.dimens.paddingSmall))
+                }
+                Text(stringResource(Res.string.edit_recipe_crop_confirm))
+            }
+        }
+    }
+}

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeBloc.kt
@@ -102,11 +102,17 @@ interface EditRecipeBloc : BackClickBloc {
 
     fun onSaveClicked()
 
+    fun onPhotoPicked(bytes: ByteArray, fileExtension: String)
+
+    fun onUploadErrorDismissed()
+
     data class Model(
         val title: TextData,
         val isLoading: Boolean,
         val isSaving: Boolean,
+        val isUploadingPhoto: Boolean,
         val showDiscardChangesDialog: Boolean,
+        val uploadError: TextData? = null,
     )
 
     sealed class Output {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeBloc.kt
@@ -41,6 +41,8 @@ interface EditRecipeBloc : BackClickBloc {
     /** User-created categories from the local DB. Built-in presets are not included. */
     val availableUserCategories: StateFlow<List<Category>>
 
+    val pendingPhotoBytes: StateFlow<ByteArray?>
+
     fun onTitleChanged(title: String)
 
     fun onDescriptionChanged(description: String)
@@ -110,7 +112,6 @@ interface EditRecipeBloc : BackClickBloc {
         val title: TextData,
         val isLoading: Boolean,
         val isSaving: Boolean,
-        val isUploadingPhoto: Boolean,
         val showDiscardChangesDialog: Boolean,
         val uploadError: TextData? = null,
     )

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AddPhotoAlternate
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
@@ -24,6 +26,7 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.InputChip
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -78,12 +81,16 @@ import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_total_time
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_total_time_placeholder
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_save
+import chefmate.client.recipe.core.public.generated.resources.edit_recipe_upload_photo
+import chefmate.client.recipe.core.public.generated.resources.edit_recipe_upload_photo_dismiss
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
+import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import com.plusmobileapps.chefmate.util.rememberImagePickerLauncher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.jetbrains.compose.resources.StringResource
@@ -99,6 +106,10 @@ fun EditRecipeScreen(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
             onConfirm = bloc::onDiscardChangesConfirmed,
             onDismiss = bloc::onDiscardChangesCancelled,
         )
+    }
+
+    state.uploadError?.let { error ->
+        UploadErrorDialog(message = error.localized(), onDismiss = bloc::onUploadErrorDismissed)
     }
 
     PlusHeaderContainer(
@@ -152,6 +163,7 @@ private fun EditRecipeContent(bloc: EditRecipeBloc, modifier: Modifier = Modifie
         RecipeDescriptionField(bloc = bloc)
         RecipeCategoryField(bloc = bloc)
         RecipeStarRatingField(bloc = bloc)
+        RecipePhotoUploader(bloc = bloc)
         RecipeImageUrlField(bloc = bloc)
         RecipeSourceUrlField(bloc = bloc)
         RecipeServingsField(bloc = bloc)
@@ -327,6 +339,66 @@ private fun RecipeStarRatingField(bloc: EditRecipeBloc, modifier: Modifier = Mod
 }
 
 @Composable
+private fun RecipePhotoUploader(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
+    val state by bloc.state.collectAsState()
+    val imageUrl by bloc.imageUrl.collectAsState()
+    val pickPhoto = rememberImagePickerLauncher { picked ->
+        if (picked != null) {
+            bloc.onPhotoPicked(picked.bytes, picked.fileExtension)
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall),
+    ) {
+        if (imageUrl.isNotBlank()) {
+            RecipeImage(
+                imageUrl = imageUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxWidth().aspectRatio(16f / 9f),
+            )
+        }
+        OutlinedButton(
+            onClick = pickPhoto,
+            enabled = !state.isUploadingPhoto,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (state.isUploadingPhoto) {
+                PlusLoadingIndicator(
+                    modifier = Modifier.padding(end = ChefMateTheme.dimens.paddingSmall)
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Filled.AddPhotoAlternate,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = ChefMateTheme.dimens.paddingSmall),
+                )
+            }
+            Text(stringResource(Res.string.edit_recipe_upload_photo))
+        }
+    }
+}
+
+@Composable
+private fun UploadErrorDialog(
+    message: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = { Text(message) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.edit_recipe_upload_photo_dismiss))
+            }
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
 private fun RecipeImageUrlField(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
     val imageUrl by bloc.imageUrl.collectAsState()
 
@@ -488,6 +560,7 @@ private val previewBloc =
                     title = FixedString("Edit Recipe"),
                     isLoading = false,
                     isSaving = false,
+                    isUploadingPhoto = false,
                     showDiscardChangesDialog = false,
                 )
             )
@@ -586,6 +659,10 @@ Salt for pasta water"""
         override fun onDiscardChangesCancelled() {}
 
         override fun onSaveClicked() {}
+
+        override fun onPhotoPicked(bytes: ByteArray, fileExtension: String) {}
+
+        override fun onUploadErrorDismissed() {}
 
         override fun onBackClicked() {}
     }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
@@ -34,11 +34,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -92,9 +95,14 @@ import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import com.plusmobileapps.chefmate.util.cropImageToSquare
+import com.plusmobileapps.chefmate.util.decodeImageBitmap
 import com.plusmobileapps.chefmate.util.rememberImagePickerLauncher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -340,13 +348,27 @@ private fun RecipeStarRatingField(bloc: EditRecipeBloc, modifier: Modifier = Mod
     }
 }
 
+private data class PendingCrop(val bytes: ByteArray, val bitmap: ImageBitmap)
+
 @Composable
 private fun RecipePhotoUploader(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
     val imageUrl by bloc.imageUrl.collectAsState()
     val pendingBytes by bloc.pendingPhotoBytes.collectAsState()
+    val scope = rememberCoroutineScope()
+    var pendingCrop by remember { mutableStateOf<PendingCrop?>(null) }
+    var isCropping by remember { mutableStateOf(false) }
     val pickPhoto = rememberImagePickerLauncher { picked ->
         if (picked != null) {
-            bloc.onPhotoPicked(picked.bytes, picked.fileExtension)
+            scope.launch {
+                val bitmap =
+                    runCatching {
+                            withContext(Dispatchers.Default) { decodeImageBitmap(picked.bytes) }
+                        }
+                        .getOrNull()
+                if (bitmap != null) {
+                    pendingCrop = PendingCrop(bytes = picked.bytes, bitmap = bitmap)
+                }
+            }
         }
     }
 
@@ -360,7 +382,7 @@ private fun RecipePhotoUploader(bloc: EditRecipeBloc, modifier: Modifier = Modif
                 model = previewModel,
                 contentDescription = null,
                 modifier =
-                    Modifier.fillMaxWidth().aspectRatio(16f / 9f).clip(MaterialTheme.shapes.medium),
+                    Modifier.fillMaxWidth().aspectRatio(1f).clip(MaterialTheme.shapes.medium),
                 contentScale = ContentScale.Crop,
             )
         }
@@ -372,6 +394,34 @@ private fun RecipePhotoUploader(bloc: EditRecipeBloc, modifier: Modifier = Modif
             )
             Text(stringResource(Res.string.edit_recipe_upload_photo))
         }
+    }
+
+    pendingCrop?.let { crop ->
+        CropPhotoOverlay(
+            bitmap = crop.bitmap,
+            isProcessing = isCropping,
+            onCancel = { pendingCrop = null },
+            onConfirm = { srcX, srcY, srcSize ->
+                isCropping = true
+                scope.launch {
+                    try {
+                        val cropped =
+                            withContext(Dispatchers.Default) {
+                                cropImageToSquare(
+                                    bytes = crop.bytes,
+                                    srcX = srcX,
+                                    srcY = srcY,
+                                    srcSize = srcSize,
+                                )
+                            }
+                        bloc.onPhotoPicked(cropped, "jpg")
+                    } finally {
+                        isCropping = false
+                        pendingCrop = null
+                    }
+                }
+            },
+        )
     }
 }
 

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
@@ -38,6 +38,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import chefmate.client.recipe.core.public.generated.resources.Res
@@ -83,12 +85,12 @@ import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_save
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_upload_photo
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_upload_photo_dismiss
+import coil3.compose.AsyncImage
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
-import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import com.plusmobileapps.chefmate.util.rememberImagePickerLauncher
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -340,8 +342,8 @@ private fun RecipeStarRatingField(bloc: EditRecipeBloc, modifier: Modifier = Mod
 
 @Composable
 private fun RecipePhotoUploader(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
-    val state by bloc.state.collectAsState()
     val imageUrl by bloc.imageUrl.collectAsState()
+    val pendingBytes by bloc.pendingPhotoBytes.collectAsState()
     val pickPhoto = rememberImagePickerLauncher { picked ->
         if (picked != null) {
             bloc.onPhotoPicked(picked.bytes, picked.fileExtension)
@@ -352,29 +354,22 @@ private fun RecipePhotoUploader(bloc: EditRecipeBloc, modifier: Modifier = Modif
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall),
     ) {
-        if (imageUrl.isNotBlank()) {
-            RecipeImage(
-                imageUrl = imageUrl,
+        val previewModel: Any? = pendingBytes ?: imageUrl.takeIf { it.isNotBlank() }
+        if (previewModel != null) {
+            AsyncImage(
+                model = previewModel,
                 contentDescription = null,
-                modifier = Modifier.fillMaxWidth().aspectRatio(16f / 9f),
+                modifier =
+                    Modifier.fillMaxWidth().aspectRatio(16f / 9f).clip(MaterialTheme.shapes.medium),
+                contentScale = ContentScale.Crop,
             )
         }
-        OutlinedButton(
-            onClick = pickPhoto,
-            enabled = !state.isUploadingPhoto,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            if (state.isUploadingPhoto) {
-                PlusLoadingIndicator(
-                    modifier = Modifier.padding(end = ChefMateTheme.dimens.paddingSmall)
-                )
-            } else {
-                Icon(
-                    imageVector = Icons.Filled.AddPhotoAlternate,
-                    contentDescription = null,
-                    modifier = Modifier.padding(end = ChefMateTheme.dimens.paddingSmall),
-                )
-            }
+        OutlinedButton(onClick = pickPhoto, modifier = Modifier.fillMaxWidth()) {
+            Icon(
+                imageVector = Icons.Filled.AddPhotoAlternate,
+                contentDescription = null,
+                modifier = Modifier.padding(end = ChefMateTheme.dimens.paddingSmall),
+            )
             Text(stringResource(Res.string.edit_recipe_upload_photo))
         }
     }
@@ -560,7 +555,6 @@ private val previewBloc =
                     title = FixedString("Edit Recipe"),
                     isLoading = false,
                     isSaving = false,
-                    isUploadingPhoto = false,
                     showDiscardChangesDialog = false,
                 )
             )
@@ -613,6 +607,7 @@ Salt for pasta water"""
         override val availableUserCategories:
             StateFlow<List<com.plusmobileapps.chefmate.recipe.data.Category>> =
             MutableStateFlow(emptyList())
+        override val pendingPhotoBytes: StateFlow<ByteArray?> = MutableStateFlow(null)
 
         override fun onTitleChanged(title: String) {}
 

--- a/client/recipe/data/impl/build.gradle.kts
+++ b/client/recipe/data/impl/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             implementation(projects.client.auth.data.public)
             implementation(libs.supabase.client)
             implementation(libs.supabase.postgrest)
+            implementation(libs.supabase.storage)
             implementation(libs.kotlinx.serialization.json)
         }
         commonTest.dependencies {

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.plusmobileapps.chefmate.di.IO
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.Category
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.RecipePhotoStorage
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import com.plusmobileapps.chefmate.recipe.data.SyncStatus
 import com.plusmobileapps.chefmate.recipe.data.impl.remote.RecipeRemoteDataSource
@@ -49,6 +50,7 @@ class RecipeRepositoryImpl(
     private val dateTimeUtil: DateTimeUtil,
     private val remoteDataSource: RecipeRemoteDataSource,
     private val authRepository: AuthenticationRepository,
+    private val photoStorage: RecipePhotoStorage,
 ) : RecipeRepository {
 
     private val scope = CoroutineScope(ioContext + SupervisorJob())
@@ -116,10 +118,11 @@ class RecipeRepositoryImpl(
     }
 
     override suspend fun updateRecipe(recipe: Recipe): Recipe {
-        val result =
+        val (result, previousImageUrl) =
             withContext(ioContext) {
                 val now = dateTimeUtil.now
-                db.transactionWithResult {
+                val previous = db.getById(recipe.id).executeAsOneOrNull()
+                val updated = db.transactionWithResult {
                     db.update(
                         id = recipe.id,
                         title = recipe.title,
@@ -140,7 +143,11 @@ class RecipeRepositoryImpl(
                     syncJoinRowsForRecipe(recipe.id, recipe.categories)
                     recipe.copy(updatedAt = now)
                 }
+                updated to previous?.imageUrl
             }
+        if (!previousImageUrl.isNullOrBlank() && previousImageUrl != recipe.imageUrl) {
+            scope.launch { photoStorage.deletePhoto(previousImageUrl) }
+        }
         pushUpdateToRemote(recipe.id)
         return result
     }
@@ -159,6 +166,10 @@ class RecipeRepositoryImpl(
                 db.delete(id)
                 entity
             }
+        entity
+            ?.imageUrl
+            ?.takeIf { it.isNotBlank() }
+            ?.let { imageUrl -> scope.launch { photoStorage.deletePhoto(imageUrl) } }
         entity?.remoteId?.let { remoteId ->
             scope.launch {
                 try {

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.recipe.data.impl
 
 import app.cash.sqldelight.coroutines.asFlow
+import co.touchlab.kermit.Logger
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
 import com.plusmobileapps.chefmate.database.CategoryQueries
@@ -237,7 +238,9 @@ class RecipeRepositoryImpl(
             } finally {
                 syncingIds.update { it - localId }
             }
-        } catch (_: Exception) {}
+        } catch (t: Throwable) {
+            Logger.e(throwable = t, tag = TAG) { "pushAddToRemote failed (localId=$localId)" }
+        }
     }
 
     private suspend fun pushUpdateToRemote(localId: Long) {
@@ -275,7 +278,9 @@ class RecipeRepositoryImpl(
             } finally {
                 syncingIds.update { it - localId }
             }
-        } catch (_: Exception) {}
+        } catch (t: Throwable) {
+            Logger.e(throwable = t, tag = TAG) { "pushUpdateToRemote failed (localId=$localId)" }
+        }
     }
 
     private suspend fun syncWithRemote(userId: String) = syncMutex.withLock {
@@ -499,6 +504,10 @@ class RecipeRepositoryImpl(
             createdAt = Instant.parse(createdAt),
             updatedAt = Instant.parse(updatedAt),
         )
+    }
+
+    private companion object {
+        const val TAG = "RecipeRepositoryImpl"
     }
 }
 

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
@@ -190,67 +190,22 @@ class RecipeRepositoryImpl(
         }
     }
 
-    private fun pushAddToRemote(localId: Long) {
+    private suspend fun pushAddToRemote(localId: Long) {
         val authState = authRepository.state.value
         if (authState !is AuthState.Authenticated) return
-        scope.launch {
-            try {
-                val entity = db.getById(localId).executeAsOneOrNull() ?: return@launch
-                val clientId =
-                    entity.clientId
-                        ?: Uuid.random().toString().also { newId ->
-                            db.updateClientId(clientId = newId, id = localId)
-                        }
-                syncingIds.update { it + localId }
-                try {
-                    val remoteRecipe =
-                        remoteDataSource.upsertRecipe(
-                            RemoteRecipe(
-                                ownerId = authState.user.userId,
-                                title = entity.title,
-                                description = entity.description,
-                                ingredients = entity.ingredients,
-                                directions = entity.directions,
-                                imageUrl = entity.imageUrl,
-                                sourceUrl = entity.sourceUrl,
-                                servings = entity.servings?.toInt(),
-                                prepTime = entity.prepTime?.toInt(),
-                                cookTime = entity.cookTime?.toInt(),
-                                totalTime = entity.totalTime?.toInt(),
-                                calories = entity.calories?.toInt(),
-                                starRating = entity.starRating?.toInt(),
-                                isFavorite = entity.isFavorite,
-                                createdAt = entity.createdAt,
-                                updatedAt = entity.updatedAt,
-                                clientId = clientId,
-                            )
-                        )
-                    db.updateRemoteId(remoteId = remoteRecipe.id, id = localId)
-                    remoteRecipe.id?.let { recipeRemoteId ->
-                        remoteDataSource.setRecipeCategories(
-                            recipeRemoteId,
-                            attachedCategoryRemoteIds(localId),
-                        )
+        try {
+            val entity =
+                withContext(ioContext) { db.getById(localId).executeAsOneOrNull() } ?: return
+            val clientId =
+                entity.clientId
+                    ?: Uuid.random().toString().also { newId ->
+                        withContext(ioContext) { db.updateClientId(clientId = newId, id = localId) }
                     }
-                } finally {
-                    syncingIds.update { it - localId }
-                }
-            } catch (_: Exception) {}
-        }
-    }
-
-    private fun pushUpdateToRemote(localId: Long) {
-        val authState = authRepository.state.value
-        if (authState !is AuthState.Authenticated) return
-        scope.launch {
+            syncingIds.update { it + localId }
             try {
-                val entity = db.getById(localId).executeAsOneOrNull() ?: return@launch
-                val remoteId = entity.remoteId ?: return@launch
-                syncingIds.update { it + localId }
-                try {
+                val remoteRecipe =
                     remoteDataSource.upsertRecipe(
                         RemoteRecipe(
-                            id = remoteId,
                             ownerId = authState.user.userId,
                             title = entity.title,
                             description = entity.description,
@@ -265,20 +220,62 @@ class RecipeRepositoryImpl(
                             calories = entity.calories?.toInt(),
                             starRating = entity.starRating?.toInt(),
                             isFavorite = entity.isFavorite,
+                            createdAt = entity.createdAt,
                             updatedAt = entity.updatedAt,
-                            clientId = entity.clientId,
+                            clientId = clientId,
                         )
                     )
+                withContext(ioContext) {
+                    db.updateRemoteId(remoteId = remoteRecipe.id, id = localId)
+                }
+                remoteRecipe.id?.let { recipeRemoteId ->
                     remoteDataSource.setRecipeCategories(
-                        remoteId,
+                        recipeRemoteId,
                         attachedCategoryRemoteIds(localId),
                     )
-                    db.clearDirty(localId)
-                } finally {
-                    syncingIds.update { it - localId }
                 }
-            } catch (_: Exception) {}
-        }
+            } finally {
+                syncingIds.update { it - localId }
+            }
+        } catch (_: Exception) {}
+    }
+
+    private suspend fun pushUpdateToRemote(localId: Long) {
+        val authState = authRepository.state.value
+        if (authState !is AuthState.Authenticated) return
+        try {
+            val entity =
+                withContext(ioContext) { db.getById(localId).executeAsOneOrNull() } ?: return
+            val remoteId = entity.remoteId ?: return
+            syncingIds.update { it + localId }
+            try {
+                remoteDataSource.upsertRecipe(
+                    RemoteRecipe(
+                        id = remoteId,
+                        ownerId = authState.user.userId,
+                        title = entity.title,
+                        description = entity.description,
+                        ingredients = entity.ingredients,
+                        directions = entity.directions,
+                        imageUrl = entity.imageUrl,
+                        sourceUrl = entity.sourceUrl,
+                        servings = entity.servings?.toInt(),
+                        prepTime = entity.prepTime?.toInt(),
+                        cookTime = entity.cookTime?.toInt(),
+                        totalTime = entity.totalTime?.toInt(),
+                        calories = entity.calories?.toInt(),
+                        starRating = entity.starRating?.toInt(),
+                        isFavorite = entity.isFavorite,
+                        updatedAt = entity.updatedAt,
+                        clientId = entity.clientId,
+                    )
+                )
+                remoteDataSource.setRecipeCategories(remoteId, attachedCategoryRemoteIds(localId))
+                withContext(ioContext) { db.clearDirty(localId) }
+            } finally {
+                syncingIds.update { it - localId }
+            }
+        } catch (_: Exception) {}
     }
 
     private suspend fun syncWithRemote(userId: String) = syncMutex.withLock {

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipePhotoStorage.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipePhotoStorage.kt
@@ -1,0 +1,39 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package com.plusmobileapps.chefmate.recipe.data.impl.remote
+
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.recipe.data.RecipePhotoStorage
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.storage.storage
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class SupabaseRecipePhotoStorage(
+    private val supabaseClient: SupabaseClient,
+    private val authRepository: AuthenticationRepository,
+) : RecipePhotoStorage {
+
+    override suspend fun uploadPhoto(bytes: ByteArray, fileExtension: String): String {
+        val ownerId =
+            (authRepository.state.value as? AuthState.Authenticated)?.user?.userId
+                ?: error("Cannot upload recipe photo while signed out")
+        val bucket = supabaseClient.storage.from(BUCKET_NAME)
+        val sanitizedExtension = fileExtension.trimStart('.').lowercase().ifBlank { "jpg" }
+        val path = "$ownerId/${Uuid.random()}.$sanitizedExtension"
+        bucket.upload(path = path, data = bytes) { upsert = false }
+        return bucket.publicUrl(path)
+    }
+
+    private companion object {
+        const val BUCKET_NAME = "recipe-photos"
+    }
+}

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipePhotoStorage.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipePhotoStorage.kt
@@ -24,9 +24,13 @@ class SupabaseRecipePhotoStorage(
 ) : RecipePhotoStorage {
 
     override suspend fun uploadPhoto(bytes: ByteArray, fileExtension: String): String {
+        // Anonymous Supabase sessions still have an auth.uid(), so every upload lands in a
+        // per-user folder and is bound by the same owner_insert/update/delete RLS policies as
+        // a real user. If we ever land here without any session (cold-start race before the
+        // anonymous bootstrap completes), surface the error rather than dump to a shared folder.
         val ownerFolder =
             (authRepository.state.value as? AuthState.Authenticated)?.user?.userId
-                ?: ANONYMOUS_FOLDER
+                ?: error("Cannot upload photo: no Supabase session")
         val bucket = supabaseClient.storage.from(BUCKET_NAME)
         val sanitizedExtension = fileExtension.trimStart('.').lowercase().ifBlank { "jpg" }
         val path = "$ownerFolder/${Uuid.random()}.$sanitizedExtension"
@@ -50,6 +54,5 @@ class SupabaseRecipePhotoStorage(
 
     private companion object {
         const val BUCKET_NAME = "recipe-photos"
-        const val ANONYMOUS_FOLDER = "anonymous"
     }
 }

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipePhotoStorage.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipePhotoStorage.kt
@@ -2,6 +2,7 @@
 
 package com.plusmobileapps.chefmate.recipe.data.impl.remote
 
+import co.touchlab.kermit.Logger
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
 import com.plusmobileapps.chefmate.di.AppScope
@@ -31,6 +32,20 @@ class SupabaseRecipePhotoStorage(
         val path = "$ownerFolder/${Uuid.random()}.$sanitizedExtension"
         bucket.upload(path = path, data = bytes) { upsert = false }
         return bucket.publicUrl(path)
+    }
+
+    override suspend fun deletePhoto(publicUrl: String) {
+        val needle = "/$BUCKET_NAME/"
+        if (!publicUrl.contains(needle)) return
+        val path = publicUrl.substringAfter(needle)
+        if (path.isBlank()) return
+        try {
+            supabaseClient.storage.from(BUCKET_NAME).delete(path)
+        } catch (t: Throwable) {
+            Logger.w(throwable = t, tag = "SupabaseRecipePhotoStorage") {
+                "Failed to delete photo at $path"
+            }
+        }
     }
 
     private companion object {

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipePhotoStorage.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipePhotoStorage.kt
@@ -23,17 +23,18 @@ class SupabaseRecipePhotoStorage(
 ) : RecipePhotoStorage {
 
     override suspend fun uploadPhoto(bytes: ByteArray, fileExtension: String): String {
-        val ownerId =
+        val ownerFolder =
             (authRepository.state.value as? AuthState.Authenticated)?.user?.userId
-                ?: error("Cannot upload recipe photo while signed out")
+                ?: ANONYMOUS_FOLDER
         val bucket = supabaseClient.storage.from(BUCKET_NAME)
         val sanitizedExtension = fileExtension.trimStart('.').lowercase().ifBlank { "jpg" }
-        val path = "$ownerId/${Uuid.random()}.$sanitizedExtension"
+        val path = "$ownerFolder/${Uuid.random()}.$sanitizedExtension"
         bucket.upload(path = path, data = bytes) { upsert = false }
         return bucket.publicUrl(path)
     }
 
     private companion object {
         const val BUCKET_NAME = "recipe-photos"
+        const val ANONYMOUS_FOLDER = "anonymous"
     }
 }

--- a/client/recipe/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImplTest.kt
+++ b/client/recipe/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImplTest.kt
@@ -15,6 +15,7 @@ import com.plusmobileapps.chefmate.recipe.data.impl.remote.CategoryRemoteDataSou
 import com.plusmobileapps.chefmate.recipe.data.impl.remote.RecipeRemoteDataSource
 import com.plusmobileapps.chefmate.recipe.data.impl.remote.RemoteCategory
 import com.plusmobileapps.chefmate.recipe.data.impl.remote.RemoteRecipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipePhotoStorage
 import com.plusmobileapps.chefmate.util.testing.FakeDateTimeUtil
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
@@ -43,6 +44,7 @@ class RecipeRepositoryImplTest {
             dateTimeUtil = dateTimeUtil,
             remoteDataSource = recipeRemote,
             authRepository = fakeAuth,
+            photoStorage = FakeRecipePhotoStorage(),
         )
 
     private val categoryRepository =

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipePhotoStorage.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipePhotoStorage.kt
@@ -1,0 +1,5 @@
+package com.plusmobileapps.chefmate.recipe.data
+
+interface RecipePhotoStorage {
+    suspend fun uploadPhoto(bytes: ByteArray, fileExtension: String): String
+}

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipePhotoStorage.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipePhotoStorage.kt
@@ -2,4 +2,10 @@ package com.plusmobileapps.chefmate.recipe.data
 
 interface RecipePhotoStorage {
     suspend fun uploadPhoto(bytes: ByteArray, fileExtension: String): String
+
+    /**
+     * Best-effort delete of a previously uploaded photo. URLs that don't point at the recipe-photos
+     * bucket are ignored; failures are swallowed so caller flows aren't disrupted.
+     */
+    suspend fun deletePhoto(publicUrl: String)
 }

--- a/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipePhotoStorage.kt
+++ b/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipePhotoStorage.kt
@@ -5,10 +5,15 @@ import com.plusmobileapps.chefmate.recipe.data.RecipePhotoStorage
 class FakeRecipePhotoStorage(var nextResult: () -> String = { "https://example.com/photo.jpg" }) :
     RecipePhotoStorage {
     val uploads = mutableListOf<Upload>()
+    val deletes = mutableListOf<String>()
 
     override suspend fun uploadPhoto(bytes: ByteArray, fileExtension: String): String {
         uploads.add(Upload(bytes = bytes, fileExtension = fileExtension))
         return nextResult()
+    }
+
+    override suspend fun deletePhoto(publicUrl: String) {
+        deletes.add(publicUrl)
     }
 
     data class Upload(val bytes: ByteArray, val fileExtension: String) {

--- a/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipePhotoStorage.kt
+++ b/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipePhotoStorage.kt
@@ -1,0 +1,25 @@
+package com.plusmobileapps.chefmate.recipe.data.testing
+
+import com.plusmobileapps.chefmate.recipe.data.RecipePhotoStorage
+
+class FakeRecipePhotoStorage(var nextResult: () -> String = { "https://example.com/photo.jpg" }) :
+    RecipePhotoStorage {
+    val uploads = mutableListOf<Upload>()
+
+    override suspend fun uploadPhoto(bytes: ByteArray, fileExtension: String): String {
+        uploads.add(Upload(bytes = bytes, fileExtension = fileExtension))
+        return nextResult()
+    }
+
+    data class Upload(val bytes: ByteArray, val fileExtension: String) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Upload) return false
+            if (fileExtension != other.fileExtension) return false
+            if (!bytes.contentEquals(other.bytes)) return false
+            return true
+        }
+
+        override fun hashCode(): Int = 31 * bytes.contentHashCode() + fileExtension.hashCode()
+    }
+}

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -31,6 +31,7 @@ class SettingsBlocImpl(
         viewModel.state.mapState {
             SettingsBloc.Model(
                 isAuthenticated = it.isAuthenticated,
+                isAnonymous = it.isAnonymous,
                 greeting = it.userName?.let { name -> createGreeting(name) },
                 verificationMessage =
                     it.emailAwaitingVerification?.let { email ->

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
@@ -34,9 +34,17 @@ class SettingsViewModel(
                 when (authState) {
                     is AuthState.Authenticated -> {
                         val isAnonymous = authState.user.isAnonymous
+                        // Anon: no greeting at all. Real user: prefer userName, fall back to
+                        // email, and only set a non-null display name when at least one is
+                        // non-blank — otherwise the greeting renders as "Hello !" (the empty
+                        // string is truthy in the let { ... } we used previously).
                         val displayName =
-                            if (isAnonymous) null
-                            else authState.user.userName.ifBlank { authState.user.userEmail }
+                            when {
+                                isAnonymous -> null
+                                authState.user.userName.isNotBlank() -> authState.user.userName
+                                authState.user.userEmail.isNotBlank() -> authState.user.userEmail
+                                else -> null
+                            }
                         _state.value =
                             State(
                                 isAuthenticated = true,

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
@@ -33,11 +33,14 @@ class SettingsViewModel(
             .onEach { authState ->
                 when (authState) {
                     is AuthState.Authenticated -> {
+                        val isAnonymous = authState.user.isAnonymous
                         val displayName =
-                            authState.user.userName.ifBlank { authState.user.userEmail }
+                            if (isAnonymous) null
+                            else authState.user.userName.ifBlank { authState.user.userEmail }
                         _state.value =
                             State(
                                 isAuthenticated = true,
+                                isAnonymous = isAnonymous,
                                 userName = displayName,
                                 emailAwaitingVerification = null,
                             )
@@ -46,6 +49,7 @@ class SettingsViewModel(
                         _state.value =
                             State(
                                 isAuthenticated = false,
+                                isAnonymous = false,
                                 userName = null,
                                 emailAwaitingVerification = null,
                             )
@@ -54,6 +58,7 @@ class SettingsViewModel(
                         _state.value =
                             State(
                                 isAuthenticated = false,
+                                isAnonymous = false,
                                 userName = null,
                                 emailAwaitingVerification = authState.email,
                             )
@@ -78,6 +83,7 @@ class SettingsViewModel(
 
     data class State(
         val isAuthenticated: Boolean = false,
+        val isAnonymous: Boolean = false,
         val userName: String? = null,
         val emailAwaitingVerification: String? = null,
         val showSignOutConfirmationDialog: Boolean = false,

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="sign_up">Sign Up</string>
     <string name="greeting_authenticated">Hello {name}!</string>
     <string name="email_verification_required">Please check your email ({email}) to verify your account before signing in.</string>
+    <string name="settings_guest_banner">You\'re using ChefMate as a guest. Sign up to back up your recipes across devices.</string>
     <string name="sign_out_confirmation_title">Sign Out</string>
     <string name="sign_out_confirmation_message">Are you sure you want to sign out?</string>
     <string name="sign_out_confirmation_confirm">Sign Out</string>

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="sign_up">Sign Up</string>
     <string name="greeting_authenticated">Hello {name}!</string>
     <string name="email_verification_required">Please check your email ({email}) to verify your account before signing in.</string>
-    <string name="settings_guest_banner">You\'re using ChefMate as a guest. Sign up to back up your recipes across devices.</string>
+    <string name="settings_guest_banner">You’re using ChefMate as a guest. Sign up to back up your recipes across devices.</string>
     <string name="sign_out_confirmation_title">Sign Out</string>
     <string name="sign_out_confirmation_message">Are you sure you want to sign out?</string>
     <string name="sign_out_confirmation_confirm">Sign Out</string>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -26,6 +26,13 @@ interface SettingsBloc {
 
     data class Model(
         val isAuthenticated: Boolean = false,
+        /**
+         * True when the user is signed in via Supabase anonymous auth. Surfaced separately from
+         * [isAuthenticated] because the UI shows neither a greeting nor a Sign-Out row in this
+         * state — anonymous sessions have no credentials to come back to, so "Sign Out" would
+         * silently orphan their data instead of doing what users expect.
+         */
+        val isAnonymous: Boolean = false,
         val greeting: TextData? = null,
         val verificationMessage: TextData? = null,
         val showSignOutConfirmationDialog: Boolean = false,

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
@@ -35,6 +35,7 @@ import chefmate.client.settings.public.generated.resources.greeting_authenticate
 import chefmate.client.settings.public.generated.resources.more
 import chefmate.client.settings.public.generated.resources.privacy_policy
 import chefmate.client.settings.public.generated.resources.settings
+import chefmate.client.settings.public.generated.resources.settings_guest_banner
 import chefmate.client.settings.public.generated.resources.sign_in
 import chefmate.client.settings.public.generated.resources.sign_out
 import chefmate.client.settings.public.generated.resources.sign_out_confirmation_cancel
@@ -71,23 +72,49 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
     PlusNavContainer(
         data = PlusHeaderData.Parent(title = Res.string.more.asTextData()),
         content = {
-            if (viewState.isAuthenticated) {
-                viewState.greeting?.let { greeting ->
-                    GreetingSection(greeting = greeting)
+            when {
+                // Anonymous Supabase session — they're authenticated under the hood (so cloud
+                // sync works) but have no credentials to come back to. Treat them as
+                // "signed out, with a hint they're using a guest account": show Sign In / Sign
+                // Up rows and hide Sign Out (which would silently orphan their data).
+                viewState.isAuthenticated && viewState.isAnonymous -> {
+                    GuestBanner()
                     HorizontalDivider()
-                }
-                SettingsRow(
-                    name = Res.string.sign_out.asTextData(),
-                    onClick = bloc::onSignOutClicked,
-                )
-            } else {
-                viewState.verificationMessage?.let { message ->
-                    EmailVerificationMessage(message = message)
+                    SettingsRow(
+                        name = Res.string.sign_in.asTextData(),
+                        onClick = bloc::onSignInClicked,
+                    )
                     HorizontalDivider()
+                    SettingsRow(
+                        name = Res.string.sign_up.asTextData(),
+                        onClick = bloc::onSignUpClicked,
+                    )
                 }
-                SettingsRow(name = Res.string.sign_in.asTextData(), onClick = bloc::onSignInClicked)
-                HorizontalDivider()
-                SettingsRow(name = Res.string.sign_up.asTextData(), onClick = bloc::onSignUpClicked)
+                viewState.isAuthenticated -> {
+                    viewState.greeting?.let { greeting ->
+                        GreetingSection(greeting = greeting)
+                        HorizontalDivider()
+                    }
+                    SettingsRow(
+                        name = Res.string.sign_out.asTextData(),
+                        onClick = bloc::onSignOutClicked,
+                    )
+                }
+                else -> {
+                    viewState.verificationMessage?.let { message ->
+                        EmailVerificationMessage(message = message)
+                        HorizontalDivider()
+                    }
+                    SettingsRow(
+                        name = Res.string.sign_in.asTextData(),
+                        onClick = bloc::onSignInClicked,
+                    )
+                    HorizontalDivider()
+                    SettingsRow(
+                        name = Res.string.sign_up.asTextData(),
+                        onClick = bloc::onSignUpClicked,
+                    )
+                }
             }
             HorizontalDivider()
             SettingsRow(
@@ -157,6 +184,23 @@ private fun EmailVerificationMessage(message: TextData, modifier: Modifier = Mod
             message.localized(),
             style = ChefMateTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+    }
+}
+
+@Composable
+private fun GuestBanner(modifier: Modifier = Modifier) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.tertiaryContainer)
+                .padding(ChefMateTheme.dimens.paddingNormal)
+    ) {
+        Text(
+            Res.string.settings_guest_banner.asTextData().localized(),
+            style = ChefMateTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
         )
     }
 }
@@ -257,6 +301,34 @@ private val previewBlocAuthenticated =
         override fun onDeveloperSettingsClicked() = Unit
     }
 
+private val previewBlocAnonymous =
+    object : SettingsBloc {
+        override val state =
+            kotlinx.coroutines.flow.MutableStateFlow(
+                SettingsBloc.Model(
+                    isAuthenticated = true,
+                    isAnonymous = true,
+                    versionName = "1.4.3",
+                )
+            )
+
+        override fun onSignInClicked() = Unit
+
+        override fun onSignUpClicked() = Unit
+
+        override fun onSignOutClicked() = Unit
+
+        override fun onSignOutConfirmed() = Unit
+
+        override fun onSignOutDismissed() = Unit
+
+        override fun onUrlClicked(url: String) = Unit
+
+        override fun onAppSettingsClicked() = Unit
+
+        override fun onDeveloperSettingsClicked() = Unit
+    }
+
 @Preview(showBackground = true)
 @Composable
 internal fun SettingsScreenUnauthenticatedPreview() {
@@ -267,6 +339,12 @@ internal fun SettingsScreenUnauthenticatedPreview() {
 @Composable
 internal fun SettingsScreenAuthenticatedPreview() {
     ChefMateTheme { SettingsScreen(bloc = previewBlocAuthenticated) }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun SettingsScreenAnonymousPreview() {
+    ChefMateTheme { SettingsScreen(bloc = previewBlocAnonymous) }
 }
 
 @Preview(showBackground = true)

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -35,29 +35,29 @@ val localProperties =
         }
     }
 
-// Read Supabase credentials from local.properties or environment variables
+// Read Supabase credentials from Gradle properties (e.g. ~/.gradle/gradle.properties) or env vars
 val supabaseUrl =
-    localProperties.getProperty("supabase.url")
+    (findProperty("supabase.url") as? String)
         ?: System.getenv("SUPABASE_URL")
         ?: "https://your-project-id.supabase.co"
 
 val supabaseKey =
-    localProperties.getProperty("supabase.key")
+    (findProperty("supabase.key") as? String)
         ?: System.getenv("SUPABASE_KEY")
         ?: "your-anon-public-key"
 
 val supabaseTestingUrl =
-    localProperties.getProperty("supabase.testing.url")
+    (findProperty("supabase.testing.url") as? String)
         ?: System.getenv("SUPABASE_TESTING_URL")
         ?: supabaseUrl
 
 val supabaseTestingKey =
-    localProperties.getProperty("supabase.testing.key")
+    (findProperty("supabase.testing.key") as? String)
         ?: System.getenv("SUPABASE_TESTING_KEY")
         ?: supabaseKey
 
 val bugsnagApiKey =
-    localProperties.getProperty("bugsnag.apiKey") ?: System.getenv("BUGSNAG_API_KEY") ?: ""
+    (findProperty("bugsnag.apiKey") as? String) ?: System.getenv("BUGSNAG_API_KEY") ?: ""
 
 // Collect test users by incrementing n until a pair is missing. Looked up in order:
 // 1. local.properties at the project root (chefmate.user.<n> / chefmate.user.password.<n>)

--- a/client/util/public/build.gradle.kts
+++ b/client/util/public/build.gradle.kts
@@ -14,7 +14,10 @@ kotlin {
             implementation(compose.ui)
         }
 
-        androidMain.dependencies { implementation(libs.androidx.annotation) }
+        androidMain.dependencies {
+            implementation(libs.androidx.annotation)
+            implementation(libs.androidx.activity.compose)
+        }
     }
 }
 

--- a/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.android.kt
+++ b/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.android.kt
@@ -1,0 +1,47 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+actual fun rememberImagePickerLauncher(onResult: (PickedImage?) -> Unit): () -> Unit {
+    val context = LocalContext.current
+    val currentOnResult = rememberUpdatedState(onResult)
+    val launcher =
+        rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            if (uri == null) {
+                currentOnResult.value(null)
+                return@rememberLauncherForActivityResult
+            }
+            val resolver = context.contentResolver
+            val bytes = resolver.openInputStream(uri)?.use { it.readBytes() }
+            if (bytes == null) {
+                currentOnResult.value(null)
+                return@rememberLauncherForActivityResult
+            }
+            val mimeType = resolver.getType(uri)
+            val extension =
+                when (mimeType) {
+                    "image/png" -> "png"
+                    "image/webp" -> "webp"
+                    "image/heic" -> "heic"
+                    "image/gif" -> "gif"
+                    else -> "jpg"
+                }
+            currentOnResult.value(PickedImage(bytes = bytes, fileExtension = extension))
+        }
+    return remember(launcher) {
+        {
+            launcher.launch(
+                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+            )
+        }
+    }
+}

--- a/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/ImageProcessingUtil.android.kt
+++ b/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/ImageProcessingUtil.android.kt
@@ -1,0 +1,31 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import java.io.ByteArrayOutputStream
+import kotlin.math.min
+
+actual fun decodeImageBitmap(bytes: ByteArray): ImageBitmap =
+    BitmapFactory.decodeByteArray(bytes, 0, bytes.size).asImageBitmap()
+
+actual fun cropImageToSquare(
+    bytes: ByteArray,
+    srcX: Int,
+    srcY: Int,
+    srcSize: Int,
+    maxOutputDim: Int,
+): ByteArray {
+    val src = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    val cropped = Bitmap.createBitmap(src, srcX, srcY, srcSize, srcSize)
+    val finalSize = min(srcSize, maxOutputDim)
+    val output =
+        if (finalSize == srcSize) cropped
+        else Bitmap.createScaledBitmap(cropped, finalSize, finalSize, true)
+    val baos = ByteArrayOutputStream()
+    output.compress(Bitmap.CompressFormat.JPEG, 90, baos)
+    return baos.toByteArray()
+}

--- a/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.kt
+++ b/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.kt
@@ -1,0 +1,21 @@
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+
+data class PickedImage(val bytes: ByteArray, val fileExtension: String) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PickedImage) return false
+        if (fileExtension != other.fileExtension) return false
+        if (!bytes.contentEquals(other.bytes)) return false
+        return true
+    }
+
+    override fun hashCode(): Int = 31 * bytes.contentHashCode() + fileExtension.hashCode()
+}
+
+/**
+ * Returns a launcher that opens the platform's image picker. The provided callback receives the
+ * picked image bytes and file extension, or `null` if the user cancelled.
+ */
+@Composable expect fun rememberImagePickerLauncher(onResult: (PickedImage?) -> Unit): () -> Unit

--- a/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/ImageProcessingUtil.kt
+++ b/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/ImageProcessingUtil.kt
@@ -1,0 +1,18 @@
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+/** Decodes encoded image bytes (JPEG/PNG/etc.) into a Compose [ImageBitmap]. */
+expect fun decodeImageBitmap(bytes: ByteArray): ImageBitmap
+
+/**
+ * Crops the encoded image to a square sub-region and re-encodes as JPEG. The output is also
+ * downscaled to [maxOutputDim] on each side when the source square is larger.
+ */
+expect fun cropImageToSquare(
+    bytes: ByteArray,
+    srcX: Int,
+    srcY: Int,
+    srcSize: Int,
+    maxOutputDim: Int = 1024,
+): ByteArray

--- a/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.ios.kt
+++ b/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.ios.kt
@@ -1,0 +1,106 @@
+@file:Suppress("ktlint:standard:filename")
+@file:OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.PhotosUI.PHPickerConfiguration
+import platform.PhotosUI.PHPickerFilter
+import platform.PhotosUI.PHPickerResult
+import platform.PhotosUI.PHPickerViewController
+import platform.PhotosUI.PHPickerViewControllerDelegateProtocol
+import platform.UIKit.UIApplication
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
+import platform.darwin.NSObject
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
+import platform.posix.memcpy
+
+@Composable
+actual fun rememberImagePickerLauncher(onResult: (PickedImage?) -> Unit): () -> Unit {
+    val currentOnResult = rememberUpdatedState(onResult)
+    return remember {
+        {
+            val configuration =
+                PHPickerConfiguration().apply {
+                    selectionLimit = 1
+                    filter = PHPickerFilter.imagesFilter()
+                }
+            val picker = PHPickerViewController(configuration = configuration)
+            val delegate = ImagePickerDelegate { picked -> currentOnResult.value(picked) }
+            picker.delegate = delegate
+            retainedDelegates[picker] = delegate
+            topViewController()?.presentViewController(picker, animated = true, completion = null)
+        }
+    }
+}
+
+private val retainedDelegates = mutableMapOf<PHPickerViewController, ImagePickerDelegate>()
+
+private class ImagePickerDelegate(private val onResult: (PickedImage?) -> Unit) :
+    NSObject(), PHPickerViewControllerDelegateProtocol {
+    override fun picker(picker: PHPickerViewController, didFinishPicking: List<*>) {
+        picker.dismissViewControllerAnimated(true, completion = null)
+        retainedDelegates.remove(picker)
+        val result = didFinishPicking.firstOrNull() as? PHPickerResult
+        if (result == null) {
+            deliver(null)
+            return
+        }
+        val provider = result.itemProvider
+        val typeIdentifier =
+            when {
+                provider.hasItemConformingToTypeIdentifier("public.jpeg") -> "public.jpeg"
+                provider.hasItemConformingToTypeIdentifier("public.png") -> "public.png"
+                else -> "public.image"
+            }
+        provider.loadDataRepresentationForTypeIdentifier(typeIdentifier) { data, _ ->
+            val bytes = data?.toByteArray()
+            if (bytes == null) {
+                deliver(null)
+            } else {
+                val extension =
+                    when (typeIdentifier) {
+                        "public.png" -> "png"
+                        else -> "jpg"
+                    }
+                deliver(PickedImage(bytes = bytes, fileExtension = extension))
+            }
+        }
+    }
+
+    private fun deliver(result: PickedImage?) {
+        dispatch_async(dispatch_get_main_queue()) { onResult(result) }
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun NSData.toByteArray(): ByteArray {
+    val size = length.toInt()
+    if (size == 0) return ByteArray(0)
+    return ByteArray(size).also { array ->
+        array.usePinned { pinned -> memcpy(pinned.addressOf(0), this.bytes, length) }
+    }
+}
+
+private fun topViewController(): UIViewController? {
+    val keyWindow =
+        UIApplication.sharedApplication.connectedScenes
+            .filterIsInstance<UIWindowScene>()
+            .flatMap { it.windows.map { w -> w as UIWindow } }
+            .firstOrNull { it.isKeyWindow() }
+    var topVC: UIViewController? = keyWindow?.rootViewController
+    while (topVC?.presentedViewController != null) {
+        topVC = topVC.presentedViewController
+    }
+    return topVC
+}

--- a/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/ImageProcessingUtil.ios.kt
+++ b/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/ImageProcessingUtil.ios.kt
@@ -1,0 +1,43 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import kotlin.math.min
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.Surface
+
+actual fun decodeImageBitmap(bytes: ByteArray): ImageBitmap =
+    Image.makeFromEncoded(bytes).toComposeImageBitmap()
+
+actual fun cropImageToSquare(
+    bytes: ByteArray,
+    srcX: Int,
+    srcY: Int,
+    srcSize: Int,
+    maxOutputDim: Int,
+): ByteArray = skikoCropToSquare(bytes, srcX, srcY, srcSize, maxOutputDim)
+
+internal fun skikoCropToSquare(
+    bytes: ByteArray,
+    srcX: Int,
+    srcY: Int,
+    srcSize: Int,
+    maxOutputDim: Int,
+): ByteArray {
+    val image = Image.makeFromEncoded(bytes)
+    val outputSize = min(srcSize, maxOutputDim)
+    val surface = Surface.makeRasterN32Premul(outputSize, outputSize)
+    val canvas = surface.canvas
+    canvas.drawImageRect(
+        image,
+        Rect.makeXYWH(srcX.toFloat(), srcY.toFloat(), srcSize.toFloat(), srcSize.toFloat()),
+        Rect.makeXYWH(0f, 0f, outputSize.toFloat(), outputSize.toFloat()),
+    )
+    val cropped = surface.makeImageSnapshot()
+    val data = cropped.encodeToData(EncodedImageFormat.JPEG, 90) ?: error("JPEG encode failed")
+    return data.bytes
+}

--- a/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.jvm.kt
+++ b/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.jvm.kt
@@ -1,0 +1,49 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import javax.swing.JFileChooser
+import javax.swing.SwingUtilities
+import javax.swing.filechooser.FileNameExtensionFilter
+
+@Composable
+actual fun rememberImagePickerLauncher(onResult: (PickedImage?) -> Unit): () -> Unit {
+    val currentOnResult = rememberUpdatedState(onResult)
+    return remember {
+        {
+            SwingUtilities.invokeLater {
+                val chooser =
+                    JFileChooser().apply {
+                        dialogTitle = "Select recipe photo"
+                        fileFilter =
+                            FileNameExtensionFilter(
+                                "Images",
+                                "jpg",
+                                "jpeg",
+                                "png",
+                                "webp",
+                                "gif",
+                                "heic",
+                            )
+                    }
+                val approved = chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION
+                if (!approved) {
+                    currentOnResult.value(null)
+                    return@invokeLater
+                }
+                val file = chooser.selectedFile
+                if (file == null || !file.canRead()) {
+                    currentOnResult.value(null)
+                    return@invokeLater
+                }
+                val extension = file.extension.ifBlank { "jpg" }.lowercase()
+                currentOnResult.value(
+                    PickedImage(bytes = file.readBytes(), fileExtension = extension)
+                )
+            }
+        }
+    }
+}

--- a/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ImageProcessingUtil.jvm.kt
+++ b/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ImageProcessingUtil.jvm.kt
@@ -1,0 +1,35 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import kotlin.math.min
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.Surface
+
+actual fun decodeImageBitmap(bytes: ByteArray): ImageBitmap =
+    Image.makeFromEncoded(bytes).toComposeImageBitmap()
+
+actual fun cropImageToSquare(
+    bytes: ByteArray,
+    srcX: Int,
+    srcY: Int,
+    srcSize: Int,
+    maxOutputDim: Int,
+): ByteArray {
+    val image = Image.makeFromEncoded(bytes)
+    val outputSize = min(srcSize, maxOutputDim)
+    val surface = Surface.makeRasterN32Premul(outputSize, outputSize)
+    val canvas = surface.canvas
+    canvas.drawImageRect(
+        image,
+        Rect.makeXYWH(srcX.toFloat(), srcY.toFloat(), srcSize.toFloat(), srcSize.toFloat()),
+        Rect.makeXYWH(0f, 0f, outputSize.toFloat(), outputSize.toFloat()),
+    )
+    val cropped = surface.makeImageSnapshot()
+    val data = cropped.encodeToData(EncodedImageFormat.JPEG, 90) ?: error("JPEG encode failed")
+    return data.bytes
+}

--- a/docs/supabase-storage-setup.sql
+++ b/docs/supabase-storage-setup.sql
@@ -1,8 +1,9 @@
 -- Supabase Storage setup for recipe photo uploads.
 -- Paste this into the Supabase SQL editor for each environment (dev, prod, ...).
+-- Idempotent: every `create policy` is preceded by `drop policy if exists`, so this
+-- file is safe to re-run when the setup changes.
 -- Notes:
 --   * storage.objects already has RLS enabled by default.
---   * `create policy` has no `if not exists`; drop a policy first if you need to re-run.
 --   * Every app session has a Supabase auth.uid() — anonymous sign-in is bootstrapped on
 --     app start (SupabaseAuthenticationRepository.kt), so the client always uploads under
 --     "<userId>/<uuid>.<ext>". There is no shared anonymous/ folder.
@@ -24,12 +25,14 @@ on conflict (id) do update set
   allowed_mime_types = excluded.allowed_mime_types;
 
 -- 2. Public read so Coil can load images via bucket.publicUrl(path).
+drop policy if exists "recipe_photos_public_read" on storage.objects;
 create policy "recipe_photos_public_read"
 on storage.objects for select
 to public
 using (bucket_id = 'recipe-photos');
 
 -- 3. Authenticated users (anon-signed-in OR upgraded) can only write inside their own folder.
+drop policy if exists "recipe_photos_owner_insert" on storage.objects;
 create policy "recipe_photos_owner_insert"
 on storage.objects for insert
 to authenticated
@@ -43,6 +46,7 @@ with check (
 -- user with a real auth.uid()) — drop it so the bucket is no longer write-open.
 drop policy if exists "recipe_photos_anon_insert" on storage.objects;
 
+drop policy if exists "recipe_photos_owner_update" on storage.objects;
 create policy "recipe_photos_owner_update"
 on storage.objects for update
 to authenticated
@@ -55,6 +59,7 @@ with check (
   and (storage.foldername(name))[1] = auth.uid()::text
 );
 
+drop policy if exists "recipe_photos_owner_delete" on storage.objects;
 create policy "recipe_photos_owner_delete"
 on storage.objects for delete
 to authenticated

--- a/docs/supabase-storage-setup.sql
+++ b/docs/supabase-storage-setup.sql
@@ -66,62 +66,22 @@ using (
   and (storage.foldername(name))[1] = auth.uid()::text
 );
 
--- 4. Cascade-delete the recipe's photo from storage when the recipe row is deleted.
--- Parses the storage path out of image_url; URLs pointing to other domains
--- (e.g. manually-typed image URLs) are left alone. `security definer` is needed
--- so the function runs as the owner role, which has delete rights on storage.objects.
-create or replace function public.delete_recipe_photo()
-returns trigger
-language plpgsql
-security definer
-set search_path = public, storage
-as $$
-declare
-  storage_path text;
-begin
-  if old.image_url is not null and old.image_url like '%/recipe-photos/%' then
-    storage_path := substring(old.image_url from '/recipe-photos/(.+)$');
-    if storage_path is not null and length(storage_path) > 0 then
-      delete from storage.objects
-      where bucket_id = 'recipe-photos' and name = storage_path;
-    end if;
-  end if;
-  return old;
-end;
-$$;
-
-drop trigger if exists recipes_delete_photo on public.recipes;
-create trigger recipes_delete_photo
-after delete on public.recipes
-for each row execute function public.delete_recipe_photo();
-
--- 4a. When a recipe's image_url is replaced, delete the previous photo from storage.
--- Mirrors the delete trigger so admin updates / other clients also clean up. The
--- client-side photo storage layer also calls deletePhoto() during updateRecipe, so
--- this is belt-and-suspenders for direct DB edits.
-create or replace function public.delete_replaced_recipe_photo()
-returns trigger
-language plpgsql
-security definer
-set search_path = public, storage
-as $$
-declare
-  storage_path text;
-begin
-  if old.image_url is not null and old.image_url like '%/recipe-photos/%' then
-    storage_path := substring(old.image_url from '/recipe-photos/(.+)$');
-    if storage_path is not null and length(storage_path) > 0 then
-      delete from storage.objects
-      where bucket_id = 'recipe-photos' and name = storage_path;
-    end if;
-  end if;
-  return new;
-end;
-$$;
+-- 4. Photo cleanup is handled client-side via the Storage REST API.
+-- Earlier revisions of this file installed AFTER DELETE / AFTER UPDATE triggers on
+-- public.recipes that ran `delete from storage.objects ...` inside `security definer`
+-- functions. Current Supabase rejects direct deletes from storage tables with
+-- "Direct deletion from storage tables is not allowed. Use the Storage API instead."
+-- (PostgrestRestException code 42501), which aborts the parent transaction — so the
+-- recipe row's own UPDATE/DELETE silently rolls back. The block below drops those
+-- triggers and functions on existing projects.
+--
+-- RecipeRepositoryImpl already calls RecipePhotoStorage.deletePhoto() during
+-- updateRecipe (photo swap) and deleteRecipe (recipe gone), which goes through the
+-- Storage REST API, so client-driven cleanup keeps working. Direct dashboard edits
+-- to image_url won't clean up the old object — accept that or re-introduce cleanup
+-- via supabase_functions.http_request once the project's http extension is enabled.
 
 drop trigger if exists recipes_update_photo on public.recipes;
-create trigger recipes_update_photo
-after update of image_url on public.recipes
-for each row
-when (old.image_url is distinct from new.image_url)
-execute function public.delete_replaced_recipe_photo();
+drop trigger if exists recipes_delete_photo on public.recipes;
+drop function if exists public.delete_replaced_recipe_photo();
+drop function if exists public.delete_recipe_photo();

--- a/docs/supabase-storage-setup.sql
+++ b/docs/supabase-storage-setup.sql
@@ -3,7 +3,11 @@
 -- Notes:
 --   * storage.objects already has RLS enabled by default.
 --   * `create policy` has no `if not exists`; drop a policy first if you need to re-run.
---   * The client uploads under "<userId>/<uuid>.<ext>" (see SupabaseRecipePhotoStorage.kt).
+--   * Every app session has a Supabase auth.uid() — anonymous sign-in is bootstrapped on
+--     app start (SupabaseAuthenticationRepository.kt), so the client always uploads under
+--     "<userId>/<uuid>.<ext>". There is no shared anonymous/ folder.
+--   * IMPORTANT: enable Anonymous Sign-ins in the Supabase dashboard under
+--     Authentication → Providers → Anonymous Sign-ins for the bootstrap to succeed.
 
 -- 1. Create the bucket (public, 5 MB cap, image MIME types only).
 insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
@@ -25,7 +29,7 @@ on storage.objects for select
 to public
 using (bucket_id = 'recipe-photos');
 
--- 3. Authenticated users can only write inside their own "<userId>/" folder.
+-- 3. Authenticated users (anon-signed-in OR upgraded) can only write inside their own folder.
 create policy "recipe_photos_owner_insert"
 on storage.objects for insert
 to authenticated
@@ -34,17 +38,10 @@ with check (
   and (storage.foldername(name))[1] = auth.uid()::text
 );
 
--- 3a. Signed-out users can write into the shared "anonymous/" folder.
--- Note: this lets anyone with the anon key upload up to 5 MB at a time.
--- The bucket's file_size_limit + allowed_mime_types are the only abuse
--- guardrails; tighten or remove this policy if quota abuse becomes an issue.
-create policy "recipe_photos_anon_insert"
-on storage.objects for insert
-to anon
-with check (
-  bucket_id = 'recipe-photos'
-  and (storage.foldername(name))[1] = 'anonymous'
-);
+-- 3a. Previous setups installed a policy that let role 'anon' write into a shared
+-- 'anonymous/' folder. We no longer use it (every session is its own anon Supabase
+-- user with a real auth.uid()) — drop it so the bucket is no longer write-open.
+drop policy if exists "recipe_photos_anon_insert" on storage.objects;
 
 create policy "recipe_photos_owner_update"
 on storage.objects for update

--- a/docs/supabase-storage-setup.sql
+++ b/docs/supabase-storage-setup.sql
@@ -1,0 +1,55 @@
+-- Supabase Storage setup for recipe photo uploads.
+-- Paste this into the Supabase SQL editor for each environment (dev, prod, ...).
+-- Notes:
+--   * storage.objects already has RLS enabled by default.
+--   * `create policy` has no `if not exists`; drop a policy first if you need to re-run.
+--   * The client uploads under "<userId>/<uuid>.<ext>" (see SupabaseRecipePhotoStorage.kt).
+
+-- 1. Create the bucket (public, 5 MB cap, image MIME types only).
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'recipe-photos',
+  'recipe-photos',
+  true,
+  5242880, -- 5 MB
+  array['image/jpeg', 'image/png', 'image/webp', 'image/heic']
+)
+on conflict (id) do update set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+-- 2. Public read so Coil can load images via bucket.publicUrl(path).
+create policy "recipe_photos_public_read"
+on storage.objects for select
+to public
+using (bucket_id = 'recipe-photos');
+
+-- 3. Authenticated users can only write inside their own "<userId>/" folder.
+create policy "recipe_photos_owner_insert"
+on storage.objects for insert
+to authenticated
+with check (
+  bucket_id = 'recipe-photos'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+create policy "recipe_photos_owner_update"
+on storage.objects for update
+to authenticated
+using (
+  bucket_id = 'recipe-photos'
+  and (storage.foldername(name))[1] = auth.uid()::text
+)
+with check (
+  bucket_id = 'recipe-photos'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+create policy "recipe_photos_owner_delete"
+on storage.objects for delete
+to authenticated
+using (
+  bucket_id = 'recipe-photos'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);

--- a/docs/supabase-storage-setup.sql
+++ b/docs/supabase-storage-setup.sql
@@ -34,6 +34,18 @@ with check (
   and (storage.foldername(name))[1] = auth.uid()::text
 );
 
+-- 3a. Signed-out users can write into the shared "anonymous/" folder.
+-- Note: this lets anyone with the anon key upload up to 5 MB at a time.
+-- The bucket's file_size_limit + allowed_mime_types are the only abuse
+-- guardrails; tighten or remove this policy if quota abuse becomes an issue.
+create policy "recipe_photos_anon_insert"
+on storage.objects for insert
+to anon
+with check (
+  bucket_id = 'recipe-photos'
+  and (storage.foldername(name))[1] = 'anonymous'
+);
+
 create policy "recipe_photos_owner_update"
 on storage.objects for update
 to authenticated

--- a/docs/supabase-storage-setup.sql
+++ b/docs/supabase-storage-setup.sql
@@ -94,3 +94,34 @@ drop trigger if exists recipes_delete_photo on public.recipes;
 create trigger recipes_delete_photo
 after delete on public.recipes
 for each row execute function public.delete_recipe_photo();
+
+-- 4a. When a recipe's image_url is replaced, delete the previous photo from storage.
+-- Mirrors the delete trigger so admin updates / other clients also clean up. The
+-- client-side photo storage layer also calls deletePhoto() during updateRecipe, so
+-- this is belt-and-suspenders for direct DB edits.
+create or replace function public.delete_replaced_recipe_photo()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, storage
+as $$
+declare
+  storage_path text;
+begin
+  if old.image_url is not null and old.image_url like '%/recipe-photos/%' then
+    storage_path := substring(old.image_url from '/recipe-photos/(.+)$');
+    if storage_path is not null and length(storage_path) > 0 then
+      delete from storage.objects
+      where bucket_id = 'recipe-photos' and name = storage_path;
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists recipes_update_photo on public.recipes;
+create trigger recipes_update_photo
+after update of image_url on public.recipes
+for each row
+when (old.image_url is distinct from new.image_url)
+execute function public.delete_replaced_recipe_photo();

--- a/docs/supabase-storage-setup.sql
+++ b/docs/supabase-storage-setup.sql
@@ -65,3 +65,32 @@ using (
   bucket_id = 'recipe-photos'
   and (storage.foldername(name))[1] = auth.uid()::text
 );
+
+-- 4. Cascade-delete the recipe's photo from storage when the recipe row is deleted.
+-- Parses the storage path out of image_url; URLs pointing to other domains
+-- (e.g. manually-typed image URLs) are left alone. `security definer` is needed
+-- so the function runs as the owner role, which has delete rights on storage.objects.
+create or replace function public.delete_recipe_photo()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, storage
+as $$
+declare
+  storage_path text;
+begin
+  if old.image_url is not null and old.image_url like '%/recipe-photos/%' then
+    storage_path := substring(old.image_url from '/recipe-photos/(.+)$');
+    if storage_path is not null and length(storage_path) > 0 then
+      delete from storage.objects
+      where bucket_id = 'recipe-photos' and name = storage_path;
+    end if;
+  end if;
+  return old;
+end;
+$$;
+
+drop trigger if exists recipes_delete_photo on public.recipes;
+create trigger recipes_delete_photo
+after delete on public.recipes
+for each row execute function public.delete_recipe_photo();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -121,6 +121,7 @@ sqldelight-dialect-sqlite335 = { group = "app.cash.sqldelight", name = "sqlite-3
 supabase-client = { module = "io.github.jan-tennert.supabase:supabase-kt", version.ref = "supabase" }
 supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
 supabase-postgrest = { module = "io.github.jan-tennert.supabase:postgrest-kt", version.ref = "supabase" }
+supabase-storage = { module = "io.github.jan-tennert.supabase:storage-kt", version.ref = "supabase" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 [plugins]


### PR DESCRIPTION
## Summary
- Adds an image picker on the edit recipe screen and uploads the selected photo to a `recipe-photos` Supabase Storage bucket, setting the returned public URL on the recipe (issue #129).
- New cross-platform `rememberImagePickerLauncher` (`client/util/public`): Android `PickVisualMedia`, iOS `PHPickerViewController`, JVM `JFileChooser`.
- New `RecipePhotoStorage` (public interface in `client/recipe/data/public`) backed by Supabase Storage; uploads land under `<userId>/<uuid>.<ext>` so RLS policies can scope per-user.
- `EditRecipeViewModel` gains upload progress + error state, surfaced through `EditRecipeBloc.Model` and a non-blocking dialog on the edit screen. Existing `Image URL` field is kept for manual entry.
- Added `FakeRecipePhotoStorage` plus tests for the success and failure paths in `EditRecipeViewModelTest`.

## Setup notes
- Create a Supabase Storage bucket named `recipe-photos` (public read or signed URLs as you prefer). The client expects `bucket.publicUrl(path)` to be reachable by Coil, so for a private bucket, swap that call for `createSignedUrl(...)`.
- Add an RLS policy that allows authenticated users to insert/select objects under `auth.uid()::text || '/'`.

## Test plan
- [x] `./gradlew ktfmtCheck`
- [x] `./gradlew :client:recipe:core:impl:allTests` (covers the new upload tests)
- [ ] Android: tap **Upload photo**, verify picker opens, image renders inline, recipe saves with the public URL.
- [ ] iOS: same flow via PHPicker.
- [ ] Desktop: same flow via JFileChooser.
- [ ] Force a failure (e.g., bad bucket name) and confirm the error dialog shows and clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)