### PR TITLE
feat: feature flag module (Supabase-backed remote config)

### DIFF
--- a/.claude/skills/add-feature-flag.md
+++ b/.claude/skills/add-feature-flag.md
@@ -1,0 +1,132 @@
+# add-feature-flag
+
+Add a new feature flag to the ChefMate KMP project — registers it in code, inserts the Supabase row, and wires it into the Bloc or ViewModel that needs it.
+
+## Required input
+
+Ask the user (if not provided):
+
+1. **Flag name** — short, snake_case key, e.g. `show_onboarding_v2`. This becomes `FeatureFlag.key` and the Supabase row primary key.
+2. **Flag type** — `Boolean` (on/off) or `String` (arbitrary text value).
+3. **Default value** — what the app uses when offline, before the first refresh, or when no row exists. Pick the *safer* outcome (usually `false` for boolean, `""` for string).
+4. **Description** — one sentence shown in the dev-settings Feature Flags screen.
+5. **Where it's consumed** — which Bloc or ViewModel should read the flag.
+
+## Where the pieces live
+
+| Concern | Path |
+|---|---|
+| Flag registry (add the object here) | `client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlag.kt` |
+| Public API (`FeatureFlags`, `isEnabled`) | `client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlags.kt` |
+| Fake for tests | `client/featureflag/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/testing/FakeFeatureFlags.kt` |
+| Supabase table docs + SQL | `docs/feature-flags.md` |
+
+## Step 1 — Register the flag in code
+
+Open `FeatureFlag.kt` and add a new `object` inside `FeatureFlagRegistry`:
+
+**Boolean flag:**
+```kotlin
+object ShowOnboardingV2 : BooleanFlag(
+    key = "show_onboarding_v2",
+    defaultValue = false,
+    description = "Show the redesigned onboarding flow.",
+)
+```
+
+**String flag:**
+```kotlin
+object HomeBannerText : StringFlag(
+    key = "home_banner_text",
+    defaultValue = "",
+    description = "Optional banner copy shown on the home screen.",
+)
+```
+
+Then append it to `FeatureFlagRegistry.all`:
+```kotlin
+val all: List<FeatureFlag<*>> = listOf(CookModeV2, HomeBannerText, ShowOnboardingV2)
+```
+
+`all` drives the dev-settings Feature Flags screen — every flag in the list gets a row there automatically.
+
+## Step 2 — Insert the Supabase row
+
+Run this in the Supabase SQL editor (Table Editor works too):
+
+**Boolean flag:**
+```sql
+insert into feature_flags (key, value_type, value, enabled, rollout_percent)
+values ('show_onboarding_v2', 'bool', 'false', true, 0);
+```
+
+**String flag:**
+```sql
+insert into feature_flags (key, value_type, value, enabled, rollout_percent)
+values ('home_banner_text', 'string', '', true, 0);
+```
+
+`rollout_percent = 0` means nobody gets the non-default value yet. Bump it when ready to roll out:
+```sql
+update feature_flags set rollout_percent = 100 where key = 'show_onboarding_v2';
+```
+
+## Step 3 — Read the flag in a Bloc or ViewModel
+
+Inject `FeatureFlags` and expose a `StateFlow`:
+
+**Boolean (most common):**
+```kotlin
+@Inject
+class MyViewModel(
+    @Main mainContext: CoroutineContext,
+    featureFlags: FeatureFlags,
+    // … other deps
+) : ViewModel(mainContext) {
+
+    val showOnboardingV2: StateFlow<Boolean> =
+        featureFlags.isEnabled(FeatureFlagRegistry.ShowOnboardingV2)
+}
+```
+
+**String:**
+```kotlin
+val bannerText: StateFlow<String> =
+    featureFlags.valueOf(FeatureFlagRegistry.HomeBannerText)
+```
+
+Then surface it through the Bloc's `Model` as usual (`mapState`, `collectAsState`, etc.).
+
+## Step 4 — Update tests that construct the ViewModel / Bloc
+
+Any test that instantiates the ViewModel or Bloc now needs `FakeFeatureFlags`. The fake defaults everything to the flag's `defaultValue`, so existing tests require no change unless they specifically need a different value:
+
+```kotlin
+// default — flag returns its in-code defaultValue
+val vm = MyViewModel(mainContext, FakeFeatureFlags(), …)
+
+// override for a specific test
+val fake = FakeFeatureFlags(mapOf(FeatureFlagRegistry.ShowOnboardingV2 to true))
+val vm = MyViewModel(mainContext, fake, …)
+
+// change the value mid-test (triggers StateFlow update)
+fake.set(FeatureFlagRegistry.ShowOnboardingV2, false)
+```
+
+## Gotchas
+
+- **`key` must match exactly** — the Supabase `key` column is the primary key and is case-sensitive. A mismatch means the client silently returns `defaultValue` for every user.
+- **`value_type` must agree with the Kotlin type** — `BooleanFlag` expects `value_type = 'bool'`; `StringFlag` expects `'string'`. A mismatch is treated as a missing row (falls back to `defaultValue`).
+- **`rollout_percent = 0` on insert** — always start at 0 and ramp deliberately. Starting at 100 is a one-way door until you edit the row.
+- **Changes propagate on cold start** — there is no live poll. To test immediately on a device, use Developer Settings → Feature Flags to force-override the flag without changing the remote row.
+- **`all` list drives the dev UI** — if you forget to append to `FeatureFlagRegistry.all`, the flag won't appear in the Feature Flags screen and can't be overridden from dev settings.
+- **`FakeFeatureFlags` is type-safe** — `fake.set(flag, value)` is generic; the compiler rejects `fake.set(BooleanFlag, "string")`. If you see a type error there, you're setting the wrong value type.
+
+## Verification checklist
+
+1. `./gradlew :client:featureflag:public:compileKotlinMetadata` — registry change compiles.
+2. `./gradlew :client:composeApp:compileDebugKotlinAndroid` — end-to-end compile check.
+3. `./gradlew :client:<consuming-module>:impl:test` — existing tests still pass.
+4. `./gradlew ktfmtFormat` — keep formatting clean.
+5. In a debug build, open Developer Settings → Feature Flags and confirm the new flag appears in the list with the correct default.
+6. Force-override it ON/OFF and confirm the consuming screen reacts correctly.

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -81,6 +81,8 @@ kotlin {
             api(projects.client.auth.usecase.impl)
             api(projects.client.cook.impl)
             api(projects.client.cook.public)
+            api(projects.client.featureflag.impl)
+            api(projects.client.featureflag.public)
             api(projects.client.grocery.data.impl)
             api(projects.client.grocery.core.impl)
             api(projects.client.grocery.core.public)

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsBlocImpl.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsBlocImpl.kt
@@ -71,6 +71,10 @@ class DeveloperSettingsBlocImpl(
     override fun onSignInErrorDismissed() {
         viewModel.dismissSignInError()
     }
+
+    override fun onFeatureFlagsClicked() {
+        output.onNext(Output.OpenFeatureFlags)
+    }
 }
 
 @ContributesTo(AppScope::class)

--- a/client/developer-settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/developer-settings/public/src/commonMain/composeResources/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="dev_restart_required_title">Restart required</string>
     <string name="dev_restart_required_message">Environment changed. Local data was wiped and you were signed out. Force-stop and reopen the app for the new environment to take effect.</string>
     <string name="dev_picker_dismiss">Cancel</string>
+    <string name="dev_feature_flags">Feature flags</string>
 </resources>

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsBloc.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsBloc.kt
@@ -28,6 +28,8 @@ interface DeveloperSettingsBloc {
 
     fun onSignInErrorDismissed()
 
+    fun onFeatureFlagsClicked()
+
     data class Model(
         val currentEnvironment: Environment = Environment.PROD,
         val availableUsers: List<TestUser> = emptyList(),
@@ -42,6 +44,8 @@ interface DeveloperSettingsBloc {
 
     sealed class Output {
         data object Back : Output()
+
+        data object OpenFeatureFlags : Output()
     }
 
     fun interface Factory {

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
@@ -49,8 +49,8 @@ import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
-import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -97,7 +97,7 @@ fun DeveloperSettingsScreen(bloc: DeveloperSettingsBloc, modifier: Modifier = Mo
     }
 
     Surface(modifier = modifier.fillMaxSize(), color = ChefMateTheme.colorScheme.background) {
-        PlusNavContainer(
+        PlusHeaderContainer(
             data =
                 PlusHeaderData.Child(
                     title = Res.string.developer_settings.asTextData(),

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsScreen.kt
@@ -30,6 +30,7 @@ import chefmate.client.developer_settings.public.generated.resources.dev_env_fak
 import chefmate.client.developer_settings.public.generated.resources.dev_env_prod
 import chefmate.client.developer_settings.public.generated.resources.dev_env_testing
 import chefmate.client.developer_settings.public.generated.resources.dev_environment
+import chefmate.client.developer_settings.public.generated.resources.dev_feature_flags
 import chefmate.client.developer_settings.public.generated.resources.dev_login_as_user
 import chefmate.client.developer_settings.public.generated.resources.dev_no_test_users
 import chefmate.client.developer_settings.public.generated.resources.dev_no_test_users_message
@@ -123,6 +124,11 @@ fun DeveloperSettingsScreen(bloc: DeveloperSettingsBloc, modifier: Modifier = Mo
                         onClick = bloc::onSignOutTestUserClicked,
                     )
                 }
+                HorizontalDivider()
+                DeveloperRow(
+                    title = Res.string.dev_feature_flags.asTextData(),
+                    onClick = bloc::onFeatureFlagsClicked,
+                )
             },
         )
     }
@@ -310,4 +316,6 @@ val previewDeveloperSettingsBloc =
         override fun onRestartPromptDismissed() = Unit
 
         override fun onSignInErrorDismissed() = Unit
+
+        override fun onFeatureFlagsClicked() = Unit
     }

--- a/client/featureflag/impl/build.gradle.kts
+++ b/client/featureflag/impl/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.kotlinSerialization)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.featureflag.public)
+            implementation(projects.client.shared)
+            implementation(projects.client.auth.data.public)
+            implementation(libs.arkivanov.decompose.core)
+            implementation(libs.kotlinx.serialization.json)
+            implementation(libs.supabase.client)
+            implementation(libs.supabase.postgrest)
+        }
+        commonTest.dependencies {
+            implementation(libs.multiplatform.settings.test)
+            implementation(libs.kotlin.coroutines.test)
+            implementation(libs.kotest.assertions)
+            implementation(libs.turbine)
+            implementation(projects.client.auth.data.testing)
+        }
+    }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.featureflag.impl"
+    enableDi = true
+    enableTesting = true
+}

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/BucketingIdentityProvider.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/BucketingIdentityProvider.kt
@@ -1,0 +1,45 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.mapState
+import com.russhwolf.settings.Settings
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.flow.StateFlow
+
+@Inject
+@SingleIn(AppScope::class)
+class BucketingIdentityProvider(
+    authRepository: AuthenticationRepository,
+    private val settings: Settings,
+) {
+    private val deviceId: String = ensureDeviceId()
+
+    val identity: StateFlow<String> =
+        authRepository.state.mapState { state ->
+            when (state) {
+                is AuthState.Authenticated -> state.user.userId
+                is AuthState.AwaitingEmailVerification,
+                AuthState.Unauthenticated -> deviceId
+            }
+        }
+
+    private fun ensureDeviceId(): String {
+        settings.getStringOrNull(KEY)?.let {
+            return it
+        }
+        val generated = Uuid.random().toString()
+        settings.putString(KEY, generated)
+        return generated
+    }
+
+    private companion object {
+        const val KEY = "flags.bucket_id"
+    }
+}

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/EvaluatorBindings.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/EvaluatorBindings.kt
@@ -1,0 +1,13 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+@ContributesTo(AppScope::class)
+interface FeatureFlagEvaluatorModule {
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideEvaluator(): FeatureFlagEvaluator = FeatureFlagEvaluator()
+}

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagCache.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagCache.kt
@@ -1,0 +1,28 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.di.AppScope
+import com.russhwolf.settings.Settings
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.serialization.json.Json
+
+@Inject
+@SingleIn(AppScope::class)
+class FeatureFlagCache(private val settings: Settings) {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun load(): List<FeatureFlagRow> {
+        val raw = settings.getStringOrNull(KEY) ?: return emptyList()
+        return runCatching { json.decodeFromString<List<FeatureFlagRow>>(raw) }
+            .getOrElse { emptyList() }
+    }
+
+    fun save(rows: List<FeatureFlagRow>) {
+        settings.putString(KEY, json.encodeToString(rows))
+    }
+
+    private companion object {
+        const val KEY = "flags.cache.v1"
+    }
+}

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagEvaluator.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagEvaluator.kt
@@ -1,0 +1,58 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.Platform
+import com.plusmobileapps.chefmate.featureflag.BooleanFlag
+import com.plusmobileapps.chefmate.featureflag.FeatureFlag
+import com.plusmobileapps.chefmate.featureflag.StringFlag
+
+data class EvaluationContext(val identity: String, val platform: Platform, val versionName: String)
+
+class FeatureFlagEvaluator {
+
+    fun <T : Any> evaluate(
+        flag: FeatureFlag<T>,
+        row: FeatureFlagRow?,
+        context: EvaluationContext,
+    ): T {
+        if (row == null) return flag.defaultValue
+        if (!row.enabled) return flag.defaultValue
+        if (!platformMatches(row.platforms, context.platform)) return flag.defaultValue
+        if (!versionMatches(row.minVersion, row.maxVersion, context.versionName)) {
+            return flag.defaultValue
+        }
+        if (!inRollout(flag.key, context.identity, row.rolloutPercent)) return flag.defaultValue
+        return parseValue(flag, row.valueType, row.value)
+    }
+
+    private fun platformMatches(allowed: List<String>?, current: Platform): Boolean {
+        if (allowed.isNullOrEmpty()) return true
+        return allowed.any { it.equals(current.name, ignoreCase = true) }
+    }
+
+    private fun versionMatches(min: String?, max: String?, current: String): Boolean {
+        if (min != null && compareSemver(current, min) < 0) return false
+        if (max != null && compareSemver(current, max) > 0) return false
+        return true
+    }
+
+    private fun inRollout(flagKey: String, identity: String, rolloutPercent: Int): Boolean {
+        val clamped = rolloutPercent.coerceIn(0, 100)
+        if (clamped <= 0) return false
+        if (clamped >= 100) return true
+        return bucket(flagKey, identity) < clamped
+    }
+
+    private fun <T : Any> parseValue(flag: FeatureFlag<T>, valueType: String, value: String): T {
+        @Suppress("UNCHECKED_CAST")
+        return when (flag) {
+            is BooleanFlag -> {
+                if (!valueType.equals("bool", ignoreCase = true)) flag.defaultValue
+                else (value.equals("true", ignoreCase = true)) as T
+            }
+            is StringFlag -> {
+                if (!valueType.equals("string", ignoreCase = true)) flag.defaultValue
+                else value as T
+            }
+        }
+    }
+}

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagOverridesImpl.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagOverridesImpl.kt
@@ -1,0 +1,76 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.featureflag.BooleanFlag
+import com.plusmobileapps.chefmate.featureflag.FeatureFlag
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagOverrides
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
+import com.plusmobileapps.chefmate.featureflag.Override
+import com.plusmobileapps.chefmate.featureflag.StringFlag
+import com.russhwolf.settings.Settings
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class FeatureFlagOverridesImpl(private val settings: Settings) : FeatureFlagOverrides {
+
+    private val states: MutableMap<String, MutableStateFlow<Override<*>>> =
+        FeatureFlagRegistry.all
+            .associate { it.key to MutableStateFlow<Override<*>>(loadOverride(it)) }
+            .toMutableMap()
+
+    override fun <T : Any> overrideOf(flag: FeatureFlag<T>): StateFlow<Override<T>> {
+        val flow = states.getOrPut(flag.key) { MutableStateFlow(loadOverride(flag)) }
+        @Suppress("UNCHECKED_CAST")
+        return flow.asStateFlow() as StateFlow<Override<T>>
+    }
+
+    override fun <T : Any> setOverride(flag: FeatureFlag<T>, override: Override<T>) {
+        when (override) {
+            Override.Default -> {
+                settings.remove(presentKey(flag.key))
+                settings.remove(valueKey(flag.key))
+            }
+            is Override.ForceValue -> {
+                settings.putBoolean(presentKey(flag.key), true)
+                settings.putString(valueKey(flag.key), override.value.toString())
+            }
+        }
+        val flow = states.getOrPut(flag.key) { MutableStateFlow(Override.Default) }
+        flow.value = override
+    }
+
+    override fun clearAll() {
+        FeatureFlagRegistry.all.forEach { flag ->
+            settings.remove(presentKey(flag.key))
+            settings.remove(valueKey(flag.key))
+            states[flag.key]?.value = Override.Default
+        }
+    }
+
+    private fun <T : Any> loadOverride(flag: FeatureFlag<T>): Override<T> {
+        val present = settings.getBooleanOrNull(presentKey(flag.key)) ?: false
+        if (!present) return Override.Default
+        val raw = settings.getStringOrNull(valueKey(flag.key)) ?: return Override.Default
+        @Suppress("UNCHECKED_CAST")
+        return when (flag) {
+            is BooleanFlag ->
+                Override.ForceValue(raw.equals("true", ignoreCase = true)) as Override<T>
+            is StringFlag -> Override.ForceValue(raw) as Override<T>
+        }
+    }
+
+    private fun presentKey(key: String): String = "$KEY_PREFIX$key.present"
+
+    private fun valueKey(key: String): String = "$KEY_PREFIX$key.value"
+
+    private companion object {
+        const val KEY_PREFIX = "flags.override."
+    }
+}

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagRepositoryImpl.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagRepositoryImpl.kt
@@ -1,0 +1,74 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import co.touchlab.kermit.Logger
+import com.plusmobileapps.chefmate.buildconfig.BuildConfig
+import com.plusmobileapps.chefmate.combineStates
+import com.plusmobileapps.chefmate.currentPlatform
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.featureflag.FeatureFlag
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagOverrides
+import com.plusmobileapps.chefmate.featureflag.FeatureFlags
+import com.plusmobileapps.chefmate.featureflag.Override
+import com.plusmobileapps.chefmate.mapState
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class FeatureFlagRepositoryImpl(
+    private val evaluator: FeatureFlagEvaluator,
+    private val cache: FeatureFlagCache,
+    private val remote: FeatureFlagRemoteDataSource,
+    private val overrides: FeatureFlagOverrides,
+    private val identityProvider: BucketingIdentityProvider,
+) : FeatureFlags {
+
+    private val log = Logger.withTag("FeatureFlags")
+
+    private val rows: MutableStateFlow<Map<String, FeatureFlagRow>> =
+        MutableStateFlow(cache.load().associateBy { it.key })
+
+    override fun <T : Any> valueOf(flag: FeatureFlag<T>): StateFlow<T> {
+        val rowFlow = rows.mapState { it[flag.key] }
+        val rowAndIdentity =
+            combineStates(rowFlow, identityProvider.identity) { row, id -> row to id }
+        return combineStates(rowAndIdentity, overrides.overrideOf(flag)) { (row, id), override ->
+            resolve(flag, row, override, id)
+        }
+    }
+
+    override suspend fun refresh() {
+        try {
+            val fetched = remote.fetch()
+            rows.value = fetched.associateBy { it.key }
+            cache.save(fetched)
+        } catch (e: Throwable) {
+            log.w(e) { "Failed to refresh feature flags; falling back to cached values." }
+        }
+    }
+
+    private fun <T : Any> resolve(
+        flag: FeatureFlag<T>,
+        row: FeatureFlagRow?,
+        override: Override<T>,
+        identity: String,
+    ): T =
+        when (override) {
+            is Override.ForceValue -> override.value
+            Override.Default ->
+                evaluator.evaluate(
+                    flag = flag,
+                    row = row,
+                    context =
+                        EvaluationContext(
+                            identity = identity,
+                            platform = currentPlatform,
+                            versionName = BuildConfig.VERSION_NAME,
+                        ),
+                )
+        }
+}

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagRow.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagRow.kt
@@ -1,0 +1,16 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FeatureFlagRow(
+    val key: String,
+    @SerialName("value_type") val valueType: String,
+    val value: String,
+    val enabled: Boolean,
+    @SerialName("rollout_percent") val rolloutPercent: Int,
+    val platforms: List<String>? = null,
+    @SerialName("min_version") val minVersion: String? = null,
+    @SerialName("max_version") val maxVersion: String? = null,
+)

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagsBlocImpl.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagsBlocImpl.kt
@@ -1,0 +1,66 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.featureflag.BooleanFlag
+import com.plusmobileapps.chefmate.featureflag.FeatureFlag
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc.Output
+import com.plusmobileapps.chefmate.featureflag.Override
+import com.plusmobileapps.chefmate.featureflag.StringFlag
+import com.plusmobileapps.chefmate.getViewModel
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides
+import kotlinx.coroutines.flow.StateFlow
+
+@AssistedInject
+class FeatureFlagsBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<Output>,
+    viewModelFactory: Provider<FeatureFlagsViewModel>,
+) : FeatureFlagsBloc, BlocContext by context {
+
+    @AssistedFactory
+    fun interface ManagedFactory {
+        fun create(context: BlocContext, output: Consumer<Output>): FeatureFlagsBlocImpl
+    }
+
+    private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
+
+    override val state: StateFlow<FeatureFlagsBloc.Model> = viewModel.state
+
+    override fun onBack() {
+        output.onNext(Output.Back)
+    }
+
+    override fun onSetBooleanOverride(flag: BooleanFlag, override: Override<Boolean>) {
+        viewModel.setBooleanOverride(flag, override)
+    }
+
+    override fun onSetStringOverride(flag: StringFlag, value: String) {
+        viewModel.setStringOverride(flag, value)
+    }
+
+    override fun onClearOverride(flag: FeatureFlag<*>) {
+        viewModel.clearOverride(flag)
+    }
+
+    override fun onClearAllOverrides() {
+        viewModel.clearAll()
+    }
+}
+
+@ContributesTo(AppScope::class)
+interface FeatureFlagsBlocBindingModule {
+    @Provides
+    fun provideFeatureFlagsBlocFactory(
+        factory: FeatureFlagsBlocImpl.ManagedFactory
+    ): FeatureFlagsBloc.Factory = FeatureFlagsBloc.Factory { context, output ->
+        factory.create(context, output)
+    }
+}

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagsViewModel.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagsViewModel.kt
@@ -1,0 +1,65 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.featureflag.BooleanFlag
+import com.plusmobileapps.chefmate.featureflag.FeatureFlag
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagOverrides
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
+import com.plusmobileapps.chefmate.featureflag.FeatureFlags
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
+import com.plusmobileapps.chefmate.featureflag.Override
+import com.plusmobileapps.chefmate.featureflag.StringFlag
+import dev.zacsweers.metro.Inject
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+
+@Inject
+class FeatureFlagsViewModel(
+    @Main mainContext: CoroutineContext,
+    private val featureFlags: FeatureFlags,
+    private val overrides: FeatureFlagOverrides,
+) : ViewModel(mainContext) {
+
+    val state: StateFlow<FeatureFlagsBloc.Model> = buildState()
+
+    private fun buildState(): StateFlow<FeatureFlagsBloc.Model> {
+        val rowFlows: List<Flow<FeatureFlagsBloc.Row>> = FeatureFlagRegistry.all.map { rowFor(it) }
+        val combined: Flow<FeatureFlagsBloc.Model> =
+            if (rowFlows.isEmpty()) {
+                flowOf(FeatureFlagsBloc.Model())
+            } else {
+                combine(rowFlows) { rows -> FeatureFlagsBloc.Model(rows = rows.toList()) }
+            }
+        return combined.stateIn(scope, SharingStarted.Eagerly, FeatureFlagsBloc.Model())
+    }
+
+    private fun <T : Any> rowFor(flag: FeatureFlag<T>): Flow<FeatureFlagsBloc.Row> =
+        combine(featureFlags.valueOf(flag), overrides.overrideOf(flag)) { value, override ->
+            FeatureFlagsBloc.Row(flag = flag, resolvedValue = value, override = override)
+        }
+
+    fun setBooleanOverride(flag: BooleanFlag, override: Override<Boolean>) {
+        overrides.setOverride(flag, override)
+    }
+
+    fun setStringOverride(flag: StringFlag, value: String) {
+        overrides.setOverride(flag, Override.ForceValue(value))
+    }
+
+    fun clearOverride(flag: FeatureFlag<*>) {
+        when (flag) {
+            is BooleanFlag -> overrides.setOverride(flag, Override.Default)
+            is StringFlag -> overrides.setOverride(flag, Override.Default)
+        }
+    }
+
+    fun clearAll() {
+        overrides.clearAll()
+    }
+}

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/Fnv1a.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/Fnv1a.kt
@@ -1,0 +1,15 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+// kotlin.String.hashCode() is not guaranteed identical across JVM and Kotlin/Native, so a flag
+// rolled out at 50% would assign different users on Android vs iOS. FNV-1a 32-bit is platform-
+// independent and good enough for bucketing (no security claims).
+internal fun fnv1a(s: String): UInt {
+    var hash = 2166136261u
+    for (byte in s.encodeToByteArray()) {
+        hash = (hash xor byte.toUByte().toUInt()) * 16777619u
+    }
+    return hash
+}
+
+internal fun bucket(flagKey: String, identity: String): Int =
+    (fnv1a("$flagKey:$identity") % 100u).toInt()

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/Semver.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/Semver.kt
@@ -1,0 +1,12 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+internal fun compareSemver(a: String, b: String): Int {
+    val aParts = a.substringBefore('-').split('.').mapNotNull { it.toIntOrNull() }
+    val bParts = b.substringBefore('-').split('.').mapNotNull { it.toIntOrNull() }
+    val len = maxOf(aParts.size, bParts.size)
+    for (i in 0 until len) {
+        val diff = aParts.getOrElse(i) { 0 } - bParts.getOrElse(i) { 0 }
+        if (diff != 0) return diff
+    }
+    return 0
+}

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/SupabaseFeatureFlagRemoteDataSource.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/SupabaseFeatureFlagRemoteDataSource.kt
@@ -1,0 +1,25 @@
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.postgrest.from
+
+interface FeatureFlagRemoteDataSource {
+    suspend fun fetch(): List<FeatureFlagRow>
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class SupabaseFeatureFlagRemoteDataSource(private val client: SupabaseClient) :
+    FeatureFlagRemoteDataSource {
+
+    override suspend fun fetch(): List<FeatureFlagRow> = client.from(TABLE).select().decodeList()
+
+    private companion object {
+        const val TABLE = "feature_flags"
+    }
+}

--- a/client/featureflag/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagEvaluatorTest.kt
+++ b/client/featureflag/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagEvaluatorTest.kt
@@ -1,0 +1,181 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.Platform
+import com.plusmobileapps.chefmate.featureflag.BooleanFlag
+import com.plusmobileapps.chefmate.featureflag.StringFlag
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class FeatureFlagEvaluatorTest {
+
+    private val evaluator = FeatureFlagEvaluator()
+
+    private object SampleBoolean : BooleanFlag("test_bool", defaultValue = false, "")
+
+    private object SampleString : StringFlag("test_string", defaultValue = "default", "")
+
+    private fun ctx(identity: String = "user-1", versionName: String = "1.4.3"): EvaluationContext =
+        EvaluationContext(
+            identity = identity,
+            platform = Platform.ANDROID,
+            versionName = versionName,
+        )
+
+    @Test
+    fun When_row_is_null_Then_default_returned() {
+        evaluator.evaluate(SampleBoolean, row = null, context = ctx()) shouldBe false
+        evaluator.evaluate(SampleString, row = null, context = ctx()) shouldBe "default"
+    }
+
+    @Test
+    fun When_row_disabled_Then_default_returned() {
+        val row = booleanRow(enabled = false, value = "true", rolloutPercent = 100)
+        evaluator.evaluate(SampleBoolean, row, ctx()) shouldBe false
+    }
+
+    @Test
+    fun When_rollout_zero_Then_default_returned() {
+        val row = booleanRow(enabled = true, value = "true", rolloutPercent = 0)
+        evaluator.evaluate(SampleBoolean, row, ctx()) shouldBe false
+    }
+
+    @Test
+    fun When_rollout_full_Then_value_returned() {
+        val row = booleanRow(enabled = true, value = "true", rolloutPercent = 100)
+        evaluator.evaluate(SampleBoolean, row, ctx()) shouldBe true
+    }
+
+    @Test
+    fun When_same_identity_Then_bucket_is_stable() {
+        val row = booleanRow(enabled = true, value = "true", rolloutPercent = 50)
+        val first = evaluator.evaluate(SampleBoolean, row, ctx(identity = "stable-id"))
+        val second = evaluator.evaluate(SampleBoolean, row, ctx(identity = "stable-id"))
+        first shouldBe second
+    }
+
+    @Test
+    fun When_platform_excluded_Then_default_returned() {
+        val row =
+            booleanRow(
+                enabled = true,
+                value = "true",
+                rolloutPercent = 100,
+                platforms = listOf("IOS"),
+            )
+        evaluator.evaluate(SampleBoolean, row, ctx()) shouldBe false
+    }
+
+    @Test
+    fun When_platform_in_allowlist_Then_value_returned() {
+        val row =
+            booleanRow(
+                enabled = true,
+                value = "true",
+                rolloutPercent = 100,
+                platforms = listOf("ANDROID", "IOS"),
+            )
+        evaluator.evaluate(SampleBoolean, row, ctx()) shouldBe true
+    }
+
+    @Test
+    fun When_below_min_version_Then_default_returned() {
+        val row =
+            booleanRow(enabled = true, value = "true", rolloutPercent = 100, minVersion = "1.5.0")
+        evaluator.evaluate(SampleBoolean, row, ctx(versionName = "1.4.3")) shouldBe false
+    }
+
+    @Test
+    fun When_above_max_version_Then_default_returned() {
+        val row =
+            booleanRow(enabled = true, value = "true", rolloutPercent = 100, maxVersion = "1.4.0")
+        evaluator.evaluate(SampleBoolean, row, ctx(versionName = "1.4.3")) shouldBe false
+    }
+
+    @Test
+    fun When_within_version_range_Then_value_returned() {
+        val row =
+            booleanRow(
+                enabled = true,
+                value = "true",
+                rolloutPercent = 100,
+                minVersion = "1.0.0",
+                maxVersion = "2.0.0",
+            )
+        evaluator.evaluate(SampleBoolean, row, ctx(versionName = "1.4.3")) shouldBe true
+    }
+
+    @Test
+    fun When_value_type_mismatch_Then_default_returned() {
+        val row =
+            FeatureFlagRow(
+                key = SampleBoolean.key,
+                valueType = "string",
+                value = "true",
+                enabled = true,
+                rolloutPercent = 100,
+            )
+        evaluator.evaluate(SampleBoolean, row, ctx()) shouldBe false
+    }
+
+    @Test
+    fun When_string_flag_active_Then_value_returned() {
+        val row =
+            FeatureFlagRow(
+                key = SampleString.key,
+                valueType = "string",
+                value = "remote-copy",
+                enabled = true,
+                rolloutPercent = 100,
+            )
+        evaluator.evaluate(SampleString, row, ctx()) shouldBe "remote-copy"
+    }
+
+    @Test
+    fun When_string_flag_out_of_rollout_Then_default_returned() {
+        val row =
+            FeatureFlagRow(
+                key = SampleString.key,
+                valueType = "string",
+                value = "remote-copy",
+                enabled = true,
+                rolloutPercent = 0,
+            )
+        evaluator.evaluate(SampleString, row, ctx()) shouldBe "default"
+    }
+
+    @Test
+    fun When_boolean_value_malformed_Then_resolved_to_false_and_default_used_only_when_default_is_false() {
+        val row =
+            FeatureFlagRow(
+                key = SampleBoolean.key,
+                valueType = "bool",
+                value = "not-a-boolean",
+                enabled = true,
+                rolloutPercent = 100,
+            )
+        // SampleBoolean.defaultValue is false; "not-a-boolean" parses to false. Either way the
+        // result is false, and that's the desired behavior on malformed remote data.
+        evaluator.evaluate(SampleBoolean, row, ctx()) shouldBe false
+    }
+
+    private fun booleanRow(
+        enabled: Boolean,
+        value: String,
+        rolloutPercent: Int,
+        platforms: List<String>? = null,
+        minVersion: String? = null,
+        maxVersion: String? = null,
+    ): FeatureFlagRow =
+        FeatureFlagRow(
+            key = SampleBoolean.key,
+            valueType = "bool",
+            value = value,
+            enabled = enabled,
+            rolloutPercent = rolloutPercent,
+            platforms = platforms,
+            minVersion = minVersion,
+            maxVersion = maxVersion,
+        )
+}

--- a/client/featureflag/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagOverridesImplTest.kt
+++ b/client/featureflag/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagOverridesImplTest.kt
@@ -1,0 +1,89 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
+import com.plusmobileapps.chefmate.featureflag.Override
+import com.russhwolf.settings.MapSettings
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class FeatureFlagOverridesImplTest {
+
+    @Test
+    fun When_no_overrides_set_Then_default_returned_for_all_flags() {
+        val overrides = FeatureFlagOverridesImpl(MapSettings())
+        FeatureFlagRegistry.all.forEach { flag ->
+            overrides.overrideOf(flag).value shouldBe Override.Default
+        }
+    }
+
+    @Test
+    fun When_boolean_override_force_on_Then_state_emits_force_value() {
+        val overrides = FeatureFlagOverridesImpl(MapSettings())
+        val flag = FeatureFlagRegistry.CookModeV2
+
+        overrides.setOverride(flag, Override.ForceValue(true))
+
+        overrides.overrideOf(flag).value shouldBe Override.ForceValue(true)
+    }
+
+    @Test
+    fun When_string_override_set_Then_state_emits_force_value() {
+        val overrides = FeatureFlagOverridesImpl(MapSettings())
+        val flag = FeatureFlagRegistry.HomeBannerText
+
+        overrides.setOverride(flag, Override.ForceValue("local copy"))
+
+        overrides.overrideOf(flag).value shouldBe Override.ForceValue("local copy")
+    }
+
+    @Test
+    fun When_override_cleared_Then_state_falls_back_to_default() {
+        val overrides = FeatureFlagOverridesImpl(MapSettings())
+        val flag = FeatureFlagRegistry.CookModeV2
+
+        overrides.setOverride(flag, Override.ForceValue(true))
+        overrides.setOverride(flag, Override.Default)
+
+        overrides.overrideOf(flag).value shouldBe Override.Default
+    }
+
+    @Test
+    fun When_overrides_persisted_Then_new_instance_loads_them() {
+        val backing = MapSettings()
+        FeatureFlagOverridesImpl(backing).apply {
+            setOverride(FeatureFlagRegistry.CookModeV2, Override.ForceValue(true))
+            setOverride(FeatureFlagRegistry.HomeBannerText, Override.ForceValue("hello"))
+        }
+
+        val reloaded = FeatureFlagOverridesImpl(backing)
+
+        reloaded.overrideOf(FeatureFlagRegistry.CookModeV2).value shouldBe Override.ForceValue(true)
+        reloaded.overrideOf(FeatureFlagRegistry.HomeBannerText).value shouldBe
+            Override.ForceValue("hello")
+    }
+
+    @Test
+    fun When_clearAll_Then_all_overrides_reset() {
+        val overrides = FeatureFlagOverridesImpl(MapSettings())
+        overrides.setOverride(FeatureFlagRegistry.CookModeV2, Override.ForceValue(true))
+        overrides.setOverride(FeatureFlagRegistry.HomeBannerText, Override.ForceValue("x"))
+
+        overrides.clearAll()
+
+        FeatureFlagRegistry.all.forEach { flag ->
+            overrides.overrideOf(flag).value shouldBe Override.Default
+        }
+    }
+
+    @Test
+    fun When_string_override_is_empty_Then_treated_as_force_value_not_default() {
+        val overrides = FeatureFlagOverridesImpl(MapSettings())
+        val flag = FeatureFlagRegistry.HomeBannerText
+
+        overrides.setOverride(flag, Override.ForceValue(""))
+
+        overrides.overrideOf(flag).value shouldBe Override.ForceValue("")
+    }
+}

--- a/client/featureflag/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagRepositoryImplTest.kt
+++ b/client/featureflag/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagRepositoryImplTest.kt
@@ -1,0 +1,152 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
+import com.plusmobileapps.chefmate.featureflag.Override
+import com.russhwolf.settings.MapSettings
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+
+class FeatureFlagRepositoryImplTest {
+
+    private val cookFlag = FeatureFlagRegistry.CookModeV2
+    private val bannerFlag = FeatureFlagRegistry.HomeBannerText
+
+    @Test
+    fun When_no_remote_or_override_Then_default_returned() = runTest {
+        val repo = buildRepo(remoteRows = emptyList())
+
+        repo.valueOf(cookFlag).value shouldBe cookFlag.defaultValue
+        repo.valueOf(bannerFlag).value shouldBe bannerFlag.defaultValue
+    }
+
+    @Test
+    fun When_remote_enables_flag_at_full_rollout_Then_value_returned_after_refresh() = runTest {
+        val rows =
+            listOf(
+                FeatureFlagRow(
+                    key = cookFlag.key,
+                    valueType = "bool",
+                    value = "true",
+                    enabled = true,
+                    rolloutPercent = 100,
+                )
+            )
+        val repo = buildRepo(remoteRows = rows)
+
+        repo.refresh()
+
+        repo.valueOf(cookFlag).value shouldBe true
+    }
+
+    @Test
+    fun When_override_force_on_Then_overrides_remote_off() = runTest {
+        val (repo, overrides) =
+            buildRepoWithOverrides(
+                remoteRows =
+                    listOf(
+                        FeatureFlagRow(
+                            key = cookFlag.key,
+                            valueType = "bool",
+                            value = "true",
+                            enabled = false, // remote says disabled
+                            rolloutPercent = 100,
+                        )
+                    )
+            )
+        repo.refresh()
+        repo.valueOf(cookFlag).value shouldBe false
+
+        overrides.setOverride(cookFlag, Override.ForceValue(true))
+
+        repo.valueOf(cookFlag).value shouldBe true
+    }
+
+    @Test
+    fun When_override_cleared_Then_falls_back_to_remote() = runTest {
+        val (repo, overrides) =
+            buildRepoWithOverrides(
+                remoteRows =
+                    listOf(
+                        FeatureFlagRow(
+                            key = bannerFlag.key,
+                            valueType = "string",
+                            value = "remote-text",
+                            enabled = true,
+                            rolloutPercent = 100,
+                        )
+                    )
+            )
+        repo.refresh()
+
+        overrides.setOverride(bannerFlag, Override.ForceValue("local-text"))
+        repo.valueOf(bannerFlag).value shouldBe "local-text"
+
+        overrides.setOverride(bannerFlag, Override.Default)
+
+        repo.valueOf(bannerFlag).value shouldBe "remote-text"
+    }
+
+    @Test
+    fun When_remote_fetch_fails_Then_cached_values_are_kept() = runTest {
+        val cache = MapSettings()
+        // Pre-populate cache so the repo loads "remote-text" without hitting the network.
+        FeatureFlagCache(cache)
+            .save(
+                listOf(
+                    FeatureFlagRow(
+                        key = bannerFlag.key,
+                        valueType = "string",
+                        value = "remote-text",
+                        enabled = true,
+                        rolloutPercent = 100,
+                    )
+                )
+            )
+        val repo =
+            buildRepo(
+                remoteRows = null, // signals throwing remote
+                cacheSettings = cache,
+            )
+
+        repo.valueOf(bannerFlag).value shouldBe "remote-text"
+        repo.refresh() // throws inside repo; should be swallowed
+        repo.valueOf(bannerFlag).value shouldBe "remote-text"
+    }
+
+    private fun buildRepo(
+        remoteRows: List<FeatureFlagRow>?,
+        cacheSettings: MapSettings = MapSettings(),
+    ): FeatureFlagRepositoryImpl = buildRepoWithOverrides(remoteRows, cacheSettings).first
+
+    private fun buildRepoWithOverrides(
+        remoteRows: List<FeatureFlagRow>?,
+        cacheSettings: MapSettings = MapSettings(),
+    ): Pair<FeatureFlagRepositoryImpl, FeatureFlagOverridesImpl> {
+        val overridesSettings = MapSettings()
+        val overrides = FeatureFlagOverridesImpl(overridesSettings)
+        val authRepo = FakeAuthenticationRepository()
+        val identity = BucketingIdentityProvider(authRepo, MapSettings())
+        val remote = FakeRemote(remoteRows)
+        val repo =
+            FeatureFlagRepositoryImpl(
+                evaluator = FeatureFlagEvaluator(),
+                cache = FeatureFlagCache(cacheSettings),
+                remote = remote,
+                overrides = overrides,
+                identityProvider = identity,
+            )
+        return repo to overrides
+    }
+
+    private class FakeRemote(private val rows: List<FeatureFlagRow>?) :
+        FeatureFlagRemoteDataSource {
+        override suspend fun fetch(): List<FeatureFlagRow> =
+            rows ?: throw RuntimeException("network down")
+    }
+}

--- a/client/featureflag/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/featureflag/impl/Fnv1aTest.kt
+++ b/client/featureflag/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/featureflag/impl/Fnv1aTest.kt
@@ -1,0 +1,41 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.featureflag.impl
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class Fnv1aTest {
+
+    @Test
+    fun fnv1a_known_vectors() {
+        // Reference values for FNV-1a 32-bit. Verified against the standard reference impl.
+        fnv1a("") shouldBe 2166136261u
+        fnv1a("a") shouldBe 3826002220u
+        fnv1a("foobar") shouldBe 3214735720u
+    }
+
+    @Test
+    fun bucket_is_deterministic_and_within_range() {
+        repeat(100) { i ->
+            val b = bucket("flag", "user-$i")
+            (b in 0..99) shouldBe true
+        }
+        val first = bucket("flag", "user-1")
+        bucket("flag", "user-1") shouldBe first
+    }
+
+    @Test
+    fun bucket_distribution_is_roughly_uniform() {
+        val counts = IntArray(10)
+        val sample = 10_000
+        repeat(sample) { i ->
+            val b = bucket("test_flag", "u-$i")
+            counts[b / 10] += 1
+        }
+        // Each bucket of 10% should have roughly sample/10 = 1000 hits. Allow 30% slack to keep
+        // the test stable across CI noise.
+        val expected = sample / 10
+        counts.forEach { (it in (expected * 7 / 10)..(expected * 13 / 10)) shouldBe true }
+    }
+}

--- a/client/featureflag/public/build.gradle.kts
+++ b/client/featureflag/public/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.arkivanov.decompose.core)
+            implementation(projects.client.shared)
+            api(projects.client.text.public)
+            implementation(projects.client.ui.public)
+            implementation(compose.components.resources)
+        }
+    }
+}
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.featureflag" }

