### PR TITLE
fix(grocery): sync prunes items/lists deleted on other devices

### DIFF
--- a/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
+++ b/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
@@ -425,6 +425,7 @@ class GroceryRepositoryImpl(
             // exist. Pulling first lets us link it to the remote list instead of
             // pushing a duplicate.
             val remoteLists = remoteDataSource.fetchGroceryLists(userId)
+            val remoteListIds = remoteLists.mapNotNull { it.id }.toSet()
             withContext(ioContext) {
                 for (remoteList in remoteLists) {
                     val remoteId = remoteList.id ?: continue
@@ -448,6 +449,19 @@ class GroceryRepositoryImpl(
                         }
                         listQueries.updateRemoteId(remoteId = remoteId, id = newId)
                     }
+                }
+
+                // Prune local lists that were deleted on another device.
+                // A local list with a remoteId that no longer appears in the
+                // fetched remote lists has been deleted remotely — drop it and
+                // its items locally so the deletion is reflected on this device.
+                val pruneLists =
+                    listQueries.getAll().executeAsList().filter {
+                        it.remoteId != null && it.remoteId !in remoteListIds
+                    }
+                for (list in pruneLists) {
+                    queries.deleteByListId(list.id)
+                    listQueries.delete(list.id)
                 }
             }
 
@@ -555,6 +569,7 @@ class GroceryRepositoryImpl(
 
                 // Pull remote items for this list
                 val remoteItems = remoteDataSource.fetchAllGroceryItems(listRemoteId)
+                val remoteItemIds = remoteItems.mapNotNull { it.id }.toSet()
                 withContext(ioContext) {
                     for (remoteItem in remoteItems) {
                         val remoteId = remoteItem.id ?: continue
@@ -584,6 +599,19 @@ class GroceryRepositoryImpl(
                                 recipeName = remoteItem.recipeName,
                             )
                         }
+                    }
+
+                    // Prune local items that were deleted on another device.
+                    // An item with a remoteId that no longer appears in the
+                    // fetched remote items has been deleted remotely. Items
+                    // without a remoteId (still pending initial push) are
+                    // preserved.
+                    val pruneItems =
+                        queries.readByListId(list.id).executeAsList().filter {
+                            it.remoteId != null && it.remoteId !in remoteItemIds
+                        }
+                    for (item in pruneItems) {
+                        queries.delete(item.id)
                     }
                 }
             }

--- a/client/grocery/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImplTest.kt
+++ b/client/grocery/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImplTest.kt
@@ -205,6 +205,183 @@ class GroceryRepositoryImplTest {
             }
         }
 
