### PR TITLE
fix(recipe): restore list→detail image morph after fullscreen feature

### DIFF
--- a/.claude/skills/add-shared-element-transition.md
+++ b/.claude/skills/add-shared-element-transition.md
@@ -120,6 +120,17 @@ The key must be unique per logical element across the whole app. Prefix with the
 6. **`Modifier.sharedElement` placement** — apply it before any `clip` / `background` so the shared bounds match the visible bounds. If clip is applied first, the shared element animates the unclipped rect.
 7. **Replicating `slide()` / `verticalSlide()`** — Decompose's animator is direction-aware. In `transitionSpec`, infer direction from `stack.items.indexOfFirst { it.key == initialState.key }` vs `targetState.key`. If `initialIndex < 0` (popped), treat as back. See `RootScreen.kt` for the full spec.
 8. **Preview support** — `RecipeImage`-style components rendered in a `@Preview` won't have `LocalSharedTransitionScope` set; the null-check above handles this. Don't wrap previews in `SharedTransitionLayout` unless the preview is specifically for the transition.
+9. **An element that participates in two transitions needs two registrations.** The shared-element framework only morphs when *both* source and destination AVSes are transitioning in opposite directions. A settled-visible AVS on either side gives a hard snap to the final bounds, not a morph. Concretely: if a recipe image is the destination of a cross-screen morph (list → detail, both in root-level AVSes) and *also* the source of an in-screen morph (detail body → fullscreen overlay, both in an inner `AnimatedContent`'s AVSes), one `Modifier.sharedElement` cannot serve both — its AVS only transitions for one of the two events. Also, **never re-provide `LocalSharedTransitionScope` from a nested `SharedTransitionLayout`**: the inner scope and outer scope are different `SharedTransitionScope` instances, and the framework only pairs keys within a single scope.
+
+    The fix: keep one `SharedTransitionLayout` (the outer one) and add a *second* shared-element registration on the bridging element with a distinct key and the inner AVS:
+
+    - Outer transition keeps the original key, primary AVS via `LocalAnimatedVisibilityScope` (the root's).
+    - Inner transition uses a distinct key (e.g. `"recipe-image-fullscreen-{id}"`), explicit AVS via `LocalSecondaryAnimatedVisibilityScope` (the inner `AnimatedContent`'s `this`).
+    - The bridging composable applies both modifiers (see `RecipeImage` for the `sharedElementKey` + `secondarySharedElementKey` pattern).
+    - The fullscreen-only target uses the inner key with the inner AVS — override `LocalAnimatedVisibilityScope` only inside the fullscreen branch.
+    - Don't override `LocalAnimatedVisibilityScope` in the body branch — it must keep pointing at the outer AVS so the cross-screen morph still pairs.
+
+    Symptom of getting this wrong: the cross-screen morph drops to a hard cut ("the destination just snaps to its final size") even though the in-screen morph still works. See `RecipeDetailScreen` (body branch provides `LocalSecondaryAnimatedVisibilityScope`; fullscreen branch overrides `LocalAnimatedVisibilityScope`) and `RecipeImage` (chains `sharedElementBy(key)` and `sharedElementBy(secondaryKey, scope)`) for the worked example.
 
 ## Verification checklist
 

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -8,7 +8,6 @@ package com.plusmobileapps.chefmate.recipe.core.detail
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -159,7 +158,7 @@ import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.KeepScreenOn
 import com.plusmobileapps.chefmate.ui.LocalAnimatedVisibilityScope
-import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
+import com.plusmobileapps.chefmate.ui.LocalSecondaryAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
@@ -229,37 +228,41 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     val fullImageSlot by bloc.fullImageSlot.subscribeAsState()
     val fullImageActive = fullImageSlot.child?.instance as? RecipeDetailBloc.FullImage.Active
 
-    SharedTransitionLayout(modifier = modifier.fillMaxSize()) {
-        AnimatedContent(
-            targetState = fullImageActive,
-            transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(250)) },
-            label = "recipe-detail-full-image",
-        ) { fullImage ->
-            CompositionLocalProvider(
-                LocalSharedTransitionScope provides this@SharedTransitionLayout,
-                LocalAnimatedVisibilityScope provides this,
-            ) {
-                if (fullImage != null) {
-                    RecipeImageFullScreenScreen(
-                        imageUrl = fullImage.imageUrl,
-                        recipeId = fullImage.recipeId,
-                        contentDescription = fullImage.title,
-                        onDismiss = bloc::onCloseFullImage,
-                    )
-                } else {
-                    RecipeDetailBody(
-                        bloc = bloc,
-                        state = state,
-                        showOverflowMenu = showOverflowMenu,
-                        onShowOverflowMenuChange = { showOverflowMenu = it },
-                        metadataCollapsed = metadataCollapsed,
-                        onMetadataCollapsedChange = { metadataCollapsed = it },
-                        snackbarHostState = snackbarHostState,
-                        shareLauncher = shareLauncher,
-                        copiedMessage = copiedMessage,
-                        scope = scope,
-                    )
-                }
+    AnimatedContent(
+        targetState = fullImageActive,
+        transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(250)) },
+        label = "recipe-detail-full-image",
+        modifier = modifier.fillMaxSize(),
+    ) { fullImage ->
+        if (fullImage != null) {
+            // Override primary AVS so the fullscreen image registers in the inner
+            // AnimatedContent's AVS — pairing with the body image's *secondary* registration
+            // (LocalSecondaryAnimatedVisibilityScope) for the morph.
+            CompositionLocalProvider(LocalAnimatedVisibilityScope provides this) {
+                RecipeImageFullScreenScreen(
+                    imageUrl = fullImage.imageUrl,
+                    recipeId = fullImage.recipeId,
+                    contentDescription = fullImage.title,
+                    onDismiss = bloc::onCloseFullImage,
+                )
+            }
+        } else {
+            // Body image keeps the *outer* (RecipeRoot) AVS via the unchanged
+            // LocalAnimatedVisibilityScope so the cross-stack list↔detail morph still works,
+            // and exposes the inner AVS as a *secondary* scope for body↔fullscreen.
+            CompositionLocalProvider(LocalSecondaryAnimatedVisibilityScope provides this) {
+                RecipeDetailBody(
+                    bloc = bloc,
+                    state = state,
+                    showOverflowMenu = showOverflowMenu,
+                    onShowOverflowMenuChange = { showOverflowMenu = it },
+                    metadataCollapsed = metadataCollapsed,
+                    onMetadataCollapsedChange = { metadataCollapsed = it },
+                    snackbarHostState = snackbarHostState,
+                    shareLauncher = shareLauncher,
+                    copiedMessage = copiedMessage,
+                    scope = scope,
+                )
             }
         }
     }
@@ -756,6 +759,7 @@ private fun ColumnScope.RecipeDetailLandscapeContent(
                 contentDescription = recipe.title,
                 modifier = Modifier.fillMaxWidth().height(140.dp),
                 sharedElementKey = "recipe-image-${recipe.id}",
+                secondarySharedElementKey = "recipe-image-fullscreen-${recipe.id}",
                 onClick = onImageClicked,
             )
             recipe.starRating?.let { rating -> StarRating(rating = rating) }
@@ -941,6 +945,7 @@ private fun ColumnScope.RecipeDetailExpandedContent(
                         contentDescription = recipe.title,
                         modifier = Modifier.fillMaxWidth().height(180.dp),
                         sharedElementKey = "recipe-image-${recipe.id}",
+                        secondarySharedElementKey = "recipe-image-fullscreen-${recipe.id}",
                         onClick = onImageClicked,
                     )
                 }
@@ -1229,6 +1234,7 @@ private fun RecipeHeroSection(
             contentDescription = recipe.title,
             modifier = Modifier.width(140.dp).height(140.dp),
             sharedElementKey = "recipe-image-${recipe.id}",
+            secondarySharedElementKey = "recipe-image-fullscreen-${recipe.id}",
             onClick = onImageClicked,
         )
         Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeImageFullScreenScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeImageFullScreenScreen.kt
@@ -71,7 +71,7 @@ internal fun RecipeImageFullScreenScreen(
             contentScale = ContentScale.Fit,
             modifier =
                 Modifier.fillMaxSize()
-                    .sharedElementBy("recipe-image-$recipeId")
+                    .sharedElementBy("recipe-image-fullscreen-$recipeId")
                     .graphicsLayer {
                         scaleX = scale
                         scaleY = scale

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/SharedTransitionScopes.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/SharedTransitionScopes.kt
@@ -14,18 +14,38 @@ val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { nu
 val LocalAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> { null }
 
 /**
+ * Secondary [AnimatedVisibilityScope] for elements that participate in *two* transitions
+ * simultaneously. Compose's shared-element framework only morphs when both source and destination
+ * AVSes are transitioning, so an element bridging an outer (cross-screen) and inner (in-screen
+ * overlay) transition needs a second registration with this scope and a distinct key. See
+ * `RecipeDetailScreen` for the reference wiring.
+ */
+val LocalSecondaryAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> { null }
+
+/**
  * Applies `Modifier.sharedElement` when [key] is non-null and both scopes are present. Use for
  * visually identical content morphing between locations (e.g. an image).
  */
 @Composable
-fun Modifier.sharedElementBy(key: String?): Modifier {
+fun Modifier.sharedElementBy(key: String?): Modifier =
+    sharedElementBy(key = key, animatedVisibilityScope = LocalAnimatedVisibilityScope.current)
+
+/**
+ * Variant of [sharedElementBy] that takes an explicit [animatedVisibilityScope] instead of pulling
+ * it from [LocalAnimatedVisibilityScope]. Use this when registering a *secondary* shared element on
+ * an element already bound to a different AVS — see [LocalSecondaryAnimatedVisibilityScope].
+ */
+@Composable
+fun Modifier.sharedElementBy(
+    key: String?,
+    animatedVisibilityScope: AnimatedVisibilityScope?,
+): Modifier {
     val sharedScope = LocalSharedTransitionScope.current
-    val animatedScope = LocalAnimatedVisibilityScope.current
-    return if (key != null && sharedScope != null && animatedScope != null) {
+    return if (key != null && sharedScope != null && animatedVisibilityScope != null) {
         with(sharedScope) {
             this@sharedElementBy.sharedElement(
                 sharedContentState = rememberSharedContentState(key = key),
-                animatedVisibilityScope = animatedScope,
+                animatedVisibilityScope = animatedVisibilityScope,
             )
         }
     } else this

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/RecipeImage.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/RecipeImage.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import coil3.compose.AsyncImage
+import com.plusmobileapps.chefmate.ui.LocalSecondaryAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.sharedElementBy
 
 @Composable
@@ -21,9 +22,15 @@ fun RecipeImage(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     sharedElementKey: String? = null,
+    secondarySharedElementKey: String? = null,
     onClick: (() -> Unit)? = null,
 ) {
     val sharedModifier = Modifier.sharedElementBy(sharedElementKey)
+    val secondarySharedModifier =
+        Modifier.sharedElementBy(
+            key = secondarySharedElementKey,
+            animatedVisibilityScope = LocalSecondaryAnimatedVisibilityScope.current,
+        )
     val clickModifier =
         if (imageUrl != null && onClick != null) {
             Modifier.clickable(onClick = onClick)
@@ -36,7 +43,11 @@ fun RecipeImage(
             model = imageUrl,
             contentDescription = contentDescription,
             modifier =
-                modifier.then(sharedModifier).clip(MaterialTheme.shapes.medium).then(clickModifier),
+                modifier
+                    .then(sharedModifier)
+                    .then(secondarySharedModifier)
+                    .clip(MaterialTheme.shapes.medium)
+                    .then(clickModifier),
             contentScale = ContentScale.Crop,
         )
     } else {
@@ -44,6 +55,7 @@ fun RecipeImage(
             modifier =
                 modifier
                     .then(sharedModifier)
+                    .then(secondarySharedModifier)
                     .clip(MaterialTheme.shapes.medium)
                     .background(MaterialTheme.colorScheme.surfaceVariant),
             contentAlignment = Alignment.Center,


### PR DESCRIPTION
## Summary

- PR #167 wrapped `RecipeDetailScreen` in a nested `SharedTransitionLayout` and re-provided `LocalSharedTransitionScope` from it. The body image then registered in a different `SharedTransitionScope` from the list image, and its AVS became the inner `AnimatedContent`'s body-AVS (settled). Result: the list→detail image morph dropped to a hard cut — the destination just snapped to its final size.
- Compose's shared-element framework only morphs when both source and destination AVSes are transitioning in opposite directions, so the body image — which bridges *two* transitions (list↔detail at root level, body↔fullscreen inside the detail screen) — needs **two** registrations.
- Fix: drop the nested `SharedTransitionLayout`, keep the body image's primary registration on the outer (RecipeRoot) AVS via the existing `LocalAnimatedVisibilityScope`, and add a *secondary* registration with a distinct `recipe-image-fullscreen-{id}` key on the inner AVS via a new `LocalSecondaryAnimatedVisibilityScope`. The fullscreen overlay matches the new key.
- Updated the `add-shared-element-transition` skill (gotcha #9) with the AVS-pair rule and the dual-key technique.

## Test plan

- [ ] Android: open recipe list → tap a recipe → image morphs from list cell into the detail hero (regression fix)
- [ ] Android: on detail, tap the hero image → morphs to fullscreen (existing PR #167 feature)
- [ ] Android: close fullscreen → morphs back to body
- [ ] Same three checks on phone landscape (`RecipeDetailLandscapeContent` body image)
- [ ] Same three checks on tablet/expanded (`RecipeDetailExpandedContent` body image)
- [ ] `./gradlew :client:composeApp:compileKotlinJvm` passes ✓
- [ ] `./gradlew :client:recipe:core:impl:jvmTest --tests "*RecipeDetailBlocImplTest*"` passes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)