--- a/client/featureflag/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/featureflag/public/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,14 @@
+<resources>
+    <string name="feature_flags_title">Feature Flags</string>
+    <string name="feature_flags_clear_all">Reset all overrides</string>
+    <string name="feature_flags_default">Default</string>
+    <string name="feature_flags_on">On</string>
+    <string name="feature_flags_off">Off</string>
+    <string name="feature_flags_save">Save</string>
+    <string name="feature_flags_reset">Reset</string>
+    <string name="feature_flags_resolved">Resolved: {value}</string>
+    <string name="feature_flags_override_active">Override active</string>
+    <string name="feature_flags_default_value">Default: {value}</string>
+    <string name="feature_flags_string_placeholder">Enter override value</string>
+    <string name="feature_flags_empty">No flags registered.</string>
+</resources>

--- a/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlag.kt
+++ b/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlag.kt
@@ -1,0 +1,37 @@
+package com.plusmobileapps.chefmate.featureflag
+
+sealed interface FeatureFlag<T : Any> {
+    val key: String
+    val defaultValue: T
+    val description: String
+}
+
+abstract class BooleanFlag(
+    override val key: String,
+    override val defaultValue: Boolean,
+    override val description: String,
+) : FeatureFlag<Boolean>
+
+abstract class StringFlag(
+    override val key: String,
+    override val defaultValue: String,
+    override val description: String,
+) : FeatureFlag<String>
+
+object FeatureFlagRegistry {
+    object CookModeV2 :
+        BooleanFlag(
+            key = "cook_mode_v2",
+            defaultValue = false,
+            description = "Opt-in flow for the next iteration of Cook Mode.",
+        )
+
+    object HomeBannerText :
+        StringFlag(
+            key = "home_banner_text",
+            defaultValue = "",
+            description = "Optional banner copy shown on the home screen. Empty hides the banner.",
+        )
+
+    val all: List<FeatureFlag<*>> = listOf(CookModeV2, HomeBannerText)
+}