+    @Test
+    fun syncWithRemote_prunes_local_items_that_were_deleted_on_another_device() =
+        runTest(testDispatcher) {
+            // Local list already linked to a remote list with two synced items.
+            // Simulates a device that previously synced both items.
+            val localListId = repository.ensureDefaultList()
+            val remoteListId = "remote-list-prune"
+            val now = "2026-01-01T00:00:00"
+            db.groceryListQueries.updateRemoteId(remoteId = remoteListId, id = localListId)
+            db.groceryQueries.createWithRemoteId(
+                name = "Milk",
+                isChecked = false,
+                createdAt = now,
+                updatedAt = now,
+                remoteId = "remote-milk",
+                listRemoteId = remoteListId,
+                clientId = "client-milk",
+                listId = localListId,
+                recipeName = null,
+            )
+            db.groceryQueries.createWithRemoteId(
+                name = "Eggs",
+                isChecked = false,
+                createdAt = now,
+                updatedAt = now,
+                remoteId = "remote-eggs",
+                listRemoteId = remoteListId,
+                clientId = "client-eggs",
+                listId = localListId,
+                recipeName = null,
+            )
+
+            // Remote now only has Milk (Eggs was deleted on another device).
+            fakeRemote.remoteLists["user-1"] =
+                mutableListOf(
+                    RemoteGroceryList(
+                        id = remoteListId,
+                        name = "My Grocery List",
+                        ownerId = "user-1",
+                    )
+                )
+            fakeRemote.remoteItems[remoteListId] =
+                mutableListOf(
+                    RemoteGroceryItem(
+                        id = "remote-milk",
+                        listId = remoteListId,
+                        name = "Milk",
+                        clientId = "client-milk",
+                    )
+                )
+
+            fakeAuth.setState(
+                AuthState.Authenticated(
+                    ChefMateUser(
+                        userId = "user-1",
+                        userName = "Test",
+                        userEmail = "test@test.com",
+                        userProfileImageUrl = null,
+                    )
+                )
+            )
+
+            repository.getGroceries(localListId).test {
+                val items = awaitItem()
+                items.size shouldBe 1
+                items.first().name shouldBe "Milk"
+            }
+        }
+
+    @Test
+    fun syncWithRemote_preserves_local_items_with_no_remote_id_during_prune() =
+        runTest(testDispatcher) {
+            // Local list linked to remote with one synced item and one unsynced item.
+            val localListId = repository.ensureDefaultList()
+            val remoteListId = "remote-list-keep-unsynced"
+            val now = "2026-01-01T00:00:00"
+            db.groceryListQueries.updateRemoteId(remoteId = remoteListId, id = localListId)
+            db.groceryQueries.createWithRemoteId(
+                name = "Milk",
+                isChecked = false,
+                createdAt = now,
+                updatedAt = now,
+                remoteId = "remote-milk",
+                listRemoteId = remoteListId,
+                clientId = "client-milk",
+                listId = localListId,
+                recipeName = null,
+            )
+            // Brand new local item — never pushed yet (no remoteId).
+            repository.addGrocery(localListId, "Bread")
+
+            // Remote has neither item (synced item was deleted on another device).
+            fakeRemote.remoteLists["user-1"] =
+                mutableListOf(
+                    RemoteGroceryList(
+                        id = remoteListId,
+                        name = "My Grocery List",
+                        ownerId = "user-1",
+                    )
+                )
+            fakeRemote.remoteItems[remoteListId] = mutableListOf()
+
+            fakeAuth.setState(
+                AuthState.Authenticated(
+                    ChefMateUser(
+                        userId = "user-1",
+                        userName = "Test",
+                        userEmail = "test@test.com",
+                        userProfileImageUrl = null,
+                    )
+                )
+            )
+
+            // The unsynced "Bread" item should survive — the push earlier in the
+            // sync will create a remote for it. The previously-synced "Milk" is
+            // pruned because it no longer exists on the remote.
+            repository.getGroceries(localListId).test {
+                val items = awaitItem()
+                items.map { it.name }.toSet() shouldBe setOf("Bread")
+            }
+        }
+
+    @Test
+    fun syncWithRemote_prunes_local_list_that_was_deleted_on_another_device() =
+        runTest(testDispatcher) {
+            // Two local lists both linked to remote. One is removed from remote.
+            val keptLocalId = repository.ensureDefaultList()
+            val keptRemoteId = "remote-list-kept"
+            db.groceryListQueries.updateRemoteId(remoteId = keptRemoteId, id = keptLocalId)
+
+            val prunedLocalId = repository.createGroceryList("Party Supplies")
+            val prunedRemoteId = "remote-list-pruned"
+            db.groceryListQueries.updateRemoteId(remoteId = prunedRemoteId, id = prunedLocalId)
+            val now = "2026-01-01T00:00:00"
+            db.groceryQueries.createWithRemoteId(
+                name = "Chips",
+                isChecked = false,
+                createdAt = now,
+                updatedAt = now,
+                remoteId = "remote-chips",
+                listRemoteId = prunedRemoteId,
+                clientId = "client-chips",
+                listId = prunedLocalId,
+                recipeName = null,
+            )
+
+            // Remote only has the kept list.
+            fakeRemote.remoteLists["user-1"] =
+                mutableListOf(
+                    RemoteGroceryList(
+                        id = keptRemoteId,
+                        name = "My Grocery List",
+                        ownerId = "user-1",
+                    )
+                )
+            fakeRemote.remoteItems[keptRemoteId] = mutableListOf()
+
+            fakeAuth.setState(
+                AuthState.Authenticated(
+                    ChefMateUser(
+                        userId = "user-1",
+                        userName = "Test",
+                        userEmail = "test@test.com",
+                        userProfileImageUrl = null,
+                    )
+                )
+            )
+
+            repository.getGroceryLists().test {
+                val lists = awaitItem()
+                lists.size shouldBe 1
+                lists.first().name shouldBe "My Grocery List"
+            }
+            // Items belonging to the pruned list are gone too.
+            db.groceryQueries.readAll().executeAsList().isEmpty() shouldBe true
+        }
+
     // ─── deleteAllGroceries ───────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #196 — grocery items deleted on one device stayed visible on other devices after resync.

`GroceryRepositoryImpl.syncWithRemote()` only pulled new remote rows and added missing ones to the local DB. It never removed locally-cached rows whose remote counterpart had been deleted, so deletions never propagated to other devices.

## Change

After fetching remote lists and items, prune any locally-synced row (`remoteId != null`) that is absent from the fetched set:
- A local list missing from the remote pull is deleted along with all its items.
- A local item missing from its list's remote pull is deleted.
- Local rows with `remoteId == null` (queued for initial push) are preserved.

## Test plan

- [x] `./gradlew :client:grocery:data:impl:allTests` passes on JVM, Android, and iOS targets, including three new tests covering: synced item deleted remotely → pruned locally; unsynced local item → preserved; whole list deleted remotely → list + items pruned locally.
- [x] `./gradlew :client:grocery:data:impl:ktfmtCheck` clean.
- [ ] Manual: delete a grocery item on device A, sync device B, confirm the item disappears on device B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)