### PR TITLE
feat(auth): Google sign-in across Android, iOS, and desktop

### DIFF
--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KtfmtConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KtfmtConventionPlugin.kt
@@ -18,6 +18,8 @@ fun Project.applyKtfmt() {
 
     configure<KtfmtExtension> {
         kotlinLangStyle()
-        srcSetPathExclusionPattern.set(Regex(".*generated.*"))
+        // Exclude all build outputs — BuildKonfig writes to build/buildkonfig/, and the rest of
+        // build/ is generated code that we don't author.
+        srcSetPathExclusionPattern.set(Regex(".*(generated|/build/).*"))
     }
 }

--- a/client/auth/data/impl/build.gradle.kts
+++ b/client/auth/data/impl/build.gradle.kts
@@ -10,8 +10,17 @@ kotlin {
             implementation(libs.supabase.auth)
             implementation(libs.supabase.postgrest)
         }
-        jvmMain.dependencies { implementation(libs.ktor.client.cio) }
-        androidMain.dependencies { implementation(libs.ktor.client.cio) }
+        jvmMain.dependencies {
+            implementation(libs.ktor.client.cio)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.json)
+        }
+        androidMain.dependencies {
+            implementation(libs.ktor.client.cio)
+            implementation(libs.androidx.credentials)
+            implementation(libs.androidx.credentials.play.services.auth)
+            implementation(libs.googleid)
+        }
         iosMain.dependencies { implementation(libs.ktor.client.darwin) }
     }
 }

--- a/client/auth/data/impl/src/androidMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/CurrentActivityHolder.kt
+++ b/client/auth/data/impl/src/androidMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/CurrentActivityHolder.kt
@@ -1,0 +1,17 @@
+package com.plusmobileapps.chefmate.auth.data.impl
+
+import android.app.Activity
+import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+/**
+ * Tracks the currently-resumed Activity so platform APIs that require an Activity context (notably
+ * Credential Manager's credential-picker UI) can resolve one at call time. The host `MyApplication`
+ * registers Activity lifecycle callbacks that drive [current].
+ */
+@Inject
+@SingleIn(AppScope::class)
+class CurrentActivityHolder {
+    @Volatile var current: Activity? = null
+}

--- a/client/auth/data/impl/src/androidMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/GoogleSignInProvider.android.kt
+++ b/client/auth/data/impl/src/androidMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/GoogleSignInProvider.android.kt
@@ -1,0 +1,75 @@
+package com.plusmobileapps.chefmate.auth.data.impl
+
+import android.content.Context
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.NoCredentialException
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+import com.plusmobileapps.chefmate.buildconfig.BuildConfig
+import java.security.MessageDigest
+import java.util.UUID
+
+actual class GoogleSignInProvider(
+    private val appContext: Context,
+    private val activityHolder: CurrentActivityHolder,
+) {
+    actual suspend fun signIn(): GoogleSignInResult {
+        val webClientId = BuildConfig.GOOGLE_WEB_CLIENT_ID
+        if (webClientId.isBlank()) {
+            throw GoogleSignInException.NotConfigured(
+                "GOOGLE_WEB_CLIENT_ID is not set — add google.webClientId to local.properties."
+            )
+        }
+
+        val activity =
+            activityHolder.current
+                ?: throw GoogleSignInException.Failed(
+                    "No resumed Activity available for Credential Manager"
+                )
+
+        val rawNonce = UUID.randomUUID().toString()
+        val hashedNonce = sha256Hex(rawNonce)
+
+        val googleIdOption =
+            GetGoogleIdOption.Builder()
+                // Show all Google accounts on the device, not just ones that have signed in here.
+                .setFilterByAuthorizedAccounts(false)
+                .setServerClientId(webClientId)
+                .setNonce(hashedNonce)
+                .setAutoSelectEnabled(false)
+                .build()
+
+        val request = GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
+
+        val credentialManager = CredentialManager.create(appContext)
+
+        val response =
+            try {
+                credentialManager.getCredential(context = activity, request = request)
+            } catch (e: GetCredentialCancellationException) {
+                throw GoogleSignInException.Cancelled()
+            } catch (e: NoCredentialException) {
+                throw GoogleSignInException.Failed("No Google account available on this device", e)
+            } catch (e: GetCredentialException) {
+                throw GoogleSignInException.Failed(e.message ?: "Credential Manager failed", e)
+            }
+
+        val credential =
+            try {
+                GoogleIdTokenCredential.createFrom(response.credential.data)
+            } catch (e: GoogleIdTokenParsingException) {
+                throw GoogleSignInException.Failed("Failed to parse Google ID token", e)
+            }
+
+        return GoogleSignInResult(idToken = credential.idToken, rawNonce = rawNonce)
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+        return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
+    }
+}

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/GoogleSignInProvider.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/GoogleSignInProvider.kt
@@ -1,0 +1,25 @@
+package com.plusmobileapps.chefmate.auth.data.impl
+
+/**
+ * Platform-specific Google Sign-In entry point. Each actual obtains a Google ID token using the
+ * native flow appropriate for the target (Credential Manager on Android, GoogleSignIn-iOS via a
+ * Swift bridge on iOS, system-browser + loopback HTTP server on JVM desktop).
+ *
+ * The raw nonce is generated inside the actual and surfaced alongside the ID token so the caller
+ * can hand both to `supabaseClient.auth.signInWith(IDToken)` — Supabase verifies that the nonce
+ * embedded (as SHA-256) inside the ID token matches.
+ */
+expect class GoogleSignInProvider {
+    suspend fun signIn(): GoogleSignInResult
+}
+
+data class GoogleSignInResult(val idToken: String, val rawNonce: String)
+
+sealed class GoogleSignInException(message: String, cause: Throwable? = null) :
+    Exception(message, cause) {
+    class Cancelled : GoogleSignInException("Google sign-in was cancelled")
+
+    class NotConfigured(message: String) : GoogleSignInException(message)
+
+    class Failed(message: String, cause: Throwable? = null) : GoogleSignInException(message, cause)
+}

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.auth.data.impl
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
 import com.plusmobileapps.chefmate.auth.data.ChefMateUser
+import com.plusmobileapps.chefmate.auth.data.GoogleSignInOutcome
 import com.plusmobileapps.chefmate.auth.data.OtpFlow
 import com.plusmobileapps.chefmate.auth.data.SignUpResult
 import com.plusmobileapps.chefmate.di.AppScope
