### PR TITLE
feat(settings): reorder bottom navigation tabs

### DIFF
--- a/client/bottomnav/impl/build.gradle.kts
+++ b/client/bottomnav/impl/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
             api(projects.client.recipe.list.public)
             api(projects.client.settings.public)
         }
+        commonTest.dependencies { implementation(libs.multiplatform.settings.test) }
     }
 }
 

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavOrderBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavOrderBlocImpl.kt
@@ -1,0 +1,55 @@
+package com.plusmobileapps.chefmate.recipe.bottomnav.impl
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.getViewModel
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc.Output
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides
+import kotlinx.coroutines.flow.StateFlow
+
+@AssistedInject
+class BottomNavOrderBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<Output>,
+    viewModelFactory: Provider<BottomNavOrderViewModel>,
+) : BottomNavOrderBloc, BlocContext by context {
+
+    @AssistedFactory
+    fun interface ManagedFactory {
+        fun create(context: BlocContext, output: Consumer<Output>): BottomNavOrderBlocImpl
+    }
+
+    private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
+
+    override val state: StateFlow<BottomNavOrderBloc.Model> = viewModel.state
+
+    override fun onMove(from: Int, to: Int) {
+        viewModel.move(from, to)
+    }
+
+    override fun onSave() {
+        viewModel.save()
+        output.onNext(Output.Back)
+    }
+
+    override fun onBack() {
+        output.onNext(Output.Back)
+    }
+}
+
+@ContributesTo(AppScope::class)
+interface BottomNavOrderBlocBindingModule {
+    @Provides
+    fun provideBottomNavOrderBlocFactory(
+        factory: BottomNavOrderBlocImpl.ManagedFactory
+    ): BottomNavOrderBloc.Factory = BottomNavOrderBloc.Factory { context, output ->
+        factory.create(context, output)
+    }
+}

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavOrderViewModel.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavOrderViewModel.kt
@@ -1,0 +1,53 @@
+package com.plusmobileapps.chefmate.recipe.bottomnav.impl
+
+import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.TabOrderPreferences
+import dev.zacsweers.metro.Inject
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+
+@Inject
+class BottomNavOrderViewModel(
+    @Main mainContext: CoroutineContext,
+    private val tabOrderPreferences: TabOrderPreferences,
+) : ViewModel(mainContext) {
+
+    private val initialOrder = tabOrderPreferences.tabOrder.value
+
+    private val _state =
+        MutableStateFlow(
+            BottomNavOrderBloc.Model(editedOrder = initialOrder, persistedOrder = initialOrder)
+        )
+    val state: StateFlow<BottomNavOrderBloc.Model> = _state.asStateFlow()
+
+    init {
+        // Keep `persistedOrder` in sync with the repository so external writes (e.g. the user adds
+        // a new tab in a future build) update the "Save" affordance correctly.
+        tabOrderPreferences.tabOrder
+            .onEach { latest -> _state.update { it.copy(persistedOrder = latest) } }
+            .launchIn(scope)
+    }
+
+    fun move(from: Int, to: Int) {
+        _state.update { current ->
+            val list = current.editedOrder
+            if (from !in list.indices || to !in list.indices || from == to) return@update current
+            val mutable = list.toMutableList()
+            val item = mutable.removeAt(from)
+            mutable.add(to, item)
+            current.copy(editedOrder = mutable)
+        }
+    }
+
+    fun save() {
+        val order = _state.value.editedOrder
+        tabOrderPreferences.setTabOrder(order)
+    }
+}

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavViewModel.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavViewModel.kt
@@ -3,21 +3,30 @@ package com.plusmobileapps.chefmate.recipe.bottomnav.impl
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
-import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Tab.BROWSER
-import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Tab.GROCERIES
-import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Tab.MEALS
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Tab.RECIPES
-import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Tab.SETTINGS
+import com.plusmobileapps.chefmate.recipe.bottomnav.TabOrderPreferences
 import dev.zacsweers.metro.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 
 @Inject