--- a/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlagOverrides.kt
+++ b/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlagOverrides.kt
@@ -1,0 +1,17 @@
+package com.plusmobileapps.chefmate.featureflag
+
+import kotlinx.coroutines.flow.StateFlow
+
+sealed interface Override<out T> {
+    data object Default : Override<Nothing>
+
+    data class ForceValue<T>(val value: T) : Override<T>
+}
+
+interface FeatureFlagOverrides {
+    fun <T : Any> overrideOf(flag: FeatureFlag<T>): StateFlow<Override<T>>
+
+    fun <T : Any> setOverride(flag: FeatureFlag<T>, override: Override<T>)
+
+    fun clearAll()
+}

--- a/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlags.kt
+++ b/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlags.kt
@@ -1,0 +1,11 @@
+package com.plusmobileapps.chefmate.featureflag
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface FeatureFlags {
+    fun <T : Any> valueOf(flag: FeatureFlag<T>): StateFlow<T>
+
+    suspend fun refresh()
+}
+
+fun FeatureFlags.isEnabled(flag: BooleanFlag): StateFlow<Boolean> = valueOf(flag)

--- a/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlagsBloc.kt
+++ b/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlagsBloc.kt
@@ -1,0 +1,31 @@
+package com.plusmobileapps.chefmate.featureflag
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import kotlinx.coroutines.flow.StateFlow
+
+interface FeatureFlagsBloc {
+    val state: StateFlow<Model>
+
+    fun onBack()
+
+    fun onSetBooleanOverride(flag: BooleanFlag, override: Override<Boolean>)
+
+    fun onSetStringOverride(flag: StringFlag, value: String)
+
+    fun onClearOverride(flag: FeatureFlag<*>)
+
+    fun onClearAllOverrides()
+
+    data class Model(val rows: List<Row> = emptyList())
+
+    data class Row(val flag: FeatureFlag<*>, val resolvedValue: Any, val override: Override<*>)
+
+    sealed class Output {
+        data object Back : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): FeatureFlagsBloc
+    }
+}

