### PR TITLE
feat(auth): route anon-to-real upgrade through an EmailChange OTP flow

### DIFF
--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
@@ -112,7 +112,10 @@ class SupabaseAuthenticationRepository(
                     this.password = password
                 }
                 _state.value = AuthState.AwaitingEmailVerification(email)
-                return Result.success(SignUpResult.AwaitingEmailVerification)
+                // Distinct from AwaitingEmailVerification: updateUser{} triggers Supabase's
+                // Change Email Address template, so verification must route through
+                // OtpFlow.EmailChange → OtpType.Email.EMAIL_CHANGE.
+                return Result.success(SignUpResult.AwaitingEmailChange)
             }
 
             val result =
@@ -171,6 +174,11 @@ class SupabaseAuthenticationRepository(
                     supabaseClient.auth.resendEmail(type = OtpType.Email.SIGNUP, email = email)
                 OtpFlow.PasswordlessSignIn ->
                     supabaseClient.auth.signInWith(OTP) { this.email = email }
+                OtpFlow.EmailChange ->
+                    supabaseClient.auth.resendEmail(
+                        type = OtpType.Email.EMAIL_CHANGE,
+                        email = email,
+                    )
             }
             Result.success(Unit)
         } catch (e: Exception) {
@@ -181,6 +189,7 @@ class SupabaseAuthenticationRepository(
         when (this) {
             OtpFlow.SignUp -> OtpType.Email.SIGNUP
             OtpFlow.PasswordlessSignIn -> OtpType.Email.EMAIL
+            OtpFlow.EmailChange -> OtpType.Email.EMAIL_CHANGE
         }
 
     override suspend fun signOut() {

--- a/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
+++ b/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
@@ -26,6 +26,15 @@ sealed class SignUpResult {
 
     data object AwaitingEmailVerification : SignUpResult()
 
+    /**
+     * Returned when a currently-anonymous user is upgraded to a real account via
+     * [AuthenticationRepository.signUpWithEmailAndPassword]. Supabase delivers a Change Email
+     * Address confirmation rather than a fresh Confirm Signup, so the caller must route to OTP
+     * verification with [OtpFlow.EmailChange] (not [OtpFlow.SignUp]) so the verify call uses the
+     * matching token type.
+     */
+    data object AwaitingEmailChange : SignUpResult()
+
     data object UserAlreadyExists : SignUpResult()
 }
 
@@ -33,4 +42,12 @@ sealed class SignUpResult {
 enum class OtpFlow {
     SignUp,
     PasswordlessSignIn,
+
+    /**
+     * Email-change confirmation used during anon-to-real account upgrades. Maps to
+     * `OtpType.Email.EMAIL_CHANGE` on the Supabase side so the verify call matches the token
+     * Supabase actually issued when [AuthenticationRepository.signUpWithEmailAndPassword] triggered
+     * `updateUser { email; password }`.
+     */
+    EmailChange,
 }

--- a/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationBlocImpl.kt
+++ b/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationBlocImpl.kt
@@ -56,6 +56,8 @@ class AuthenticationBlocImpl(
                         output.onNext(Output.AuthenticationSuccess)
                     is AuthenticationViewModel.Output.EmailVerificationRequired ->
                         output.onNext(Output.EmailVerificationRequired(it.email))
+                    is AuthenticationViewModel.Output.EmailChangeRequired ->
+                        output.onNext(Output.EmailChangeRequired(it.email))
                     is AuthenticationViewModel.Output.PasswordlessOtpSent ->
                         output.onNext(Output.PasswordlessOtpSent(it.email))
                     is AuthenticationViewModel.Output.OpenUrl ->

--- a/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationViewModel.kt
+++ b/client/auth/ui/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/impl/AuthenticationViewModel.kt
@@ -279,6 +279,10 @@ class AuthenticationViewModel(
                             _state.value = _state.value.copy(isLoading = false)
                             output.send(Output.EmailVerificationRequired(email))
                         }
+                        SignUpResult.AwaitingEmailChange -> {
+                            _state.value = _state.value.copy(isLoading = false)
+                            output.send(Output.EmailChangeRequired(email))
+                        }
                         SignUpResult.UserAlreadyExists -> {
                             _state.value =
                                 _state.value.copy(
@@ -472,6 +476,8 @@ class AuthenticationViewModel(
         data object AuthenticationSuccess : Output()
 
         data class EmailVerificationRequired(val email: String) : Output()
+
+        data class EmailChangeRequired(val email: String) : Output()
 
         data class PasswordlessOtpSent(val email: String) : Output()
 

--- a/client/auth/ui/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/auth/ui/public/src/commonMain/composeResources/values/strings.xml
@@ -30,6 +30,7 @@
     <!-- OTP screen -->
     <string name="auth_otp_screen_title_signup">Verify your email</string>
     <string name="auth_otp_screen_title_passwordless">Sign in with code</string>
+    <string name="auth_otp_screen_title_email_change">Confirm your new email</string>
     <string name="auth_otp_instructions">We sent a code to {email}. Enter it below to continue.</string>
     <string name="auth_otp_label_code">Verification code</string>
     <string name="auth_otp_button_verify">Verify</string>

--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationBloc.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationBloc.kt
@@ -66,6 +66,14 @@ interface AuthenticationBloc : BackClickBloc {
 
         data class EmailVerificationRequired(val email: String) : Output()
 
+        /**
+         * Fired when a currently-anonymous user signs up to upgrade their account. Routes to the
+         * OTP screen with [com.plusmobileapps.chefmate.auth.data.OtpFlow.EmailChange] because
+         * Supabase issues an email-change confirmation token (not a signup token) for the
+         * underlying `updateUser{}` call.
+         */
+        data class EmailChangeRequired(val email: String) : Output()
+
         data class PasswordlessOtpSent(val email: String) : Output()
 
         data class OpenUrl(val url: String) : Output()

--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/otp/OtpScreen.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/otp/OtpScreen.kt
@@ -40,6 +40,7 @@ import chefmate.client.auth.ui.public.generated.resources.auth_otp_button_verify
 import chefmate.client.auth.ui.public.generated.resources.auth_otp_instructions
 import chefmate.client.auth.ui.public.generated.resources.auth_otp_label_code
 import chefmate.client.auth.ui.public.generated.resources.auth_otp_loading_verifying
+import chefmate.client.auth.ui.public.generated.resources.auth_otp_screen_title_email_change
 import chefmate.client.auth.ui.public.generated.resources.auth_otp_screen_title_passwordless
 import chefmate.client.auth.ui.public.generated.resources.auth_otp_screen_title_signup
 import com.plusmobileapps.chefmate.auth.data.OtpFlow
@@ -65,6 +66,7 @@ fun OtpScreen(bloc: OtpBloc, modifier: Modifier = Modifier) {
             OtpFlow.SignUp -> ResourceString(Res.string.auth_otp_screen_title_signup)
             OtpFlow.PasswordlessSignIn ->
                 ResourceString(Res.string.auth_otp_screen_title_passwordless)
+            OtpFlow.EmailChange -> ResourceString(Res.string.auth_otp_screen_title_email_change)
         }
 
     PlusHeaderContainer(

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -328,6 +328,10 @@ class RootBlocImpl(
                 navigation.bringToFront(
                     Configuration.OtpVerification(email = output.email, flow = OtpFlow.SignUp)
                 )
+            is AuthenticationBloc.Output.EmailChangeRequired ->
+                navigation.bringToFront(
+                    Configuration.OtpVerification(email = output.email, flow = OtpFlow.EmailChange)
+                )
             is AuthenticationBloc.Output.PasswordlessOtpSent ->
                 navigation.bringToFront(
                     Configuration.OtpVerification(


### PR DESCRIPTION
## Summary

- The anon-to-real upgrade path called `supabaseClient.auth.updateUser { email; password }`, which triggers Supabase's **Change Email Address** template, but the navigation still routed verification through `OtpFlow.SignUp` → `OtpType.Email.SIGNUP`. Result: the user got a click-to-confirm magic link instead of the OTP code we use elsewhere, and even if their template emitted `{{ .Token }}`, `verifyEmailOtp` would fail with a token-type mismatch.
- Add a third `OtpFlow.EmailChange` variant that maps end-to-end to `OtpType.Email.EMAIL_CHANGE`, with its own `SignUpResult.AwaitingEmailChange`, `AuthenticationBloc.Output.EmailChangeRequired`, `RootBlocImpl` route, and OTP screen title ("Confirm your new email").
- No change to the fresh-signup or passwordless paths.

## Required Supabase dashboard change

For the OTP code to actually appear in the upgrade email, **Authentication → Email Templates → Change Email Address** must be edited to include `{{ .Token }}` (the default template only emits `{{ .ConfirmationURL }}`). Code can't do that. Worth also rewriting the "from {{ .Email }} to {{ .NewEmail }}" wording — for anon users it renders as "from to …" since there's no previous email.

## Test plan

- [x] Update the Change Email Address Supabase template to include `{{ .Token }}`.
- [x] Clean install of the app → Settings should land on the guest banner (anon bootstrap working).
- [ ] Settings → Sign Up → enter `you+1@example.com` + a password → submit.
- [ ] Verify the email arrives with a 6-digit OTP code (not just a magic link).
- [ ] App navigates to the OTP screen with the title "Confirm your new email".
- [ ] Enter the code → screen succeeds, app returns to home.
- [ ] Settings now shows the real-user state: greeting + Sign Out row, no guest banner.
- [ ] In the Supabase dashboard, the user record's `email` reads `you+1@example.com` (plus alias preserved) and `is_anonymous` is `false`.
- [ ] Optional: tap Resend on the OTP screen → another email arrives via the same EMAIL_CHANGE path.
- [ ] `./gradlew :client:auth:data:impl:jvmTest :client:auth:ui:impl:jvmTest :client:root:impl:jvmTest :client:composeApp:compileKotlinJvm` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)