### PR TITLE
fix(aichat): keyboard no longer covers the chat input

### DIFF
--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatScreen.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -85,7 +86,7 @@ fun AiChatScreen(bloc: AiChatBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
 
     PlusHeaderContainer(
-        modifier = modifier.fillMaxSize().testTag(AiChatTestTags.SCREEN),
+        modifier = modifier.fillMaxSize().imePadding().testTag(AiChatTestTags.SCREEN),
         data =
             PlusHeaderData.Child(
                 title = Res.string.aichat_title.asTextData(),


### PR DESCRIPTION
## Summary
- The AI chat screen applied no IME inset, so an open soft keyboard overlapped the message input field (#213).
- Add `imePadding()` to the `AiChatScreen` `PlusHeaderContainer` modifier so the screen shrinks above the keyboard and the input stays visible — matching the established pattern in `EditRecipeScreen`.

## Test plan
- [ ] Android: open AI Chat, tap the input, confirm the field and send button sit above the keyboard.
- [ ] iOS: same check; confirm the existing "Done" button still dismisses the keyboard.
- [x] `:client:aichat:impl:compileKotlinJvm` compiles.
- [x] `:client:aichat:impl:ktfmtCheck` passes.

No snapshot update needed — `imePadding()` has no effect without a live keyboard, so existing AiChat reference screenshots are unchanged.

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)