-class BottomNavViewModel(@Main mainContext: CoroutineContext) : ViewModel(mainContext) {
-    private val _state = MutableStateFlow(State())
+class BottomNavViewModel(
+    @Main mainContext: CoroutineContext,
+    tabOrderPreferences: TabOrderPreferences,
+) : ViewModel(mainContext) {
+    private val _state = MutableStateFlow(State(tabs = tabOrderPreferences.tabOrder.value))
     val state: StateFlow<State> = _state.asStateFlow()
+
+    init {
+        tabOrderPreferences.tabOrder
+            .onEach { latest -> _state.update { it.copy(tabs = latest) } }
+            .launchIn(scope)
+    }
 
     fun selectTab(tab: BottomNavBloc.Tab) {
         _state.value = _state.value.copy(selectedTab = tab)
@@ -25,6 +34,6 @@ class BottomNavViewModel(@Main mainContext: CoroutineContext) : ViewModel(mainCo
 
     data class State(
         val selectedTab: BottomNavBloc.Tab = RECIPES,
-        val tabs: List<BottomNavBloc.Tab> = listOf(RECIPES, GROCERIES, MEALS, BROWSER, SETTINGS),
+        val tabs: List<BottomNavBloc.Tab>,
     )
 }

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/TabOrderPreferencesImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/TabOrderPreferencesImpl.kt
@@ -1,0 +1,57 @@
+package com.plusmobileapps.chefmate.recipe.bottomnav.impl
+
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.recipe.bottomnav.BOTTOM_NAV_TAB_ORDER_KEY
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.DEFAULT_TAB_ORDER
+import com.plusmobileapps.chefmate.recipe.bottomnav.TabOrderPreferences
+import com.plusmobileapps.chefmate.recipe.bottomnav.stableId
+import com.plusmobileapps.chefmate.recipe.bottomnav.tabFromStableId
+import com.russhwolf.settings.Settings
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class TabOrderPreferencesImpl(private val settings: Settings) : TabOrderPreferences {
+
+    private val _tabOrder = MutableStateFlow(readPersisted())
+
+    override val tabOrder: StateFlow<List<BottomNavBloc.Tab>> = _tabOrder.asStateFlow()
+
+    override fun setTabOrder(tabs: List<BottomNavBloc.Tab>) {
+        val normalized = normalize(tabs)
+        settings.putString(
+            BOTTOM_NAV_TAB_ORDER_KEY,
+            normalized.joinToString(SEPARATOR) { it.stableId },
+        )
+        _tabOrder.value = normalized
+    }
+
+    private fun readPersisted(): List<BottomNavBloc.Tab> {
+        val raw = settings.getStringOrNull(BOTTOM_NAV_TAB_ORDER_KEY) ?: return DEFAULT_TAB_ORDER
+        if (raw.isBlank()) return DEFAULT_TAB_ORDER
+        val parsed = raw.split(SEPARATOR).mapNotNull(::tabFromStableId)
+        return normalize(parsed)
+    }
+
+    /**
+     * Drops duplicates and unknown ids, then appends any tabs missing from the persisted list so
+     * newly added tabs surface at the end without corrupting user order.
+     */
+    private fun normalize(tabs: List<BottomNavBloc.Tab>): List<BottomNavBloc.Tab> {
+        val seen = LinkedHashSet<BottomNavBloc.Tab>()
+        tabs.forEach { seen.add(it) }
+        BottomNavBloc.Tab.entries.forEach { seen.add(it) }
+        return seen.toList()
+    }
+
+    private companion object {
+        const val SEPARATOR = ","
+    }
+}

--- a/client/bottomnav/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavOrderViewModelTest.kt
+++ b/client/bottomnav/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavOrderViewModelTest.kt
@@ -1,0 +1,111 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.plusmobileapps.chefmate.recipe.bottomnav.impl
+
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.DEFAULT_TAB_ORDER
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+class BottomNavOrderViewModelTest {
+
+    private val mainContext = UnconfinedTestDispatcher()
+
+    @Test
+    fun initial_state_mirrors_persisted_order_with_no_unsaved_changes() {
+        val prefs = FakeTabOrderPreferences()
+        val vm = BottomNavOrderViewModel(mainContext = mainContext, tabOrderPreferences = prefs)
+        vm.state.value.editedOrder shouldBe DEFAULT_TAB_ORDER
+        vm.state.value.persistedOrder shouldBe DEFAULT_TAB_ORDER
+        vm.state.value.hasUnsavedChanges shouldBe false
+    }
+
+    @Test
+    fun move_reorders_edited_order_and_marks_unsaved_changes() {
+        val vm = newViewModel()
+        // Move RECIPES (idx 0) to idx 2; edited order becomes GROCERIES, MEALS, RECIPES, BROWSER,
+        // MORE
+        vm.move(0, 2)
+        vm.state.value.editedOrder shouldBe
+            listOf(
+                BottomNavBloc.Tab.GROCERIES,
+                BottomNavBloc.Tab.MEALS,
+                BottomNavBloc.Tab.RECIPES,
+                BottomNavBloc.Tab.BROWSER,
+                BottomNavBloc.Tab.SETTINGS,
+            )
+        vm.state.value.hasUnsavedChanges shouldBe true
+    }
+
+    @Test
+    fun move_with_out_of_bounds_indices_is_a_no_op() {
+        val vm = newViewModel()
+        vm.move(from = -1, to = 3)
+        vm.move(from = 0, to = 99)
+        vm.move(from = 0, to = 0)
+        vm.state.value.editedOrder shouldBe DEFAULT_TAB_ORDER
+        vm.state.value.hasUnsavedChanges shouldBe false
+    }
+
+    @Test
+    fun save_writes_edited_order_to_preferences_and_clears_unsaved_changes() {
+        val prefs = FakeTabOrderPreferences()
+        val vm = BottomNavOrderViewModel(mainContext = mainContext, tabOrderPreferences = prefs)
+        vm.move(0, 4)
+        vm.state.value.hasUnsavedChanges shouldBe true
+
+        vm.save()
+
+        val expected =
+            listOf(
+                BottomNavBloc.Tab.GROCERIES,
+                BottomNavBloc.Tab.MEALS,
+                BottomNavBloc.Tab.BROWSER,
+                BottomNavBloc.Tab.SETTINGS,
+                BottomNavBloc.Tab.RECIPES,
+            )
+        prefs.tabOrder.value shouldBe expected
+        vm.state.value.persistedOrder shouldBe expected
+        vm.state.value.hasUnsavedChanges shouldBe false
+    }
+
+    @Test
+    fun cancel_path_dropping_view_model_does_not_mutate_persisted_order() {
+        val prefs = FakeTabOrderPreferences()
+        val vm = BottomNavOrderViewModel(mainContext = mainContext, tabOrderPreferences = prefs)
+        vm.move(0, 3)
+
+        // Simulating "cancel": discard the ViewModel without calling save(). The persisted order
+        // must remain untouched, which is what the production path achieves by simply not calling
+        // save() before the bloc's `Output.Back` is delivered.
+        vm.onCleared()
+
+        prefs.tabOrder.value shouldBe DEFAULT_TAB_ORDER
+    }
+
+    @Test
+    fun external_preference_change_updates_persisted_order_in_state() {
+        val prefs = FakeTabOrderPreferences()
+        val vm = BottomNavOrderViewModel(mainContext = mainContext, tabOrderPreferences = prefs)
+
+        val newOrder =
+            listOf(
+                BottomNavBloc.Tab.SETTINGS,
+                BottomNavBloc.Tab.BROWSER,
+                BottomNavBloc.Tab.MEALS,
+                BottomNavBloc.Tab.GROCERIES,
+                BottomNavBloc.Tab.RECIPES,
+            )
+        prefs.setTabOrder(newOrder)
+
+        vm.state.value.persistedOrder shouldBe newOrder
+    }
+
+    private fun newViewModel(
+        prefs: FakeTabOrderPreferences = FakeTabOrderPreferences()
+    ): BottomNavOrderViewModel =
+        BottomNavOrderViewModel(mainContext = mainContext, tabOrderPreferences = prefs)
+}

--- a/client/bottomnav/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavViewModelTest.kt
+++ b/client/bottomnav/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavViewModelTest.kt
@@ -1,0 +1,49 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.plusmobileapps.chefmate.recipe.bottomnav.impl
+
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.DEFAULT_TAB_ORDER
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+class BottomNavViewModelTest {
+
+    private val mainContext = UnconfinedTestDispatcher()
+
+    @Test
+    fun initial_tabs_are_seeded_from_preferences() {
+        val customOrder =
+            listOf(
+                BottomNavBloc.Tab.SETTINGS,
+                BottomNavBloc.Tab.RECIPES,
+                BottomNavBloc.Tab.GROCERIES,
+                BottomNavBloc.Tab.MEALS,
+                BottomNavBloc.Tab.BROWSER,
+            )
+        val prefs = FakeTabOrderPreferences(initial = customOrder)
+        val vm = BottomNavViewModel(mainContext = mainContext, tabOrderPreferences = prefs)
+        vm.state.value.tabs shouldBe customOrder
+    }
+
+    @Test
+    fun preferences_updates_propagate_to_state() {
+        val prefs = FakeTabOrderPreferences()
+        val vm = BottomNavViewModel(mainContext = mainContext, tabOrderPreferences = prefs)
+        vm.state.value.tabs shouldBe DEFAULT_TAB_ORDER
+
+        val newOrder =
+            listOf(
+                BottomNavBloc.Tab.MEALS,
+                BottomNavBloc.Tab.RECIPES,
+                BottomNavBloc.Tab.GROCERIES,
+                BottomNavBloc.Tab.BROWSER,
+                BottomNavBloc.Tab.SETTINGS,
+            )
+        prefs.setTabOrder(newOrder)
+        vm.state.value.tabs shouldBe newOrder
+    }
+}

--- a/client/bottomnav/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/FakeTabOrderPreferences.kt
+++ b/client/bottomnav/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/FakeTabOrderPreferences.kt
@@ -1,0 +1,18 @@
+package com.plusmobileapps.chefmate.recipe.bottomnav.impl
+
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.DEFAULT_TAB_ORDER
+import com.plusmobileapps.chefmate.recipe.bottomnav.TabOrderPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeTabOrderPreferences(initial: List<BottomNavBloc.Tab> = DEFAULT_TAB_ORDER) :
+    TabOrderPreferences {
+    private val _tabOrder = MutableStateFlow(initial)
+    override val tabOrder: StateFlow<List<BottomNavBloc.Tab>> = _tabOrder.asStateFlow()
+
+    override fun setTabOrder(tabs: List<BottomNavBloc.Tab>) {
+        _tabOrder.value = tabs
+    }
+}

--- a/client/bottomnav/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/TabOrderPreferencesImplTest.kt
+++ b/client/bottomnav/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/TabOrderPreferencesImplTest.kt
@@ -1,0 +1,77 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.recipe.bottomnav.impl
+
+import com.plusmobileapps.chefmate.recipe.bottomnav.BOTTOM_NAV_TAB_ORDER_KEY
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.DEFAULT_TAB_ORDER
+import com.russhwolf.settings.MapSettings
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class TabOrderPreferencesImplTest {
+
+    @Test
+    fun defaults_to_canonical_order_when_no_persisted_value() {
+        val prefs = TabOrderPreferencesImpl(MapSettings())
+        prefs.tabOrder.value shouldBe DEFAULT_TAB_ORDER
+    }
+
+    @Test
+    fun reads_persisted_order_from_settings() {
+        val settings = MapSettings()
+        settings.putString(BOTTOM_NAV_TAB_ORDER_KEY, "more,recipes,groceries,meal_plan,browser")
+        val prefs = TabOrderPreferencesImpl(settings)
+        prefs.tabOrder.value shouldBe
+            listOf(
+                BottomNavBloc.Tab.SETTINGS,
+                BottomNavBloc.Tab.RECIPES,
+                BottomNavBloc.Tab.GROCERIES,
+                BottomNavBloc.Tab.MEALS,
+                BottomNavBloc.Tab.BROWSER,
+            )
+    }
+
+    @Test
+    fun unknown_ids_are_dropped_and_missing_tabs_appended() {
+        val settings = MapSettings()
+        // Only two known ids, plus an unknown — the rest should append in canonical order.
+        settings.putString(BOTTOM_NAV_TAB_ORDER_KEY, "more,unknown,recipes")
+        val prefs = TabOrderPreferencesImpl(settings)
+        prefs.tabOrder.value shouldBe
+            listOf(
+                BottomNavBloc.Tab.SETTINGS,
+                BottomNavBloc.Tab.RECIPES,
+                BottomNavBloc.Tab.GROCERIES,
+                BottomNavBloc.Tab.MEALS,
+                BottomNavBloc.Tab.BROWSER,
+            )
+    }
+
+    @Test
+    fun setTabOrder_persists_stable_ids_and_updates_state_flow() {
+        val settings = MapSettings()
+        val prefs = TabOrderPreferencesImpl(settings)
+
+        prefs.setTabOrder(
+            listOf(
+                BottomNavBloc.Tab.SETTINGS,
+                BottomNavBloc.Tab.BROWSER,
+                BottomNavBloc.Tab.MEALS,
+                BottomNavBloc.Tab.GROCERIES,
+                BottomNavBloc.Tab.RECIPES,
+            )
+        )
+
+        settings.getString(BOTTOM_NAV_TAB_ORDER_KEY, "") shouldBe
+            "more,browser,meal_plan,groceries,recipes"
+        prefs.tabOrder.value shouldBe
+            listOf(
+                BottomNavBloc.Tab.SETTINGS,
+                BottomNavBloc.Tab.BROWSER,
+                BottomNavBloc.Tab.MEALS,
+                BottomNavBloc.Tab.GROCERIES,
+                BottomNavBloc.Tab.RECIPES,
+            )
+    }
+}

--- a/client/bottomnav/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/bottomnav/public/src/commonMain/composeResources/values/strings.xml
@@ -4,4 +4,8 @@
     <string name="tab_meals">Meals</string>
     <string name="tab_recipes">Recipes</string>
     <string name="tab_more">More</string>
+    <string name="bottom_nav_order_title">Bottom navigation order</string>
+    <string name="bottom_nav_order_settings_row">Bottom navigation order</string>
+    <string name="bottom_nav_order_save">Save</string>
+    <string name="bottom_nav_order_drag_handle_content_description">Drag to reorder</string>
 </resources>

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderBloc.kt
@@ -1,0 +1,31 @@
+package com.plusmobileapps.chefmate.recipe.bottomnav
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import kotlinx.coroutines.flow.StateFlow
+
+interface BottomNavOrderBloc {
+    val state: StateFlow<Model>
+
+    fun onMove(from: Int, to: Int)
+
+    fun onSave()
+
+    fun onBack()
+
+    data class Model(
+        val editedOrder: List<BottomNavBloc.Tab> = DEFAULT_TAB_ORDER,
+        val persistedOrder: List<BottomNavBloc.Tab> = DEFAULT_TAB_ORDER,
+    ) {
+        val hasUnsavedChanges: Boolean
+            get() = editedOrder != persistedOrder
+    }
+
+    sealed class Output {
+        data object Back : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): BottomNavOrderBloc
+    }
+}

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderPreviews.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderPreviews.kt
@@ -20,8 +20,7 @@ val previewBottomNavOrderBloc: BottomNavOrderBloc = bottomNavOrderBloc(BottomNav
 
 /**
  * A reordered + dirty state: SETTINGS has been moved to the top so
- * [BottomNavOrderBloc.Model. hasUnsavedChanges] resolves to `true` and the Save button renders
- * enabled.
+ * [BottomNavOrderBloc.Model.hasUnsavedChanges] resolves to `true` and the Save FAB is visible.
  */
 val previewBottomNavOrderDirtyBloc: BottomNavOrderBloc =
     bottomNavOrderBloc(

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderPreviews.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderPreviews.kt
@@ -1,0 +1,57 @@
+package com.plusmobileapps.chefmate.recipe.bottomnav
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+
+private fun bottomNavOrderBloc(model: BottomNavOrderBloc.Model): BottomNavOrderBloc =
+    object : BottomNavOrderBloc {
+        override val state = MutableStateFlow(model)
+
+        override fun onMove(from: Int, to: Int) = Unit
+
+        override fun onSave() = Unit
+
+        override fun onBack() = Unit
+    }
+
+val previewBottomNavOrderBloc: BottomNavOrderBloc = bottomNavOrderBloc(BottomNavOrderBloc.Model())
+
+/**
+ * A reordered + dirty state: SETTINGS has been moved to the top so
+ * [BottomNavOrderBloc.Model. hasUnsavedChanges] resolves to `true` and the Save button renders
+ * enabled.
+ */
+val previewBottomNavOrderDirtyBloc: BottomNavOrderBloc =
+    bottomNavOrderBloc(
+        BottomNavOrderBloc.Model(
+            editedOrder =
+                listOf(
+                    BottomNavBloc.Tab.SETTINGS,
+                    BottomNavBloc.Tab.RECIPES,
+                    BottomNavBloc.Tab.GROCERIES,
+                    BottomNavBloc.Tab.MEALS,
+                    BottomNavBloc.Tab.BROWSER,
+                ),
+            persistedOrder = DEFAULT_TAB_ORDER,
+        )
+    )
+
+@Preview(showBackground = true)
+@Composable
+internal fun BottomNavOrderScreenPreview() {
+    ChefMateTheme { BottomNavOrderScreen(bloc = previewBottomNavOrderBloc) }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun BottomNavOrderScreenDarkPreview() {
+    ChefMateTheme(darkTheme = true) { BottomNavOrderScreen(bloc = previewBottomNavOrderBloc) }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun BottomNavOrderScreenDirtyPreview() {
+    ChefMateTheme { BottomNavOrderScreen(bloc = previewBottomNavOrderDirtyBloc) }
+}

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderScreen.kt
@@ -1,9 +1,13 @@
 package com.plusmobileapps.chefmate.recipe.bottomnav
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,8 +22,8 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DragHandle
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -43,8 +47,9 @@ import chefmate.client.bottomnav.public.generated.resources.bottom_nav_order_dra
 import chefmate.client.bottomnav.public.generated.resources.bottom_nav_order_save
 import chefmate.client.bottomnav.public.generated.resources.bottom_nav_order_title
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusFloatingActionButton
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
-import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import org.jetbrains.compose.resources.stringResource
 
@@ -52,41 +57,35 @@ import org.jetbrains.compose.resources.stringResource
 fun BottomNavOrderScreen(bloc: BottomNavOrderBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
 
-    // Wrap in a themed Surface so the empty area between the tab list and the Save bar respects
-    // the active color scheme — matches the pattern PR #161 used for AppSettings to avoid white
-    // background bleed in dark mode.
-    Surface(
-        modifier = modifier.fillMaxSize(),
-        color = ChefMateTheme.colorScheme.background,
-        contentColor = ChefMateTheme.colorScheme.onBackground,
+    PlusHeaderContainer(
+        modifier = modifier,
+        scrollEnabled = false,
+        data =
+            PlusHeaderData.Child(
+                title = Res.string.bottom_nav_order_title.asTextData(),
+                onBackClick = bloc::onBack,
+            ),
+        floatingActionButton = {
+            // Hide the Save FAB until something has actually been reordered. AnimatedVisibility
+            // gives it a quick fade+scale entrance so the affordance doesn't pop in abruptly on
+            // the first move.
+            AnimatedVisibility(
+                visible = state.hasUnsavedChanges,
+                enter = scaleIn() + fadeIn(),
+                exit = scaleOut() + fadeOut(),
+            ) {
+                PlusFloatingActionButton(
+                    text = stringResource(Res.string.bottom_nav_order_save),
+                    icon = Icons.Default.Check,
+                    onClick = bloc::onSave,
+                )
+            }
+        },
     ) {
-        PlusNavContainer(
-            scrollEnabled = false,
-            data =
-                PlusHeaderData.Child(
-                    title = Res.string.bottom_nav_order_title.asTextData(),
-                    onBackClick = bloc::onBack,
-                ),
-            content = {
-                Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                    ReorderableTabList(
-                        tabs = state.editedOrder,
-                        onMove = bloc::onMove,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
-                Surface(tonalElevation = 4.dp) {
-                    Row(
-                        modifier =
-                            Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal),
-                        horizontalArrangement = Arrangement.End,
-                    ) {
-                        Button(onClick = bloc::onSave, enabled = state.hasUnsavedChanges) {
-                            Text(stringResource(Res.string.bottom_nav_order_save))
-                        }
-                    }
-                }
-            },
+        ReorderableTabList(
+            tabs = state.editedOrder,
+            onMove = bloc::onMove,
+            modifier = Modifier.fillMaxSize(),
         )
     }
 }
@@ -102,12 +101,17 @@ private fun ReorderableTabList(
     var dragOffsetY by remember { mutableStateOf(0f) }
 
     LazyColumn(state = listState, modifier = modifier) {
-        itemsIndexed(items = tabs, key = { _, tab -> tab.name }) { index, tab ->
+        itemsIndexed(items = tabs, key = { _, tab -> tab.name }) { _, tab ->
             val isDragging = tab == draggingId
             ReorderableTabRow(
                 tab = tab,
                 isDragging = isDragging,
                 offsetY = if (isDragging) dragOffsetY else 0f,
+                // Animate placement for non-dragged rows so they slide into the slot the dragged
+                // row vacates. Skip it for the dragged row itself — its position is driven by a
+                // manual translationY and offset compensation in `onDrag`, so an animated
+                // placement would fight that and visually lag the finger.
+                modifier = if (isDragging) Modifier else Modifier.animateItem(),
                 onDragStart = {
                     draggingId = tab
                     dragOffsetY = 0f
@@ -147,6 +151,7 @@ private fun ReorderableTabRow(
     onDragStart: () -> Unit,
     onDrag: (Float) -> Unit,
     onDragEnd: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val dragDescription =
         stringResource(Res.string.bottom_nav_order_drag_handle_content_description)
@@ -169,7 +174,8 @@ private fun ReorderableTabRow(
         shadowElevation = elevation,
         shape = RoundedCornerShape(cornerRadius),
         modifier =
-            Modifier.fillMaxWidth()
+            modifier
+                .fillMaxWidth()
                 // LazyColumn paints items in source order, so a row dragged downward would render
                 // beneath the rows it overlaps. Lifting `zIndex` keeps the dragged row on top in
                 // either direction.

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderScreen.kt
@@ -48,34 +48,43 @@ import org.jetbrains.compose.resources.stringResource
 fun BottomNavOrderScreen(bloc: BottomNavOrderBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
 
-    PlusNavContainer(
-        modifier = modifier,
-        scrollEnabled = false,
-        data =
-            PlusHeaderData.Child(
-                title = Res.string.bottom_nav_order_title.asTextData(),
-                onBackClick = bloc::onBack,
-            ),
-        content = {
-            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                ReorderableTabList(
-                    tabs = state.editedOrder,
-                    onMove = bloc::onMove,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            }
-            Surface(tonalElevation = 4.dp) {
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    Button(onClick = bloc::onSave, enabled = state.hasUnsavedChanges) {
-                        Text(stringResource(Res.string.bottom_nav_order_save))
+    // Wrap in a themed Surface so the empty area between the tab list and the Save bar respects
+    // the active color scheme — matches the pattern PR #161 used for AppSettings to avoid white
+    // background bleed in dark mode.
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = ChefMateTheme.colorScheme.background,
+        contentColor = ChefMateTheme.colorScheme.onBackground,
+    ) {
+        PlusNavContainer(
+            scrollEnabled = false,
+            data =
+                PlusHeaderData.Child(
+                    title = Res.string.bottom_nav_order_title.asTextData(),
+                    onBackClick = bloc::onBack,
+                ),
+            content = {
+                Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                    ReorderableTabList(
+                        tabs = state.editedOrder,
+                        onMove = bloc::onMove,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+                Surface(tonalElevation = 4.dp) {
+                    Row(
+                        modifier =
+                            Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        Button(onClick = bloc::onSave, enabled = state.hasUnsavedChanges) {
+                            Text(stringResource(Res.string.bottom_nav_order_save))
+                        }
                     }
                 }
-            }
-        },
-    )
+            },
+        )
+    }
 }
 
 @Composable
@@ -191,20 +200,3 @@ private fun androidx.compose.foundation.lazy.LazyListState.rowHeightFor(
     tab: BottomNavBloc.Tab
 ): Float? =
     layoutInfo.visibleItemsInfo.firstOrNull { (it.key as? String) == tab.name }?.size?.toFloat()
-
-private val previewBloc =
-    object : BottomNavOrderBloc {
-        override val state = kotlinx.coroutines.flow.MutableStateFlow(BottomNavOrderBloc.Model())
-
-        override fun onMove(from: Int, to: Int) = Unit
-
-        override fun onSave() = Unit
-
-        override fun onBack() = Unit
-    }
-
-@androidx.compose.ui.tooling.preview.Preview
-@Composable
-internal fun BottomNavOrderScreenPreview() {
-    ChefMateTheme { BottomNavOrderScreen(bloc = previewBloc) }
-}

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderScreen.kt
@@ -1,0 +1,210 @@
+package com.plusmobileapps.chefmate.recipe.bottomnav
+
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import chefmate.client.bottomnav.public.generated.resources.Res
+import chefmate.client.bottomnav.public.generated.resources.bottom_nav_order_drag_handle_content_description
+import chefmate.client.bottomnav.public.generated.resources.bottom_nav_order_save
+import chefmate.client.bottomnav.public.generated.resources.bottom_nav_order_title
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun BottomNavOrderScreen(bloc: BottomNavOrderBloc, modifier: Modifier = Modifier) {
+    val state by bloc.state.collectAsState()
+
+    PlusNavContainer(
+        modifier = modifier,
+        scrollEnabled = false,
+        data =
+            PlusHeaderData.Child(
+                title = Res.string.bottom_nav_order_title.asTextData(),
+                onBackClick = bloc::onBack,
+            ),
+        content = {
+            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                ReorderableTabList(
+                    tabs = state.editedOrder,
+                    onMove = bloc::onMove,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+            Surface(tonalElevation = 4.dp) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    Button(onClick = bloc::onSave, enabled = state.hasUnsavedChanges) {
+                        Text(stringResource(Res.string.bottom_nav_order_save))
+                    }
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun ReorderableTabList(
+    tabs: List<BottomNavBloc.Tab>,
+    onMove: (Int, Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberLazyListState()
+    var draggingId by remember { mutableStateOf<BottomNavBloc.Tab?>(null) }
+    var dragOffsetY by remember { mutableStateOf(0f) }
+
+    LazyColumn(state = listState, modifier = modifier) {
+        itemsIndexed(items = tabs, key = { _, tab -> tab.name }) { index, tab ->
+            val isDragging = tab == draggingId
+            ReorderableTabRow(
+                tab = tab,
+                isDragging = isDragging,
+                offsetY = if (isDragging) dragOffsetY else 0f,
+                onDragStart = {
+                    draggingId = tab
+                    dragOffsetY = 0f
+                },
+                onDrag = { delta ->
+                    dragOffsetY += delta
+                    val rowHeight = listState.rowHeightFor(tab) ?: return@ReorderableTabRow
+                    val draggedIndex =
+                        tabs.indexOf(draggingId).takeIf { it >= 0 } ?: return@ReorderableTabRow
+                    val rowsCrossed = (dragOffsetY / rowHeight).toInt()
+                    if (rowsCrossed != 0) {
+                        val target = (draggedIndex + rowsCrossed).coerceIn(0, tabs.lastIndex)
+                        if (target != draggedIndex) {
+                            onMove(draggedIndex, target)
+                            // The dragged row has visually moved by `rowsCrossed * rowHeight`
+                            // pixels because the underlying list rebuilt. Subtract that distance
+                            // from the running offset so the visual offset stays continuous with
+                            // the user's finger.
+                            dragOffsetY -= (target - draggedIndex) * rowHeight
+                        }
+                    }
+                },
+                onDragEnd = {
+                    draggingId = null
+                    dragOffsetY = 0f
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReorderableTabRow(
+    tab: BottomNavBloc.Tab,
+    isDragging: Boolean,
+    offsetY: Float,
+    onDragStart: () -> Unit,
+    onDrag: (Float) -> Unit,
+    onDragEnd: () -> Unit,
+) {
+    val dragDescription =
+        stringResource(Res.string.bottom_nav_order_drag_handle_content_description)
+    Surface(
+        tonalElevation = if (isDragging) 8.dp else 0.dp,
+        shadowElevation = if (isDragging) 8.dp else 0.dp,
+        modifier =
+            Modifier.fillMaxWidth()
+                .graphicsLayer {
+                    translationY = offsetY
+                    val scale = if (isDragging) 1.02f else 1f
+                    scaleX = scale
+                    scaleY = scale
+                }
+                .shadow(elevation = if (isDragging) 4.dp else 0.dp),
+    ) {
+        Row(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .height(ChefMateTheme.dimens.rowHeight)
+                    .padding(horizontal = ChefMateTheme.dimens.paddingNormal),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(imageVector = tab.getIcon(), contentDescription = null)
+            Spacer(modifier = Modifier.width(ChefMateTheme.dimens.paddingNormal))
+            Text(
+                text = stringResource(tab.getLabel()),
+                style = ChefMateTheme.typography.titleMedium,
+                modifier = Modifier.weight(1f),
+            )
+            Box(
+                modifier =
+                    Modifier.size(48.dp)
+                        .semantics { contentDescription = dragDescription }
+                        .pointerInput(tab) {
+                            detectDragGesturesAfterLongPress(
+                                onDragStart = { onDragStart() },
+                                onDragEnd = { onDragEnd() },
+                                onDragCancel = { onDragEnd() },
+                                onDrag = { change, drag ->
+                                    change.consume()
+                                    onDrag(drag.y)
+                                },
+                            )
+                        },
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(imageVector = Icons.Default.DragHandle, contentDescription = null)
+            }
+        }
+    }
+}
+
+private fun androidx.compose.foundation.lazy.LazyListState.rowHeightFor(
+    tab: BottomNavBloc.Tab
+): Float? =
+    layoutInfo.visibleItemsInfo.firstOrNull { (it.key as? String) == tab.name }?.size?.toFloat()
+
+private val previewBloc =
+    object : BottomNavOrderBloc {
+        override val state = kotlinx.coroutines.flow.MutableStateFlow(BottomNavOrderBloc.Model())
+
+        override fun onMove(from: Int, to: Int) = Unit
+
+        override fun onSave() = Unit
+
+        override fun onBack() = Unit
+    }
+
+@androidx.compose.ui.tooling.preview.Preview
+@Composable
+internal fun BottomNavOrderScreenPreview() {
+    ChefMateTheme { BottomNavOrderScreen(bloc = previewBloc) }
+}

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material3.Button
@@ -25,15 +26,17 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import chefmate.client.bottomnav.public.generated.resources.Res
 import chefmate.client.bottomnav.public.generated.resources.bottom_nav_order_drag_handle_content_description
 import chefmate.client.bottomnav.public.generated.resources.bottom_nav_order_save
@@ -146,18 +149,32 @@ private fun ReorderableTabRow(
 ) {
     val dragDescription =
         stringResource(Res.string.bottom_nav_order_drag_handle_content_description)
+    // `pointerInput(tab)` is keyed by the tab, which is stable across reorders (LazyColumn keys by
+    // `tab.name`). That means the gesture coroutine never restarts and would otherwise capture the
+    // first `onDrag`/`onDragStart`/`onDragEnd` lambdas forever — which in turn close over the
+    // original `tabs` list from the parent. Route through `rememberUpdatedState` so each gesture
+    // event invokes the latest lambda (and the freshest `tabs` snapshot it captures).
+    val currentOnDragStart by rememberUpdatedState(onDragStart)
+    val currentOnDrag by rememberUpdatedState(onDrag)
+    val currentOnDragEnd by rememberUpdatedState(onDragEnd)
     Surface(
         tonalElevation = if (isDragging) 8.dp else 0.dp,
         shadowElevation = if (isDragging) 8.dp else 0.dp,
+        // Rounded corners only while dragging give the lifted row a card-like silhouette without
+        // changing the flat list-row appearance at rest.
+        shape = if (isDragging) RoundedCornerShape(12.dp) else RectangleShape,
         modifier =
             Modifier.fillMaxWidth()
+                // LazyColumn paints items in source order, so a row dragged downward would render
+                // beneath the rows it overlaps. Lifting `zIndex` keeps the dragged row on top in
+                // either direction.
+                .zIndex(if (isDragging) 1f else 0f)
                 .graphicsLayer {
                     translationY = offsetY
-                    val scale = if (isDragging) 1.02f else 1f
+                    val scale = if (isDragging) 0.96f else 1f
                     scaleX = scale
                     scaleY = scale
-                }
-                .shadow(elevation = if (isDragging) 4.dp else 0.dp),
+                },
     ) {
         Row(
             modifier =
@@ -179,12 +196,12 @@ private fun ReorderableTabRow(
                         .semantics { contentDescription = dragDescription }
                         .pointerInput(tab) {
                             detectDragGesturesAfterLongPress(
-                                onDragStart = { onDragStart() },
-                                onDragEnd = { onDragEnd() },
-                                onDragCancel = { onDragEnd() },
+                                onDragStart = { currentOnDragStart() },
+                                onDragEnd = { currentOnDragEnd() },
+                                onDragCancel = { currentOnDragEnd() },
                                 onDrag = { change, drag ->
                                     change.consume()
-                                    onDrag(drag.y)
+                                    currentOnDrag(drag.y)
                                 },
                             )
                         },

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavOrderScreen.kt
@@ -1,5 +1,7 @@
 package com.plusmobileapps.chefmate.recipe.bottomnav
 
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,7 +32,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.contentDescription
@@ -157,12 +158,16 @@ private fun ReorderableTabRow(
     val currentOnDragStart by rememberUpdatedState(onDragStart)
     val currentOnDrag by rememberUpdatedState(onDrag)
     val currentOnDragEnd by rememberUpdatedState(onDragEnd)
+    // Spring between the resting list-row look and the lifted card look so picking up / dropping
+    // a tab feels physical instead of snapping. `animate*AsState` starts at the target on first
+    // composition, so rest-state screenshots remain unchanged.
+    val elevation by animateDpAsState(if (isDragging) 8.dp else 0.dp, label = "drag-elevation")
+    val cornerRadius by animateDpAsState(if (isDragging) 12.dp else 0.dp, label = "drag-corner")
+    val scale by animateFloatAsState(if (isDragging) 0.96f else 1f, label = "drag-scale")
     Surface(
-        tonalElevation = if (isDragging) 8.dp else 0.dp,
-        shadowElevation = if (isDragging) 8.dp else 0.dp,
-        // Rounded corners only while dragging give the lifted row a card-like silhouette without
-        // changing the flat list-row appearance at rest.
-        shape = if (isDragging) RoundedCornerShape(12.dp) else RectangleShape,
+        tonalElevation = elevation,
+        shadowElevation = elevation,
+        shape = RoundedCornerShape(cornerRadius),
         modifier =
             Modifier.fillMaxWidth()
                 // LazyColumn paints items in source order, so a row dragged downward would render
@@ -171,7 +176,6 @@ private fun ReorderableTabRow(
                 .zIndex(if (isDragging) 1f else 0f)
                 .graphicsLayer {
                     translationY = offsetY
-                    val scale = if (isDragging) 0.96f else 1f
                     scaleX = scale
                     scaleY = scale
                 },

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -181,7 +181,7 @@ private fun PlusBottomBar(state: BottomNavBloc.Model, onClick: (BottomNavBloc.Ta
     }
 }
 
-private fun BottomNavBloc.Tab.getLabel(): StringResource =
+internal fun BottomNavBloc.Tab.getLabel(): StringResource =
     when (this) {
         RECIPES -> Res.string.tab_recipes
         GROCERIES -> Res.string.tab_grocery
@@ -190,7 +190,7 @@ private fun BottomNavBloc.Tab.getLabel(): StringResource =
         SETTINGS -> Res.string.tab_more
     }
 
-private fun BottomNavBloc.Tab.getIcon() =
+internal fun BottomNavBloc.Tab.getIcon() =
     when (this) {
         RECIPES -> Icons.AutoMirrored.Filled.List
         GROCERIES -> Icons.Default.ShoppingCart

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/TabOrderPreferences.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/TabOrderPreferences.kt
@@ -1,0 +1,36 @@
+package com.plusmobileapps.chefmate.recipe.bottomnav
+
+import kotlinx.coroutines.flow.StateFlow
+
+const val BOTTOM_NAV_TAB_ORDER_KEY = "bottomnav.tab.order"
+
+val DEFAULT_TAB_ORDER: List<BottomNavBloc.Tab> =
+    listOf(
+        BottomNavBloc.Tab.RECIPES,
+        BottomNavBloc.Tab.GROCERIES,
+        BottomNavBloc.Tab.MEALS,
+        BottomNavBloc.Tab.BROWSER,
+        BottomNavBloc.Tab.SETTINGS,
+    )
+
+/**
+ * Stable identifier for the tab, decoupled from enum ordinal so persistence survives reordering.
+ */
+val BottomNavBloc.Tab.stableId: String
+    get() =
+        when (this) {
+            BottomNavBloc.Tab.RECIPES -> "recipes"
+            BottomNavBloc.Tab.GROCERIES -> "groceries"
+            BottomNavBloc.Tab.MEALS -> "meal_plan"
+            BottomNavBloc.Tab.BROWSER -> "browser"
+            BottomNavBloc.Tab.SETTINGS -> "more"
+        }
+
+fun tabFromStableId(id: String): BottomNavBloc.Tab? =
+    BottomNavBloc.Tab.entries.firstOrNull { it.stableId == id }
+
+interface TabOrderPreferences {
+    val tabOrder: StateFlow<List<BottomNavBloc.Tab>>
+
+    fun setTabOrder(tabs: List<BottomNavBloc.Tab>)
+}

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -16,6 +16,7 @@ import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc.Props.Detail
@@ -40,6 +41,7 @@ class RootBlocImpl(
     private val mealPlannerRoot: MealPlannerRootBloc.Factory,
     private val authentication: AuthenticationBloc.Factory,
     private val appSettings: AppSettingsBloc.Factory,
+    private val bottomNavOrder: BottomNavOrderBloc.Factory,
     private val cookMode: CookModeBloc.Factory,
 ) : RootBloc, BlocContext by context {
 
@@ -136,6 +138,15 @@ class RootBlocImpl(
                     bloc = appSettings.create(context = context, output = ::handleAppSettingsOutput)
                 )
 
+            Configuration.BottomNavOrder ->
+                RootBloc.Child.BottomNavOrder(
+                    bloc =
+                        bottomNavOrder.create(
+                            context = context,
+                            output = ::handleBottomNavOrderOutput,
+                        )
+                )
+
             is Configuration.CookMode ->
                 RootBloc.Child.CookMode(
                     bloc =
@@ -200,6 +211,15 @@ class RootBlocImpl(
     private fun handleAppSettingsOutput(output: AppSettingsBloc.Output) {
         when (output) {
             AppSettingsBloc.Output.Back -> navigation.pop()
+            AppSettingsBloc.Output.OpenBottomNavOrder -> {
+                navigation.bringToFront(Configuration.BottomNavOrder)
+            }
+        }
+    }
+
+    private fun handleBottomNavOrderOutput(output: BottomNavOrderBloc.Output) {
+        when (output) {
+            BottomNavOrderBloc.Output.Back -> navigation.pop()
         }
     }
 
@@ -271,6 +291,8 @@ class RootBlocImpl(
         @Serializable data class MealPlanner(val props: MealPlannerRootBloc.Props) : Configuration()
 
         @Serializable data object AppSettings : Configuration()
+
+        @Serializable data object BottomNavOrder : Configuration()
 
         @Serializable data class CookMode(val recipeId: Long) : Configuration()
     }

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -8,6 +8,7 @@ import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
@@ -28,6 +29,7 @@ class RootBlocTest {
     var recipeProps: RecipeRootBloc.Props? = null
     var groceryDetailId: Long? = null
     var appSettingsOutput: Consumer<AppSettingsBloc.Output> = Consumer {}
+    var bottomNavOrderOutput: Consumer<BottomNavOrderBloc.Output> = Consumer {}
 
     val rootBloc =
         RootBlocImpl(
@@ -59,6 +61,10 @@ class RootBlocTest {
             authentication = { context, props, output -> mock() },
             appSettings = { _, output ->
                 appSettingsOutput = output
+                mock()
+            },
+            bottomNavOrder = { _, output ->
+                bottomNavOrderOutput = output
                 mock()
             },
             cookMode = CookModeBloc.Factory { _, _, _ -> mock() },
@@ -141,6 +147,22 @@ class RootBlocTest {
         rootBloc.instance() should instanceOf<RootBloc.Child.AppSettings>()
         appSettingsOutput.onNext(AppSettingsBloc.Output.Back)
         rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+    }
+
+    @Test
+    fun Given_app_settings_When_open_bottom_nav_order_Then_bottom_nav_order_shown() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenAppSettings)
+        appSettingsOutput.onNext(AppSettingsBloc.Output.OpenBottomNavOrder)
+        rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavOrder>()
+        rootBloc.state.value.backStack.size shouldBe 2
+    }
+
+    @Test
+    fun Given_bottom_nav_order_When_back_outputted_Then_app_settings_is_shown() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenAppSettings)
+        appSettingsOutput.onNext(AppSettingsBloc.Output.OpenBottomNavOrder)
+        bottomNavOrderOutput.onNext(BottomNavOrderBloc.Output.Back)
+        rootBloc.instance() should instanceOf<RootBloc.Child.AppSettings>()
     }
 
     @Test

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -10,6 +10,7 @@ import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.settings.AppSettingsBloc
@@ -33,6 +34,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class MealPlanner(val bloc: MealPlannerRootBloc) : Child()
 
         data class AppSettings(val bloc: AppSettingsBloc) : Child()
+
+        data class BottomNavOrder(val bloc: BottomNavOrderBloc) : Child()
 
         data class CookMode(val bloc: CookModeBloc) : Child()
     }

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -29,6 +29,7 @@ import com.plusmobileapps.chefmate.auth.ui.AuthenticationScreen
 import com.plusmobileapps.chefmate.browser.BrowserRootScreen
 import com.plusmobileapps.chefmate.cook.CookModeScreen
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailScreen
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderScreen
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavigationScreen
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootScreen
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootScreen
@@ -153,6 +154,7 @@ private fun RootChildContent(child: RootBloc.Child, onBack: () -> Unit) {
             )
         is RootBloc.Child.MealPlanner -> MealPlannerRootScreen(child.bloc)
         is RootBloc.Child.AppSettings -> AppSettingsScreen(child.bloc)
+        is RootBloc.Child.BottomNavOrder -> BottomNavOrderScreen(child.bloc)
         is RootBloc.Child.CookMode -> CookModeScreen(child.bloc)
     }
 }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/AppSettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/AppSettingsBlocImpl.kt
@@ -49,6 +49,10 @@ class AppSettingsBlocImpl(
     override fun onClearHistoryDismissed() {
         viewModel.dismissClearHistoryDialog()
     }
+
+    override fun onBottomNavOrderClicked() {
+        output.onNext(Output.OpenBottomNavOrder)
+    }
 }
 
 @ContributesTo(AppScope::class)

--- a/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/AppSettingsBlocImplTest.kt
+++ b/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/AppSettingsBlocImplTest.kt
@@ -92,4 +92,11 @@ class AppSettingsBlocImplTest {
         bloc.onBack()
         output.lastValue shouldBe AppSettingsBloc.Output.Back
     }
+
+    @Test
+    fun When_bottom_nav_order_clicked_Then_open_bottom_nav_order_output_emitted() {
+        val bloc = createBloc()
+        bloc.onBottomNavOrderClicked()
+        output.lastValue shouldBe AppSettingsBloc.Output.OpenBottomNavOrder
+    }
 }

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -21,4 +21,6 @@
     <string name="app_settings_clear_history_dialog_message">This will remove all sites from your history on this device.</string>
     <string name="app_settings_clear_history_dialog_confirm">Clear</string>
     <string name="app_settings_clear_history_dialog_cancel">Cancel</string>
+    <string name="app_settings_navigation_section">Navigation</string>
+    <string name="app_settings_bottom_nav_order">Bottom navigation order</string>
 </resources>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/AppSettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/AppSettingsBloc.kt
@@ -18,6 +18,8 @@ interface AppSettingsBloc : BackHandlerOwner {
 
     fun onClearHistoryDismissed()
 
+    fun onBottomNavOrderClicked()
+
     data class Model(
         val isHistoryEnabled: Boolean = true,
         val showClearHistoryDialog: Boolean = false,
@@ -25,6 +27,8 @@ interface AppSettingsBloc : BackHandlerOwner {
 
     sealed class Output {
         data object Back : Output()
+
+        data object OpenBottomNavOrder : Output()
     }
 
     fun interface Factory {

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/AppSettingsPreviews.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/AppSettingsPreviews.kt
@@ -21,6 +21,8 @@ private fun appSettingsBloc(model: AppSettingsBloc.Model): AppSettingsBloc =
         override fun onClearHistoryConfirmed() = Unit
 
         override fun onClearHistoryDismissed() = Unit
+
+        override fun onBottomNavOrderClicked() = Unit
     }
 
 val previewAppSettingsBloc: AppSettingsBloc =

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/AppSettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/AppSettingsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import chefmate.client.settings.public.generated.resources.Res
+import chefmate.client.settings.public.generated.resources.app_settings_bottom_nav_order
 import chefmate.client.settings.public.generated.resources.app_settings_browser_history_enabled
 import chefmate.client.settings.public.generated.resources.app_settings_browser_section
 import chefmate.client.settings.public.generated.resources.app_settings_clear_history
@@ -22,6 +23,7 @@ import chefmate.client.settings.public.generated.resources.app_settings_clear_hi
 import chefmate.client.settings.public.generated.resources.app_settings_clear_history_dialog_confirm
 import chefmate.client.settings.public.generated.resources.app_settings_clear_history_dialog_message
 import chefmate.client.settings.public.generated.resources.app_settings_clear_history_dialog_title
+import chefmate.client.settings.public.generated.resources.app_settings_navigation_section
 import chefmate.client.settings.public.generated.resources.app_settings_title
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
@@ -49,6 +51,12 @@ fun AppSettingsScreen(bloc: AppSettingsBloc, modifier: Modifier = Modifier) {
                 onBackClick = bloc::onBack,
             ),
         content = {
+            SectionHeader(name = Res.string.app_settings_navigation_section.asTextData())
+            SettingsRow(
+                name = Res.string.app_settings_bottom_nav_order.asTextData(),
+                onClick = bloc::onBottomNavOrderClicked,
+            )
+            HorizontalDivider()
             SectionHeader(name = Res.string.app_settings_browser_section.asTextData())
             HistoryToggleRow(
                 name = Res.string.app_settings_browser_history_enabled.asTextData(),

--- a/client/ui/screenshot-test/build.gradle.kts
+++ b/client/ui/screenshot-test/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } }
 dependencies {
     implementation(project(":client:ui:public"))
     implementation(project(":client:text:public"))
+    implementation(project(":client:bottomnav:public"))
     implementation(project(":client:cook:public"))
     implementation(project(":client:recipe:list:public"))
     implementation(project(":client:settings:public"))

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTest.kt
@@ -1,0 +1,32 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderScreen
+import com.plusmobileapps.chefmate.recipe.bottomnav.previewBottomNavOrderBloc
+import com.plusmobileapps.chefmate.recipe.bottomnav.previewBottomNavOrderDirtyBloc
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun BottomNavOrderLightScreenshot() {
+    ChefMateTheme { BottomNavOrderScreen(bloc = previewBottomNavOrderBloc) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun BottomNavOrderDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) { BottomNavOrderScreen(bloc = previewBottomNavOrderBloc) }
+}
+
+// Locks in the dirty-state visual: a non-default order with the Save button rendered enabled.
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun BottomNavOrderReorderedDirtyScreenshot() {
+    ChefMateTheme { BottomNavOrderScreen(bloc = previewBottomNavOrderDirtyBloc) }
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AppSettingsScreenshotTestKt/AppSettingsDarkScreenshot_4d30ee2f_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AppSettingsScreenshotTestKt/AppSettingsDarkScreenshot_4d30ee2f_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf3061acc9f5f9761d472eb598e2f9e4c91d1803911be189091744b821882dfb
-size 41365
+oid sha256:3c0b59990619fd7f7dc04ba55bf0a352be3e3e7d6136a21237b89e82ad3a534a
+size 50204

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AppSettingsScreenshotTestKt/AppSettingsLightScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AppSettingsScreenshotTestKt/AppSettingsLightScreenshot_748aa731_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fea11d995e25e7f859593cdb8b7c3252d9ba504e28de18205733df42e28123fa
-size 40995
+oid sha256:b3b0b3fdb63de9e862bc452c0f2256252aacb9ef209cc2469b62c35995d1887d
+size 49739

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderDarkScreenshot_4d30ee2f_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderDarkScreenshot_4d30ee2f_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cdf028e42d3b814ee1e8bbc61f0be640be3cc575d3c6bd402747d641b7c85ae
-size 48461
+oid sha256:0f1c35644e0e1f32bdfa3737602b35a8ecf3dc8fa609b2ef31b91b5d6b870f21
+size 44821

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderDarkScreenshot_4d30ee2f_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderDarkScreenshot_4d30ee2f_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cdf028e42d3b814ee1e8bbc61f0be640be3cc575d3c6bd402747d641b7c85ae
+size 48461

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderLightScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderLightScreenshot_748aa731_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed843f0078347ce980f5e4d6f50c3874d5932ea0a976e651886e5714b0e97f41
+size 47910

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderLightScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderLightScreenshot_748aa731_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ed843f0078347ce980f5e4d6f50c3874d5932ea0a976e651886e5714b0e97f41
-size 47910
+oid sha256:411350703f895fe4459ba6bee66e6aa917fe6b944a1abbbb838552b79d38b424
+size 44424

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderReorderedDirtyScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderReorderedDirtyScreenshot_748aa731_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acb62731d10862130acb1e9dfceba5dafcb4a8cbdcc12cdc7e3c5ff20efe0c9c
+size 48522

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderReorderedDirtyScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderReorderedDirtyScreenshot_748aa731_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:acb62731d10862130acb1e9dfceba5dafcb4a8cbdcc12cdc7e3c5ff20efe0c9c
-size 48522
+oid sha256:3a61098880aab21478fec6f737aa9c717e31e35dfa4dd4e6069b5de9420a10c2
+size 57945

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderReorderedDirtyScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavOrderScreenshotTestKt/BottomNavOrderReorderedDirtyScreenshot_748aa731_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a61098880aab21478fec6f737aa9c717e31e35dfa4dd4e6069b5de9420a10c2
-size 57945
+oid sha256:7cc00464525be28a4c92d141c9cb4b1fe9f30d73636a1aa829345ced5b92b1ee
+size 57947


### PR DESCRIPTION
## Summary

- New sub-screen reachable from **More → Settings → Navigation → Bottom navigation order** that lets the user reorder the bottom navigation tabs by long-pressing the trailing drag handle. The Save button is disabled until the order diverges from what's persisted; backing out without saving leaves the persisted value untouched.
- `BottomNavViewModel` now reads its tab list from a new `TabOrderPreferences` repository so saves take effect reactively (both bottom bar and side rail re-render). The bottom-nav scaffold continues to iterate `state.tabs` — only the source has changed.
- Persistence uses `multiplatform-settings` and stores tabs by **stable string id** (`recipes`, `groceries`, `meal_plan`, `browser`, `more`) rather than enum ordinal. The loader normalises the persisted list — dropping unknown ids and appending any new tabs — so future enum additions/renames don't corrupt user data.

## Modules touched

- `client/bottomnav/public` — `TabOrderPreferences` interface, `BottomNavOrderBloc` interface, `BottomNavOrderScreen`, strings
- `client/bottomnav/impl` — `TabOrderPreferencesImpl`, `BottomNavOrderBlocImpl`, `BottomNavOrderViewModel`, `BottomNavViewModel` consumes the new preference, tests
- `client/settings/public` — `AppSettingsBloc.Output.OpenBottomNavOrder`, new "Navigation" section + row in `AppSettingsScreen`, strings
- `client/settings/impl` — `AppSettingsBlocImpl` forwards the click as the new output; test updated
- `client/root/public` — `RootBloc.Child.BottomNavOrder`, render in `RootScreen`
- `client/root/impl` — new `Configuration.BottomNavOrder`, factory wiring, output handling; test updated

## Conflict note re: #161

[#161](https://github.com/plusmobileapps/chef-mate/pull/161) is the in-flight dark-mode / edge-to-edge fix that wraps `AppSettingsScreen` content in a `Surface`. This PR also touches `AppSettingsScreen.kt` (added a "Navigation" section header and a new "Bottom navigation order" row above the existing Browser section), so a small conflict around that file is expected if #161 lands first. The conflict is purely additive — re-applying the new section + row inside the `Surface` wrapper from #161 is a one-liner.

## Test plan

- [x] `./gradlew :client:bottomnav:public:compileKotlinJvm :client:bottomnav:impl:compileKotlinJvm :client:settings:public:compileKotlinJvm :client:settings:impl:compileKotlinJvm :client:root:public:compileKotlinJvm :client:root:impl:compileKotlinJvm` — clean
- [x] `./gradlew :client:bottomnav:impl:jvmTest :client:settings:impl:jvmTest :client:root:impl:jvmTest` — all green (`BottomNavOrderViewModelTest` 6/6, `BottomNavViewModelTest` 2/2, `TabOrderPreferencesImplTest` 4/4, plus existing tests still pass)
- [x] `./gradlew :client:composeApp:compileKotlinJvm` — full app compiles cleanly with the new DI bindings
- [ ] Manual QA: verify drag, save (button greys/un-greys), back-without-save discards edits, currently-selected tab is preserved after save, bottom bar updates without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)