### PR TITLE
docs(ci): document RELEASE_TOKEN and match PAT rotation under the org

### DIFF
--- a/docs/ci/VERSION_BUMP_SETUP.md
+++ b/docs/ci/VERSION_BUMP_SETUP.md
@@ -61,7 +61,7 @@ Configure these in **Settings → Secrets and variables → Actions → Reposito
 
 | Secret | Description |
 |---|---|
-| `RELEASE_TOKEN` | Personal Access Token with `repo` scope (or fine-grained with `contents: write` + `workflows: write`). Without this, `android-release`, `desktop-release`, and `ios-release` will **not** run after the tag is pushed, because the default `GITHUB_TOKEN` cannot trigger other workflows. |
+| `RELEASE_TOKEN` | Fine-grained PAT scoped to `Plus-Mobile-Apps/chef-mate` with **Contents: Read and write** + **Workflows: Read and write** (or a classic PAT with `repo` + `workflow`). Without this, `android-release`, `desktop-release`, and `ios-release` will **not** run after the tag is pushed, because the default `GITHUB_TOKEN` cannot trigger other workflows. See [Configuring `RELEASE_TOKEN`](#configuring-release_token) for the full creation/rotation walkthrough. |
 
 ### Required by existing workflows (already configured)
 
@@ -94,11 +94,57 @@ Configure these in **Settings → Secrets and variables → Actions → Reposito
 
 ## Configuring `RELEASE_TOKEN`
 
-1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens**.
-2. Create a token scoped to this repository with these permissions:
-   - **Contents**: Read and write (for creating tags)
-   - **Workflows**: Read and write (for triggering workflow runs)
-3. Add it as a repository secret named `RELEASE_TOKEN`.
+`RELEASE_TOKEN` is a Personal Access Token used by `build-release.yml` to push
+the `vX.Y.Z` tag. The push needs to come from a token (not `GITHUB_TOKEN`) so
+that the downstream `android-release` / `desktop-release` / `ios-release`
+workflows actually fire — GitHub deliberately does not let a workflow triggered
+by `GITHUB_TOKEN` trigger another workflow.
+
+### Creating the token
+
+1. Open <https://github.com/settings/personal-access-tokens> (Settings →
+   Developer settings → Personal access tokens → **Fine-grained tokens**).
+2. **Generate new token** with:
+   - **Token name**: `chef-mate RELEASE_TOKEN` (or similar)
+   - **Resource owner**: **`Plus-Mobile-Apps`** — this is the critical field.
+     The repo lives under the org, so a token issued under your personal
+     account will hit `403 Permission denied to <user>` when it tries to push
+     the tag, even with the right permissions.
+   - **Expiration**: pick a date you can commit to and put it on your calendar.
+     Max is one year. When it expires, repeat this whole section.
+   - **Repository access**: **Only select repositories** → `Plus-Mobile-Apps/chef-mate`.
+3. **Repository permissions** (leave everything else as "No access"):
+   - **Contents**: **Read and write** — needed to push the release tag.
+   - **Workflows**: **Read and write** — needed so the tag push can trigger the
+     other release workflows.
+   - **Metadata**: Read-only (auto-selected, can't be turned off).
+4. **Generate token** and copy the value immediately — you can't see it again.
+5. If the org has fine-grained PATs gated, the token will be in **Pending**
+   state until an org owner approves it under `Plus-Mobile-Apps` → Settings →
+   Personal access tokens → **Pending requests**.
+
+### Storing it
+
+6. Go to <https://github.com/Plus-Mobile-Apps/chef-mate/settings/secrets/actions>.
+7. If `RELEASE_TOKEN` already exists, click it → **Update secret** and paste the
+   new value. Otherwise click **New repository secret**, name it `RELEASE_TOKEN`,
+   paste the value, save.
+
+### Rotating (or reacting to a 403)
+
+If a tag-push step fails with `remote: Permission to ... denied to <user>` or
+`The requested URL returned error: 403`, the PAT has expired, been revoked, or
+lost access (e.g. after a repo transfer). Generate a new token following the
+steps above and update the secret. There's no need to change anything in
+`build-release.yml`.
+
+### Classic PAT alternative
+
+If the org disables fine-grained PATs, fall back to a classic token:
+**Settings → Developer settings → Tokens (classic)** → check the `repo` and
+`workflow` scopes → after generating, click **Configure SSO** on the token's
+page and authorize it for `Plus-Mobile-Apps`. Store as `RELEASE_TOKEN` the
+same way.
 
 ## Setting up Android signing
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,7 +69,7 @@ These are read by BuildKonfig at build time. See [buildconfig-setup.md](buildcon
 | Secret | Description |
 |--------|-------------|
 | `MATCH_PASSWORD` | Encryption password for the match certificates repository |
-| `MATCH_GIT_BASIC_AUTHORIZATION` | Base64-encoded `username:personal_access_token` for accessing the certificates repo |
+| `MATCH_GIT_BASIC_AUTHORIZATION` | Base64-encoded `username:personal_access_token` for read access to the certificates repo. See [Fastlane Match (iOS Certificates)](#fastlane-match-ios-certificates) for the creation/rotation walkthrough. |
 
 #### App Store Connect
 
@@ -226,21 +226,55 @@ Store the output as the `ANDROID_KEYSTORE_BASE64` secret.
 
 ### Fastlane Match (iOS Certificates)
 
-1. Create a **private** git repository to store encrypted certificates (e.g., `plusmobileapps/certificates`)
+The certificates repo (`Plus-Mobile-Apps/certificates`) is configured in
+`fastlane/Matchfile`. Match runs in `readonly: true` mode on CI, so the PAT
+behind `MATCH_GIT_BASIC_AUTHORIZATION` only needs read access.
+
+#### First-time setup
+
+1. Create a **private** git repository under the org to store encrypted
+   certificates (currently `Plus-Mobile-Apps/certificates`). If you move it,
+   update `fastlane/Matchfile`.
 2. Run match locally to generate and store certificates:
 
-```bash
-bundle exec fastlane match appstore
-```
+   ```bash
+   bundle exec fastlane match appstore
+   ```
 
-3. Set the `MATCH_PASSWORD` secret to the encryption password you chose
-4. Generate a personal access token with `repo` scope and base64-encode it:
+3. Set the `MATCH_PASSWORD` secret to the encryption password you chose.
 
-```bash
-echo -n "username:ghp_your_token_here" | base64
-```
+#### Creating / rotating `MATCH_GIT_BASIC_AUTHORIZATION`
 
-5. Store the result as `MATCH_GIT_BASIC_AUTHORIZATION`
+`MATCH_GIT_BASIC_AUTHORIZATION` is **not** the raw PAT — it's a base64-encoded
+`username:token` string that Fastlane passes as an HTTP Basic Auth header to
+clone the cert repo. Rotate it whenever the underlying PAT expires.
+
+1. Open <https://github.com/settings/personal-access-tokens> →
+   **Generate new token** (fine-grained) with:
+   - **Token name**: `chef-mate match certificates (read)`
+   - **Resource owner**: **`Plus-Mobile-Apps`** (the org owns the cert repo;
+     a personally-owned token will hit `403 Write access to repository not
+     granted` even on a clone).
+   - **Expiration**: pick a date and calendar it.
+   - **Repository access**: **Only select repositories** → `Plus-Mobile-Apps/certificates`.
+   - **Repository permissions** → **Contents: Read-only**, Metadata: Read-only.
+   Approve via org settings if pending.
+2. Base64-encode `username:token`. Use `printf`, not `echo` — a trailing
+   newline silently breaks Basic Auth:
+
+   ```bash
+   printf 'Plus-Mobile-Apps:<PAT>' | base64
+   ```
+
+   The username field is essentially decorative for fine-grained PATs; what
+   matters is that the token itself is valid.
+3. Paste the entire base64 string into the `MATCH_GIT_BASIC_AUTHORIZATION`
+   secret at
+   <https://github.com/Plus-Mobile-Apps/chef-mate/settings/secrets/actions>.
+
+If the `match` step fails with `Error cloning certificates git repo` or
+`The requested URL returned error: 403`, the PAT has expired, been revoked,
+or was issued under the wrong Resource owner. Regenerate and re-encode.
 
 ### App Store Connect API Key
 


### PR DESCRIPTION
## Summary
- After the move to the `Plus-Mobile-Apps` org, both PATs (`RELEASE_TOKEN` and the token behind `MATCH_GIT_BASIC_AUTHORIZATION`) need to be re-issued under the org instead of a personal account, which surfaces as confusing 403s in `build-release` and `ios-release`. The existing docs didn't cover this.
- Expand `docs/ci/VERSION_BUMP_SETUP.md` → "Configuring `RELEASE_TOKEN`" with the full fine-grained PAT walkthrough (Resource owner, permissions, org approval, expiration/rotation, classic PAT fallback).
- Expand `docs/deployment.md` → "Fastlane Match (iOS Certificates)" with the org-owned cert repo URL, a read-only fine-grained PAT recipe, and the `printf` vs `echo` newline gotcha when base64-encoding the basic-auth header.

## Test plan
- [ ] Skim the rendered Markdown on GitHub once merged to make sure the table-row anchors (`#configuring-release_token`, `#fastlane-match-ios-certificates`) resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)