@@ -13,7 +14,9 @@ import dev.zacsweers.metro.SingleIn
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.OtpType
 import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.providers.Google
 import io.github.jan.supabase.auth.providers.builtin.Email
+import io.github.jan.supabase.auth.providers.builtin.IDToken
 import io.github.jan.supabase.auth.providers.builtin.OTP
 import io.github.jan.supabase.auth.status.SessionStatus
 import io.github.jan.supabase.auth.user.UserInfo
@@ -29,6 +32,7 @@ import kotlinx.coroutines.launch
 @ContributesBinding(AppScope::class)
 class SupabaseAuthenticationRepository(
     private val supabaseClient: SupabaseClient,
+    private val googleSignInProvider: GoogleSignInProvider,
     @Main private val mainContext: CoroutineContext,
 ) : AuthenticationRepository {
     private val scope = CoroutineScope(mainContext)
@@ -149,6 +153,21 @@ class SupabaseAuthenticationRepository(
             println("Error signing out: ${e.message}")
         }
     }
+
+    override suspend fun signInWithGoogle(): Result<GoogleSignInOutcome> =
+        try {
+            val token = googleSignInProvider.signIn()
+            supabaseClient.auth.signInWith(IDToken) {
+                idToken = token.idToken
+                provider = Google
+                nonce = token.rawNonce
+            }
+            Result.success(GoogleSignInOutcome.Success)
+        } catch (e: GoogleSignInException.Cancelled) {
+            Result.success(GoogleSignInOutcome.Cancelled)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
 
     override suspend fun sendPasswordResetEmail(email: String): Result<Unit> =
         try {

--- a/client/auth/data/impl/src/iosMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/GoogleSignInProvider.ios.kt
+++ b/client/auth/data/impl/src/iosMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/GoogleSignInProvider.ios.kt
@@ -1,0 +1,40 @@
+package com.plusmobileapps.chefmate.auth.data.impl
+
+/**
+ * Swift-side hook. The iOS app registers an implementation at startup by setting
+ * [IosGoogleSignInBridgeHolder.bridge]. Swift owns the entire flow — generating the raw nonce,
+ * hashing it for GoogleSignIn-iOS, and returning the resulting ID token paired with the original
+ * raw nonce so Supabase can verify.
+ *
+ * Keeping nonce generation on the Swift side avoids pulling cinterop / CryptoKit references into
+ * Kotlin/Native; Swift already has CryptoKit for free.
+ */
+fun interface IosGoogleSignInBridge {
+    @Throws(Exception::class) suspend fun signIn(): IosGoogleSignInResponse
+}
+
+data class IosGoogleSignInResponse(val idToken: String, val rawNonce: String)
+
+object IosGoogleSignInBridgeHolder {
+    // Set once at app startup by Swift; read by [GoogleSignInProvider.signIn]. Not contended.
+    var bridge: IosGoogleSignInBridge? = null
+}
+
+actual class GoogleSignInProvider {
+    actual suspend fun signIn(): GoogleSignInResult {
+        val bridge =
+            IosGoogleSignInBridgeHolder.bridge
+                ?: throw GoogleSignInException.NotConfigured(
+                    "IosGoogleSignInBridgeHolder.bridge was not set by the iOS app on startup"
+                )
+
+        return try {
+            val response = bridge.signIn()
+            GoogleSignInResult(idToken = response.idToken, rawNonce = response.rawNonce)
+        } catch (e: GoogleSignInException) {
+            throw e
+        } catch (e: Exception) {
+            throw GoogleSignInException.Failed(e.message ?: "Google sign-in failed", e)
+        }
+    }
+}

--- a/client/auth/data/impl/src/jvmMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/GoogleSignInProvider.jvm.kt
+++ b/client/auth/data/impl/src/jvmMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/GoogleSignInProvider.jvm.kt
@@ -1,0 +1,266 @@
+package com.plusmobileapps.chefmate.auth.data.impl
+
+import com.plusmobileapps.chefmate.buildconfig.BuildConfig
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.http.isSuccess
+import io.ktor.serialization.kotlinx.json.json
+import java.awt.Desktop
+import java.io.OutputStreamWriter
+import java.net.InetSocketAddress
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.security.SecureRandom
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+actual class GoogleSignInProvider {
+
+    actual suspend fun signIn(): GoogleSignInResult {
+        val clientId = BuildConfig.GOOGLE_DESKTOP_CLIENT_ID
+        val clientSecret = BuildConfig.GOOGLE_DESKTOP_CLIENT_SECRET
+        if (clientId.isBlank()) {
+            throw GoogleSignInException.NotConfigured(
+                "GOOGLE_DESKTOP_CLIENT_ID is not set — add google.desktopClientId to local.properties."
+            )
+        }
+
+        val codeVerifier = randomUrlSafeString(64)
+        val codeChallenge = sha256Base64Url(codeVerifier)
+        val state = randomUrlSafeString(32)
+        val rawNonce = randomUrlSafeString(32)
+        val hashedNonce = sha256Base64Url(rawNonce)
+
+        val codeDeferred = CompletableDeferred<String>()
+        val server = startCallbackServer(expectedState = state, codeDeferred = codeDeferred)
+        val redirectUri = "http://127.0.0.1:${server.address.port}/callback"
+
+        try {
+            val authUrl =
+                buildAuthorizationUrl(clientId, redirectUri, codeChallenge, state, hashedNonce)
+            openInBrowser(authUrl)
+
+            val code = withTimeout(AUTH_TIMEOUT_MS) { codeDeferred.await() }
+            val idToken =
+                exchangeCodeForIdToken(code, clientId, clientSecret, redirectUri, codeVerifier)
+            return GoogleSignInResult(idToken = idToken, rawNonce = rawNonce)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    private fun startCallbackServer(
+        expectedState: String,
+        codeDeferred: CompletableDeferred<String>,
+    ): HttpServer {
+        // Port 0 lets the OS pick any free port — Google allows arbitrary loopback ports.
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/callback") { exchange ->
+            handleCallback(exchange, expectedState, codeDeferred)
+        }
+        server.executor = null
+        server.start()
+        return server
+    }
+
+    private fun handleCallback(
+        exchange: HttpExchange,
+        expectedState: String,
+        codeDeferred: CompletableDeferred<String>,
+    ) {
+        val query = exchange.requestURI.rawQuery.orEmpty()
+        val params = parseQuery(query)
+        val error = params["error"]
+        val state = params["state"]
+        val code = params["code"]
+
+        val (status, html) =
+            when {
+                error == "access_denied" -> {
+                    codeDeferred.completeExceptionally(GoogleSignInException.Cancelled())
+                    HttpStatusCode.OK.value to
+                        closeWindowHtml("Sign-in cancelled. You can close this window.")
+                }
+                error != null -> {
+                    codeDeferred.completeExceptionally(
+                        GoogleSignInException.Failed("OAuth error: $error")
+                    )
+                    HttpStatusCode.OK.value to
+                        closeWindowHtml("Sign-in failed. You can close this window.")
+                }
+                state != expectedState -> {
+                    codeDeferred.completeExceptionally(
+                        GoogleSignInException.Failed("OAuth state mismatch")
+                    )
+                    HttpStatusCode.BadRequest.value to closeWindowHtml("Invalid request.")
+                }
+                code.isNullOrBlank() -> {
+                    codeDeferred.completeExceptionally(
+                        GoogleSignInException.Failed("Missing authorization code in callback")
+                    )
+                    HttpStatusCode.BadRequest.value to closeWindowHtml("Invalid request.")
+                }
+                else -> {
+                    codeDeferred.complete(code)
+                    HttpStatusCode.OK.value to
+                        closeWindowHtml("Signed in. You can close this window.")
+                }
+            }
+
+        val bytes = html.toByteArray(StandardCharsets.UTF_8)
+        exchange.responseHeaders["Content-Type"] = listOf("text/html; charset=utf-8")
+        exchange.sendResponseHeaders(status, bytes.size.toLong())
+        exchange.responseBody.use {
+            OutputStreamWriter(it, StandardCharsets.UTF_8).apply {
+                write(html)
+                flush()
+            }
+        }
+    }
+
+    private fun buildAuthorizationUrl(
+        clientId: String,
+        redirectUri: String,
+        codeChallenge: String,
+        state: String,
+        hashedNonce: String,
+    ): String {
+        val params =
+            mapOf(
+                "client_id" to clientId,
+                "redirect_uri" to redirectUri,
+                "response_type" to "code",
+                "scope" to "openid email profile",
+                "code_challenge" to codeChallenge,
+                "code_challenge_method" to "S256",
+                "state" to state,
+                "nonce" to hashedNonce,
+                "access_type" to "offline",
+                "prompt" to "select_account",
+            )
+        val query = params.entries.joinToString("&") { (k, v) -> "${urlEncode(k)}=${urlEncode(v)}" }
+        return "https://accounts.google.com/o/oauth2/v2/auth?$query"
+    }
+
+    private suspend fun exchangeCodeForIdToken(
+        code: String,
+        clientId: String,
+        clientSecret: String,
+        redirectUri: String,
+        codeVerifier: String,
+    ): String {
+        val client = HttpClient {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+        try {
+            val formParams = Parameters.build {
+                append("client_id", clientId)
+                if (clientSecret.isNotBlank()) append("client_secret", clientSecret)
+                append("code", code)
+                append("code_verifier", codeVerifier)
+                append("grant_type", "authorization_code")
+                append("redirect_uri", redirectUri)
+            }
+            val response: HttpResponse =
+                client.post("https://oauth2.googleapis.com/token") {
+                    setBody(FormDataContent(formParams))
+                }
+            if (!response.status.isSuccess()) {
+                val body = response.body<String>()
+                throw GoogleSignInException.Failed(
+                    "Token exchange failed: ${response.status}: $body"
+                )
+            }
+            val tokenResponse: GoogleTokenResponse = response.body()
+            return tokenResponse.idToken
+                ?: throw GoogleSignInException.Failed("Token exchange response missing id_token")
+        } finally {
+            client.close()
+        }
+    }
+
+    private fun openInBrowser(url: String) {
+        try {
+            if (
+                Desktop.isDesktopSupported() &&
+                    Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)
+            ) {
+                Desktop.getDesktop().browse(URI(url))
+                return
+            }
+        } catch (_: Exception) {
+            // Fall through to the manual-instruction path below.
+        }
+        throw GoogleSignInException.Failed(
+            "Couldn't open the system browser. Open this URL manually:\n$url"
+        )
+    }
+
+    private fun sha256Base64Url(input: String): String {
+        val digest =
+            MessageDigest.getInstance("SHA-256").digest(input.toByteArray(StandardCharsets.UTF_8))
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(digest)
+    }
+
+    private fun randomUrlSafeString(byteLen: Int): String {
+        val bytes = ByteArray(byteLen)
+        SecureRandom().nextBytes(bytes)
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    private fun parseQuery(query: String): Map<String, String> =
+        query
+            .split("&")
+            .mapNotNull {
+                val parts = it.split("=", limit = 2)
+                if (parts.size == 2) parts[0] to urlDecode(parts[1]) else null
+            }
+            .toMap()
+
+    private fun urlEncode(value: String): String =
+        URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
+
+    private fun urlDecode(value: String): String =
+        java.net.URLDecoder.decode(value, StandardCharsets.UTF_8)
+
+    private fun closeWindowHtml(message: String): String =
+        """
+        <!doctype html>
+        <html><head><title>Chef Mate</title><meta charset="utf-8" /></head>
+        <body style="font-family:-apple-system,Segoe UI,sans-serif;padding:48px;text-align:center;">
+        <h2>$message</h2>
+        <script>window.close()</script>
+        </body></html>
+        """
+            .trimIndent()
+
+    @Serializable
+    private data class GoogleTokenResponse(
+        val access_token: String? = null,
+        val id_token: String? = null,
+        val expires_in: Int? = null,
+        val token_type: String? = null,
+        val refresh_token: String? = null,
+        val scope: String? = null,
+    ) {
+        val idToken: String?
+            get() = id_token
+    }
+
+    private companion object {
+        const val AUTH_TIMEOUT_MS = 5L * 60L * 1000L
+    }
+}

--- a/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
+++ b/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
@@ -19,6 +19,15 @@ interface AuthenticationRepository {
     suspend fun verifyEmailOtp(email: String, token: String, flow: OtpFlow): Result<Unit>
 
     suspend fun resendOtp(email: String, flow: OtpFlow): Result<Unit>
+
+    suspend fun signInWithGoogle(): Result<GoogleSignInOutcome>
+}
+
+sealed class GoogleSignInOutcome {
+    data object Success : GoogleSignInOutcome()
+
+    // User dismissed the credential picker / closed the browser — not an error worth surfacing.
+    data object Cancelled : GoogleSignInOutcome()
 }
 
 sealed class SignUpResult {

--- a/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
+++ b/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.auth.data.testing
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
 import com.plusmobileapps.chefmate.auth.data.ChefMateUser
+import com.plusmobileapps.chefmate.auth.data.GoogleSignInOutcome
 import com.plusmobileapps.chefmate.auth.data.OtpFlow
 import com.plusmobileapps.chefmate.auth.data.SignUpResult
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,6 +19,8 @@ class FakeAuthenticationRepository : AuthenticationRepository {
     var sendSignInOtpResult: Result<Unit> = Result.success(Unit)
     var verifyEmailOtpResult: Result<Unit> = Result.success(Unit)
     var resendOtpResult: Result<Unit> = Result.success(Unit)
+    var signInWithGoogleResult: Result<GoogleSignInOutcome> =
+        Result.success(GoogleSignInOutcome.Success)
 
     var lastVerifyOtpFlow: OtpFlow? = null
         private set
@@ -61,6 +64,13 @@ class FakeAuthenticationRepository : AuthenticationRepository {
         lastResendOtpFlow = flow
         return resendOtpResult
     }
+
+    override suspend fun signInWithGoogle(): Result<GoogleSignInOutcome> =
+        signInWithGoogleResult.also { result ->
+            if (result.getOrNull() == GoogleSignInOutcome.Success) {
+                _state.value = AuthState.Authenticated(fakeUser())
+            }
+        }
 
     companion object {
         fun fakeUser(email: String = "test@example.com") =

--- a/client/auth/ui/impl/src/commonMain/composeResources/values/strings.xml
+++ b/client/auth/ui/impl/src/commonMain/composeResources/values/strings.xml
@@ -27,4 +27,8 @@
 
     <!-- Success messages -->
     <string name="auth_success_password_reset_sent">Password reset email sent</string>
+
+    <!-- Google sign-in errors -->
+    <string name="auth_error_google_sign_in_failed">Google sign-in failed. Please try again.</string>
+    <string name="auth_error_google_sign_in_not_configured">Google sign-in isn\'t available in this build. Check the developer setup.</string>
 </resources>

--- a/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationBlocImpl.kt
+++ b/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationBlocImpl.kt
@@ -98,6 +98,10 @@ class AuthenticationBlocImpl(
         viewModel.onEmailMeACodeClicked()
     }
 
+    override fun onGoogleSignInClicked() {
+        viewModel.onGoogleSignInClicked()
+    }
+
     override fun onBackClicked() {
         output.onNext(Output.Finished)
     }

--- a/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationViewModel.kt
+++ b/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationViewModel.kt
@@ -4,6 +4,8 @@ import chefmate.client.auth.ui.impl.generated.resources.Res
 import chefmate.client.auth.ui.impl.generated.resources.auth_error_authentication_failed
 import chefmate.client.auth.ui.impl.generated.resources.auth_error_confirm_password_required
 import chefmate.client.auth.ui.impl.generated.resources.auth_error_email_required
+import chefmate.client.auth.ui.impl.generated.resources.auth_error_google_sign_in_failed
+import chefmate.client.auth.ui.impl.generated.resources.auth_error_google_sign_in_not_configured
 import chefmate.client.auth.ui.impl.generated.resources.auth_error_invalid_credentials
 import chefmate.client.auth.ui.impl.generated.resources.auth_error_invalid_email
 import chefmate.client.auth.ui.impl.generated.resources.auth_error_password_required
@@ -19,6 +21,7 @@ import chefmate.client.auth.ui.impl.generated.resources.auth_success_password_re
 import co.touchlab.kermit.Logger
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.data.GoogleSignInOutcome
 import com.plusmobileapps.chefmate.auth.data.SignUpResult
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc
 import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc.Model.Mode.SignIn
@@ -320,6 +323,41 @@ class AuthenticationViewModel(
         }
     }
 
+    fun onGoogleSignInClicked() {
+        _state.value =
+            _state.value.copy(
+                isLoading = true,
+                errorMessage = null,
+                emailError = null,
+                confirmPasswordError = null,
+            )
+
+        scope.launch {
+            val result = authRepository.signInWithGoogle()
+            result.fold(
+                onSuccess = { outcome ->
+                    when (outcome) {
+                        GoogleSignInOutcome.Success -> {
+                            _state.value = _state.value.copy(isLoading = false)
+                            output.send(Output.AuthenticationSuccess)
+                        }
+                        GoogleSignInOutcome.Cancelled -> {
+                            _state.value = _state.value.copy(isLoading = false)
+                        }
+                    }
+                },
+                onFailure = { e ->
+                    Logger.e("Google sign-in failed", e)
+                    _state.value =
+                        _state.value.copy(
+                            isLoading = false,
+                            errorMessage = getGoogleSignInErrorMessage(e),
+                        )
+                },
+            )
+        }
+    }
+
     fun onDismissError() {
         _state.value = _state.value.copy(errorMessage = null)
     }
@@ -355,6 +393,15 @@ class AuthenticationViewModel(
             message.contains("not found") || message.contains("no user") ->
                 Res.string.auth_error_password_reset_user_not_found.asTextData()
             else -> Res.string.auth_error_password_reset_failed.asTextData()
+        }
+    }
+
+    private fun getGoogleSignInErrorMessage(e: Throwable): TextData {
+        val message = e.message?.lowercase() ?: ""
+        return when {
+            message.contains("not configured") || message.contains("not set") ->
+                Res.string.auth_error_google_sign_in_not_configured.asTextData()
+            else -> Res.string.auth_error_google_sign_in_failed.asTextData()
         }
     }
 

--- a/client/auth/ui/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationViewModelGoogleTest.kt
+++ b/client/auth/ui/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationViewModelGoogleTest.kt
@@ -1,0 +1,83 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.plusmobileapps.chefmate.auth.ui.impl
+
+import app.cash.turbine.test
+import com.plusmobileapps.chefmate.auth.data.GoogleSignInOutcome
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc
+import com.plusmobileapps.chefmate.util.EmailUtil
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+class AuthenticationViewModelGoogleTest {
+
+    private fun TestScope.viewModel(
+        repo: FakeAuthenticationRepository = FakeAuthenticationRepository()
+    ): AuthenticationViewModel =
+        AuthenticationViewModel(
+            initialProps = AuthenticationBloc.Props.SignIn,
+            mainContext = UnconfinedTestDispatcher(testScheduler),
+            authRepository = repo,
+            emailUtil = AlwaysValidEmailUtil,
+        )
+
+    @Test
+    fun Given_repo_succeeds_When_google_clicked_Then_authentication_success_emitted() = runTest {
+        val repo =
+            FakeAuthenticationRepository().apply {
+                signInWithGoogleResult = Result.success(GoogleSignInOutcome.Success)
+            }
+        val viewModel = viewModel(repo = repo)
+
+        viewModel.outputs.test {
+            viewModel.onGoogleSignInClicked()
+
+            awaitItem() shouldBe AuthenticationViewModel.Output.AuthenticationSuccess
+            cancelAndIgnoreRemainingEvents()
+        }
+        viewModel.state.value.isLoading shouldBe false
+    }
+
+    @Test
+    fun Given_repo_returns_cancelled_When_google_clicked_Then_loading_cleared_with_no_output() =
+        runTest {
+            val repo =
+                FakeAuthenticationRepository().apply {
+                    signInWithGoogleResult = Result.success(GoogleSignInOutcome.Cancelled)
+                }
+            val viewModel = viewModel(repo = repo)
+
+            viewModel.outputs.test {
+                viewModel.onGoogleSignInClicked()
+                expectNoEvents()
+            }
+
+            viewModel.state.value.isLoading shouldBe false
+            viewModel.state.value.errorMessage shouldBe null
+        }
+
+    @Test
+    fun Given_repo_fails_When_google_clicked_Then_loading_cleared_and_error_set() = runTest {
+        val repo =
+            FakeAuthenticationRepository().apply {
+                signInWithGoogleResult = Result.failure(IllegalStateException("kaboom"))
+            }
+        val viewModel = viewModel(repo = repo)
+
+        viewModel.onGoogleSignInClicked()
+
+        viewModel.state.value.isLoading shouldBe false
+        viewModel.state.value.errorMessage shouldNotBe null
+    }
+
+    private object AlwaysValidEmailUtil : EmailUtil {
+        override fun isValidEmail(email: String): Boolean = true
+    }
+}

--- a/client/auth/ui/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/auth/ui/public/src/commonMain/composeResources/values/strings.xml
@@ -14,6 +14,8 @@
     <string name="auth_button_forgot_password">Forgot Password?</string>
     <string name="auth_button_email_me_a_code">Email me a code</string>
     <string name="auth_button_okay">OK</string>
+    <string name="auth_button_continue_with_google">Continue with Google</string>
+    <string name="auth_divider_or">or</string>
 
     <!-- Loading messages -->
     <string name="auth_loading_signing_in">Signing in...</string>

--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationBloc.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationBloc.kt
@@ -27,6 +27,8 @@ interface AuthenticationBloc : BackClickBloc {
 
     fun onEmailMeACodeClicked()
 
+    fun onGoogleSignInClicked()
+
     fun onUrlClicked(url: String)
 
     fun onDismissError()

--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -27,6 +28,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -46,11 +48,13 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import chefmate.client.auth.ui.public.generated.resources.Res
+import chefmate.client.auth.ui.public.generated.resources.auth_button_continue_with_google
 import chefmate.client.auth.ui.public.generated.resources.auth_button_email_me_a_code
 import chefmate.client.auth.ui.public.generated.resources.auth_button_forgot_password
 import chefmate.client.auth.ui.public.generated.resources.auth_button_okay
 import chefmate.client.auth.ui.public.generated.resources.auth_button_sign_in
 import chefmate.client.auth.ui.public.generated.resources.auth_button_sign_up
+import chefmate.client.auth.ui.public.generated.resources.auth_divider_or
 import chefmate.client.auth.ui.public.generated.resources.auth_label_confirm_password
 import chefmate.client.auth.ui.public.generated.resources.auth_label_email
 import chefmate.client.auth.ui.public.generated.resources.auth_label_password
@@ -105,6 +109,7 @@ fun AuthenticationScreen(bloc: AuthenticationBloc, modifier: Modifier = Modifier
                     onToggleMode = bloc::onToggleMode,
                     onForgotPasswordClicked = bloc::onForgotPasswordClicked,
                     onEmailMeACodeClicked = bloc::onEmailMeACodeClicked,
+                    onGoogleSignInClicked = bloc::onGoogleSignInClicked,
                     onDismissError = bloc::onDismissError,
                     onUrlClicked = bloc::onUrlClicked,
                 )
@@ -153,6 +158,7 @@ private fun AuthenticationBody(
     onToggleMode: () -> Unit,
     onForgotPasswordClicked: () -> Unit,
     onEmailMeACodeClicked: () -> Unit,
+    onGoogleSignInClicked: () -> Unit,
     onDismissError: () -> Unit,
     onUrlClicked: (String) -> Unit,
 ) {
@@ -188,6 +194,14 @@ private fun AuthenticationBody(
                 ),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        GoogleSignInButton(onClick = onGoogleSignInClicked)
+
+        Spacer(modifier = Modifier.height(ChefMateTheme.dimens.paddingLarge))
+
+        OrDivider()
+
+        Spacer(modifier = Modifier.height(ChefMateTheme.dimens.paddingLarge))
+
         EmailField(
             email = email,
             error = model.emailError,
@@ -331,6 +345,41 @@ fun EmailField(
             KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
         keyboardActions = KeyboardActions(onNext = { onImeAction() }),
     )
+}
+
+@Composable
+private fun GoogleSignInButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        contentPadding =
+            PaddingValues(
+                vertical = ChefMateTheme.dimens.paddingNormal,
+                horizontal = ChefMateTheme.dimens.paddingLarge,
+            ),
+    ) {
+        Text(
+            text = stringResource(Res.string.auth_button_continue_with_google),
+            style = MaterialTheme.typography.titleMedium,
+        )
+    }
+}
+
+@Composable
+private fun OrDivider(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal),
+    ) {
+        HorizontalDivider(modifier = Modifier.weight(1f))
+        Text(
+            text = stringResource(Res.string.auth_divider_or),
+            style = MaterialTheme.typography.labelMedium,
+        )
+        HorizontalDivider(modifier = Modifier.weight(1f))
+    }
 }
 
 @Composable

--- a/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/MyApplication.kt
+++ b/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/MyApplication.kt
@@ -1,6 +1,8 @@
 package com.plusmobileapps.chefmate
 
+import android.app.Activity
 import android.app.Application
+import android.os.Bundle
 import com.plusmobileapps.chefmate.buildconfig.BuildConfig
 import com.plusmobileapps.chefmate.di.AndroidApplicationComponent
 import dev.zacsweers.metro.createGraphFactory
@@ -12,5 +14,29 @@ class MyApplication : Application() {
         super.onCreate()
         BugsnagInitializer(this).initialize(BuildConfig.BUGSNAG_API_KEY)
         appComponent = createGraphFactory<AndroidApplicationComponent.Factory>().create(this)
+        registerActivityLifecycleCallbacks(CurrentActivityTracker(appComponent))
+    }
+
+    private class CurrentActivityTracker(private val appComponent: AndroidApplicationComponent) :
+        ActivityLifecycleCallbacks {
+        override fun onActivityResumed(activity: Activity) {
+            appComponent.currentActivityHolder.current = activity
+        }
+
+        override fun onActivityPaused(activity: Activity) {
+            if (appComponent.currentActivityHolder.current === activity) {
+                appComponent.currentActivityHolder.current = null
+            }
+        }
+
+        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+
+        override fun onActivityStarted(activity: Activity) = Unit
+
+        override fun onActivityStopped(activity: Activity) = Unit
+
+        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+        override fun onActivityDestroyed(activity: Activity) = Unit
     }
 }

--- a/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/di/AndroidApplicationComponent.kt
+++ b/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/di/AndroidApplicationComponent.kt
@@ -2,6 +2,8 @@ package com.plusmobileapps.chefmate.di
 
 import android.content.Context
 import com.plusmobileapps.chefmate.ApplicationComponent
+import com.plusmobileapps.chefmate.auth.data.impl.CurrentActivityHolder
+import com.plusmobileapps.chefmate.auth.data.impl.GoogleSignInProvider
 import com.plusmobileapps.chefmate.client.database.DriverFactory
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
@@ -10,10 +12,20 @@ import dev.zacsweers.metro.SingleIn
 @DependencyGraph(AppScope::class)
 @SingleIn(AppScope::class)
 abstract class AndroidApplicationComponent : ApplicationComponent {
+    abstract val currentActivityHolder: CurrentActivityHolder
+
     @DependencyGraph.Factory
     fun interface Factory {
         fun create(@Provides context: Context): AndroidApplicationComponent
     }
 
     @Provides fun driverFactory(context: Context): DriverFactory = DriverFactory(context = context)
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideGoogleSignInProvider(
+        context: Context,
+        activityHolder: CurrentActivityHolder,
+    ): GoogleSignInProvider =
+        GoogleSignInProvider(appContext = context, activityHolder = activityHolder)
 }

--- a/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/di/IosApplicationComponent.kt
+++ b/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/di/IosApplicationComponent.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.di
 
 import com.plusmobileapps.chefmate.ApplicationComponent
+import com.plusmobileapps.chefmate.auth.data.impl.GoogleSignInProvider
 import com.plusmobileapps.chefmate.client.database.DriverFactory
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
@@ -16,4 +17,8 @@ abstract class IosApplicationComponent : ApplicationComponent {
     }
 
     @Provides fun driverFactory(): DriverFactory = DriverFactory()
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideGoogleSignInProvider(): GoogleSignInProvider = GoogleSignInProvider()
 }

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/JvmApplicationComponent.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/JvmApplicationComponent.kt
@@ -1,5 +1,6 @@
 package com.plusmobileapps.chefmate
 
+import com.plusmobileapps.chefmate.auth.data.impl.GoogleSignInProvider
 import com.plusmobileapps.chefmate.client.database.DriverFactory
 import com.plusmobileapps.chefmate.di.AppScope
 import dev.zacsweers.metro.DependencyGraph
@@ -10,4 +11,8 @@ import dev.zacsweers.metro.SingleIn
 @DependencyGraph(AppScope::class)
 abstract class JvmApplicationComponent : ApplicationComponent {
     @Provides fun providesDriverFactory(): DriverFactory = DriverFactory()
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideGoogleSignInProvider(): GoogleSignInProvider = GoogleSignInProvider()
 }

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -59,6 +59,25 @@ val supabaseTestingKey =
 val bugsnagApiKey =
     localProperties.getProperty("bugsnag.apiKey") ?: System.getenv("BUGSNAG_API_KEY") ?: ""
 
+// Web OAuth client ID from Google Cloud Console. Used by Android Credential Manager as
+// `serverClientId` so the issued ID token's audience is something Supabase will accept.
+val googleWebClientId =
+    localProperties.getProperty("google.webClientId") ?: System.getenv("GOOGLE_WEB_CLIENT_ID") ?: ""
+
+// Desktop OAuth client ID + secret from Google Cloud Console (client type = "Desktop app").
+// Used by the JVM loopback flow to exchange the auth code for an ID token. Desktop clients
+// can ship a "secret" — Google explicitly documents it as not actually secret for this
+// client type, and PKCE is the real protection.
+val googleDesktopClientId =
+    localProperties.getProperty("google.desktopClientId")
+        ?: System.getenv("GOOGLE_DESKTOP_CLIENT_ID")
+        ?: ""
+
+val googleDesktopClientSecret =
+    localProperties.getProperty("google.desktopClientSecret")
+        ?: System.getenv("GOOGLE_DESKTOP_CLIENT_SECRET")
+        ?: ""
+
 // Collect test users by incrementing n until a pair is missing. Looked up in order:
 // 1. local.properties at the project root (chefmate.user.<n> / chefmate.user.password.<n>)
 // 2. ~/.gradle/gradle.properties or any other Gradle property source (same keys)
@@ -117,5 +136,8 @@ buildkonfig {
         buildConfigField(STRING, "TEST_USERS", testUsersSerialized)
         buildConfigField(BOOLEAN, "IS_DEBUG", isDebugBuildFlag.toString())
         buildConfigField(STRING, "VERSION_NAME", appVersionName)
+        buildConfigField(STRING, "GOOGLE_WEB_CLIENT_ID", googleWebClientId)
+        buildConfigField(STRING, "GOOGLE_DESKTOP_CLIENT_ID", googleDesktopClientId)
+        buildConfigField(STRING, "GOOGLE_DESKTOP_CLIENT_SECRET", googleDesktopClientSecret)
     }
 }