--- a/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlagsScreen.kt
+++ b/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlagsScreen.kt
@@ -1,0 +1,202 @@
+package com.plusmobileapps.chefmate.featureflag
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import chefmate.client.featureflag.public.generated.resources.Res
+import chefmate.client.featureflag.public.generated.resources.feature_flags_clear_all
+import chefmate.client.featureflag.public.generated.resources.feature_flags_default
+import chefmate.client.featureflag.public.generated.resources.feature_flags_default_value
+import chefmate.client.featureflag.public.generated.resources.feature_flags_empty
+import chefmate.client.featureflag.public.generated.resources.feature_flags_off
+import chefmate.client.featureflag.public.generated.resources.feature_flags_on
+import chefmate.client.featureflag.public.generated.resources.feature_flags_reset
+import chefmate.client.featureflag.public.generated.resources.feature_flags_resolved
+import chefmate.client.featureflag.public.generated.resources.feature_flags_save
+import chefmate.client.featureflag.public.generated.resources.feature_flags_string_placeholder
+import chefmate.client.featureflag.public.generated.resources.feature_flags_title
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.PhraseModel
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@Composable
+fun FeatureFlagsScreen(bloc: FeatureFlagsBloc, modifier: Modifier = Modifier) {
+    val state by bloc.state.collectAsState()
+
+    PlusHeaderContainer(
+        modifier = modifier,
+        data =
+            PlusHeaderData.Child(
+                title = Res.string.feature_flags_title.asTextData(),
+                onBackClick = bloc::onBack,
+                trailingAccessory =
+                    PlusHeaderData.TrailingAccessory.Button(
+                        text = Res.string.feature_flags_clear_all.asTextData(),
+                        onClick = bloc::onClearAllOverrides,
+                    ),
+            ),
+        content = {
+            if (state.rows.isEmpty()) {
+                Text(
+                    text = Res.string.feature_flags_empty.asTextData().localized(),
+                    style = ChefMateTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(ChefMateTheme.dimens.paddingNormal),
+                )
+            } else {
+                state.rows.forEach { row ->
+                    FlagRow(row = row, bloc = bloc)
+                    HorizontalDivider()
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun FlagRow(row: FeatureFlagsBloc.Row, bloc: FeatureFlagsBloc) {
+    Card(modifier = Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingSmall)) {
+        Column(modifier = Modifier.padding(ChefMateTheme.dimens.paddingNormal)) {
+            Text(text = row.flag.key, style = ChefMateTheme.typography.titleMedium)
+            Text(
+                text = row.flag.description,
+                style = ChefMateTheme.typography.bodySmall,
+                color = ChefMateTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text =
+                    PhraseModel(
+                            resource = Res.string.feature_flags_resolved,
+                            "value" to FixedString(row.resolvedValue.toString()),
+                        )
+                        .localized(),
+                style = ChefMateTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = ChefMateTheme.dimens.paddingSmall),
+            )
+            Text(
+                text =
+                    PhraseModel(
+                            resource = Res.string.feature_flags_default_value,
+                            "value" to FixedString(row.flag.defaultValue.toString()),
+                        )
+                        .localized(),
+                style = ChefMateTheme.typography.bodySmall,
+                color = ChefMateTheme.colorScheme.onSurfaceVariant,
+            )
+
+            when (val flag = row.flag) {
+                is BooleanFlag -> {
+                    @Suppress("UNCHECKED_CAST")
+                    BooleanFlagControls(
+                        flag = flag,
+                        override = row.override as Override<Boolean>,
+                        onSetOverride = bloc::onSetBooleanOverride,
+                    )
+                }
+                is StringFlag -> {
+                    @Suppress("UNCHECKED_CAST")
+                    StringFlagControls(
+                        flag = flag,
+                        override = row.override as Override<String>,
+                        onSave = bloc::onSetStringOverride,
+                        onReset = { bloc.onClearOverride(flag) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BooleanFlagControls(
+    flag: BooleanFlag,
+    override: Override<Boolean>,
+    onSetOverride: (BooleanFlag, Override<Boolean>) -> Unit,
+) {
+    val selectedIndex =
+        when (override) {
+            Override.Default -> 0
+            is Override.ForceValue -> if (override.value) 1 else 2
+        }
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier.fillMaxWidth().padding(top = ChefMateTheme.dimens.paddingSmall)
+    ) {
+        SegmentedButton(
+            selected = selectedIndex == 0,
+            onClick = { onSetOverride(flag, Override.Default) },
+            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 3),
+        ) {
+            Text(Res.string.feature_flags_default.asTextData().localized())
+        }
+        SegmentedButton(
+            selected = selectedIndex == 1,
+            onClick = { onSetOverride(flag, Override.ForceValue(true)) },
+            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 3),
+        ) {
+            Text(Res.string.feature_flags_on.asTextData().localized())
+        }
+        SegmentedButton(
+            selected = selectedIndex == 2,
+            onClick = { onSetOverride(flag, Override.ForceValue(false)) },
+            shape = SegmentedButtonDefaults.itemShape(index = 2, count = 3),
+        ) {
+            Text(Res.string.feature_flags_off.asTextData().localized())
+        }
+    }
+}
+
+@Composable
+private fun StringFlagControls(
+    flag: StringFlag,
+    override: Override<String>,
+    onSave: (StringFlag, String) -> Unit,
+    onReset: () -> Unit,
+) {
+    val initialText =
+        when (override) {
+            Override.Default -> ""
+            is Override.ForceValue -> override.value
+        }
+    var input by rememberSaveable(flag.key) { mutableStateOf(initialText) }
+    OutlinedTextField(
+        value = input,
+        onValueChange = { input = it },
+        placeholder = {
+            Text(Res.string.feature_flags_string_placeholder.asTextData().localized())
+        },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth().padding(top = ChefMateTheme.dimens.paddingSmall),
+    )
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TextButton(onClick = onReset) {
+            Text(Res.string.feature_flags_reset.asTextData().localized())
+        }
+        TextButton(onClick = { onSave(flag, input) }) {
+            Text(Res.string.feature_flags_save.asTextData().localized())
+        }
+    }
+}

--- a/client/featureflag/testing/build.gradle.kts
+++ b/client/featureflag/testing/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins { alias(libs.plugins.kmpLibrary) }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.featureflag.public)
+            implementation(projects.client.shared)
+        }
+    }
+}
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.featureflag.testing" }

--- a/client/featureflag/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/testing/FakeFeatureFlags.kt
+++ b/client/featureflag/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/testing/FakeFeatureFlags.kt
@@ -1,0 +1,30 @@
+package com.plusmobileapps.chefmate.featureflag.testing
+
+import com.plusmobileapps.chefmate.featureflag.FeatureFlag
+import com.plusmobileapps.chefmate.featureflag.FeatureFlags
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class FakeFeatureFlags(initial: Map<FeatureFlag<*>, Any> = emptyMap()) : FeatureFlags {
+
+    private val flows: MutableMap<FeatureFlag<*>, MutableStateFlow<Any>> =
+        initial.mapValues { (_, value) -> MutableStateFlow(value) }.toMutableMap()
+
+    var refreshCount: Int = 0
+        private set
+
+    override fun <T : Any> valueOf(flag: FeatureFlag<T>): StateFlow<T> {
+        val flow = flows.getOrPut(flag) { MutableStateFlow(flag.defaultValue) }
+        @Suppress("UNCHECKED_CAST")
+        return flow as StateFlow<T>
+    }
+
+    override suspend fun refresh() {
+        refreshCount += 1
+    }
+
+    fun <T : Any> set(flag: FeatureFlag<T>, value: T) {
+        val flow = flows.getOrPut(flag) { MutableStateFlow(value) }
+        flow.value = value
+    }
+}

--- a/client/root/impl/build.gradle.kts
+++ b/client/root/impl/build.gradle.kts
@@ -12,11 +12,13 @@ kotlin {
             implementation(projects.client.bottomnav.public)
             implementation(projects.client.browser.public)
             implementation(projects.client.cook.public)
+            implementation(projects.client.featureflag.public)
             implementation(projects.client.grocery.core.public)
             implementation(projects.client.recipe.core.public)
             implementation(projects.client.auth.ui.public)
             implementation(libs.kotlinx.serialization.json)
         }
+        commonTest.dependencies { implementation(projects.client.featureflag.testing) }
     }
 }
 

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -15,6 +15,8 @@ import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.featureflag.FeatureFlags
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
@@ -30,6 +32,7 @@ import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @AssistedInject
@@ -45,11 +48,17 @@ class RootBlocImpl(
     private val bottomNavOrder: BottomNavOrderBloc.Factory,
     private val developerSettings: DeveloperSettingsBloc.Factory,
     private val cookMode: CookModeBloc.Factory,
+    private val featureFlags: FeatureFlags,
+    private val featureFlagsBlocFactory: FeatureFlagsBloc.Factory,
 ) : RootBloc, BlocContext by context {
 
     @AssistedFactory
     fun interface ManagedFactory {
         fun create(context: BlocContext): RootBlocImpl
+    }
+
+    init {
+        createScope().launch { featureFlags.refresh() }
     }
 
     private val navigation = StackNavigation<Configuration>()
@@ -158,6 +167,15 @@ class RootBlocImpl(
                         )
                 )
 
