### PR TITLE
ci(ios): point match at Plus-Mobile-Apps/certificates after org transfer

### DIFF
--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,4 +1,4 @@
-git_url(ENV["MATCH_GIT_URL"] || "git@github.com:plusmobileapps/certificates.git")
+git_url(ENV["MATCH_GIT_URL"] || "git@github.com:Plus-Mobile-Apps/certificates.git")
 type("appstore")
 app_identifier(["com.plusmobileapps.chefmate.ChefMate", "com.plusmobileapps.chefmate.ChefMate.ShareExtension"])
 username("andrew@plusmobileapps.com")


### PR DESCRIPTION
## Summary
- The `certificates` repo was moved from `plusmobileapps/certificates` to `Plus-Mobile-Apps/certificates` as part of the org transfer.
- Update `fastlane/Matchfile` so `match` clones the new canonical URL instead of relying on GitHub's HTTPS redirect.
- Paired with rotating `MATCH_GIT_BASIC_AUTHORIZATION` to a fine-grained PAT owned by the `Plus-Mobile-Apps` org with read access to the new cert repo (see iOS release run #26076128927 for the 403 this resolves).

## Test plan
- [ ] After merge, re-run the failed `iOS Release` job and confirm the `match` step clones successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)