### PR TITLE
fix(aichat): stop chat stuttering as the response streams in

### DIFF
--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatScreen.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatScreen.kt
@@ -141,9 +141,20 @@ fun AiChatScreen(bloc: AiChatBloc, modifier: Modifier = Modifier) {
 @Composable
 private fun MessageList(messages: List<ChatMessage>, modifier: Modifier = Modifier) {
     val listState = rememberLazyListState()
-    LaunchedEffect(messages.size, messages.lastOrNull()?.content?.length) {
+    val lastIndex = messages.lastIndex
+    val isStreaming = messages.lastOrNull()?.isStreaming == true
+    // A newly appended message animates into view.
+    LaunchedEffect(messages.size) {
         if (messages.isNotEmpty()) {
-            listState.animateScrollToItem(messages.lastIndex)
+            listState.animateScrollToItem(lastIndex)
+        }
+    }
+    // While the last message streams, jump to the bottom instantly on each
+    // delta. Animating here would restart the scroll animation many times per
+    // second, which is what makes the chat stutter as the response loads in.
+    LaunchedEffect(messages.lastOrNull()?.content?.length) {
+        if (isStreaming && messages.isNotEmpty()) {
+            listState.scrollToItem(lastIndex)
         }
     }
     LazyColumn(


### PR DESCRIPTION
## Summary
- The AI chat message list animated to the bottom on every streamed delta, keyed on the last message's `content.length`. Each delta cancelled the in-flight scroll animation and started a new one many times per second — the visible stutter as a response loads in.
- Split auto-scroll into two effects: animate only when a *new* message is appended (`messages.size`), and while the last message is streaming, pin to the bottom with an instant `scrollToItem` so there is no animation to restart.

Fixes #214

## Test plan
- [x] `:client:aichat:impl:compileDevKotlinJvm` compiles
- [x] ktfmt formatting clean
- [ ] Manual: send a chat message and confirm the response scrolls smoothly (no jump/stutter) as it streams in
- [ ] Manual: confirm a newly sent message still animates into view

Change is scroll-behavior only (no visual difference), so existing streaming snapshot references are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)