+            Configuration.FeatureFlags ->
+                RootBloc.Child.FeatureFlags(
+                    bloc =
+                        featureFlagsBlocFactory.create(
+                            context = context,
+                            output = ::handleFeatureFlagsOutput,
+                        )
+                )
+
             is Configuration.CookMode ->
                 RootBloc.Child.CookMode(
                     bloc =
@@ -241,6 +259,15 @@ class RootBlocImpl(
     private fun handleDeveloperSettingsOutput(output: DeveloperSettingsBloc.Output) {
         when (output) {
             DeveloperSettingsBloc.Output.Back -> navigation.pop()
+            DeveloperSettingsBloc.Output.OpenFeatureFlags -> {
+                navigation.bringToFront(Configuration.FeatureFlags)
+            }
+        }
+    }
+
+    private fun handleFeatureFlagsOutput(output: FeatureFlagsBloc.Output) {
+        when (output) {
+            FeatureFlagsBloc.Output.Back -> navigation.pop()
         }
     }
 
@@ -316,6 +343,8 @@ class RootBlocImpl(
         @Serializable data object BottomNavOrder : Configuration()
 
         @Serializable data object DeveloperSettings : Configuration()
+
+        @Serializable data object FeatureFlags : Configuration()
 
         @Serializable data class CookMode(val recipeId: Long) : Configuration()
     }

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -6,6 +6,7 @@ import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
+import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
@@ -30,6 +31,9 @@ class RootBlocTest {
     var groceryDetailId: Long? = null
     var appSettingsOutput: Consumer<AppSettingsBloc.Output> = Consumer {}
     var bottomNavOrderOutput: Consumer<BottomNavOrderBloc.Output> = Consumer {}
+    var developerSettingsOutput:
+        Consumer<com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc.Output> =
+        Consumer {}
 
     val rootBloc =
         RootBlocImpl(
@@ -67,8 +71,13 @@ class RootBlocTest {
                 bottomNavOrderOutput = output
                 mock()
             },
-            developerSettings = { _, _ -> mock() },
+            developerSettings = { _, output ->
+                developerSettingsOutput = output
+                mock()
+            },
             cookMode = CookModeBloc.Factory { _, _, _ -> mock() },
+            featureFlags = FakeFeatureFlags(),
+            featureFlagsBlocFactory = { _, _ -> mock() },
         )
 
     fun RootBloc.instance(): RootBloc.Child = state.value.active.instance
@@ -164,6 +173,16 @@ class RootBlocTest {
         appSettingsOutput.onNext(AppSettingsBloc.Output.OpenBottomNavOrder)
         bottomNavOrderOutput.onNext(BottomNavOrderBloc.Output.Back)
         rootBloc.instance() should instanceOf<RootBloc.Child.AppSettings>()
+    }
+
+    @Test
+    fun When_dev_settings_outputs_open_feature_flags_Then_feature_flags_shown() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenDeveloperSettings)
+        rootBloc.instance() should instanceOf<RootBloc.Child.DeveloperSettings>()
+        developerSettingsOutput.onNext(
+            com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc.Output.OpenFeatureFlags
+        )
+        rootBloc.instance() should instanceOf<RootBloc.Child.FeatureFlags>()
     }
 
     @Test

--- a/client/root/public/build.gradle.kts
+++ b/client/root/public/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
             api(projects.client.browser.public)
             api(projects.client.cook.public)
             api(projects.client.developerSettings.public)
+            api(projects.client.featureflag.public)
             api(projects.client.grocery.core.public)
             api(projects.client.recipe.core.public)
             api(projects.client.auth.ui.public)

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -9,6 +9,7 @@ import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc
 import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
@@ -39,6 +40,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class BottomNavOrder(val bloc: BottomNavOrderBloc) : Child()
 
         data class DeveloperSettings(val bloc: DeveloperSettingsBloc) : Child()
+
+        data class FeatureFlags(val bloc: FeatureFlagsBloc) : Child()
 
         data class CookMode(val bloc: CookModeBloc) : Child()
     }

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -29,6 +29,7 @@ import com.plusmobileapps.chefmate.auth.ui.AuthenticationScreen
 import com.plusmobileapps.chefmate.browser.BrowserRootScreen
 import com.plusmobileapps.chefmate.cook.CookModeScreen
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsScreen
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagsScreen
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailScreen
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderScreen
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavigationScreen
@@ -157,6 +158,7 @@ private fun RootChildContent(child: RootBloc.Child, onBack: () -> Unit) {
         is RootBloc.Child.AppSettings -> AppSettingsScreen(child.bloc)
         is RootBloc.Child.BottomNavOrder -> BottomNavOrderScreen(child.bloc)
         is RootBloc.Child.DeveloperSettings -> DeveloperSettingsScreen(child.bloc)
+        is RootBloc.Child.FeatureFlags -> FeatureFlagsScreen(child.bloc)
         is RootBloc.Child.CookMode -> CookModeScreen(child.bloc)
     }
 }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -2,6 +2,7 @@ package com.plusmobileapps.chefmate.settings.impl
 
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.buildconfig.BuildConfig
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.isDebugBuild
@@ -43,6 +44,7 @@ class SettingsBlocImpl(
                     },
                 showSignOutConfirmationDialog = it.showSignOutConfirmationDialog,
                 isDebugBuild = isDebugBuild,
