### PR TITLE
docs: add Compose testing docs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ in your IDE’s toolbar or open the [/iosApp](./iosApp) directory in Xcode and r
 * [Mokkery](https://mokkery.dev/) - mocking library
 * [Turbine](https://github.com/cashapp/turbine) - coroutines testing library
 * [Compose Preview Screenshot Testing](https://developer.android.com/studio/preview/compose-screenshot-testing) - snapshot tests for `@Preview` composables (see `client/ui/screenshot-test/` and `CLAUDE.md` for the workflow)
+* [Compose testing](https://kotlinlang.org/docs/multiplatform/compose-test.html) - official KMP Compose UI testing docs


### PR DESCRIPTION
## Summary

Adds a reference to the official Kotlin Multiplatform [Compose testing](https://kotlinlang.org/docs/multiplatform/compose-test.html) documentation under the **Testing** section of the README's Libraries Used list.

## Change

Added one bullet to `README.md → Libraries Used → Testing`:

```
* [Compose testing](https://kotlinlang.org/docs/multiplatform/compose-test.html) - official KMP Compose UI testing docs
```

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)