### PR TITLE
build: clean up AGP 9 compat flags and migrate KMP modules to new plugin

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -40,6 +40,7 @@ repositories {
 dependencies {
     compileOnly(libs.kotlin.gradle.plugin)
     compileOnly(libs.android.gradle.plugin)
+    compileOnly(libs.android.kmp.library.gradle.plugin)
     compileOnly(libs.compose.gradle.plugin)
     compileOnly(libs.compose.multiplatform.gradle.plugin)
     compileOnly(libs.ktfmt.gradle.plugin)

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/ComposeConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/ComposeConventionPlugin.kt
@@ -46,17 +46,16 @@ class ComposeConventionPlugin : Plugin<Project> {
                     androidMain?.dependencies {
                         implementation(libs.compose.ui.tooling.preview)
                         implementation(libs.androidx.activity.compose)
+                        // The new com.android.kotlin.multiplatform.library plugin doesn't
+                        // expose per-build-type configurations (no `debugImplementation`),
+                        // so add the preview-rendering runtime to the main android source
+                        // set. It only ships with the Android variant.
+                        implementation(compose.uiTooling)
                     }
                     jvmMain?.dependencies {
                         implementation(compose.desktop.currentOs)
                         implementation(libs.kotlinx.coroutinesSwing)
                     }
-                }
-
-                // Add debug-specific dependencies
-                dependencies {
-                    val compose = ComposePlugin.Dependencies(project)
-                    "debugImplementation"(compose.uiTooling)
                 }
             }
         }

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KmpLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KmpLibraryConventionPlugin.kt
@@ -69,6 +69,15 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
                     // Pin Android JVM bytecode level. iOS targets are unaffected.
                     compilerOptions.jvmTarget.set(JvmTarget.JVM_11)
 
+                    // Compose Multiplatform's resources system (strings.xml in
+                    // commonMain/composeResources/) bundles its compiled `.cvr` files into
+                    // the Android AAR via the Android asset/resource pipeline. The new
+                    // KMP plugin defaults `androidResources.enable` to `false` (vs `true`
+                    // for plain `com.android.library`), which silently drops those
+                    // resources and makes `stringResource(...)` throw MissingResourceException
+                    // at runtime. Re-enable it so consumers can resolve common strings.
+                    androidResources.enable = true
+
                     // Tests that previously lived in `androidUnitTest` now live in
                     // `androidHostTest` (host-side JVM tests); instrumented tests live in
                     // `androidDeviceTest`. Opt into the host-test compilation so existing

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KmpLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KmpLibraryConventionPlugin.kt
@@ -1,9 +1,8 @@
 package com.plusmobileapps.chefmate.convention
 
-import com.android.build.api.variant.LibraryAndroidComponentsExtension
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import com.android.build.api.variant.KotlinMultiplatformAndroidComponentsExtension
 import com.plusmobileapps.chefmate.libs
-import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -30,43 +29,52 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
 
             with(pluginManager) {
                 apply("org.jetbrains.kotlin.multiplatform")
-                apply("com.android.library")
+                // AGP 9: the new KMP-aware Android library plugin replaces
+                // `com.android.library` for multiplatform modules. It registers the
+                // Android target itself and exposes its DSL inside `kotlin { }`
+                // under the `android` extension.
+                apply("com.android.kotlin.multiplatform.library")
             }
 
             target.applyKtfmt()
 
+            // Defer namespace resolution until after the module's build.gradle.kts has
+            // evaluated. compileSdk, minSdk, withHostTest, and jvmTarget don't depend on
+            // user input and are safe to set eagerly, but `namespace` requires the
+            // per-module value from `plusLibrary { ... }`, which isn't available yet.
             val androidComponents =