+                versionName = BuildConfig.VERSION_NAME,
             )
         }
 

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -24,4 +24,5 @@
     <string name="app_settings_navigation_section">Navigation</string>
     <string name="app_settings_bottom_nav_order">Bottom navigation order</string>
     <string name="developer_settings">Developer Settings</string>
+    <string name="version_label">Version {version}</string>
 </resources>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -30,6 +30,7 @@ interface SettingsBloc {
         val verificationMessage: TextData? = null,
         val showSignOutConfirmationDialog: Boolean = false,
         val isDebugBuild: Boolean = false,
+        val versionName: String = "",
     )
 
     sealed class Output {

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsScreen.kt
@@ -43,6 +43,9 @@ import chefmate.client.settings.public.generated.resources.sign_out_confirmation
 import chefmate.client.settings.public.generated.resources.sign_out_confirmation_title
 import chefmate.client.settings.public.generated.resources.sign_up
 import chefmate.client.settings.public.generated.resources.terms_of_use
+import chefmate.client.settings.public.generated.resources.version_label
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
@@ -115,6 +118,8 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
                     onClick = bloc::onDeveloperSettingsClicked,
                 )
             }
+            HorizontalDivider()
+            VersionLabel(versionName = viewState.versionName)
         },
     )
     Column(modifier = modifier.fillMaxSize()) {
@@ -157,6 +162,27 @@ private fun EmailVerificationMessage(message: TextData, modifier: Modifier = Mod
 }
 
 @Composable
+private fun VersionLabel(versionName: String, modifier: Modifier = Modifier) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = ChefMateTheme.dimens.paddingNormal,
+                    vertical = ChefMateTheme.dimens.paddingSmall,
+                ),
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            PhraseModel(resource = Res.string.version_label, "version" to FixedString(versionName))
+                .localized(),
+            style = ChefMateTheme.typography.bodySmall,
+            color = ChefMateTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
 internal fun SettingsRow(name: TextData, onClick: () -> Unit, modifier: Modifier = Modifier) {
     val contentDescription = name.localized()
     Row(
@@ -179,7 +205,7 @@ private val previewBlocUnauthenticated =
     object : SettingsBloc {
         override val state =
             kotlinx.coroutines.flow.MutableStateFlow(
-                SettingsBloc.Model(isAuthenticated = false, greeting = null)
+                SettingsBloc.Model(isAuthenticated = false, greeting = null, versionName = "1.4.3")
             )
 
         override fun onSignInClicked() = Unit
@@ -210,6 +236,7 @@ private val previewBlocAuthenticated =
                             resource = Res.string.greeting_authenticated,
                             "name" to com.plusmobileapps.chefmate.text.FixedString("John Doe"),
                         ),
+                    versionName = "1.4.3",
                 )
             )
 

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -91,6 +91,16 @@ val isDebugBuildFlag: Boolean =
             taskName.contains("bundleRelease", ignoreCase = true)
     }
 
