### PR TITLE
fix(settings): respect dark mode and edge-to-edge insets

### DIFF
--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/AppSettingsPreviews.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/AppSettingsPreviews.kt
@@ -1,0 +1,39 @@
+package com.plusmobileapps.chefmate.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.arkivanov.essenty.backhandler.BackDispatcher
+import com.arkivanov.essenty.backhandler.BackHandler
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+
+private fun appSettingsBloc(model: AppSettingsBloc.Model): AppSettingsBloc =
+    object : AppSettingsBloc {
+        override val backHandler: BackHandler = BackDispatcher()
+        override val state = MutableStateFlow(model)
+
+        override fun onBack() = Unit
+
+        override fun onHistoryEnabledChanged(enabled: Boolean) = Unit
+
+        override fun onClearHistoryClicked() = Unit
+
+        override fun onClearHistoryConfirmed() = Unit
+
+        override fun onClearHistoryDismissed() = Unit
+    }
+
+val previewAppSettingsBloc: AppSettingsBloc =
+    appSettingsBloc(AppSettingsBloc.Model(isHistoryEnabled = true, showClearHistoryDialog = false))
+
+@Preview(showBackground = true)
+@Composable
+internal fun AppSettingsScreenPreview() {
+    ChefMateTheme { AppSettingsScreen(bloc = previewAppSettingsBloc) }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun AppSettingsScreenDarkPreview() {
+    ChefMateTheme(darkTheme = true) { AppSettingsScreen(bloc = previewAppSettingsBloc) }
+}

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/AppSettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/AppSettingsScreen.kt
@@ -26,8 +26,8 @@ import chefmate.client.settings.public.generated.resources.app_settings_title
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
-import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
 @Composable
@@ -41,7 +41,7 @@ fun AppSettingsScreen(bloc: AppSettingsBloc, modifier: Modifier = Modifier) {
         )
     }
 
-    PlusNavContainer(
+    PlusHeaderContainer(
         modifier = modifier,
         data =
             PlusHeaderData.Child(

--- a/client/ui/screenshot-test/build.gradle.kts
+++ b/client/ui/screenshot-test/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(project(":client:text:public"))
     implementation(project(":client:cook:public"))
     implementation(project(":client:recipe:list:public"))
+    implementation(project(":client:settings:public"))
 
     screenshotTestImplementation(libs.screenshot.validation.api)
     screenshotTestImplementation(libs.androidx.compose.ui.tooling)

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AppSettingsScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AppSettingsScreenshotTest.kt
@@ -1,0 +1,27 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.settings.AppSettingsScreen
+import com.plusmobileapps.chefmate.settings.previewAppSettingsBloc
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+// Regression coverage for PR #161: the App Settings screen used PlusNavContainer (no themed
+// background, zeroed status-bar inset) which rendered white in dark mode and pushed the TopAppBar
+// behind the system bars. Migrating to PlusHeaderContainer fixed both. These shots lock that in.
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun AppSettingsLightScreenshot() {
+    ChefMateTheme { AppSettingsScreen(bloc = previewAppSettingsBloc) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun AppSettingsDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) { AppSettingsScreen(bloc = previewAppSettingsBloc) }
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AppSettingsScreenshotTestKt/AppSettingsDarkScreenshot_4d30ee2f_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AppSettingsScreenshotTestKt/AppSettingsDarkScreenshot_4d30ee2f_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf3061acc9f5f9761d472eb598e2f9e4c91d1803911be189091744b821882dfb
+size 41365

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AppSettingsScreenshotTestKt/AppSettingsLightScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AppSettingsScreenshotTestKt/AppSettingsLightScreenshot_748aa731_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fea11d995e25e7f859593cdb8b7c3252d9ba504e28de18205733df42e28123fa
+size 40995


### PR DESCRIPTION
## Symptoms

App Settings (More tab → Settings) had two visible bugs:
- **Dark mode ignored** — the body of the screen rendered white even when the system theme was dark. The "Browser" section header (themed purple) and the toggle (themed accent) drew correctly, but the surrounding surface was white.
- **Edge-to-edge broken** — the dark status bar abutted a white content surface with a visible seam, and the title text overlapped the status bar / back arrow region.

## Root cause

`AppSettingsScreen` was using [`PlusNavContainer`](client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusNavContainer.kt), which:
1. Wraps content in a plain `Column` with **no `.background(...)`** and no `Surface` — it inherits whatever color is behind it.
2. Calls `PlusHeader(..., windowInsets = WindowInsets())`, explicitly **zeroing out the status-bar inset**.

That contract works for the bottom-nav children (`RecipeList`, `GroceryList`, `MealPlan`, `SettingsScreen` More-tab) because [`MobileBottomNavContent`](client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt) wraps them in a Material 3 `Scaffold`, which supplies both `containerColor = colorScheme.background` and the system-bar padding via `paddingValues`.

`AppSettingsScreen` is **not** a bottom-nav child. It is a root-stack child rendered directly by [`RootScreen`](client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt) (`is RootBloc.Child.AppSettings -> AppSettingsScreen(child.bloc)`), with no `Scaffold` between it and the `SharedTransitionLayout`. So the missing background fell through to white, and the zeroed status-bar inset put the TopAppBar at `y=0`.

The fix is to use [`PlusHeaderContainer`](client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt), which is what every other root-stack screen (`RecipeDetailScreen`, `GroceryDetailScreen`, `EditRecipeScreen`, …) already uses. It wraps content in a `Surface` colored `ChefMateTheme.colorScheme.background` and lets `PlusHeader` resolve its own `statusBars + displayCutout` insets.

## Diff

```diff
-import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 ...
-    PlusNavContainer(
+    PlusHeaderContainer(
         modifier = modifier,
         data =
             PlusHeaderData.Child(
```

Two-line import + call-site swap; no behavior change for screens that still use `PlusNavContainer` (the bottom-nav tabs).

## Tests / snapshots

- No snapshot tests exist for `AppSettingsScreen` (or any settings screen) in `client/ui/screenshot-test/`, so nothing to regenerate.
- `:client:settings:public:compileKotlinJvm` — passes.
- `:client:settings:impl:jvmTest` — passes (`AppSettingsBlocImplTest`, `SettingsBlocImplTest`).
- `:client:settings:public:ktfmtCheck` — passes.

## Test plan

- [ ] Open the app on Android in **dark mode**, navigate More → Settings, and confirm the body, toggle row, and "Clear browser history" row use the dark surface.
- [ ] Confirm in **light mode** the screen still looks the same as before (no regression).
- [ ] Confirm the TopAppBar is below the status bar (no seam, no overlap with the back arrow).
- [ ] Confirm the back arrow still navigates back to the More tab.
- [ ] Toggle "Browser history enabled" and confirm the switch state still persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)