-                extensions.getByType(LibraryAndroidComponentsExtension::class.java)
-
-            androidComponents.finalizeDsl {
-                extensions.configure<LibraryExtension> {
-                    // Use the configured namespace or fall back to the default
-                    namespace =
-                        plusLibraryExtension.namespace
-                            ?: throw IllegalStateException(
-                                """
+                extensions.getByType(KotlinMultiplatformAndroidComponentsExtension::class.java)
+            androidComponents.finalizeDsl { extension ->
+                extension.namespace =
+                    plusLibraryExtension.namespace
+                        ?: throw IllegalStateException(
+                            """
                     Please set the namespace for the module $name in the plusMobile extension in the module's build.gradle.kts file.
                     Example:
                     plusLibrary {
                         namespace = "com.plusmobileapps.chefmate.${project.name}"
                     }
                 """
-                                    .trimIndent()
-                            )
-                    compileSdk = libs.versions.android.compileSdk.get().toInt()
-
-                    compileOptions {
-                        sourceCompatibility = JavaVersion.VERSION_11
-                        targetCompatibility = JavaVersion.VERSION_11
-                    }
-
-                    defaultConfig { minSdk = libs.versions.android.minSdk.get().toInt() }
-                }
+                                .trimIndent()
+                        )
             }
 
             extensions.configure<KotlinMultiplatformExtension> {
-                // Configure Android target
-                androidTarget { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } }
+                // Configure the Android library target via the new plugin's DSL,
+                // which is exposed on the Kotlin multiplatform extension as `android`.
+                extensions.configure<KotlinMultiplatformAndroidLibraryTarget>("android") {
+                    compileSdk = libs.versions.android.compileSdk.get().toInt()
+                    minSdk = libs.versions.android.minSdk.get().toInt()
+
+                    // Pin Android JVM bytecode level. iOS targets are unaffected.
+                    compilerOptions.jvmTarget.set(JvmTarget.JVM_11)
+
+                    // Tests that previously lived in `androidUnitTest` now live in
+                    // `androidHostTest` (host-side JVM tests); instrumented tests live in
+                    // `androidDeviceTest`. Opt into the host-test compilation so existing
+                    // test source sets continue to compile.
+                    withHostTest {}
+                }
 
                 // Configure iOS targets with explicit source set assignment
                 val iosArm64Target = iosArm64()
@@ -81,7 +89,7 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
                 }
 
                 // Configure JVM target
-                jvm()
+                jvm { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } }
 
                 // Remove once kotlin.time is stable in 2.3.0
                 compilerOptions.optIn.add("kotlin.time.ExperimentalTime")

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/TestingConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/TestingConventionPlugin.kt
@@ -29,9 +29,6 @@ fun Project.applyTesting(enableDatabaseTesting: Boolean = false) {
 
         sourceSets.apply {
             val commonTest = getByName("commonTest")
-            val jvmTest = getByName("jvmTest")
-            val androidUnitTest = getByName("androidUnitTest")
-            val iosMain = getByName("iosMain")
 
             commonTest.dependencies {
                 implementation(libs.kotlin.test)

--- a/client/util/public/build.gradle.kts
+++ b/client/util/public/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.kotlin.dsl.implementation
-
 plugins {
     alias(libs.plugins.kmpLibrary)
     alias(libs.plugins.compose)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,16 +8,9 @@ org.gradle.configuration-cache=true
 org.gradle.caching=true
 
 #Android
-android.nonTransitiveRClass=true
 android.useAndroidX=true
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
-android.uniquePackageNames=false
-android.dependency.useConstraints=true
-android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
+android.nonTransitiveRClass=true
+android.dependency.useConstraints=false
 android.builtInKotlin=false
 android.newDsl=false
 android.experimental.enableScreenshotTest=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ turbine = "1.2.1"
 
 [libraries]
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+android-kmp-library-gradle-plugin = { module = "com.android.kotlin.multiplatform.library:com.android.kotlin.multiplatform.library.gradle.plugin", version.ref = "agp" }
 bugsnag-kmp = { module = "com.bugsnag:bugsnag-kmp", version.ref = "bugsnag-kmp" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
@@ -126,6 +127,7 @@ turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
+androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }
 composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }


### PR DESCRIPTION
## Summary

Two commits, both addressing the AGP 9 migration cleanup tracked in #158:

**Commit 1 — `gradle.properties` cleanup**
- Removed 7 of the 10 AGP 9 compat flags whose new defaults are safe for this codebase
- Replaced the deprecated `excludeLibraryComponentsFromConstraints` perf warning with `android.dependency.useConstraints=false` (AGP 9.1's recommended replacement)
- Kept `android.builtInKotlin=false` / `android.newDsl=false` — still required because composeApp's `com.android.application` + `kotlin.multiplatform` combo has no KMP-compatible app plugin yet (AGP 9 explicitly tells us to keep them)

**Commit 2 — KMP plugin migration**
- Switched the `KmpLibraryConventionPlugin` from `com.android.library` to `com.android.kotlin.multiplatform.library`
- Android target is now configured inside `kotlin { android { ... } }` via `KotlinMultiplatformAndroidLibraryTarget`
- `namespace` is set through `KotlinMultiplatformAndroidComponentsExtension.finalizeDsl { }` (the new equivalent of the old `LibraryExtension.finalizeDsl` hook)
- `withHostTest { }` opts into the renamed `androidHostTest` source set (replaces `androidUnitTest`)
- The Compose convention plugin moves `compose.uiTooling` out of the no-longer-existing `debugImplementation` configuration and into `androidMain` (the new plugin has no build-type-scoped configurations for KMP libraries)
- One stale `import org.gradle.kotlin.dsl.implementation` in `client/util/public/build.gradle.kts` had to be dropped (the new plugin's script-compilation context doesn't auto-resolve it)

## Why composeApp and screenshot-test aren't migrated

- **composeApp** uses `com.android.application` — AGP 9 has no KMP-compatible application plugin yet. The two `gradle.properties` deprecation warnings (`builtInKotlin=false`, `newDsl=false`) plus the `com.android.application + KMP` deprecation warning are AGP's recommended workaround until that plugin exists.
- **client/ui/screenshot-test** is a plain (non-KMP) Android library that depends on `com.android.compose.screenshot`. It stays on `com.android.library`.

## What deprecation warnings are gone

Before: the per-library `com.android.library` + `kotlin.multiplatform` deprecation warning fired for **every** KMP library module (~40 of them) on every sync.

After: those are all gone. Only three warning sources remain, all unavoidable until AGP ships a KMP application plugin:
1. `experimental.enableScreenshotTest=true` (required for screenshot tests)
2. `builtInKotlin=false` / `newDsl=false` deprecation (required for composeApp)
3. `com.android.application` + KMP deprecation (required for composeApp)
4. `kotlin.android` plugin warning on `screenshot-test` (it's not a KMP module so this is expected)

## Test plan

- [x] `./gradlew :client:composeApp:assembleDebug`
- [x] `./gradlew jvmTest testDebugUnitTest koverXmlReport koverHtmlReport --continue` (matches CI tests.yml `jvm-android-tests` job)
- [x] `./gradlew compileKotlinIosSimulatorArm64 --continue` (covers iOS CI compile)
- [x] `./gradlew :client:ui:screenshot-test:compileDebugKotlin`
- [ ] CI green

Tracks #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)