### PR TITLE
fix(recipe-detail): remove keep-screen-on toggle

### DIFF
--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -116,7 +116,6 @@ class RecipeDetailBlocImpl(
                 formattedTotalTime =
                     it.recipe.totalTime?.let { time -> timeFormatterUtil.formatMinutes(time) },
                 showGroceryAddedSnackbar = it.showGroceryAddedSnackbar,
-                keepScreenOn = it.keepScreenOn,
             )
         }
 
@@ -175,10 +174,6 @@ class RecipeDetailBlocImpl(
     override fun onViewGroceryListClicked() {
         viewModel.dismissGroceryAddedSnackbar()
         output.onNext(Output.OpenGroceryList)
-    }
-
-    override fun onKeepScreenOnToggled() {
-        viewModel.toggleKeepScreenOn()
     }
 
     override fun onGrocerySnackbarDismissed() {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -1,7 +1,6 @@
 package com.plusmobileapps.chefmate.recipe.core.impl.detail
 
 import com.plusmobileapps.chefmate.ViewModel
-import com.plusmobileapps.chefmate.di.KeepScreenOnRepository
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
@@ -24,23 +23,16 @@ class RecipeDetailViewModel(
     @Assisted private val recipeId: Long,
     @Main mainContext: CoroutineContext,
     private val repository: RecipeRepository,
-    private val keepScreenOnRepository: KeepScreenOnRepository,
 ) : ViewModel(mainContext) {
 
     private val _output = Channel<Output>(Channel.BUFFERED)
     val output: Flow<Output> = _output.receiveAsFlow()
 
-    private val _state =
-        MutableStateFlow(State(keepScreenOn = keepScreenOnRepository.keepScreenOn.value))
+    private val _state = MutableStateFlow(State())
     val state: StateFlow<State> = _state.asStateFlow()
 
     init {
         scope.launch { observeRecipe() }
-        scope.launch {
-            keepScreenOnRepository.keepScreenOn.collect { keepScreenOn ->
-                _state.update { it.copy(keepScreenOn = keepScreenOn) }
-            }
-        }
     }
 
     private suspend fun observeRecipe() {
@@ -85,17 +77,12 @@ class RecipeDetailViewModel(
         _state.update { it.copy(showGroceryAddedSnackbar = false) }
     }
 
-    fun toggleKeepScreenOn() {
-        keepScreenOnRepository.toggle()
-    }
-
     data class State(
         val isLoading: Boolean = true,
         val isDeleting: Boolean = false,
         val showDeleteConfirmationDialog: Boolean = false,
         val recipe: Recipe = Recipe.Empty,
         val showGroceryAddedSnackbar: Boolean = false,
-        val keepScreenOn: Boolean = true,
     )
 
     sealed class Output {

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
@@ -5,7 +5,6 @@ package com.plusmobileapps.chefmate.recipe.core.impl.detail
 
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
-import com.plusmobileapps.chefmate.di.KeepScreenOnRepository
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.data.Recipe
@@ -14,7 +13,6 @@ import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
 import com.plusmobileapps.chefmate.util.DateTimeUtil
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
-import com.russhwolf.settings.MapSettings
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
@@ -55,13 +53,11 @@ class RecipeDetailBlocImplTest {
 
     private fun createBloc(recipe: Recipe? = sampleRecipe): RecipeDetailBlocImpl {
         if (recipe != null) recipes.value = listOf(recipe)
-        val keepScreenOnRepository = KeepScreenOnRepository(MapSettings())
         val viewModelFactory = RecipeDetailViewModel.Factory { id ->
             RecipeDetailViewModel(
                 recipeId = id,
                 mainContext = context.mainContext,
                 repository = repository,
-                keepScreenOnRepository = keepScreenOnRepository,
             )
         }
         val dateTimeUtil =

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -42,8 +42,6 @@
 <string name="recipe_detail_share_url">Share recipe URL</string>
 <string name="recipe_detail_share_text">Share recipe text</string>
     <string name="recipe_detail_copied_to_clipboard">Copied to clipboard</string>
-    <string name="recipe_detail_keep_screen_on">Keep screen on</string>
-    <string name="recipe_detail_allow_screen_off">Allow screen to turn off</string>
     <string name="recipe_full_image_close">Close</string>
 
     <!-- Add to Meal Plan -->

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -43,8 +43,6 @@ interface RecipeDetailBloc : BackClickBloc {
 
     fun onViewGroceryListClicked()
 
-    fun onKeepScreenOnToggled()
-
     fun onGrocerySnackbarDismissed()
 
     data class Model(
@@ -58,7 +56,6 @@ interface RecipeDetailBloc : BackClickBloc {
         val formattedCookTime: TextData? = null,
         val formattedTotalTime: TextData? = null,
         val showGroceryAddedSnackbar: Boolean = false,
-        val keepScreenOn: Boolean = true,
     )
 
     sealed class Output {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -60,8 +60,6 @@ import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SoupKitchen
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Timer
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
@@ -117,7 +115,6 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_groc
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_favorite
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_grocery
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_meal_plan
-import chefmate.client.recipe.core.public.generated.resources.recipe_detail_allow_screen_off
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_calories
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_mode
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_time
@@ -136,7 +133,6 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_dire
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_edit
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_ingredients
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_kcal
-import chefmate.client.recipe.core.public.generated.resources.recipe_detail_keep_screen_on
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_prep_time
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_remove_favorite
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_servings
@@ -156,7 +152,6 @@ import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
-import com.plusmobileapps.chefmate.ui.KeepScreenOn
 import com.plusmobileapps.chefmate.ui.LocalAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.LocalSecondaryAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
@@ -179,9 +174,6 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
-    if (state.keepScreenOn) {
-        KeepScreenOn()
-    }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val shareLauncher = rememberShareLauncher()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -295,26 +287,6 @@ private fun RecipeDetailBody(
                         titleSharedElementKey = "recipe-title-${state.recipe.id}",
                         trailingAccessory =
                             PlusHeaderData.TrailingAccessory.Custom {
-                                IconButton(onClick = bloc::onKeepScreenOnToggled) {
-                                    Icon(
-                                        imageVector =
-                                            if (state.keepScreenOn) {
-                                                Icons.Default.Visibility
-                                            } else {
-                                                Icons.Default.VisibilityOff
-                                            },
-                                        contentDescription =
-                                            if (state.keepScreenOn) {
-                                                stringResource(
-                                                    Res.string.recipe_detail_allow_screen_off
-                                                )
-                                            } else {
-                                                stringResource(
-                                                    Res.string.recipe_detail_keep_screen_on
-                                                )
-                                            },
-                                    )
-                                }
                                 Box {
                                     IconButton(onClick = { onShowOverflowMenuChange(true) }) {
                                         Icon(
@@ -1672,10 +1644,6 @@ private val previewBloc =
         }
 
         override fun onViewGroceryListClicked() {
-            TODO("Not yet implemented")
-        }
-
-        override fun onKeepScreenOnToggled() {
             TODO("Not yet implemented")
         }
 


### PR DESCRIPTION
## Summary
- Removes the keep-screen-on toggle and `KeepScreenOn()` call from `RecipeDetailScreen`; cook mode now owns this feature exclusively.
- Drops the corresponding state, handler, and `KeepScreenOnRepository` dependency from `RecipeDetailBloc` / `RecipeDetailViewModel` (and its test).
- Deletes the two now-unused string resources (`recipe_detail_keep_screen_on`, `recipe_detail_allow_screen_off`).

## Why
When navigating recipe list → recipe detail → cook mode, the screen would not stay on. Both screens called the same `KeepScreenOn()` composable, which toggles a global flag (`view.keepScreenOn` on Android, `idleTimerDisabled` on iOS). During the Decompose stack animation both children are composed, so cook mode's `DisposableEffect` fires first (no-op, flag already on), then recipe detail's `onDispose` runs and clears the flag — cook mode never re-fires its effect because its `view` key never changed. Pulling the toggle out of recipe detail removes the second caller and the race goes with it.

## Test plan
- [x] `./gradlew :client:recipe:core:impl:test :client:recipe:core:public:test`
- [x] `./gradlew :client:composeApp:assembleDebug`
- [x] `./gradlew ktfmtFormat`
- [ ] Manually verify on Android: list → detail → cook mode keeps the screen on
- [ ] Manually verify on iOS: list → detail → cook mode keeps the screen on

🤖 Generated with [Claude Code](https://claude.com/claude-code)