--- a/docs/google-sign-in-setup.md
+++ b/docs/google-sign-in-setup.md
@@ -1,0 +1,115 @@
+# Google Sign-In Setup
+
+This guide walks through the one-time external setup required for "Continue with Google" to
+actually work on each platform. The code in this PR is wired up end-to-end — but none of it will
+function until the OAuth clients exist and the Supabase project knows about them.
+
+## 1. Google Cloud Console — create four OAuth client IDs
+
+In a single project at <https://console.cloud.google.com/apis/credentials>:
+
+1. **Web application** — server-side client ID used by Supabase to verify ID tokens, AND used by
+   Android Credential Manager as `serverClientId`.
+   - Authorized redirect URI: `https://<your-project>.supabase.co/auth/v1/callback`
+2. **Android** — package name `com.plusmobileapps.chefmate`, plus the **debug** and **release**
+   SHA-1 fingerprints (get them from `./gradlew :client:composeApp:signingReport`).
+3. **iOS** — bundle ID `com.plusmobileapps.chefmate.ChefMate`. After creation, Google shows a
+   reverse-client URL scheme — you'll add this to the iOS Info.plist (step 4 below).
+4. **Desktop app** — used by the JVM loopback flow. No host/redirect to configure. A "secret" is
+   shown — store it in `local.properties` as `google.desktopClientSecret`. Google explicitly
+   documents this as not a real secret; PKCE is what protects the desktop flow.
+
+## 2. Supabase dashboard — enable the Google provider
+
+Authentication → Providers → Google → Enable.
+
+- **Client ID (for OAuth)**: paste the **Web** client ID from step 1.
+- **Client Secret (for OAuth)**: paste the Web client secret.
+- **Authorized Client IDs**: comma-separated list of the **Android + iOS + Desktop** client IDs.
+  This is what tells Supabase to accept ID tokens whose `aud` claim matches one of these — i.e.
+  ID tokens minted by the native SDKs on-device.
+
+## 3. `local.properties` — wire the keys into BuildKonfig
+
+Add to `local.properties` at the repo root (already in `.gitignore`):
+
+```properties
+google.webClientId=<your-web-client-id>.apps.googleusercontent.com
+google.desktopClientId=<your-desktop-client-id>.apps.googleusercontent.com
+google.desktopClientSecret=<your-desktop-client-secret>
+```
+
+`google.webClientId` is what Android Credential Manager passes as `serverClientId`. The desktop
+ones are used by the JVM loopback flow.
+
+The iOS client ID lives in the iOS app's Info.plist (next section) — Kotlin/native code doesn't
+need it.
+
+## 4. iOS — add GoogleSignIn SDK + Info.plist entries + Bridge
+
+The iOS app needs the GoogleSignIn-iOS SDK to actually drive the native sign-in sheet.
+
+1. **Open `iosApp/iosApp.xcodeproj` in Xcode.**
+2. **Add Swift Package**: File → Add Package Dependencies →
+   `https://github.com/google/GoogleSignIn-iOS` → choose "Up to next major version" from `7.1.0`.
+   Add the `GoogleSignIn` library to the `iosApp` target.
+3. **Add `GoogleSignInBridge.swift` to the project**: drag `iosApp/iosApp/GoogleSignInBridge.swift`
+   into Xcode's `iosApp` group (the file is already on disk from this PR).
+4. **Info.plist** — add two entries:
+   ```xml
+   <key>GIDClientID</key>
+   <string>YOUR_IOS_CLIENT_ID.apps.googleusercontent.com</string>
+   <key>CFBundleURLTypes</key>
+   <array>
+       <!-- existing chefmate:// entry stays -->
+       <dict>
+           <key>CFBundleURLSchemes</key>
+           <array>
+               <string>com.googleusercontent.apps.YOUR_IOS_CLIENT_ID</string>
+           </array>
+       </dict>
+   </array>
+   ```
+   The URL scheme is exactly Google's reverse-client-id format. Find it on the iOS OAuth client's
+   page in Google Cloud Console.
+5. **AppDelegate** — `iOSApp.swift` already registers the bridge:
+   `IosGoogleSignInBridgeHolder.shared.bridge = GoogleSignInBridge()`. Nothing else to do.
+
+## 5. Android — release SHA-1
+
+For Play Store builds: the **release signing** SHA-1 must be added to the Android OAuth client.
+Get it from your release keystore:
+```bash
+keytool -list -v -keystore release.keystore -alias <your-alias>
+```
+
+## 6. Verify
+
+- **Android**: `./gradlew :client:composeApp:installDebug` → tap "Continue with Google" → native
+  Credential Manager bottom sheet.
+- **iOS**: open Xcode, run on simulator → tap "Continue with Google" → ASWebAuthenticationSession
+  presents Google's consent screen.
+- **Desktop**: `./gradlew :client:composeApp:run` → tap "Continue with Google" → system browser
+  opens; sign in; redirect lands on `http://127.0.0.1:<random-port>/callback`; window auto-closes
+  and the app proceeds.
+
+## Architecture notes
+
+- `GoogleSignInProvider` is an `expect class` in `client/auth/data/impl/commonMain`. The actual on
+  each platform returns a `(idToken, rawNonce)` pair that `SupabaseAuthenticationRepository` hands
+  to `supabase.auth.signInWith(IDToken) { provider = Google; idToken = ...; nonce = ... }`.
+- The raw nonce → SHA-256 → ID token's `nonce` claim chain is what stops replay attacks. Each
+  platform's actual is responsible for generating the raw nonce, hashing it, passing the hash to
+  the SDK, and returning the raw nonce to Kotlin.
+- **Android**: Credential Manager + `com.google.android.libraries.identity.googleid:googleid`.
+  Activity context comes from `CurrentActivityHolder`, populated by `MyApplication`'s
+  `ActivityLifecycleCallbacks`.
+- **iOS**: Swift bridge implementing the Kotlin `IosGoogleSignInBridge` fun interface. CryptoKit
+  generates the nonce; GoogleSignIn-iOS handles the rest.
+- **Desktop**: RFC 8252 — system browser + PKCE + loopback HTTP server on a random localhost port.
+  Google's docs explicitly bless this pattern for installed apps.
+
+## See also
+
+- [buildconfig-setup.md](buildconfig-setup.md) — for the broader BuildKonfig story.
+- [Supabase Kotlin docs — signInWith(IDToken)](https://supabase.com/docs/reference/kotlin/auth-signinwithidtoken)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,8 @@ composeMultiplatform = "1.10.3"
 composeUi = "1.11.1"
 composeMaterialIcons = "1.7.3"
 coroutines = "1.10.2"
+androidx-credentials = "1.5.0"
+googleid = "1.1.1"
 kermit = "2.1.0"
 decompose = "3.4.0"
 essenty = "2.5.0"
@@ -62,6 +64,9 @@ androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", vers
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-annotation = "androidx.annotation:annotation:1.9.1"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidx-credentials" }
+androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "androidx-credentials" }
+googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 arkivanov-decompose-core = { group = "com.arkivanov.decompose", name = "decompose", version.ref = "decompose" }

