### PR TITLE
feat(grocery): empty state + input hint, fix Edit Recipe FAB IME

### DIFF
--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -172,6 +172,9 @@ class BottomNavBlocImpl(
             is GroceryListBloc.Output.OpenDetail -> {
                 this.output.onNext(OpenGrocery(output.id))
             }
+            GroceryListBloc.Output.OpenRecipes -> {
+                onTabSelected(BottomNavBloc.Tab.RECIPES)
+            }
         }
     }
 

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
@@ -128,4 +128,8 @@ class GroceryListBlocImpl(
     override fun onListSelectorDismissed() {
         viewModel.onListSelectorDismissed()
     }
+
+    override fun onBrowseRecipesClicked() {
+        output.onNext(GroceryListBloc.Output.OpenRecipes)
+    }
 }

--- a/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
+++ b/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
@@ -330,6 +330,12 @@ class GroceryListBlocTest {
     }
 
     @Test
+    fun When_browse_recipes_clicked_Then_open_recipes_output_emitted() = runTest {
+        bloc.onBrowseRecipesClicked()
+        output.lastValue shouldBe GroceryListBloc.Output.OpenRecipes
+    }
+
+    @Test
     fun When_items_have_recipe_name_Then_model_contains_recipe_name() = runTest {
         bloc.state.test {
             awaitItem() shouldBe GroceryListBloc.Model()

--- a/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
@@ -51,4 +51,8 @@
     <string name="grocery_category_baking">Baking</string>
     <string name="grocery_category_spices">Spices &amp; Seasonings</string>
     <string name="grocery_category_other">Other</string>
+    <string name="grocery_add_item_hint">Add an item…</string>
+    <string name="grocery_list_empty_title">Your grocery list is empty</string>
+    <string name="grocery_list_empty_description">Add items below, or pull ingredients in from one of your recipes.</string>
+    <string name="grocery_list_empty_browse_recipes">Browse my recipes</string>
 </resources>

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
@@ -48,6 +48,8 @@ interface GroceryListBloc {
 
     fun onListSelectorDismissed()
 
+    fun onBrowseRecipesClicked()
+
     data class GroceryGroup(val category: GroceryCategory, val items: List<GroceryItem>)
 
     enum class GrocerySort {
@@ -78,6 +80,8 @@ interface GroceryListBloc {
 
     sealed class Output {
         data class OpenDetail(val id: Long) : Output()
+
+        data object OpenRecipes : Output()
     }
 
     fun interface Factory {

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListPreviews.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListPreviews.kt
@@ -1,0 +1,134 @@
+package com.plusmobileapps.chefmate.grocery.core.list
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryFilter
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryGroup
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GrocerySort
+import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
+import com.plusmobileapps.chefmate.grocery.data.GroceryItem
+import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
+import com.plusmobileapps.chefmate.grocery.data.SyncStatus
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+
+private val sampleList = GroceryListModel(id = 1L, name = "My List", syncStatus = SyncStatus.SYNCED)
+
+private val sampleGroups =
+    listOf(
+        GroceryGroup(
+            category = GroceryCategory.PRODUCE,
+            items =
+                listOf(
+                    GroceryItem(
+                        id = 1L,
+                        name = "Apples",
+                        quantity = "6",
+                        category = GroceryCategory.PRODUCE,
+                        syncStatus = SyncStatus.SYNCED,
+                    ),
+                    GroceryItem(
+                        id = 2L,
+                        name = "Spinach",
+                        quantity = "1 bag",
+                        category = GroceryCategory.PRODUCE,
+                        isChecked = true,
+                        syncStatus = SyncStatus.SYNCED,
+                    ),
+                ),
+        ),
+        GroceryGroup(
+            category = GroceryCategory.DAIRY,
+            items =
+                listOf(
+                    GroceryItem(
+                        id = 3L,
+                        name = "Whole milk",
+                        quantity = "1 gal",
+                        category = GroceryCategory.DAIRY,
+                        syncStatus = SyncStatus.SYNCED,
+                        recipeName = "Pancakes",
+                    )
+                ),
+        ),
+    )
+
+private fun groceryListBloc(
+    model: GroceryListBloc.Model,
+    pendingInput: String = "",
+): GroceryListBloc =
+    object : GroceryListBloc {
+        override val state = MutableStateFlow(model)
+        override val newGroceryItemName = MutableStateFlow(pendingInput)
+
+        override fun onGroceryItemCheckedChange(item: GroceryItem, isChecked: Boolean) = Unit
+
+        override fun onGroceryItemDelete(item: GroceryItem) = Unit
+
+        override fun onNewGroceryItemNameChange(name: String) = Unit
+
+        override fun saveGroceryItem() = Unit
+
+        override fun onGroceryItemClicked(item: GroceryItem) = Unit
+
+        override fun onSyncClicked() = Unit
+
+        override fun onListSelected(list: GroceryListModel) = Unit
+
+        override fun onCreateListClicked() = Unit
+
+        override fun onCreateListDismissed() = Unit
+
+        override fun onCreateListConfirmed(name: String) = Unit
+
+        override fun onDeleteListClicked(list: GroceryListModel) = Unit
+
+        override fun onApplySortAndFilter(
+            sort: GrocerySort,
+            filter: GroceryFilter,
+            recipeFilter: String?,
+        ) = Unit
+
+        override fun onDeleteClicked() = Unit
+
+        override fun onDeleteDismissed() = Unit
+
+        override fun onDeletePurchasedConfirmed() = Unit
+
+        override fun onDeleteAllConfirmed() = Unit
+
+        override fun onListSelectorClicked() = Unit
+
+        override fun onListSelectorDismissed() = Unit
+
+        override fun onBrowseRecipesClicked() = Unit
+    }
+
+/** Grocery list with items in two categories — exercises grouped rendering + sync badges. */
+val previewGroceryListBloc: GroceryListBloc =
+    groceryListBloc(
+        GroceryListBloc.Model(
+            groupedItems = sampleGroups,
+            lists = listOf(sampleList),
+            selectedList = sampleList,
+        )
+    )
+
+/**
+ * Empty grocery list — exercises the empty state CTA introduced alongside the "Browse my recipes"
+ * jump-to-recipes flow. Should NOT appear when filters are active (see `previewGroceryListBloc`).
+ */
+val previewGroceryListBlocEmpty: GroceryListBloc =
+    groceryListBloc(GroceryListBloc.Model(lists = listOf(sampleList), selectedList = sampleList))
+
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+internal fun GroceryListPreview() {
+    ChefMateTheme { GroceryListScreen(bloc = previewGroceryListBloc) }
+}
+
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+internal fun GroceryListEmptyPreview() {
+    ChefMateTheme { GroceryListScreen(bloc = previewGroceryListBlocEmpty) }
+}

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.outlined.CloudDone
 import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material.icons.outlined.ShoppingCart
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -66,9 +67,11 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import chefmate.client.grocery.core.public.generated.resources.Res
 import chefmate.client.grocery.core.public.generated.resources.grocery_add_item
+import chefmate.client.grocery.core.public.generated.resources.grocery_add_item_hint
 import chefmate.client.grocery.core.public.generated.resources.grocery_apply
 import chefmate.client.grocery.core.public.generated.resources.grocery_cancel
 import chefmate.client.grocery.core.public.generated.resources.grocery_clear_filters
@@ -93,6 +96,9 @@ import chefmate.client.grocery.core.public.generated.resources.grocery_filter_no
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_purchased
 import chefmate.client.grocery.core.public.generated.resources.grocery_filter_unpurchased
 import chefmate.client.grocery.core.public.generated.resources.grocery_list
+import chefmate.client.grocery.core.public.generated.resources.grocery_list_empty_browse_recipes
+import chefmate.client.grocery.core.public.generated.resources.grocery_list_empty_description
+import chefmate.client.grocery.core.public.generated.resources.grocery_list_empty_title
 import chefmate.client.grocery.core.public.generated.resources.grocery_select_list
 import chefmate.client.grocery.core.public.generated.resources.grocery_sort_aisle
 import chefmate.client.grocery.core.public.generated.resources.grocery_sort_alphabetical
@@ -191,46 +197,58 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
                 onRefresh = bloc::onSyncClicked,
                 modifier = Modifier.weight(1f),
             ) {
-                GroceryGroupedList(
-                    groups =
-                        state.groupedItems.map { group ->
-                            GroceryDisplayGroup(
-                                category = group.category,
-                                items =
-                                    group.items.map { item ->
-                                        GroceryDisplayItem(
-                                            key = item.id,
-                                            displayName = item.displayName,
-                                            quantity = item.quantity,
-                                            isChecked = item.isChecked,
-                                            recipeName = item.recipeName,
-                                        )
-                                    },
-                            )
+                val showEmptyState =
+                    state.groupedItems.isEmpty() &&
+                        state.filter == GroceryListBloc.GroceryFilter.ALL &&
+                        state.recipeFilter == null &&
+                        !state.isSyncing
+                if (showEmptyState) {
+                    EmptyGroceryListState(
+                        onBrowseRecipesClicked = bloc::onBrowseRecipesClicked,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                } else {
+                    GroceryGroupedList(
+                        groups =
+                            state.groupedItems.map { group ->
+                                GroceryDisplayGroup(
+                                    category = group.category,
+                                    items =
+                                        group.items.map { item ->
+                                            GroceryDisplayItem(
+                                                key = item.id,
+                                                displayName = item.displayName,
+                                                quantity = item.quantity,
+                                                isChecked = item.isChecked,
+                                                recipeName = item.recipeName,
+                                            )
+                                        },
+                                )
+                            },
+                        onItemClick = { key ->
+                            itemLookup[key as Long]?.let { bloc.onGroceryItemClicked(it) }
                         },
-                    onItemClick = { key ->
-                        itemLookup[key as Long]?.let { bloc.onGroceryItemClicked(it) }
-                    },
-                    onCheckedChange = { key ->
-                        itemLookup[key as Long]?.let {
-                            bloc.onGroceryItemCheckedChange(it, !it.isChecked)
-                        }
-                    },
-                    modifier =
-                        Modifier.fillMaxSize().pointerInput(Unit) {
-                            detectTapGestures(onTap = { focusManager.clearFocus() })
+                        onCheckedChange = { key ->
+                            itemLookup[key as Long]?.let {
+                                bloc.onGroceryItemCheckedChange(it, !it.isChecked)
+                            }
                         },
-                    showHeaders = state.sort == GroceryListBloc.GrocerySort.AISLE,
-                    trailingContent = { displayItem ->
-                        val item = itemLookup[displayItem.key as Long]
-                        if (item != null) {
-                            GroceryItemTrailingContent(
-                                item = item,
-                                onDeleteClick = { bloc.onGroceryItemDelete(item) },
-                            )
-                        }
-                    },
-                )
+                        modifier =
+                            Modifier.fillMaxSize().pointerInput(Unit) {
+                                detectTapGestures(onTap = { focusManager.clearFocus() })
+                            },
+                        showHeaders = state.sort == GroceryListBloc.GrocerySort.AISLE,
+                        trailingContent = { displayItem ->
+                            val item = itemLookup[displayItem.key as Long]
+                            if (item != null) {
+                                GroceryItemTrailingContent(
+                                    item = item,
+                                    onDeleteClick = { bloc.onGroceryItemDelete(item) },
+                                )
+                            }
+                        },
+                    )
+                }
             }
             GroceryListInput(
                 name = bloc.newGroceryItemName,
@@ -573,6 +591,7 @@ private fun GroceryListInput(
             onValueChange = onNameChange,
             modifier = Modifier.weight(1f).onFocusChanged { isFocused = it.isFocused },
             singleLine = true,
+            placeholder = { Text(stringResource(Res.string.grocery_add_item_hint)) },
             keyboardOptions =
                 KeyboardOptions(
                     capitalization = KeyboardCapitalization.Sentences,
@@ -639,5 +658,40 @@ private fun GroceryItemTrailingContent(item: GroceryItem, onDeleteClick: () -> U
 
     IconButton(onClick = onDeleteClick) {
         Icon(Icons.Default.Delete, stringResource(Res.string.grocery_delete_item))
+    }
+}
+
+@Composable
+private fun EmptyGroceryListState(
+    onBrowseRecipesClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth().padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.ShoppingCart,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stringResource(Res.string.grocery_list_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(Res.string.grocery_list_empty_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(24.dp))
+        Button(onClick = onBrowseRecipesClicked, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(Res.string.grocery_list_empty_browse_recipes))
+        }
     }
 }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
@@ -123,7 +123,7 @@ fun EditRecipeScreen(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
     }
 
     PlusHeaderContainer(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize().imePadding(),
         data = PlusHeaderData.Child(title = state.title, onBackClick = bloc::onBackClicked),
         verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal),
         floatingActionButton = {
@@ -166,7 +166,7 @@ private fun LoadingIndicator(modifier: Modifier = Modifier) {
 @Composable
 private fun EditRecipeContent(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal).imePadding(),
+        modifier = modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal),
         verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal),
     ) {
         RecipeTitleField(bloc = bloc)

--- a/client/ui/screenshot-test/build.gradle.kts
+++ b/client/ui/screenshot-test/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(project(":client:auth:ui:public"))
     implementation(project(":client:bottomnav:public"))
     implementation(project(":client:cook:public"))
+    implementation(project(":client:grocery:core:public"))
     implementation(project(":client:recipe:core:public"))
     implementation(project(":client:recipe:list:public"))
     implementation(project(":client:recipe:data:public"))

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTest.kt
@@ -1,0 +1,58 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListScreen
+import com.plusmobileapps.chefmate.grocery.core.list.previewGroceryListBloc
+import com.plusmobileapps.chefmate.grocery.core.list.previewGroceryListBlocEmpty
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+// GroceryListScreen has no top-level Surface — its background comes from the app shell in
+// production. Wrap each test in one so dark snapshots actually render dark.
+@Composable
+private fun GroceryListScreenshot(bloc: GroceryListBloc, darkTheme: Boolean = false) {
+    ChefMateTheme(darkTheme = darkTheme) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            GroceryListScreen(bloc = bloc)
+        }
+    }
+}
+
+// ── Populated list ─────────────────────────────────────────────────────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun GroceryListPhonePortraitLightScreenshot() {
+    GroceryListScreenshot(bloc = previewGroceryListBloc)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun GroceryListPhonePortraitDarkScreenshot() {
+    GroceryListScreenshot(bloc = previewGroceryListBloc, darkTheme = true)
+}
+
+// ── Empty state — regression coverage for the "Browse my recipes" CTA ──────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun GroceryListEmptyPhonePortraitLightScreenshot() {
+    GroceryListScreenshot(bloc = previewGroceryListBlocEmpty)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun GroceryListEmptyPhonePortraitDarkScreenshot() {
+    GroceryListScreenshot(bloc = previewGroceryListBlocEmpty, darkTheme = true)
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListEmptyPhonePortraitDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListEmptyPhonePortraitDarkScreenshot_805fa67c_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54e3e48e59fba9fe4a16b3d9c1f470fef18615de9079639c8524bf7a6cc7fdf5
+size 56529

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListEmptyPhonePortraitLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListEmptyPhonePortraitLightScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d95a3d3cbb4e2e7a75b38a664c469f5be414b22d78589862da00ff3ef3f0e5d3
+size 56549

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListPhonePortraitDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListPhonePortraitDarkScreenshot_805fa67c_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b51eb5cb53059d290f01f5a2c51d6215c1d30fbe8d89600a3a5a26013bcddb7e
+size 56376

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListPhonePortraitLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListPhonePortraitLightScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f963fc4e2016a836f390cc7947984757f8f7c3d95e2ce0db95843ded8ca1e185
+size 56531


### PR DESCRIPTION
## Summary
- Adds an empty state to the grocery list (cart icon + title + description + "Browse my recipes" button that switches the bottom-nav to the Recipes tab). Only shown when the list is genuinely empty — filtered-empty cases still fall through to the existing list.
- Adds a placeholder hint ("Add an item…") to the grocery list add-item text field, which previously rendered unlabeled.
- Fixes the Edit Recipe save FAB getting covered by the keyboard: moves `.imePadding()` from the inner `EditRecipeContent` Column to the outer `PlusHeaderContainer` wrapper modifier (matches the existing `AuthenticationScreen` pattern).

## Test plan
- [x] `./gradlew ktfmtFormat`
- [x] JVM compile for the touched modules (`grocery:core:public`, `grocery:core:impl`, `bottomnav:impl`, `recipe:core:public`)
- [x] `./gradlew :client:grocery:core:impl:jvmTest` (new coverage for `onBrowseRecipesClicked` output emission)
- [x] `./gradlew :client:bottomnav:impl:jvmTest`
- [ ] Manual: launch app on Android, clear grocery list → confirm empty state renders + tapping the button switches to the Recipes tab
- [ ] Manual: focus a text field on the Edit Recipe screen on Android and confirm the Save FAB rises above the keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)