### PR TITLE
refactor(di): adopt metro-extensions to remove BLoC assisted-factory boilerplate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,9 @@ Add strings at `client/<module>/src/commonMain/composeResources/values/strings.x
 
 ### Dependency Injection
 
-- `kotlin-inject` + `kotlin-inject-anvil` + `kotlin-inject-anvil-extensions` (assisted factory)
-- `AppScope` is the standard scope for binding implementations
-- `@ContributesAssistedFactory` binds impl classes to their assisted factory interface
-- KSP is set to v1 (not v2) for iOS compatibility — do not change this
+- `dev.zacsweers.metro` is the DI framework (compiler plugin). `AppScope` is the standard scope.
+- `@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = FooBloc.Factory::class)` from `com.plusmobileapps.metro-extensions` is placed alongside `@AssistedInject` on each BLoC impl. A KSP processor generates the Metro `@AssistedFactory` and a `@ContributesBinding`/`@Origin`-tagged bridge to the public `Factory` interface — no manual binding modules needed.
+- KSP + metro-extensions are wired automatically by `MetroConventionPlugin` for any module with `plusLibrary { enableDi = true }`.
 
 ### Snapshot Testing
 

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/MetroConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/MetroConventionPlugin.kt
@@ -12,4 +12,12 @@ class MetroConventionPlugin : Plugin<Project> {
 
 fun Project.applyMetro() {
     pluginManager.apply(libs.plugins.metro.get().pluginId)
+    pluginManager.apply(libs.plugins.ksp.get().pluginId)
+
+    dependencies.apply {
+        add("commonMainImplementation", libs.metroExtensions.assistedFactory.runtime)
+        listOf("kspAndroid", "kspJvm", "kspIosArm64", "kspIosSimulatorArm64").forEach { config ->
+            add(config, libs.metroExtensions.assistedFactory.compiler)
+        }
+    }
 }

--- a/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationBlocImpl.kt
+++ b/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationBlocImpl.kt
@@ -7,30 +7,23 @@ import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc.Output
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = AuthenticationBloc.Factory::class,
+)
 class AuthenticationBlocImpl(
     @Assisted context: BlocContext,
     @Assisted props: AuthenticationBloc.Props,
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: AuthenticationViewModel.Factory,
 ) : AuthenticationBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            props: AuthenticationBloc.Props,
-            output: Consumer<Output>,
-        ): AuthenticationBlocImpl
-    }
 
     private val scope = createScope()
 
@@ -108,15 +101,5 @@ class AuthenticationBlocImpl(
 
     override fun onDismissError() {
         viewModel.onDismissError()
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface AuthenticationBlocBindingModule {
-    @Provides
-    fun provideAuthenticationBlocFactory(
-        factory: AuthenticationBlocImpl.ManagedFactory
-    ): AuthenticationBloc.Factory = AuthenticationBloc.Factory { context, props, output ->
-        factory.create(context, props, output)
     }
 }

--- a/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/otp/OtpBlocImpl.kt
+++ b/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/otp/OtpBlocImpl.kt
@@ -7,30 +7,20 @@ import com.plusmobileapps.chefmate.auth.ui.otp.OtpBloc.Output
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @AssistedInject
+@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = OtpBloc.Factory::class)
 class OtpBlocImpl(
     @Assisted context: BlocContext,
     @Assisted props: OtpBloc.Props,
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: OtpViewModel.Factory,
 ) : OtpBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            props: OtpBloc.Props,
-            output: Consumer<Output>,
-        ): OtpBlocImpl
-    }
 
     private val scope = createScope()
 
@@ -81,13 +71,4 @@ class OtpBlocImpl(
     override fun onBackClicked() {
         output.onNext(Output.Cancelled)
     }
-}
-
-@ContributesTo(AppScope::class)
-interface OtpBlocBindingModule {
-    @Provides
-    fun provideOtpBlocFactory(factory: OtpBlocImpl.ManagedFactory): OtpBloc.Factory =
-        OtpBloc.Factory { context, props, output ->
-            factory.create(context, props, output)
-        }
 }

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -29,16 +29,15 @@ import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Output.OpenSig
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Output.OpenSignUp
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc
 import com.plusmobileapps.chefmate.settings.SettingsBloc
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
 
 @AssistedInject
+@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = BottomNavBloc.Factory::class)
 class BottomNavBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<BottomNavBloc.Output>,
@@ -49,11 +48,6 @@ class BottomNavBlocImpl(
     private val recipeList: RecipeListBloc.Factory,
     private val settings: SettingsBloc.Factory,
 ) : BottomNavBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<BottomNavBloc.Output>): BottomNavBlocImpl
-    }
 
     private val scope = createScope()
 
@@ -230,15 +224,5 @@ class BottomNavBlocImpl(
         @Serializable data object Browser : Configuration()
 
         @Serializable data object Settings : Configuration()
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface BottomNavBlocBindingModule {
-    @Provides
-    fun provideBottomNavBlocFactory(
-        factory: BottomNavBlocImpl.ManagedFactory
-    ): BottomNavBloc.Factory = BottomNavBloc.Factory { context, output ->
-        factory.create(context, output)
     }
 }

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavOrderBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavOrderBlocImpl.kt
@@ -6,25 +6,22 @@ import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc.Output
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = BottomNavOrderBloc.Factory::class,
+)
 class BottomNavOrderBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<Output>,
     viewModelFactory: Provider<BottomNavOrderViewModel>,
 ) : BottomNavOrderBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<Output>): BottomNavOrderBlocImpl
-    }
 
     private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
 
@@ -41,15 +38,5 @@ class BottomNavOrderBlocImpl(
 
     override fun onBack() {
         output.onNext(Output.Back)
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface BottomNavOrderBlocBindingModule {
-    @Provides
-    fun provideBottomNavOrderBlocFactory(
-        factory: BottomNavOrderBlocImpl.ManagedFactory
-    ): BottomNavOrderBloc.Factory = BottomNavOrderBloc.Factory { context, output ->
-        factory.create(context, output)
     }
 }

--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserBlocImpl.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserBlocImpl.kt
@@ -7,30 +7,20 @@ import com.plusmobileapps.chefmate.browser.createExtractionFailedMessage
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = BrowserBloc.Factory::class)
 class BrowserBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<BrowserBloc.Output>,
     @Assisted private val showControls: Boolean,
     viewModelFactory: Provider<BrowserViewModel>,
 ) : BrowserBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            output: Consumer<BrowserBloc.Output>,
-            showControls: Boolean,
-        ): BrowserBlocImpl
-    }
 
     private val viewModel = instanceKeeper.getViewModel {
         viewModelFactory().also { it.setOutput(output) }
@@ -93,17 +83,4 @@ class BrowserBlocImpl(
     override fun onAddressBarFocused() {
         viewModel.onAddressBarFocused()
     }
-}
-
-@ContributesTo(AppScope::class)
-interface BrowserBlocBindingModule {
-    @Provides
-    fun provideBrowserBlocFactory(factory: BrowserBlocImpl.ManagedFactory): BrowserBloc.Factory =
-        object : BrowserBloc.Factory {
-            override fun create(
-                context: BlocContext,
-                output: Consumer<BrowserBloc.Output>,
-                showControls: Boolean,
-            ): BrowserBloc = factory.create(context, output, showControls)
-        }
 }

--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserEditQueryBlocImpl.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserEditQueryBlocImpl.kt
@@ -6,30 +6,23 @@ import com.plusmobileapps.chefmate.browser.BrowserEditQueryBloc
 import com.plusmobileapps.chefmate.browser.BrowserHistoryEntry
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = BrowserEditQueryBloc.Factory::class,
+)
 class BrowserEditQueryBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<BrowserEditQueryBloc.Output>,
     @Assisted initialText: String,
     viewModelFactory: Provider<BrowserEditQueryViewModel>,
 ) : BrowserEditQueryBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            output: Consumer<BrowserEditQueryBloc.Output>,
-            initialText: String,
-        ): BrowserEditQueryBlocImpl
-    }
 
     private val viewModel = instanceKeeper.getViewModel {
         viewModelFactory().also {
@@ -59,15 +52,5 @@ class BrowserEditQueryBlocImpl(
 
     override fun onHistoryItemDeleteClicked(entry: BrowserHistoryEntry) {
         viewModel.deleteHistoryEntry(entry)
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface BrowserEditQueryBlocBindingModule {
-    @Provides
-    fun provideBrowserEditQueryBlocFactory(
-        factory: BrowserEditQueryBlocImpl.ManagedFactory
-    ): BrowserEditQueryBloc.Factory = BrowserEditQueryBloc.Factory { context, output, initialText ->
-        factory.create(context, output, initialText)
     }
 }

--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserLandingBlocImpl.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserLandingBlocImpl.kt
@@ -4,37 +4,21 @@ import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.browser.BrowserLandingBloc
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = BrowserLandingBloc.Factory::class,
+)
 class BrowserLandingBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<BrowserLandingBloc.Output>,
 ) : BrowserLandingBloc, BlocContext by context {
 
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            output: Consumer<BrowserLandingBloc.Output>,
-        ): BrowserLandingBlocImpl
-    }
-
     override fun onSearchFieldFocused() {
         output.onNext(BrowserLandingBloc.Output.OpenEditQuery)
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface BrowserLandingBlocBindingModule {
-    @Provides
-    fun provideBrowserLandingBlocFactory(
-        factory: BrowserLandingBlocImpl.ManagedFactory
-    ): BrowserLandingBloc.Factory = BrowserLandingBloc.Factory { context, output ->
-        factory.create(context, output)
     }
 }

--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserRootBlocImpl.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserRootBlocImpl.kt
@@ -21,16 +21,18 @@ import com.plusmobileapps.chefmate.browser.BrowserEditQueryBloc
 import com.plusmobileapps.chefmate.browser.BrowserLandingBloc
 import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = BrowserRootBloc.Factory::class,
+)
 class BrowserRootBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<BrowserRootBloc.Output>,
@@ -40,16 +42,6 @@ class BrowserRootBlocImpl(
     private val landingBlocFactory: BrowserLandingBloc.Factory,
     private val editQueryBlocFactory: BrowserEditQueryBloc.Factory,
 ) : BrowserRootBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            output: Consumer<BrowserRootBloc.Output>,
-            initialUrl: String?,
-            showControls: Boolean,
-        ): BrowserRootBlocImpl
-    }
 
     private val navigation = StackNavigation<Configuration>()
     private val scope = createScope()
@@ -200,20 +192,4 @@ class BrowserRootBlocImpl(
 
         @Serializable data class Browser(val url: String) : Configuration()
     }
-}
-
-@ContributesTo(AppScope::class)
-interface BrowserRootBlocBindingModule {
-    @Provides
-    fun provideBrowserRootBlocFactory(
-        factory: BrowserRootBlocImpl.ManagedFactory
-    ): BrowserRootBloc.Factory =
-        object : BrowserRootBloc.Factory {
-            override fun create(
-                context: BlocContext,
-                output: Consumer<BrowserRootBloc.Output>,
-                initialUrl: String?,
-                showControls: Boolean,
-            ): BrowserRootBloc = factory.create(context, output, initialUrl, showControls)
-        }
 }

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeBlocImpl.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeBlocImpl.kt
@@ -7,14 +7,13 @@ import com.plusmobileapps.chefmate.cook.WhatsCookingBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = CookModeBloc.Factory::class)
 class CookModeBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val initialRecipeId: Long,
@@ -22,15 +21,6 @@ class CookModeBlocImpl(
     private val viewModelFactory: CookModeViewModel.Factory,
     whatsCookingFactory: WhatsCookingBloc.Factory,
 ) : CookModeBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            initialRecipeId: Long,
-            output: Consumer<CookModeBloc.Output>,
-        ): CookModeBlocImpl
-    }
 
     private val viewModel: CookModeViewModel = instanceKeeper.getViewModel {
         viewModelFactory.create(initialRecipeId)
@@ -87,13 +77,4 @@ class CookModeBlocImpl(
             is WhatsCookingBloc.Output.RecipeSelected -> viewModel.selectRecipe(out.recipeId)
         }
     }
-}
-
-@ContributesTo(AppScope::class)
-interface CookModeBlocBindingModule {
-    @Provides
-    fun provideCookModeBlocFactory(factory: CookModeBlocImpl.ManagedFactory): CookModeBloc.Factory =
-        CookModeBloc.Factory { context, initialRecipeId, output ->
-            factory.create(context, initialRecipeId, output)
-        }
 }

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/WhatsCookingBlocImpl.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/WhatsCookingBlocImpl.kt
@@ -6,28 +6,22 @@ import com.plusmobileapps.chefmate.cook.WhatsCookingBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = WhatsCookingBloc.Factory::class,
+)
 class WhatsCookingBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<WhatsCookingBloc.Output>,
     viewModelFactory: Provider<WhatsCookingViewModel>,
 ) : WhatsCookingBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            output: Consumer<WhatsCookingBloc.Output>,
-        ): WhatsCookingBlocImpl
-    }
 
     private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
 
@@ -58,15 +52,5 @@ class WhatsCookingBlocImpl(
 
     override fun onCloseClicked() {
         output.onNext(WhatsCookingBloc.Output.Closed)
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface WhatsCookingBlocBindingModule {
-    @Provides
-    fun provideWhatsCookingBlocFactory(
-        factory: WhatsCookingBlocImpl.ManagedFactory
-    ): WhatsCookingBloc.Factory = WhatsCookingBloc.Factory { context, output ->
-        factory.create(context, output)
     }
 }

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsBlocImpl.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsBlocImpl.kt
@@ -8,25 +8,22 @@ import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc.Output
 import com.plusmobileapps.chefmate.devsettings.TestUser
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = DeveloperSettingsBloc.Factory::class,
+)
 class DeveloperSettingsBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<Output>,
     viewModelFactory: Provider<DeveloperSettingsViewModel>,
 ) : DeveloperSettingsBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<Output>): DeveloperSettingsBlocImpl
-    }
 
     private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
 
@@ -74,15 +71,5 @@ class DeveloperSettingsBlocImpl(
 
     override fun onFeatureFlagsClicked() {
         output.onNext(Output.OpenFeatureFlags)
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface DeveloperSettingsBlocBindingModule {
-    @Provides
-    fun provideDeveloperSettingsBlocFactory(
-        factory: DeveloperSettingsBlocImpl.ManagedFactory
-    ): DeveloperSettingsBloc.Factory = DeveloperSettingsBloc.Factory { context, output ->
-        factory.create(context, output)
     }
 }

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagsBlocImpl.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagsBlocImpl.kt
@@ -10,25 +10,22 @@ import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc.Output
 import com.plusmobileapps.chefmate.featureflag.Override
 import com.plusmobileapps.chefmate.featureflag.StringFlag
 import com.plusmobileapps.chefmate.getViewModel
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = FeatureFlagsBloc.Factory::class,
+)
 class FeatureFlagsBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<Output>,
     viewModelFactory: Provider<FeatureFlagsViewModel>,
 ) : FeatureFlagsBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<Output>): FeatureFlagsBlocImpl
-    }
 
     private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
 
@@ -52,15 +49,5 @@ class FeatureFlagsBlocImpl(
 
     override fun onClearAllOverrides() {
         viewModel.clearAll()
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface FeatureFlagsBlocBindingModule {
-    @Provides
-    fun provideFeatureFlagsBlocFactory(
-        factory: FeatureFlagsBlocImpl.ManagedFactory
-    ): FeatureFlagsBloc.Factory = FeatureFlagsBloc.Factory { context, output ->
-        factory.create(context, output)
     }
 }

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/detail/GroceryDetailBlocImpl.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/detail/GroceryDetailBlocImpl.kt
@@ -8,26 +8,23 @@ import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc.Output
 import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
 import com.plusmobileapps.chefmate.mapState
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = GroceryDetailBloc.Factory::class,
+)
 class GroceryDetailBlocImpl(
     @Assisted context: BlocContext,
     @Assisted id: Long,
     @Assisted private val output: Consumer<Output>,
     repository: GroceryRepository,
 ) : GroceryDetailBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, id: Long, output: Consumer<Output>): GroceryDetailBlocImpl
-    }
 
     private val scope = createScope()
 
@@ -68,15 +65,5 @@ class GroceryDetailBlocImpl(
 
     override fun onBackClicked() {
         output.onNext(Output.Finished)
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface GroceryDetailBlocBindingModule {
-    @Provides
-    fun provideGroceryDetailBlocFactory(
-        factory: GroceryDetailBlocImpl.ManagedFactory
-    ): GroceryDetailBloc.Factory = GroceryDetailBloc.Factory { context, id, output ->
-        factory.create(context, id, output)
     }
 }

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
@@ -10,28 +10,22 @@ import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GrocerySort
 import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
 import com.plusmobileapps.chefmate.mapState
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = GroceryListBloc.Factory::class,
+)
 class GroceryListBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<GroceryListBloc.Output>,
     viewModelFactory: Provider<GroceryListViewModel>,
 ) : GroceryListBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            output: Consumer<GroceryListBloc.Output>,
-        ): GroceryListBlocImpl
-    }
 
     private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
 
@@ -133,15 +127,5 @@ class GroceryListBlocImpl(
 
     override fun onListSelectorDismissed() {
         viewModel.onListSelectorDismissed()
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface GroceryListBlocBindingModule {
-    @Provides
-    fun provideGroceryListBlocFactory(
-        factory: GroceryListBlocImpl.ManagedFactory
-    ): GroceryListBloc.Factory = GroceryListBloc.Factory { context, output ->
-        factory.create(context, output)
     }
 }

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
@@ -10,26 +10,20 @@ import com.plusmobileapps.chefmate.meal.core.MealPlanBloc.Output
 import com.plusmobileapps.chefmate.meal.data.MealPlanItem
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.datetime.LocalDate
 
 @AssistedInject
+@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = MealPlanBloc.Factory::class)
 class MealPlanBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: Provider<MealPlanViewModel>,
 ) : MealPlanBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<Output>): MealPlanBlocImpl
-    }
 
     private val viewModel: MealPlanViewModel = instanceKeeper.getViewModel { viewModelFactory() }
 
@@ -101,13 +95,4 @@ class MealPlanBlocImpl(
     override fun onSyncClicked() {
         viewModel.onSyncClicked()
     }
-}
-
-@ContributesTo(AppScope::class)
-interface MealPlanBlocBindingModule {
-    @Provides
-    fun provideMealPlanBlocFactory(factory: MealPlanBlocImpl.ManagedFactory): MealPlanBloc.Factory =
-        MealPlanBloc.Factory { context, output ->
-            factory.create(context, output)
-        }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListBlocImpl.kt
@@ -7,30 +7,23 @@ import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc.Output
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = AddRecipeToGroceryListBloc.Factory::class,
+)
 class AddRecipeToGroceryListBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val recipeId: Long,
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: AddRecipeToGroceryListViewModel.Factory,
 ) : AddRecipeToGroceryListBloc, BlocContext by context {
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            recipeId: Long,
-            output: Consumer<Output>,
-        ): AddRecipeToGroceryListBlocImpl
-    }
-
     private val scope = createScope()
 
     private val viewModel = instanceKeeper.getViewModel { viewModelFactory.create(recipeId) }
@@ -76,15 +69,4 @@ class AddRecipeToGroceryListBlocImpl(
     override fun onBackClicked() {
         output.onNext(Output.Finished)
     }
-}
-
-@ContributesTo(AppScope::class)
-interface AddRecipeToGroceryListBlocBindingModule {
-    @Provides
-    fun provideAddRecipeToGroceryListBlocFactory(
-        factory: AddRecipeToGroceryListBlocImpl.ManagedFactory
-    ): AddRecipeToGroceryListBloc.Factory =
-        AddRecipeToGroceryListBloc.Factory { context, recipeId, output ->
-            factory.create(context, recipeId, output)
-        }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/ChooseDateBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/ChooseDateBlocImpl.kt
@@ -7,26 +7,23 @@ import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.chefmate.recipe.core.addmeal.ChooseDateBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.ChooseDateBloc.Output
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.datetime.LocalDate
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = ChooseDateBloc.Factory::class,
+)
 class ChooseDateBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: Provider<ChooseDateViewModel>,
 ) : ChooseDateBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<Output>): ChooseDateBlocImpl
-    }
 
     private val viewModel: ChooseDateViewModel = instanceKeeper.getViewModel { viewModelFactory() }
 
@@ -65,15 +62,5 @@ class ChooseDateBlocImpl(
 
     override fun onBackClicked() {
         output.onNext(Output.Back)
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface ChooseDateBlocBindingModule {
-    @Provides
-    fun provideChooseDateBlocFactory(
-        factory: ChooseDateBlocImpl.ManagedFactory
-    ): ChooseDateBloc.Factory = ChooseDateBloc.Factory { context, output ->
-        factory.create(context, output)
     }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/ChooseMealTypeBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/ChooseMealTypeBlocImpl.kt
@@ -8,15 +8,17 @@ import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.chefmate.meal.data.MealType
 import com.plusmobileapps.chefmate.recipe.core.addmeal.ChooseMealTypeBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.ChooseMealTypeBloc.Output
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = ChooseMealTypeBloc.Factory::class,
+)
 class ChooseMealTypeBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val recipeId: Long,
@@ -24,16 +26,6 @@ class ChooseMealTypeBlocImpl(
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: ChooseMealTypeViewModel.Factory,
 ) : ChooseMealTypeBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            recipeId: Long,
-            date: String,
-            output: Consumer<Output>,
-        ): ChooseMealTypeBlocImpl
-    }
 
     private val scope = createScope()
 
@@ -71,15 +63,5 @@ class ChooseMealTypeBlocImpl(
 
     override fun onBackClicked() {
         output.onNext(Output.Back)
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface ChooseMealTypeBlocBindingModule {
-    @Provides
-    fun provideChooseMealTypeBlocFactory(
-        factory: ChooseMealTypeBlocImpl.ManagedFactory
-    ): ChooseMealTypeBloc.Factory = ChooseMealTypeBloc.Factory { context, recipeId, date, output ->
-        factory.create(context, recipeId, date, output)
     }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/MealPlannerRootBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/MealPlannerRootBlocImpl.kt
@@ -14,14 +14,16 @@ import com.plusmobileapps.chefmate.recipe.core.addmeal.ChooseMealTypeBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc.Output
 import com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.serialization.Serializable
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = MealPlannerRootBloc.Factory::class,
+)
 class MealPlannerRootBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val props: MealPlannerRootBloc.Props,
@@ -30,15 +32,6 @@ class MealPlannerRootBlocImpl(
     private val chooseDateFactory: ChooseDateBloc.Factory,
     private val chooseMealTypeFactory: ChooseMealTypeBloc.Factory,
 ) : MealPlannerRootBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            props: MealPlannerRootBloc.Props,
-            output: Consumer<Output>,
-        ): MealPlannerRootBlocImpl
-    }
 
     private val navigation = StackNavigation<Configuration>()
     private val stack =
@@ -133,15 +126,5 @@ class MealPlannerRootBlocImpl(
 
         @Serializable
         data class ChooseMealType(val recipeId: Long, val date: String) : Configuration()
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface MealPlannerRootBlocBindingModule {
-    @Provides
-    fun provideMealPlannerRootBlocFactory(
-        factory: MealPlannerRootBlocImpl.ManagedFactory
-    ): MealPlannerRootBloc.Factory = MealPlannerRootBloc.Factory { context, props, output ->
-        factory.create(context, props, output)
     }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/RecipePickerBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/RecipePickerBlocImpl.kt
@@ -7,25 +7,22 @@ import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc.Output
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = RecipePickerBloc.Factory::class,
+)
 class RecipePickerBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: Provider<RecipePickerViewModel>,
 ) : RecipePickerBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<Output>): RecipePickerBlocImpl
-    }
 
     private val viewModel: RecipePickerViewModel = instanceKeeper.getViewModel {
         viewModelFactory()
@@ -46,15 +43,5 @@ class RecipePickerBlocImpl(
 
     override fun onRecipeSelected(item: RecipePickerBloc.RecipePickerItem) {
         output.onNext(Output.RecipeSelected(recipeId = item.id))
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface RecipePickerBlocBindingModule {
-    @Provides
-    fun provideRecipePickerBlocFactory(
-        factory: RecipePickerBlocImpl.ManagedFactory
-    ): RecipePickerBloc.Factory = RecipePickerBloc.Factory { context, output ->
-        factory.create(context, output)
     }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -18,16 +18,18 @@ import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc.Output
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.util.DateTimeUtil
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = RecipeDetailBloc.Factory::class,
+)
 class RecipeDetailBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val recipeId: Long,
@@ -37,15 +39,6 @@ class RecipeDetailBlocImpl(
     private val timeFormatterUtil: TimeFormatterUtil,
     private val addToGroceryList: AddRecipeToGroceryListBloc.Factory,
 ) : RecipeDetailBloc, BlocContext by context {
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            recipeId: Long,
-            output: Consumer<Output>,
-        ): RecipeDetailBlocImpl
-    }
-
     private val scope = createScope()
 
     private val viewModel: RecipeDetailViewModel = instanceKeeper.getViewModel {
@@ -217,19 +210,4 @@ class RecipeDetailBlocImpl(
 
     @Serializable
     data class FullImageConfig(val imageUrl: String, val recipeId: Long, val title: String)
-}
-
-@ContributesTo(AppScope::class)
-interface RecipeDetailBlocBindingModule {
-    @Provides
-    fun provideRecipeDetailBlocFactory(
-        factory: RecipeDetailBlocImpl.ManagedFactory
-    ): RecipeDetailBloc.Factory =
-        object : RecipeDetailBloc.Factory {
-            override fun create(
-                context: BlocContext,
-                recipeId: Long,
-                output: Consumer<Output>,
-            ): RecipeDetailBloc = factory.create(context, recipeId, output)
-        }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeBlocImpl.kt
@@ -12,15 +12,17 @@ import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc
 import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc.Output
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
 import com.plusmobileapps.chefmate.text.ResourceString
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = EditRecipeBloc.Factory::class,
+)
 class EditRecipeBlocImpl(
     @Assisted context: BlocContext,
     @Assisted recipeId: Long?,
@@ -28,16 +30,6 @@ class EditRecipeBlocImpl(
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: EditRecipeViewModel.Factory,
 ) : EditRecipeBloc, BlocContext by context {
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            recipeId: Long?,
-            extractedRecipe: ExtractedRecipeData?,
-            output: Consumer<Output>,
-        ): EditRecipeBlocImpl
-    }
-
     private val scope = createScope()
 
     private val viewModel: EditRecipeViewModel = instanceKeeper.getViewModel {
@@ -150,15 +142,4 @@ class EditRecipeBlocImpl(
     override fun onBackClicked() {
         viewModel.tryToClose()
     }
-}
-
-@ContributesTo(AppScope::class)
-interface EditRecipeBlocBindingModule {
-    @Provides
-    fun provideEditRecipeBlocFactory(
-        factory: EditRecipeBlocImpl.ManagedFactory
-    ): EditRecipeBloc.Factory =
-        EditRecipeBloc.Factory { context, recipeId, extractedRecipe, output ->
-            factory.create(context, recipeId, extractedRecipe, output)
-        }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
@@ -15,14 +15,16 @@ import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.serialization.Serializable
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = RecipeRootBloc.Factory::class,
+)
 class RecipeRootBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val props: RecipeRootBloc.Props,
@@ -30,15 +32,6 @@ class RecipeRootBlocImpl(
     private val detailBloc: RecipeDetailBloc.Factory,
     private val editBloc: EditRecipeBloc.Factory,
 ) : RecipeRootBloc, BlocContext by context {
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(
-            context: BlocContext,
-            props: RecipeRootBloc.Props,
-            output: Consumer<RecipeRootBloc.Output>,
-        ): RecipeRootBlocImpl
-    }
-
     private val navigation = StackNavigation<Configuration>()
     private val stack =
         childStack(
@@ -139,15 +132,5 @@ class RecipeRootBlocImpl(
 
         @Serializable
         data class Edit(val recipeId: Long?, val extracted: ExtractedRecipeData?) : Configuration()
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface RecipeRootBlocBindingModule {
-    @Provides
-    fun provideRecipeRootBlocFactory(
-        factory: RecipeRootBlocImpl.ManagedFactory
-    ): RecipeRootBloc.Factory = RecipeRootBloc.Factory { context, props, output ->
-        factory.create(context, props, output)
     }
 }

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
@@ -12,26 +12,23 @@ import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc.Output
 import com.plusmobileapps.chefmate.recipe.list.RecipeListItem
 import com.plusmobileapps.chefmate.recipe.list.RecipeSortOption
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = RecipeListBloc.Factory::class,
+)
 class RecipeListBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: Provider<RecipeListViewModel>,
     private val timeFormatterUtil: TimeFormatterUtil,
 ) : RecipeListBloc, BlocContext by context {
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<Output>): RecipeListBlocImpl
-    }
-
     private val viewModel: RecipeListViewModel = instanceKeeper.getViewModel { viewModelFactory() }
 
     override val state: StateFlow<RecipeListBloc.Model> =
@@ -131,16 +128,4 @@ class RecipeListBlocImpl(
             isFavorite = isFavorite,
             syncStatus = syncStatus,
         )
-}
-
-@ContributesTo(AppScope::class)
-interface RecipeListBlocBindingModule {
-    @Provides
-    fun provideRecipeListBlocFactory(
-        factory: RecipeListBlocImpl.ManagedFactory
-    ): RecipeListBloc.Factory =
-        object : RecipeListBloc.Factory {
-            override fun create(context: BlocContext, output: Consumer<Output>): RecipeListBloc =
-                factory.create(context, output)
-        }
 }

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -29,15 +29,14 @@ import com.plusmobileapps.chefmate.root.RootBloc.Child.BottomNavigation
 import com.plusmobileapps.chefmate.root.RootBlocImpl.Configuration.GroceryDetail
 import com.plusmobileapps.chefmate.root.RootBlocImpl.Configuration.RecipeRoot
 import com.plusmobileapps.chefmate.settings.AppSettingsBloc
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @AssistedInject
+@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = RootBloc.Factory::class)
 class RootBlocImpl(
     @Assisted context: BlocContext,
     private val bottomNav: BottomNavBloc.Factory,
@@ -54,11 +53,6 @@ class RootBlocImpl(
     private val featureFlags: FeatureFlags,
     private val featureFlagsBlocFactory: FeatureFlagsBloc.Factory,
 ) : RootBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext): RootBlocImpl
-    }
 
     init {
         createScope().launch { featureFlags.refresh() }
@@ -381,13 +375,4 @@ class RootBlocImpl(
 
         @Serializable data class CookMode(val recipeId: Long) : Configuration()
     }
-}
-
-@ContributesTo(AppScope::class)
-interface RootBlocBindingModule {
-    @Provides
-    fun provideRootBlocFactory(factory: RootBlocImpl.ManagedFactory): RootBloc.Factory =
-        RootBloc.Factory { context ->
-            factory.create(context)
-        }
 }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/AppSettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/AppSettingsBlocImpl.kt
@@ -6,25 +6,22 @@ import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.settings.AppSettingsBloc
 import com.plusmobileapps.chefmate.settings.AppSettingsBloc.Output
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = AppSettingsBloc.Factory::class,
+)
 class AppSettingsBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<Output>,
     viewModelFactory: Provider<AppSettingsViewModel>,
 ) : AppSettingsBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<Output>): AppSettingsBlocImpl
-    }
 
     private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
 
@@ -52,15 +49,5 @@ class AppSettingsBlocImpl(
 
     override fun onBottomNavOrderClicked() {
         output.onNext(Output.OpenBottomNavOrder)
-    }
-}
-
-@ContributesTo(AppScope::class)
-interface AppSettingsBlocBindingModule {
-    @Provides
-    fun provideAppSettingsBlocFactory(
-        factory: AppSettingsBlocImpl.ManagedFactory
-    ): AppSettingsBloc.Factory = AppSettingsBloc.Factory { context, output ->
-        factory.create(context, output)
     }
 }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -11,25 +11,19 @@ import com.plusmobileapps.chefmate.settings.SettingsBloc
 import com.plusmobileapps.chefmate.settings.SettingsBloc.Output
 import com.plusmobileapps.chefmate.settings.createEmailVerificationMessage
 import com.plusmobileapps.chefmate.settings.createGreeting
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
-import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provider
-import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
+@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = SettingsBloc.Factory::class)
 class SettingsBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<Output>,
     viewModelFactory: Provider<SettingsViewModel>,
 ) : SettingsBloc, BlocContext by context {
-
-    @AssistedFactory
-    fun interface ManagedFactory {
-        fun create(context: BlocContext, output: Consumer<Output>): SettingsBlocImpl
-    }
 
     private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
 
@@ -79,13 +73,4 @@ class SettingsBlocImpl(
     override fun onDeveloperSettingsClicked() {
         output.onNext(Output.OpenDeveloperSettings)
     }
-}
-
-@ContributesTo(AppScope::class)
-interface SettingsBlocBindingModule {
-    @Provides
-    fun provideSettingsBlocFactory(factory: SettingsBlocImpl.ManagedFactory): SettingsBloc.Factory =
-        SettingsBloc.Factory { context, output ->
-            factory.create(context, output)
-        }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.9.0"
 metro = "0.13.2"
+metroExtensions = "0.1.0"
 multiplatform-settings = "1.3.0"
 multiplatform-webview = "2.0.3"
 openjfx = "21.0.7"
@@ -90,6 +91,8 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlin-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlin-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+metroExtensions-assistedFactory-runtime = { module = "com.plusmobileapps.metro-extensions:assisted-factory-runtime", version.ref = "metroExtensions" }
+metroExtensions-assistedFactory-compiler = { module = "com.plusmobileapps.metro-extensions:assisted-factory-compiler", version.ref = "metroExtensions" }
 
 ktfmt-gradle-plugin = { module = "com.ncorti.ktfmt.gradle:plugin", version.ref = "ktfmt" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }


### PR DESCRIPTION
## Summary

Wires [`com.plusmobileapps.metro-extensions:0.1.0`](https://github.com/Plus-Mobile-Apps/metro-extensions) into the Metro convention plugin and replaces the nested `ManagedFactory` + manual `@ContributesTo`/`@Provides` bridge module on **27 BLoC impls** with a single `@ContributesAssistedFactory` annotation. Net change: **125 insertions, 559 deletions**.

### Before

```kotlin
@AssistedInject
class SettingsBlocImpl(
    @Assisted context: BlocContext,
    @Assisted private val output: Consumer<Output>,
    viewModelFactory: Provider<SettingsViewModel>,
) : SettingsBloc, BlocContext by context {

    @AssistedFactory
    fun interface ManagedFactory {
        fun create(context: BlocContext, output: Consumer<Output>): SettingsBlocImpl
    }
    // ...
}