--- a/iosApp/iosApp/GoogleSignInBridge.swift
+++ b/iosApp/iosApp/GoogleSignInBridge.swift
@@ -1,0 +1,85 @@
+import Foundation
+import UIKit
+import ComposeApp
+import CryptoKit
+import GoogleSignIn
+
+/// Implements the Kotlin `IosGoogleSignInBridge` contract by driving GoogleSignIn-iOS.
+/// Generates the nonce on the Swift side (CryptoKit gives us SHA-256 for free) so the Kotlin
+/// actual stays free of cinterop / native crypto code.
+final class GoogleSignInBridge: NSObject, IosGoogleSignInBridge {
+    func signIn() async throws -> IosGoogleSignInResponse {
+        guard let presenter = Self.topViewController() else {
+            throw NSError(
+                domain: "GoogleSignInBridge",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "No view controller to present from"]
+            )
+        }
+
+        let rawNonce = Self.randomNonceString()
+        let hashedNonce = Self.sha256(rawNonce)
+
+        let result = try await GIDSignIn.sharedInstance.signIn(
+            withPresenting: presenter,
+            hint: nil,
+            additionalScopes: nil,
+            nonce: hashedNonce
+        )
+
+        guard let idToken = result.user.idToken?.tokenString else {
+            throw NSError(
+                domain: "GoogleSignInBridge",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "Google sign-in returned no ID token"]
+            )
+        }
+
+        return IosGoogleSignInResponse(idToken: idToken, rawNonce: rawNonce)
+    }
+
+    private static func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: [Character] =
+            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remaining = length
+        while remaining > 0 {
+            var randoms = [UInt8](repeating: 0, count: 16)
+            let status = SecRandomCopyBytes(kSecRandomDefault, randoms.count, &randoms)
+            precondition(status == errSecSuccess)
+            randoms.forEach { random in
+                if remaining == 0 { return }
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remaining -= 1
+                }
+            }
+        }
+        return result
+    }
+
+    private static func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashed = SHA256.hash(data: inputData)
+        return hashed.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func topViewController(
+        from root: UIViewController? = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first(where: { $0.isKeyWindow })?.rootViewController
+    ) -> UIViewController? {
+        if let nav = root as? UINavigationController {
+            return topViewController(from: nav.visibleViewController)
+        }
+        if let tab = root as? UITabBarController, let selected = tab.selectedViewController {
+            return topViewController(from: selected)
+        }
+        if let presented = root?.presentedViewController {
+            return topViewController(from: presented)
+        }
+        return root
+    }
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -16,6 +16,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     override init() {
         super.init()
         BugsnagStartup_iosKt.initializeBugsnag()
+        IosGoogleSignInBridgeHolder.shared.bridge = GoogleSignInBridge()
     }
 
     lazy var root: RootBloc = RootBlocProvider.shared.buildRootBloc(


### PR DESCRIPTION
## Summary

Adds a **Continue with Google** button to the auth screen, wired up natively on all three targets via Supabase's `signInWith(IDToken)`:

- **Android**: Credential Manager + `googleid` library
- **iOS**: Swift bridge calling GoogleSignIn-iOS SDK
- **Desktop (JVM)**: system browser + loopback HTTP server on `localhost:<random-port>` (RFC 8252, with PKCE)

`GoogleSignInProvider` is an `expect class` in `client/auth/data/impl`. Each actual returns a `(idToken, rawNonce)` pair that `SupabaseAuthenticationRepository` hands to Supabase. The `raw nonce → SHA-256 → ID-token nonce claim` chain prevents replay attacks — Supabase verifies it on its side.

Cancellation is modelled as `Result.success(GoogleSignInOutcome.Cancelled)` so the UI just clears the loading dialog without navigating forward or showing an error.

## Required setup before this works

Detailed walkthrough in [`docs/google-sign-in-setup.md`](docs/google-sign-in-setup.md). The short version:

1. **Google Cloud Console** — create 4 OAuth client IDs: Web (for Supabase), Android, iOS, Desktop.
2. **Supabase dashboard** — Auth → Providers → Google → paste Web client ID/secret + add Android/iOS/Desktop client IDs to "Authorized Client IDs".
3. **`local.properties`** — add `google.webClientId`, `google.desktopClientId`, `google.desktopClientSecret`.
4. **Xcode (one-time)** — File → Add Package Dependencies → `https://github.com/google/GoogleSignIn-iOS`, add `GoogleSignInBridge.swift` to the iosApp target, add `GIDClientID` + reverse-client URL scheme to `Info.plist`.

Until those are done, the button shows a "not configured" error on each platform — nothing else breaks.

## Notable design choices

- **Activity holder pattern** for Android — `MyApplication` registers an `ActivityLifecycleCallbacks` that populates a `CurrentActivityHolder` singleton, so the provider can resolve a resumed `Activity` at call time without baking it into the DI graph lifetime.
- **Swift owns nonce generation on iOS** — CryptoKit gives us SHA-256 for free; avoids pulling cinterop / native crypto into Kotlin/Native.
- **Apple skipped intentionally** — adding it on Android requires resurrecting the deeplink plumbing removed in #160. Plan is to add Apple as a follow-up PR (iOS native + Desktop loopback only, mirroring how Spotify/Slack handle it).
- **`build/` excluded from ktfmt** — newly-generated `BuildConfig.kt` fields were causing `ktfmtCheck` to fail on a generated file. The convention plugin now skips all `build/` outputs, not just paths matching `generated`.

## Test plan

- [x] `./gradlew ktfmtCheck` — passes
- [x] `./gradlew :client:auth:data:impl:compileKotlinJvm :client:auth:data:impl:compileDebugKotlinAndroid :client:auth:data:impl:compileKotlinIosSimulatorArm64` — all three compile
- [x] `./gradlew :client:composeApp:compileKotlinJvm :client:composeApp:compileDebugKotlinAndroid :client:composeApp:compileKotlinIosSimulatorArm64` — all compile
- [x] `./gradlew :client:auth:ui:impl:test` — new `AuthenticationViewModelGoogleTest` covers success / cancelled / failure cases
- [ ] Manual: Android — `installDebug` → tap "Continue with Google" → Credential Manager sheet → sign in → land on main
- [ ] Manual: iOS — open Xcode, add GoogleSignIn SPM dep + Info.plist entries, run on simulator → tap "Continue with Google" → consent sheet → sign in
- [ ] Manual: Desktop — `./gradlew :client:composeApp:run` → tap "Continue with Google" → system browser opens → sign in → browser auto-closes → land on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)