### PR TITLE
feat(recipe): full-screen recipe image with shared element transition

### DIFF
--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -6,6 +6,7 @@ import com.arkivanov.decompose.router.slot.activate
 import com.arkivanov.decompose.router.slot.childSlot
 import com.arkivanov.decompose.router.slot.dismiss
 import com.arkivanov.decompose.value.Value
+import com.arkivanov.essenty.backhandler.BackCallback
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
@@ -72,6 +73,33 @@ class RecipeDetailBlocImpl(
 
     override val childSlot: Value<ChildSlot<*, RecipeDetailBloc.Sheet>> = sheetRouter
 
+    private val fullImageNavigation = SlotNavigation<FullImageConfig>()
+    private val fullImageRouter =
+        childSlot(
+            source = fullImageNavigation,
+            serializer = FullImageConfig.serializer(),
+            key = "RecipeDetailBloc_FullImage",
+            childFactory = { config, _ ->
+                RecipeDetailBloc.FullImage.Active(
+                    imageUrl = config.imageUrl,
+                    recipeId = config.recipeId,
+                    title = config.title,
+                )
+            },
+        )
+
+    override val fullImageSlot: Value<ChildSlot<*, RecipeDetailBloc.FullImage>> = fullImageRouter
+
+    private val fullImageBackCallback =
+        BackCallback(isEnabled = fullImageRouter.value.child != null) {
+            fullImageNavigation.dismiss()
+        }
+
+    init {
+        backHandler.register(fullImageBackCallback)
+        fullImageRouter.subscribe { slot -> fullImageBackCallback.isEnabled = slot.child != null }
+    }
+
     override val state: StateFlow<RecipeDetailBloc.Model> =
         viewModel.state.mapState {
             RecipeDetailBloc.Model(
@@ -116,6 +144,18 @@ class RecipeDetailBlocImpl(
         sheetNavigation.activate(SheetConfig.AddToGroceryList(recipeId))
     }
 
+    override fun onImageClicked() {
+        val recipe = viewModel.state.value.recipe
+        val imageUrl = recipe.imageUrl ?: return
+        fullImageNavigation.activate(
+            FullImageConfig(imageUrl = imageUrl, recipeId = recipe.id, title = recipe.title)
+        )
+    }
+
+    override fun onCloseFullImage() {
+        fullImageNavigation.dismiss()
+    }
+
     override fun onAddToMealPlanClicked() {
         output.onNext(Output.OpenMealPlanner(recipeId))
     }
@@ -146,7 +186,11 @@ class RecipeDetailBlocImpl(
     }
 
     override fun onBackClicked() {
-        output.onNext(Output.Finished)
+        if (fullImageRouter.value.child != null) {
+            fullImageNavigation.dismiss()
+        } else {
+            output.onNext(Output.Finished)
+        }
     }
 
     private fun createSheet(config: SheetConfig, context: BlocContext): RecipeDetailBloc.Sheet =
@@ -175,6 +219,9 @@ class RecipeDetailBlocImpl(
     sealed class SheetConfig {
         data class AddToGroceryList(val recipeId: Long) : SheetConfig()
     }
+
+    @Serializable
+    data class FullImageConfig(val imageUrl: String, val recipeId: Long, val title: String)
 }
 
 @ContributesTo(AppScope::class)

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
@@ -1,0 +1,132 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalTime::class)
+
+package com.plusmobileapps.chefmate.recipe.core.impl.detail
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.KeepScreenOnRepository
+import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
+import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
+import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.plusmobileapps.chefmate.testing.TestConsumer
+import com.plusmobileapps.chefmate.util.DateTimeUtil
+import com.plusmobileapps.chefmate.util.TimeFormatterUtil
+import com.russhwolf.settings.MapSettings
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class RecipeDetailBlocImplTest {
+
+    private val context = TestBlocContext.create()
+    private val output = TestConsumer<RecipeDetailBloc.Output>()
+    private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
+    private val repository = FakeRecipeRepository(recipes)
+
+    private val sampleRecipe =
+        Recipe(
+            id = 7L,
+            title = "Pancakes",
+            description = null,
+            ingredients = "flour\negg",
+            directions = "mix\ncook",
+            imageUrl = "https://example.com/pancakes.jpg",
+            sourceUrl = null,
+            servings = 2,
+            prepTime = 5,
+            cookTime = 10,
+            totalTime = 15,
+            calories = 300,
+            starRating = null,
+            isFavorite = false,
+            createdAt = Instant.parse("2024-01-01T00:00:00Z"),
+            updatedAt = Instant.parse("2024-01-02T00:00:00Z"),
+        )
+
+    private fun createBloc(recipe: Recipe? = sampleRecipe): RecipeDetailBlocImpl {
+        if (recipe != null) recipes.value = listOf(recipe)
+        val keepScreenOnRepository = KeepScreenOnRepository(MapSettings())
+        val viewModelFactory = RecipeDetailViewModel.Factory { id ->
+            RecipeDetailViewModel(
+                recipeId = id,
+                mainContext = context.mainContext,
+                repository = repository,
+                keepScreenOnRepository = keepScreenOnRepository,
+            )
+        }
+        val dateTimeUtil =
+            mock<DateTimeUtil>().also { every { it.formatDateTime(any()) } returns "" }
+        val timeFormatterUtil = mock<TimeFormatterUtil>()
+        val groceryFactory =
+            object : AddRecipeToGroceryListBloc.Factory {
+                override fun create(
+                    context: BlocContext,
+                    recipeId: Long,
+                    output: Consumer<AddRecipeToGroceryListBloc.Output>,
+                ): AddRecipeToGroceryListBloc = mock()
+            }
+        return RecipeDetailBlocImpl(
+            context = context,
+            recipeId = recipe?.id ?: 1L,
+            output = output,
+            viewModelFactory = viewModelFactory,
+            dateTimeUtil = dateTimeUtil,
+            timeFormatterUtil = timeFormatterUtil,
+            addToGroceryList = groceryFactory,
+        )
+    }
+
+    @Test
+    fun When_onImageClicked_with_imageUrl_Then_full_image_slot_is_active() {
+        val bloc = createBloc()
+        bloc.onImageClicked()
+        val active =
+            bloc.fullImageSlot.value.child
+                ?.instance
+                .shouldBeInstanceOf<RecipeDetailBloc.FullImage.Active>()
+        active.imageUrl shouldBe sampleRecipe.imageUrl
+        active.recipeId shouldBe sampleRecipe.id
+        active.title shouldBe sampleRecipe.title
+    }
+
+    @Test
+    fun When_onImageClicked_with_null_imageUrl_Then_slot_stays_inactive() {
+        val bloc = createBloc(recipe = sampleRecipe.copy(imageUrl = null))
+        bloc.onImageClicked()
+        bloc.fullImageSlot.value.child shouldBe null
+    }
+
+    @Test
+    fun When_onCloseFullImage_Then_slot_is_dismissed() {
+        val bloc = createBloc()
+        bloc.onImageClicked()
+        bloc.onCloseFullImage()
+        bloc.fullImageSlot.value.child shouldBe null
+    }
+
+    @Test
+    fun When_onBackClicked_with_active_overlay_Then_overlay_dismisses_and_no_output() {
+        val bloc = createBloc()
+        bloc.onImageClicked()
+        bloc.onBackClicked()
+        bloc.fullImageSlot.value.child shouldBe null
+        output.values shouldBe emptyList()
+    }
+
+    @Test
+    fun When_onBackClicked_with_inactive_overlay_Then_output_finished_emitted() {
+        val bloc = createBloc()
+        bloc.onBackClicked()
+        output.lastValue shouldBe RecipeDetailBloc.Output.Finished
+    }
+}

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="recipe_detail_copied_to_clipboard">Copied to clipboard</string>
     <string name="recipe_detail_keep_screen_on">Keep screen on</string>
     <string name="recipe_detail_allow_screen_off">Allow screen to turn off</string>
+    <string name="recipe_full_image_close">Close</string>
 
     <!-- Add to Meal Plan -->
     <string name="recipe_detail_add_to_meal_plan">Add to meal plan</string>

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -15,6 +15,12 @@ interface RecipeDetailBloc : BackClickBloc {
 
     val childSlot: Value<ChildSlot<*, Sheet>>
 
+    val fullImageSlot: Value<ChildSlot<*, FullImage>>
+
+    fun onImageClicked()
+
+    fun onCloseFullImage()
+
     fun onEditClicked()
 
     fun onDeleteClicked()
@@ -71,6 +77,10 @@ interface RecipeDetailBloc : BackClickBloc {
 
     sealed class Sheet {
         data class AddToGroceryList(val bloc: AddRecipeToGroceryListBloc) : Sheet()
+    }
+
+    sealed class FullImage {
+        data class Active(val imageUrl: String, val recipeId: Long, val title: String) : FullImage()
     }
 
     interface Factory {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -1,7 +1,18 @@
-@file:OptIn(ExperimentalTime::class, ExperimentalMaterial3ExpressiveApi::class)
+@file:OptIn(
+    ExperimentalTime::class,
+    ExperimentalMaterial3ExpressiveApi::class,
+    ExperimentalSharedTransitionApi::class,
+)
 
 package com.plusmobileapps.chefmate.recipe.core.detail
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -78,6 +89,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -146,6 +158,8 @@ import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.KeepScreenOn
+import com.plusmobileapps.chefmate.ui.LocalAnimatedVisibilityScope
+import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
@@ -156,6 +170,7 @@ import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import com.plusmobileapps.chefmate.util.rememberShareLauncher
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -211,7 +226,60 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     var showOverflowMenu by remember { mutableStateOf(false) }
     var metadataCollapsed by rememberSaveable { mutableStateOf(false) }
 
-    Box(modifier = modifier.fillMaxSize().testTag(RecipeDetailTestTags.SCREEN)) {
+    val fullImageSlot by bloc.fullImageSlot.subscribeAsState()
+    val fullImageActive = fullImageSlot.child?.instance as? RecipeDetailBloc.FullImage.Active
+
+    SharedTransitionLayout(modifier = modifier.fillMaxSize()) {
+        AnimatedContent(
+            targetState = fullImageActive,
+            transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(250)) },
+            label = "recipe-detail-full-image",
+        ) { fullImage ->
+            CompositionLocalProvider(
+                LocalSharedTransitionScope provides this@SharedTransitionLayout,
+                LocalAnimatedVisibilityScope provides this,
+            ) {
+                if (fullImage != null) {
+                    RecipeImageFullScreenScreen(
+                        imageUrl = fullImage.imageUrl,
+                        recipeId = fullImage.recipeId,
+                        contentDescription = fullImage.title,
+                        onDismiss = bloc::onCloseFullImage,
+                    )
+                } else {
+                    RecipeDetailBody(
+                        bloc = bloc,
+                        state = state,
+                        showOverflowMenu = showOverflowMenu,
+                        onShowOverflowMenuChange = { showOverflowMenu = it },
+                        metadataCollapsed = metadataCollapsed,
+                        onMetadataCollapsedChange = { metadataCollapsed = it },
+                        snackbarHostState = snackbarHostState,
+                        shareLauncher = shareLauncher,
+                        copiedMessage = copiedMessage,
+                        scope = scope,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RecipeDetailBody(
+    bloc: RecipeDetailBloc,
+    state: RecipeDetailBloc.Model,
+    showOverflowMenu: Boolean,
+    onShowOverflowMenuChange: (Boolean) -> Unit,
+    metadataCollapsed: Boolean,
+    onMetadataCollapsedChange: (Boolean) -> Unit,
+    snackbarHostState: SnackbarHostState,
+    shareLauncher: (String) -> Boolean,
+    copiedMessage: String,
+    scope: CoroutineScope,
+) {
+    Box(modifier = Modifier.fillMaxSize().testTag(RecipeDetailTestTags.SCREEN)) {
         PlusResponsiveContainer(modifier = Modifier.fillMaxSize()) { windowSizeClass ->
             val isCompact = windowSizeClass == WindowSizeClass.COMPACT
             val showToolbar = isCompact || !metadataCollapsed
@@ -245,7 +313,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                     )
                                 }
                                 Box {
-                                    IconButton(onClick = { showOverflowMenu = true }) {
+                                    IconButton(onClick = { onShowOverflowMenuChange(true) }) {
                                         Icon(
                                             imageVector = Icons.Default.MoreVert,
                                             contentDescription =
@@ -254,7 +322,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                     }
                                     DropdownMenu(
                                         expanded = showOverflowMenu,
-                                        onDismissRequest = { showOverflowMenu = false },
+                                        onDismissRequest = { onShowOverflowMenuChange(false) },
                                     ) {
                                         DropdownMenuItem(
                                             text = {
@@ -264,7 +332,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                                 Icon(Icons.Default.Edit, contentDescription = null)
                                             },
                                             onClick = {
-                                                showOverflowMenu = false
+                                                onShowOverflowMenuChange(false)
                                                 bloc.onEditClicked()
                                             },
                                         )
@@ -284,7 +352,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                                     )
                                                 },
                                                 onClick = {
-                                                    showOverflowMenu = false
+                                                    onShowOverflowMenuChange(false)
                                                     if (shareLauncher(url)) {
                                                         scope.launch {
                                                             snackbarHostState.showSnackbar(
@@ -307,7 +375,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                                 Icon(Icons.Default.Share, contentDescription = null)
                                             },
                                             onClick = {
-                                                showOverflowMenu = false
+                                                onShowOverflowMenuChange(false)
                                                 if (
                                                     shareLauncher(formatRecipeAsText(state.recipe))
                                                 ) {
@@ -332,7 +400,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                                 )
                                             },
                                             onClick = {
-                                                showOverflowMenu = false
+                                                onShowOverflowMenuChange(false)
                                                 bloc.onDeleteClicked()
                                             },
                                         )
@@ -424,6 +492,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                         formattedCookTime = state.formattedCookTime,
                                         formattedTotalTime = state.formattedTotalTime,
                                         onSourceUrlClicked = bloc::onSourceUrlClicked,
+                                        onImageClicked = bloc::onImageClicked,
                                     )
                                 isCompact ->
                                     RecipeDetailCompactContent(
@@ -434,6 +503,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                         formattedCookTime = state.formattedCookTime,
                                         formattedTotalTime = state.formattedTotalTime,
                                         onSourceUrlClicked = bloc::onSourceUrlClicked,
+                                        onImageClicked = bloc::onImageClicked,
                                         modifier = Modifier.weight(1f),
                                     )
                                 else ->
@@ -445,8 +515,9 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                                         formattedCookTime = state.formattedCookTime,
                                         formattedTotalTime = state.formattedTotalTime,
                                         onSourceUrlClicked = bloc::onSourceUrlClicked,
+                                        onImageClicked = bloc::onImageClicked,
                                         metadataCollapsed = metadataCollapsed,
-                                        onMetadataCollapsedChange = { metadataCollapsed = it },
+                                        onMetadataCollapsedChange = onMetadataCollapsedChange,
                                     )
                             }
                         }
@@ -525,6 +596,7 @@ private fun RecipeDetailCompactContent(
     formattedCookTime: TextData?,
     formattedTotalTime: TextData?,
     onSourceUrlClicked: (String) -> Unit,
+    onImageClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val pagerState = rememberPagerState(pageCount = { 2 })
@@ -568,6 +640,7 @@ private fun RecipeDetailCompactContent(
                 formattedCookTime = formattedCookTime,
                 formattedTotalTime = formattedTotalTime,
                 onSourceUrlClicked = onSourceUrlClicked,
+                onImageClicked = onImageClicked,
                 modifier = Modifier.padding(horizontal = padding),
             )
         }
@@ -648,6 +721,7 @@ private fun ColumnScope.RecipeDetailLandscapeContent(
     formattedCookTime: TextData?,
     formattedTotalTime: TextData?,
     onSourceUrlClicked: (String) -> Unit,
+    onImageClicked: () -> Unit,
 ) {
     val padding = ChefMateTheme.dimens.paddingNormal
     val navBarBottom = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
@@ -682,6 +756,7 @@ private fun ColumnScope.RecipeDetailLandscapeContent(
                 contentDescription = recipe.title,
                 modifier = Modifier.fillMaxWidth().height(140.dp),
                 sharedElementKey = "recipe-image-${recipe.id}",
+                onClick = onImageClicked,
             )
             recipe.starRating?.let { rating -> StarRating(rating = rating) }
             recipe.servings?.let { servings ->
@@ -806,6 +881,7 @@ private fun ColumnScope.RecipeDetailExpandedContent(
     formattedCookTime: TextData?,
     formattedTotalTime: TextData?,
     onSourceUrlClicked: (String) -> Unit,
+    onImageClicked: () -> Unit,
     metadataCollapsed: Boolean,
     onMetadataCollapsedChange: (Boolean) -> Unit,
 ) {
@@ -865,6 +941,7 @@ private fun ColumnScope.RecipeDetailExpandedContent(
                         contentDescription = recipe.title,
                         modifier = Modifier.fillMaxWidth().height(180.dp),
                         sharedElementKey = "recipe-image-${recipe.id}",
+                        onClick = onImageClicked,
                     )
                 }
                 recipe.starRating?.let { rating ->
@@ -1143,6 +1220,7 @@ private fun RecipeHeroSection(
     formattedCookTime: TextData?,
     formattedTotalTime: TextData?,
     onSourceUrlClicked: (String) -> Unit,
+    onImageClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -1151,6 +1229,7 @@ private fun RecipeHeroSection(
             contentDescription = recipe.title,
             modifier = Modifier.width(140.dp).height(140.dp),
             sharedElementKey = "recipe-image-${recipe.id}",
+            onClick = onImageClicked,
         )
         Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
             // Star Rating
@@ -1534,6 +1613,17 @@ private val previewBloc =
             )
         override val childSlot: Value<ChildSlot<*, RecipeDetailBloc.Sheet>> =
             MutableValue(ChildSlot<Any, RecipeDetailBloc.Sheet>(null))
+
+        override val fullImageSlot: Value<ChildSlot<*, RecipeDetailBloc.FullImage>> =
+            MutableValue(ChildSlot<Any, RecipeDetailBloc.FullImage>(null))
+
+        override fun onImageClicked() {
+            // Preview no-op
+        }
+
+        override fun onCloseFullImage() {
+            // Preview no-op
+        }
 
         override fun onEditClicked() {
             TODO("Not yet implemented")

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeImageFullScreenScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeImageFullScreenScreen.kt
@@ -1,0 +1,131 @@
+package com.plusmobileapps.chefmate.recipe.core.detail
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import chefmate.client.recipe.core.public.generated.resources.Res
+import chefmate.client.recipe.core.public.generated.resources.recipe_full_image_close
+import coil3.compose.AsyncImage
+import com.plusmobileapps.chefmate.ui.sharedElementBy
+import kotlin.math.abs
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun RecipeImageFullScreenScreen(
+    imageUrl: String,
+    recipeId: Long,
+    contentDescription: String?,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val density = LocalDensity.current
+    val dismissThresholdPx = with(density) { 150.dp.toPx() }
+
+    var scale by remember { mutableStateOf(1f) }
+    var pan by remember { mutableStateOf(Offset.Zero) }
+
+    val animatedDragY = remember { Animatable(0f) }
+    val scope = rememberCoroutineScope()
+
+    val dismissProgress = (abs(animatedDragY.value) / dismissThresholdPx).coerceIn(0f, 1f)
+
+    Box(
+        modifier =
+            modifier.fillMaxSize().background(Color.Black.copy(alpha = 1f - dismissProgress * 0.6f))
+    ) {
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Fit,
+            modifier =
+                Modifier.fillMaxSize()
+                    .sharedElementBy("recipe-image-$recipeId")
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                        translationX = pan.x
+                        translationY = pan.y + animatedDragY.value
+                    }
+                    .pointerInput(Unit) {
+                        detectTransformGestures { _, gPan, gZoom, _ ->
+                            val newScale = (scale * gZoom).coerceIn(1f, 5f)
+                            scale = newScale
+                            pan = if (newScale > 1f) pan + gPan else Offset.Zero
+                        }
+                    }
+                    .pointerInput(scale) {
+                        if (scale <= 1.01f) {
+                            detectVerticalDragGestures(
+                                onDragEnd = {
+                                    if (abs(animatedDragY.value) >= dismissThresholdPx) {
+                                        onDismiss()
+                                    } else {
+                                        scope.launch { animatedDragY.animateTo(0f, tween(200)) }
+                                    }
+                                },
+                                onDragCancel = {
+                                    scope.launch { animatedDragY.animateTo(0f, tween(200)) }
+                                },
+                            ) { _, delta ->
+                                scope.launch { animatedDragY.snapTo(animatedDragY.value + delta) }
+                            }
+                        }
+                    },
+        )
+
+        IconButton(
+            onClick = onDismiss,
+            modifier =
+                Modifier.align(Alignment.TopEnd)
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
+                    .padding(8.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.4f))
+                    .alpha(1f - dismissProgress),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(Res.string.recipe_full_image_close),
+                tint = Color.White,
+            )
+        }
+    }
+
+    LaunchedEffect(scale) {
+        if (scale <= 1.01f && pan != Offset.Zero) {
+            pan = Offset.Zero
+        }
+    }
+}

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/RecipeImage.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/RecipeImage.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
@@ -20,14 +21,22 @@ fun RecipeImage(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     sharedElementKey: String? = null,
+    onClick: (() -> Unit)? = null,
 ) {
     val sharedModifier = Modifier.sharedElementBy(sharedElementKey)
+    val clickModifier =
+        if (imageUrl != null && onClick != null) {
+            Modifier.clickable(onClick = onClick)
+        } else {
+            Modifier
+        }
 
     if (imageUrl != null) {
         AsyncImage(
             model = imageUrl,
             contentDescription = contentDescription,
-            modifier = modifier.then(sharedModifier).clip(MaterialTheme.shapes.medium),
+            modifier =
+                modifier.then(sharedModifier).clip(MaterialTheme.shapes.medium).then(clickModifier),
             contentScale = ContentScale.Crop,
         )
     } else {


### PR DESCRIPTION
Tap the recipe image on the detail screen to open a full-screen viewer that morphs from the thumbnail. Supports pinch-to-zoom + pan, swipe-down-to-dismiss, close button, and system back. Implemented as a SlotNavigation overlay on RecipeDetailBloc with a local SharedTransitionLayout so the same recipe-image-{id} key already on RecipeImage drives the morph automatically.