@ContributesTo(AppScope::class)
interface SettingsBlocBindingModule {
    @Provides
    fun provideSettingsBlocFactory(factory: SettingsBlocImpl.ManagedFactory): SettingsBloc.Factory =
        SettingsBloc.Factory { context, output -> factory.create(context, output) }
}
```

### After

```kotlin
@AssistedInject
@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = SettingsBloc.Factory::class)
class SettingsBlocImpl(
    @Assisted context: BlocContext,
    @Assisted private val output: Consumer<Output>,
    viewModelFactory: Provider<SettingsViewModel>,
) : SettingsBloc, BlocContext by context {
    // ...
}
```

The KSP processor emits an equivalent Metro `@AssistedFactory` plus an `@Inject @ContributesBinding(AppScope::class) @Origin(SettingsBlocImpl::class)` bridge to `SettingsBloc.Factory`. The `@Origin` tag keeps Metro's contribution-merging exclusions aligned with the source impl, so test-graph exclusions continue to work.

## Wiring

- `gradle/libs.versions.toml` — adds `metroExtensions = "0.1.0"` and the two artifact coordinates.
- `build-logic/.../MetroConventionPlugin.kt` — `applyMetro()` now also applies the KSP plugin, adds `assisted-factory-runtime` to `commonMainImplementation`, and adds `assisted-factory-compiler` to `kspAndroid`, `kspJvm`, `kspIosArm64`, `kspIosSimulatorArm64`. Every module with `plusLibrary { enableDi = true }` picks this up automatically — no per-module edits.

## Test plan

- [x] `./gradlew :client:settings:impl:compileKotlinJvm :client:settings:impl:compileDebugKotlinAndroid :client:settings:impl:compileKotlinIosArm64 :client:settings:impl:compileKotlinIosSimulatorArm64` — green on all 4 targets; generated bridge inspected and correct
- [x] `./gradlew :client:composeApp:assembleDebug` — green; confirms the full `AppScope` graph still resolves every `<Feature>Bloc.Factory`
- [x] `./gradlew test -x :server:test` — green (the `:server:test > ApplicationTest > testRoot` failure is **pre-existing on `main`**, a leftover bug from the original compose-multiplatform wizard template; unrelated to this change)
- [x] `./gradlew ktfmtFormat` — clean
- [ ] **Screenshot tests** — `validateDebugScreenshotTest` reports 4 failures (3× `OtpScreenshotTestKt`, 1× `BottomNavOrderScreenshotTestKt`); each says `Difference: 0.00%` with PNGs differing by 1 byte (60218 vs 60219). Pixels are bit-identical, only metadata differs — classic AGP screenshot-test `0.0.1-alpha14` flake. Previews render through fake `previewOtpBloc`/`previewBottomNavOrderBloc` which were not touched. **Not regenerated** — CLAUDE.md requires visual inspection before committing reference PNGs.
- [ ] Manual smoke on Android (`installDebug`) — exercising Settings, Recipe list/detail, Browser, Cook mode, Bottom nav reorder
- [ ] Manual smoke on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)