+// Single source of truth lives in client/composeApp/build.gradle.kts (versionName = "..").
+// The bump-version scripts already update that file via sed; we mirror its value into
+// BuildConfig so common code (e.g. feature-flag version targeting) can read it.
+val composeAppGradleFile = rootProject.file("client/composeApp/build.gradle.kts")
+val appVersionName =
+    Regex("""versionName\s*=\s*"([^"]+)"""")
+        .find(composeAppGradleFile.readText())
+        ?.groupValues
+        ?.get(1) ?: "0.0.0"
+
 buildkonfig {
     packageName = "com.plusmobileapps.chefmate.buildconfig"
     objectName = "BuildConfig"
@@ -106,5 +116,6 @@ buildkonfig {
         buildConfigField(STRING, "BUGSNAG_API_KEY", bugsnagApiKey)
         buildConfigField(STRING, "TEST_USERS", testUsersSerialized)
         buildConfigField(BOOLEAN, "IS_DEBUG", isDebugBuildFlag.toString())
+        buildConfigField(STRING, "VERSION_NAME", appVersionName)
     }
 }

--- a/client/shared/src/androidMain/kotlin/com/plusmobileapps/chefmate/Platform.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/plusmobileapps/chefmate/Platform.android.kt
@@ -1,0 +1,3 @@
+package com.plusmobileapps.chefmate
+
+actual val currentPlatform: Platform = Platform.ANDROID

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/Platform.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/Platform.kt
@@ -1,0 +1,9 @@
+package com.plusmobileapps.chefmate
+
+enum class Platform {
+    ANDROID,
+    IOS,
+    JVM,
+}
+
+expect val currentPlatform: Platform

--- a/client/shared/src/iosMain/kotlin/com/plusmobileapps/chefmate/Platform.ios.kt
+++ b/client/shared/src/iosMain/kotlin/com/plusmobileapps/chefmate/Platform.ios.kt
@@ -1,0 +1,3 @@
+package com.plusmobileapps.chefmate
+
+actual val currentPlatform: Platform = Platform.IOS

--- a/client/shared/src/jvmMain/kotlin/com/plusmobileapps/chefmate/Platform.jvm.kt
+++ b/client/shared/src/jvmMain/kotlin/com/plusmobileapps/chefmate/Platform.jvm.kt
@@ -1,0 +1,3 @@
+package com.plusmobileapps.chefmate
+
+actual val currentPlatform: Platform = Platform.JVM

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,85 @@
+# Feature Flags
+
+Lightweight remote-config / feature-flag system that works on Android, iOS, and Desktop (JVM). Rules are stored in Supabase; values are fetched on app start, cached in `multiplatform-settings`, and merged with optional dev-only overrides at evaluation time.
+
+## Backend
+
+A single Postgres table in your existing Supabase project. Run this once via the SQL editor in Supabase Studio:
+
+```sql
+create table public.feature_flags (
+    key text primary key,
+    value_type text not null check (value_type in ('bool', 'string')),
+    value text not null,
+    enabled boolean not null default true,
+    rollout_percent int not null default 0 check (rollout_percent between 0 and 100),
+    platforms text[],
+    min_version text,
+    max_version text,
+    updated_at timestamptz not null default now()
+);
+
+alter table public.feature_flags enable row level security;
+
+create policy "feature_flags read" on public.feature_flags
+    for select to anon, authenticated using (true);
+```
+
+Writes go through the service role / Studio UI — clients only ever read.
+
+### Columns
+
+- `key` — must match one of the `FeatureFlag.key` values defined in code.
+- `value_type` — `'bool'` or `'string'`. If this disagrees with the in-code flag type, the client falls back to the default.
+- `value` — for `bool` flags use `'true'` / `'false'`. For `string` flags, the literal value.
+- `enabled` — global kill switch. `false` means everyone gets the default.
+- `rollout_percent` — % of users for whom the flag is "active". Active users get `value`; the rest get the default. Bucketing is stable per (`key`, identity) and uses FNV-1a 32-bit so Android, iOS, and JVM agree.
+- `platforms` — `null` / empty = all platforms. Otherwise an array of `'ANDROID'` / `'IOS'` / `'JVM'`.
+- `min_version` / `max_version` — optional semver bounds, compared against the app's current `versionName` (only major/minor/patch are used; `-pre` suffixes are ignored).
+
+## Adding a flag
+
+1. Add the flag to `FeatureFlagRegistry` in `client/featureflag/public/.../FeatureFlag.kt`:
+
+   ```kotlin
+   object MyNewFlag : BooleanFlag("my_new_flag", defaultValue = false, "What this flag controls.")
+   ```
+
+   Append it to `all`. The `defaultValue` is what every client returns when offline / before the first refresh / when no row exists — pick the safer of the two outcomes.
+
+2. Insert a row in the `feature_flags` table with the same key.
+
+3. Read the flag from any Bloc / repository:
+
+   ```kotlin
+   class MyViewModel(featureFlags: FeatureFlags) {
+       val showNewFlow: StateFlow<Boolean> = featureFlags.isEnabled(FeatureFlagRegistry.MyNewFlag)
+   }
+   ```
+
+   For string flags use `featureFlags.valueOf(flag)` directly.
+
+## Refresh model
+
+`FeatureFlags.refresh()` is called once on app start from `RootBlocImpl.init`. On failure (no network, malformed response) the call swallows the exception and the client keeps using whatever was in the local cache (or the in-code defaults if the cache is empty). There is no periodic poll — flags propagate on next cold start.
+
+## Identity / bucketing
+
+The bucket id is the authenticated Supabase user id when signed in, otherwise a UUID generated on first launch and stored in `multiplatform-settings` under `flags.bucket_id`. Signing in causes the bucket id to switch from the device UUID to the user id; a flag at 50% rollout may flip values across that boundary. This is intentional — once signed in a user gets the same experience across devices.
+
+## Dev overrides
+
+`FeatureFlagOverrides` lets a developer force any flag ON / OFF / Default. Overrides are persisted in `multiplatform-settings` under `flags.override.<key>.{present,value}`. Resolution order is **override → remote+rollout → in-code default**.
+
+The override mechanism works in any build, but the UI for setting overrides is wired into the developer-settings menu (see PR #157), which is itself gated by `isDebugBuild`. To open it manually for a one-off test, call `FeatureFlagOverrides.setOverride(flag, Override.ForceValue(true))` from anywhere with DI access.
+
+## Files of interest
+
+| Concern | Path |
+|---|---|
+| Public API + flag registry | `client/featureflag/public/` |
+| Repo, evaluator, cache, overrides | `client/featureflag/impl/` |
+| Fake for other modules' tests | `client/featureflag/testing/` |
+| Stable cross-platform hash | `client/featureflag/impl/.../Fnv1a.kt` |
+| App-start refresh hook | `client/root/impl/.../RootBlocImpl.kt` (init block) |
+| `BuildConfig.VERSION_NAME` source | `client/shared/build.gradle.kts` |

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -64,6 +64,12 @@ include(":client:cook:public")
 
 include(":client:database:core")
 
+include(":client:featureflag:impl")
+
+include(":client:featureflag:public")
+
+include(":client:featureflag:testing")
+
 include(":client:database:testing")
 
 include(":client:grocery:core:impl")


### PR DESCRIPTION
## Summary
- New `client/featureflag/{public,impl,testing}` KMP module exposing typed flags (`BooleanFlag` + `StringFlag` via a sealed `FeatureFlag<T>` hierarchy) backed by a Supabase `feature_flags` table — supports global enable, percentage rollout, platform allow-list, and semver bounds.
- Stable cross-platform bucketing via FNV-1a 32-bit (Kotlin `String.hashCode()` differs between JVM and Native, so hand-rolled). Identity is the auth user id when signed in, otherwise a per-device UUID persisted in `multiplatform-settings`.
- Values are fetched once on app start (called from `RootBlocImpl.init`), cached locally, and fall back to in-code defaults when offline / on fetch failure.
- Per-flag override API (`Override.Default` / `Override.ForceValue<T>`) with a "Feature Flags" screen surfaced under the developer-settings menu (#157) — debug builds only since the entry point is gated by `isDebugBuild`. Override > remote+rollout > default.
- `BuildConfig.VERSION_NAME` exposed via buildkonfig (read out of `client/composeApp/build.gradle.kts` so the existing `bump-version` scripts remain the single source of truth).
- `Platform` expect/actual added to `client/shared` (Android / iOS / JVM).
- See `docs/feature-flags.md` for the SQL migration to create the `feature_flags` table and the workflow for adding a new flag.

## Test plan
- [x] `./gradlew ktfmtCheck`
- [x] `./gradlew :client:featureflag:impl:testDebugUnitTest` — evaluator (rollout, version/platform bounds, type-mismatch fallback), overrides round-trip, repository precedence (override > remote > default), FNV-1a reference vectors + bucket distribution
- [x] `./gradlew :client:root:impl:testDebugUnitTest` — including new `dev_settings → feature_flags` navigation case
- [x] `./gradlew :client:composeApp:compileDebugKotlinAndroid`
- [x] Manual on Android: create the `feature_flags` table per `docs/feature-flags.md`, insert a `cook_mode_v2` row, verify `rollout_percent` + `min_version` + override toggles all behave as expected; airplane-mode cold start uses the cache; sign-in flips bucket id from device UUID to user id
- [x] Manual on iOS + JVM (build/launch + override toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)