### PR TITLE
build(desktop): scaffold Hydraulic Conveyor for cross-platform installers

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -98,6 +98,11 @@ jobs:
           # Android versionName
           sed -i "s/versionName = \"[^\"]*\"/versionName = \"${NEW_VERSION}\"/" "$GRADLE_FILE"
 
+          # Top-level Gradle project version (read by Hydraulic Conveyor).
+          # Anchored to start-of-line so only the project-level declaration
+          # matches — not packageVersion / versionName.
+          sed -i "s/^version = \"[^\"]*\"/version = \"${NEW_VERSION}\"/" "$GRADLE_FILE"
+
           # Desktop packageVersion — first occurrence (generic/JVM)
           awk -v new="$NEW_VERSION" '
             /packageVersion[[:space:]]*=/ && !done {
@@ -163,6 +168,7 @@ jobs:
             echo "| iOS | \`CURRENT_PROJECT_VERSION\` | \`${OLD_BUILD}\` | \`${NEW_BUILD}\` |"
             echo "| Desktop (JVM) | \`packageVersion\` | \`${OLD_VERSION}\` | \`${NEW_VERSION}\` |"
             echo "| Desktop (macOS) | \`packageVersion\` | — | \`${MAC_VERSION}\` |"
+            echo "| Desktop (Conveyor) | top-level \`version\` | \`${OLD_VERSION}\` | \`${NEW_VERSION}\` |"
             echo ""
             echo "After merging this PR (**squash merge recommended**), the \`build-release\` workflow"
             echo "will detect the bump commit on \`main\`, create a \`v${NEW_VERSION}\` git tag, build the"

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -28,7 +28,15 @@ plugins {
     alias(libs.plugins.metro)
     alias(libs.plugins.compose)
     alias(libs.plugins.plusKtfmt)
+    alias(libs.plugins.conveyor)
 }
+
+// Top-level project version is read by Hydraulic Conveyor (`printConveyorConfig`
+// task) when generating cross-platform desktop installers. Keep this in sync
+// with `android.defaultConfig.versionName` below and with
+// `compose.desktop.application.nativeDistributions.packageVersion`.
+// scripts/bump-version.sh keeps all three aligned.
+version = "1.6.0"
 
 kotlin {
     androidTarget {
@@ -224,6 +232,32 @@ android {
 dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4.android)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+
+    // ── Hydraulic Conveyor cross-platform inputs ──────────────────────────
+    // The Conveyor Gradle plugin creates these configurations. Each one feeds
+    // the package built for the corresponding OS/arch. Local `./gradlew run`
+    // and the existing compose.desktop `package*` tasks are unaffected — they
+    // keep using the host-classified deps declared above in kotlin.jvmMain.
+    //
+    // Compose Desktop ships per-platform aggregator artifacts that pull in
+    // Skiko natives with the right classifier; we just declare one per target.
+    macAmd64(compose.desktop.macos_x64)
+    macAarch64(compose.desktop.macos_arm64)
+    linuxAmd64(compose.desktop.linux_x64)
+    windowsAmd64(compose.desktop.windows_x64)
+
+    // JavaFX is required at runtime for the Compose Desktop browser WebView
+    // (see client/browser/public/src/jvmMain/.../PlatformWebView.jvm.kt).
+    // The host-classified versions in kotlin.jvmMain cover local dev; these
+    // fan out the native classifiers Conveyor needs for cross-compilation.
+    val fxVersion = libs.versions.openjfx.get()
+    val fxModules = listOf("base", "controls", "graphics", "media", "swing", "web")
+    fxModules.forEach { mod ->
+        macAmd64("org.openjfx:javafx-$mod:$fxVersion:mac")
+        macAarch64("org.openjfx:javafx-$mod:$fxVersion:mac-aarch64")
+        linuxAmd64("org.openjfx:javafx-$mod:$fxVersion:linux")
+        windowsAmd64("org.openjfx:javafx-$mod:$fxVersion:win")
+    }
 }
 
 compose.desktop {

--- a/client/composeApp/conveyor.conf
+++ b/client/composeApp/conveyor.conf
@@ -1,0 +1,80 @@
+// Hydraulic Conveyor configuration for Chef Mate desktop.
+//
+// Goal of this file (probe phase): produce signed, cross-platform desktop
+// installers (DMG, MSI, DEB) from a single host, with built-in auto-update,
+// replacing the per-OS matrix in .github/workflows/desktop-release.yml.
+//
+// Free-tier guard: app.site.base-url points at localhost. Conveyor only
+// requires a license when the site URL is non-localhost. Chef Mate is
+// Apache-2.0 so we'll qualify for the OSS free tier when we switch to a
+// real URL — see the GitHub Releases TODO below.
+//
+// JavaFX wrinkle: the desktop browser screen renders an embedded
+// `javafx.scene.web.WebView` (client/browser/public/src/jvmMain/.../
+// PlatformWebView.jvm.kt), so JavaFX must be present at runtime on each
+// target OS with the right native classifier. The Conveyor configurations
+// in client/composeApp/build.gradle.kts (`macAmd64`, `macAarch64`,
+// `linuxAmd64`, `windowsAmd64`) fan out the JavaFX classifiers per target.
+// If a packaged app crashes on launch with `UnsatisfiedLinkError` or
+// `libprism_es2.dylib not found` (etc.), audit those lines first — odds
+// are a JavaFX module is missing for that platform.
+//
+// Run the probe locally with:
+//   cd client/composeApp
+//   conveyor make site        # builds for the host OS, serves on localhost:3000
+//   conveyor make mac-app     # build a Mac DMG (host or cross)
+//   conveyor make windows-app # build a Windows MSI
+//   conveyor make linux-app   # build a Linux DEB
+
+include required("/stdlib/jdk/21/openjdk.conf")
+include required("#!./gradlew -q :client:composeApp:printConveyorConfig")
+
+app {
+  display-name = "Chef Mate"
+  fsname = "chef-mate"
+  rdns-name = "com.plusmobileapps.chefmate"
+  license = "Apache-2.0"
+  vendor = "Plus Mobile Apps"
+
+  // Localhost during evaluation — Conveyor stays in free mode.
+  //
+  // When ready to publish, replace this whole block with:
+  //
+  //   vcs-url = "github.com/Plus-Mobile-Apps/chef-mate"
+  //   site.github.oauth-token = ${env.GITHUB_TOKEN}
+  //
+  // That auto-sets app.site.base-url to
+  //   https://github.com/Plus-Mobile-Apps/chef-mate/releases/latest/download
+  // so existing installs self-update from whatever the `/releases/latest`
+  // tag points to. `conveyor make copied-site` will then upload signed
+  // artifacts to a new GitHub Release and publish the download page to
+  // gh-pages.
+  site.base-url = "localhost:3000"
+
+  icons = "client/composeApp/src/jvmMain/resources/app-icon.png"
+
+  mac {
+    info-plist.LSApplicationCategoryType = "public.app-category.food-and-drink"
+    // Once we have an Apple Developer ID, signing config goes here:
+    //   signing-key = "keychain"     (local dev: read from macOS keychain)
+    //   signing-key = ${env.APPLE_SIGNING_KEY}    (CI: encrypted file)
+    //   notarization.app-specific-password = ${env.APPLE_NOTARIZATION_PASSWORD}
+    //   notarization.apple-id = "andrew@plusmobileapps.com"
+    //   notarization.team-id = "REPLACE_WITH_TEAM_ID"
+  }
+
+  windows {
+    // Without a cert: Conveyor self-signs and SmartScreen warns on install.
+    // Recommended cheapest path with good UX is Azure Trusted Signing
+    // (~$10/mo, cloud-hosted, no USB token, fast SmartScreen reputation):
+    //
+    //   signing-key = "azure-trusted-signing"
+    //   azure-trusted-signing {
+    //     endpoint = "https://eus.codesigning.azure.net"
+    //     account-name = "REPLACE"
+    //     profile-name = "REPLACE"
+    //   }
+    //
+    // Auth via AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET in CI.
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ buildkonfig = "0.17.1"
 composeHotReload = "1.0.0"
 composeMaterialExpressive = "1.10.0-alpha05"
 composeMultiplatform = "1.10.3"
+conveyor = "2.0"
 composeUi = "1.11.1"
 composeMaterialIcons = "1.7.3"
 coroutines = "1.10.2"
@@ -135,6 +136,7 @@ buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig"
 composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+conveyor = { id = "dev.hydraulic.conveyor", version.ref = "conveyor" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -24,6 +24,9 @@ read_ios_version() { sed -n 's/MARKETING_VERSION=\(.*\)/\1/p' "$XCCONFIG_FILE"; 
 read_desktop_version()     { sed -n 's/.*packageVersion = "\([^"]*\)".*/\1/p' "$GRADLE_FILE" | head -1; }
 read_desktop_mac_version() { sed -n 's/.*packageVersion = "\([^"]*\)".*/\1/p' "$GRADLE_FILE" | tail -1; }
 
+# Top-level Gradle `version = "..."` — read by Hydraulic Conveyor.
+read_gradle_project_version() { sed -n 's/^version = "\([^"]*\)".*/\1/p' "$GRADLE_FILE" | head -1; }
+
 show_current() {
     bold "Current versions:"
     echo ""
@@ -33,6 +36,7 @@ show_current() {
     printf "  %-18s  %-14s  %s\n" "iOS"               "$(read_ios_version)"          "$(read_ios_build)"
     printf "  %-18s  %-14s  %s\n" "Desktop"           "$(read_desktop_version)"      "—"
     printf "  %-18s  %-14s  %s\n" "Desktop (macOS)"   "$(read_desktop_mac_version)"  "—"
+    printf "  %-18s  %-14s  %s\n" "Conveyor (gradle)" "$(read_gradle_project_version)" "—"
     echo ""
 }
 
@@ -68,6 +72,11 @@ apply_versions() {
 
     # Android versionName
     sed -i '' "s/versionName = \"[^\"]*\"/versionName = \"${new_version}\"/" "$GRADLE_FILE"
+
+    # Top-level Gradle project version (read by Hydraulic Conveyor).
+    # Anchored to start-of-line so we only match the project-level declaration,
+    # not packageVersion / versionName / versionCode lines further down.
+    sed -i '' "s/^version = \"[^\"]*\"/version = \"${new_version}\"/" "$GRADLE_FILE"
 
     # Desktop packageVersion (generic — first occurrence)
     # Use awk to only replace the first match

--- a/scripts/test-version-bump.sh
+++ b/scripts/test-version-bump.sh
@@ -62,6 +62,9 @@ sed_inplace "s/versionCode = [0-9]*/versionCode = ${TEST_BUILD}/" "${GRADLE_COPY
 # Android versionName
 sed_inplace "s/versionName = \"[^\"]*\"/versionName = \"${TEST_VERSION}\"/" "${GRADLE_COPY}"
 
+# Top-level Gradle project version (read by Hydraulic Conveyor).
+sed_inplace "s/^version = \"[^\"]*\"/version = \"${TEST_VERSION}\"/" "${GRADLE_COPY}"
+
 # Desktop packageVersion — first occurrence (generic/JVM)
 awk -v new="${TEST_VERSION}" '
     /packageVersion[[:space:]]*=/ && !done {
@@ -100,6 +103,7 @@ check() {
 
 ACTUAL_VCODE=$(sed -n 's/.*versionCode = \([0-9]*\).*/\1/p' "${GRADLE_COPY}")
 ACTUAL_VNAME=$(sed -n 's/.*versionName = "\([^"]*\)".*/\1/p' "${GRADLE_COPY}")
+ACTUAL_GRADLE_VERSION=$(sed -n 's/^version = "\([^"]*\)".*/\1/p' "${GRADLE_COPY}" | head -1)
 ACTUAL_PKG_VERSIONS=$(sed -n 's/.*packageVersion = "\([^"]*\)".*/\1/p' "${GRADLE_COPY}")
 ACTUAL_PKG_FIRST=$(printf '%s\n' "${ACTUAL_PKG_VERSIONS}" | head -1)
 ACTUAL_PKG_LAST=$(printf '%s\n' "${ACTUAL_PKG_VERSIONS}" | tail -1)
@@ -112,6 +116,7 @@ printf '\nTest: bump to version \033[1m%s\033[0m (build \033[1m%s\033[0m)\n\n' \
 printf "Checking %s:\n" "${GRADLE_COPY}"
 check "versionCode" "${TEST_BUILD}" "${ACTUAL_VCODE}"
 check "versionName" "${TEST_VERSION}" "${ACTUAL_VNAME}"
+check "top-level gradle version (Conveyor)" "${TEST_VERSION}" "${ACTUAL_GRADLE_VERSION}"
 check "packageVersion (JVM/generic, first occurrence)" "${TEST_VERSION}" "${ACTUAL_PKG_FIRST}"
 check "packageVersion (macOS, last occurrence)" "${EXPECTED_MAC_VERSION}" "${ACTUAL_PKG_LAST}"
 


### PR DESCRIPTION
## Summary

Probe scaffolding for replacing the per-OS desktop release matrix in [`.github/workflows/desktop-release.yml`](../blob/main/.github/workflows/desktop-release.yml) with [Hydraulic Conveyor](https://conveyor.hydraulic.dev/) — one host produces signed, notarized, cross-platform installers (DMG / MSI / DEB) with built-in auto-update.

- Adds the `dev.hydraulic.conveyor` Gradle plugin (v2.0 — earlier versions fail on Gradle 9.3.1 with `Extending a detachedConfiguration is not allowed`) and a top-level project `version` accessor.
- Fans out Compose Desktop + JavaFX deps across Conveyor's `macAmd64` / `macAarch64` / `linuxAmd64` / `windowsAmd64` configurations. JavaFX is required because [`PlatformWebView.jvm.kt`](../blob/main/client/browser/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/browser/PlatformWebView.jvm.kt) embeds a `javafx.scene.web.WebView`.
- Adds [`client/composeApp/conveyor.conf`](../blob/feat/conveyor-jvm-desktop/client/composeApp/conveyor.conf) pinned to a localhost update site (Conveyor's free tier — no license needed). Inline TODOs document the transitions to GitHub Releases, Apple Developer ID notarization, and Azure Trusted Signing.
- Extends [`scripts/bump-version.sh`](../blob/feat/conveyor-jvm-desktop/scripts/bump-version.sh), its dry-run test, and the [`bump-version`](../blob/feat/conveyor-jvm-desktop/.github/workflows/bump-version.yml) CI workflow to keep the new top-level Gradle version in lock-step with Android / iOS / desktop `packageVersion`.

The existing `compose.desktop.application` block, `./gradlew :client:composeApp:run`, and the `packageDmg` / `packageMsi` / `packageDeb` flow are deliberately untouched. This PR is scaffolding only — `desktop-release.yml` keeps building unsigned per-OS artifacts until we decide to cut over.

## Findings from the probe

Verified empirically by running `./gradlew :client:composeApp:printConveyorConfig` against this branch — the generated fragment is 232 lines and emits the expected sections:

- ✅ Plugin loads on Gradle 9.3.1 with Compose Multiplatform 1.10.3.
- ✅ Per-platform inputs populate `app.mac.amd64.inputs`, `app.linux.amd64.glibc.inputs`, and `app.windows.amd64.inputs` with the right Skiko + JavaFX classifiers.
- ⚠️ Host-classified JavaFX/Skiko in `kotlin.jvmMain.implementation` leak into Conveyor's universal `app.inputs`. On a Mac arm64 host that's ~80 MB of `mac-aarch64` jars tagging along into Windows and Linux packages. The `macAarch64` Conveyor configuration's contents get deduped against this leak and aren't emitted as their own `app.mac.aarch64.inputs` section.

Resolving the leak is the next blocker before any real Conveyor build, but it's intentionally **out of scope** here so this scaffolding can land independently and reviewers can validate Conveyor itself before we restructure how JavaFX/Skiko natives are wired.

## Commits

Split per CLAUDE.md's PR-split guidance so each concern can be stepped through individually:

1. **`build(desktop):`** wire Hydraulic Conveyor plugin + cross-platform inputs — `composeApp/build.gradle.kts` + `libs.versions.toml`.
2. **`chore(scripts):`** sync top-level Gradle version across bump tooling — `bump-version.sh`, its test, and the `bump-version` workflow.
3. **`build(desktop):`** add Conveyor configuration baseline — new `client/composeApp/conveyor.conf`.

## Test plan

- [x] `./gradlew :client:composeApp:tasks --group=conveyor` lists `printConveyorConfig` / `writeConveyorConfig`.
- [x] `./gradlew :client:composeApp:printConveyorConfig` succeeds end-to-end.
- [x] `./gradlew :client:composeApp:ktfmtCheck` passes.
- [x] `./scripts/test-version-bump.sh 2.0.0 100` passes all 7 checks including the new `top-level gradle version (Conveyor)` assertion.
- [ ] Existing `./gradlew :client:composeApp:run` still launches the desktop app (no changes to `kotlin.jvmMain` or the `compose.desktop` block, so no regression expected).
- [ ] Existing `./gradlew :client:composeApp:packageDmg` / `packageMsi` / `packageDeb` still produce installers (CI exercises this via `desktop-release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)