### PR TITLE
feat(root): add chefmate:// deeplinks for faster dev iteration

### DIFF
--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -44,6 +44,7 @@ import kotlinx.serialization.Serializable
 class BottomNavBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<BottomNavBloc.Output>,
+    @Assisted initialTab: BottomNavBloc.Tab?,
     viewModelFactory: Provider<BottomNavViewModel>,
     private val browser: BrowserRootBloc.Factory,
     private val groceryList: GroceryListBloc.Factory,
@@ -65,13 +66,24 @@ class BottomNavBlocImpl(
         childStack(
             source = navigation,
             serializer = Configuration.serializer(),
-            initialStack = { listOf(Configuration.Recipe) },
+            initialStack = { listOf(initialTab.toInitialConfiguration()) },
             handleBackButton = true,
             key = "BottomNavRouter",
             childFactory = ::createChild,
         )
 
+    private fun BottomNavBloc.Tab?.toInitialConfiguration(): Configuration =
+        when (this) {
+            null,
+            BottomNavBloc.Tab.RECIPES -> Configuration.Recipe
+            BottomNavBloc.Tab.GROCERIES -> Configuration.Grocery
+            BottomNavBloc.Tab.MEALS -> Configuration.Meals
+            BottomNavBloc.Tab.BROWSER -> Configuration.Browser
+            BottomNavBloc.Tab.SETTINGS -> Configuration.Settings
+        }
+
     init {
+        initialTab?.let(viewModel::selectTab)
         observeRouter()
     }
 

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -74,6 +74,6 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
     }
 
     fun interface Factory {
-        fun create(context: BlocContext, output: Consumer<Output>): BottomNavBloc
+        fun create(context: BlocContext, output: Consumer<Output>, initialTab: Tab?): BottomNavBloc
     }
 }

--- a/client/composeApp/src/androidMain/AndroidManifest.xml
+++ b/client/composeApp/src/androidMain/AndroidManifest.xml
@@ -30,6 +30,16 @@
 
                 <data android:mimeType="text/plain" />
             </intent-filter>
+
+            <!-- chefmate:// deeplinks (dev convenience) -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="chefmate" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/MainActivity.kt
+++ b/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.arkivanov.decompose.defaultComponentContext
+import com.plusmobileapps.chefmate.root.DeepLink
 import com.plusmobileapps.chefmate.root.RootBloc
 
 class MainActivity : ComponentActivity() {
@@ -20,6 +21,7 @@ class MainActivity : ComponentActivity() {
             buildRootBloc(
                 componentContext = defaultComponentContext(),
                 applicationComponent = appComponent,
+                deepLink = parseDeepLink(intent),
             )
         setContent { App(rootBloc) }
 
@@ -29,6 +31,12 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleShareIntent(intent)
+    }
+
+    private fun parseDeepLink(intent: Intent?): DeepLink {
+        if (intent?.action != Intent.ACTION_VIEW) return DeepLink.None
+        val data = intent.data?.toString() ?: return DeepLink.None
+        return DeepLink.parse(data)
     }
 
     private fun handleShareIntent(intent: Intent) {

--- a/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/RootBloc.kt
+++ b/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/RootBloc.kt
@@ -1,12 +1,15 @@
 package com.plusmobileapps.chefmate
 
 import com.arkivanov.decompose.ComponentContext
+import com.plusmobileapps.chefmate.root.DeepLink
 import com.plusmobileapps.chefmate.root.RootBloc
 
 fun buildRootBloc(
     componentContext: ComponentContext,
     applicationComponent: ApplicationComponent,
+    deepLink: DeepLink = DeepLink.None,
 ): RootBloc =
     applicationComponent.rootBlocFactory.create(
-        DefaultBlocContext(componentContext = componentContext)
+        context = DefaultBlocContext(componentContext = componentContext),
+        deepLink = deepLink,
     )

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
@@ -13,6 +13,7 @@ import com.plusmobileapps.chefmate.DefaultBlocContext
 import com.plusmobileapps.chefmate.di.TestApplicationComponent
 import com.plusmobileapps.chefmate.di.createTestApplicationComponent
 import com.plusmobileapps.chefmate.fixtures.TestRecipes
+import com.plusmobileapps.chefmate.root.DeepLink
 import com.plusmobileapps.chefmate.root.RootBloc
 import kotlinx.coroutines.test.TestResult
 
@@ -23,10 +24,13 @@ import kotlinx.coroutines.test.TestResult
  * ready to be passed into `App(rootBloc = …)`.
  */
 fun TestApplicationComponent.createRootBloc(
-    lifecycle: LifecycleRegistry = LifecycleRegistry().apply { resume() }
+    lifecycle: LifecycleRegistry = LifecycleRegistry().apply { resume() },
+    deepLink: DeepLink = DeepLink.None,
 ): RootBloc =
     rootBlocFactory.create(
-        DefaultBlocContext(componentContext = DefaultComponentContext(lifecycle = lifecycle))
+        context =
+            DefaultBlocContext(componentContext = DefaultComponentContext(lifecycle = lifecycle)),
+        deepLink = deepLink,
     )
 
 /**

--- a/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/RootBlocProvider.kt
+++ b/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/RootBlocProvider.kt
@@ -2,16 +2,22 @@ package com.plusmobileapps.chefmate
 
 import com.arkivanov.decompose.ComponentContext
 import com.plusmobileapps.chefmate.di.IosApplicationComponent
+import com.plusmobileapps.chefmate.root.DeepLink
 import com.plusmobileapps.chefmate.root.RootBloc
 import dev.zacsweers.metro.createGraphFactory
 import platform.UIKit.UIApplication
 
 object RootBlocProvider {
-    fun buildRootBloc(componentContext: ComponentContext, application: UIApplication): RootBloc {
+    fun buildRootBloc(
+        componentContext: ComponentContext,
+        application: UIApplication,
+        deepLinkUrl: String? = null,
+    ): RootBloc {
         val applicationComponent =
             createGraphFactory<IosApplicationComponent.Factory>().create(application)
         return applicationComponent.rootBlocFactory.create(
-            DefaultBlocContext(componentContext = componentContext)
+            context = DefaultBlocContext(componentContext = componentContext),
+            deepLink = DeepLink.parse(deepLinkUrl),
         )
     }
 }

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/RootBloc.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/RootBloc.kt
@@ -1,12 +1,15 @@
 package com.plusmobileapps.chefmate
 
 import com.arkivanov.decompose.ComponentContext
+import com.plusmobileapps.chefmate.root.DeepLink
 import com.plusmobileapps.chefmate.root.RootBloc
 
 fun buildRoot(
     componentContext: ComponentContext,
     applicationComponent: ApplicationComponent,
+    deepLink: DeepLink = DeepLink.None,
 ): RootBloc =
     applicationComponent.rootBlocFactory.create(
-        DefaultBlocContext(componentContext = componentContext)
+        context = DefaultBlocContext(componentContext = componentContext),
+        deepLink = deepLink,
     )

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/main.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/main.kt
@@ -20,6 +20,7 @@ import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.backhandler.BackDispatcher
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.plusmobileapps.chefmate.buildconfig.BuildConfig
+import com.plusmobileapps.chefmate.root.DeepLink
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
@@ -31,7 +32,8 @@ private const val KEY_WINDOW_Y = "window.y"
 private const val KEY_WINDOW_PLACEMENT = "window.placement"
 
 @OptIn(ExperimentalTime::class, FlowPreview::class)
-fun main() {
+fun main(args: Array<String>) {
+    val deepLink = DeepLink.parse(args.firstOrNull())
     // Initialize Bugsnag + Kermit logging for JVM
     BugsnagInitializer().initialize(BuildConfig.BUGSNAG_API_KEY)
     // Only initialize the lifecycle outside the application block
@@ -68,6 +70,7 @@ fun main() {
                 componentContext =
                     DefaultComponentContext(lifecycle = lifecycle, backHandler = backDispatcher),
                 applicationComponent = appComponent,
+                deepLink = deepLink,
             )
 
         val windowState =

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -39,6 +39,7 @@ import kotlinx.serialization.Serializable
 @ContributesAssistedFactory(scope = AppScope::class, assistedFactory = RootBloc.Factory::class)
 class RootBlocImpl(
     @Assisted context: BlocContext,
+    @Assisted deepLink: DeepLink,
     private val bottomNav: BottomNavBloc.Factory,
     private val browserRootBlocFactory: BrowserRootBloc.Factory,
     private val groceryDetail: GroceryDetailBloc.Factory,
@@ -58,17 +59,45 @@ class RootBlocImpl(
         createScope().launch { featureFlags.refresh() }
     }
 
+    private val initialBottomNavTab: BottomNavBloc.Tab? =
+        when (deepLink) {
+            DeepLink.Groceries -> BottomNavBloc.Tab.GROCERIES
+            DeepLink.MealPlanner -> BottomNavBloc.Tab.MEALS
+            else -> null
+        }
+
     private val navigation = StackNavigation<Configuration>()
 
     private val stack =
         childStack(
             source = navigation,
             serializer = Configuration.serializer(),
-            initialStack = { listOf(Configuration.BottomNavigation) },
+            initialStack = { initialStackFor(deepLink) },
             handleBackButton = true,
             key = "RootRouter",
             childFactory = ::createChild,
         )
+
+    private fun initialStackFor(deepLink: DeepLink): List<Configuration> =
+        when (deepLink) {
+            DeepLink.None,
+            DeepLink.Groceries,
+            DeepLink.MealPlanner -> listOf(Configuration.BottomNavigation)
+            is DeepLink.RecipeDetail ->
+                listOf(Configuration.BottomNavigation, RecipeRoot(Detail(deepLink.recipeId)))
+            DeepLink.AppSettings ->
+                listOf(Configuration.BottomNavigation, Configuration.SettingsRoot)
+            DeepLink.SignIn ->
+                listOf(
+                    Configuration.BottomNavigation,
+                    Configuration.Authentication(AuthenticationBloc.Props.SignIn),
+                )
+            DeepLink.SignUp ->
+                listOf(
+                    Configuration.BottomNavigation,
+                    Configuration.Authentication(AuthenticationBloc.Props.SignUp),
+                )
+        }
 
     override val state: Value<ChildStack<*, RootBloc.Child>> = stack
 
@@ -87,7 +116,11 @@ class RootBlocImpl(
         when (config) {
             Configuration.BottomNavigation ->
                 BottomNavigation(
-                    bottomNav.create(context = context, output = ::handleBottomNavOutput)
+                    bottomNav.create(
+                        context = context,
+                        output = ::handleBottomNavOutput,
+                        initialTab = initialBottomNavTab,
+                    )
                 )
 
             is Configuration.GroceryDetail ->

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/DeepLinkTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/DeepLinkTest.kt
@@ -1,0 +1,52 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.root
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class DeepLinkTest {
+    @Test
+    fun parse_returns_none_for_null_or_blank() {
+        DeepLink.parse(null) shouldBe DeepLink.None
+        DeepLink.parse("") shouldBe DeepLink.None
+        DeepLink.parse("   ") shouldBe DeepLink.None
+    }
+
+    @Test
+    fun parse_returns_none_for_unknown_scheme() {
+        DeepLink.parse("https://example.com/recipe/1") shouldBe DeepLink.None
+    }
+
+    @Test
+    fun parse_returns_none_for_unknown_host() {
+        DeepLink.parse("chefmate://unknown") shouldBe DeepLink.None
+    }
+
+    @Test
+    fun parse_recipe_detail_with_id() {
+        DeepLink.parse("chefmate://recipe/42") shouldBe DeepLink.RecipeDetail(42L)
+    }
+
+    @Test
+    fun parse_recipe_detail_returns_none_when_id_is_missing_or_invalid() {
+        DeepLink.parse("chefmate://recipe") shouldBe DeepLink.None
+        DeepLink.parse("chefmate://recipe/") shouldBe DeepLink.None
+        DeepLink.parse("chefmate://recipe/abc") shouldBe DeepLink.None
+    }
+
+    @Test
+    fun parse_known_hosts() {
+        DeepLink.parse("chefmate://groceries") shouldBe DeepLink.Groceries
+        DeepLink.parse("chefmate://meal-planner") shouldBe DeepLink.MealPlanner
+        DeepLink.parse("chefmate://settings") shouldBe DeepLink.AppSettings
+        DeepLink.parse("chefmate://signin") shouldBe DeepLink.SignIn
+        DeepLink.parse("chefmate://signup") shouldBe DeepLink.SignUp
+    }
+
+    @Test
+    fun parse_tolerates_trailing_slash() {
+        DeepLink.parse("chefmate://groceries/") shouldBe DeepLink.Groceries
+        DeepLink.parse("chefmate://recipe/42/") shouldBe DeepLink.RecipeDetail(42L)
+    }
+}

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -37,15 +37,22 @@ class RootBlocTest {
         Consumer<com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc.Output> =
         Consumer {}
     var authOutput: Consumer<AuthenticationBloc.Output> = Consumer {}
+    var authProps: AuthenticationBloc.Props? = null
     var otpOutput: Consumer<OtpBloc.Output> = Consumer {}
     var otpProps: OtpBloc.Props? = null
     var aiChatOutput: Consumer<AiChatBloc.Output> = Consumer {}
+    var bottomNavInitialTab: BottomNavBloc.Tab? = null
 
-    val rootBloc =
+    fun createRoot(
+        deepLink: DeepLink = DeepLink.None,
+        context: BlocContext = TestBlocContext.create(),
+    ): RootBlocImpl =
         RootBlocImpl(
             context = context,
-            bottomNav = { context, output ->
+            deepLink = deepLink,
+            bottomNav = { _, output, initialTab ->
                 bottomNavOutput = output
+                bottomNavInitialTab = initialTab
                 mock()
             },
             browserRootBlocFactory =
@@ -58,7 +65,7 @@ class RootBlocTest {
                         presentation: BrowserRootBloc.Presentation,
                     ): BrowserRootBloc = mock(MockMode.autoUnit)
                 },
-            recipeRoot = { context, props, output ->
+            recipeRoot = { _, props, output ->
                 recipeOutput = output
                 recipeProps = props
                 mock()
@@ -69,7 +76,8 @@ class RootBlocTest {
                 mock()
             },
             mealPlannerRoot = MealPlannerRootBloc.Factory { _, _, _ -> mock() },
-            authentication = { _, _, output ->
+            authentication = { _, props, output ->
+                authProps = props
                 authOutput = output
                 mock()
             },
@@ -94,6 +102,8 @@ class RootBlocTest {
                 mock()
             },
         )
+
+    val rootBloc = createRoot(context = context)
 
     fun RootBloc.instance(): RootBloc.Child = state.value.active.instance
 
@@ -280,5 +290,52 @@ class RootBlocTest {
 
         rootBloc.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
         recipeProps shouldBe RecipeRootBloc.Props.CreateFromExtracted(extracted, fromAi = true)
+    }
+
+    @Test
+    fun Given_recipe_detail_deeplink_When_initialized_Then_recipe_root_is_on_top() {
+        val root = createRoot(DeepLink.RecipeDetail(recipeId = 42L))
+        root.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
+        root.state.value.backStack.size shouldBe 1
+        recipeProps shouldBe RecipeRootBloc.Props.Detail(recipeId = 42L)
+    }
+
+    @Test
+    fun Given_groceries_deeplink_When_initialized_Then_bottom_nav_uses_groceries_tab() {
+        val root = createRoot(DeepLink.Groceries)
+        root.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+        root.state.value.backStack.size shouldBe 0
+        bottomNavInitialTab shouldBe BottomNavBloc.Tab.GROCERIES
+    }
+
+    @Test
+    fun Given_meal_planner_deeplink_When_initialized_Then_bottom_nav_uses_meals_tab() {
+        val root = createRoot(DeepLink.MealPlanner)
+        root.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+        root.state.value.backStack.size shouldBe 0
+        bottomNavInitialTab shouldBe BottomNavBloc.Tab.MEALS
+    }
+
+    @Test
+    fun Given_app_settings_deeplink_When_initialized_Then_settings_root_is_on_top() {
+        val root = createRoot(DeepLink.AppSettings)
+        root.instance() should instanceOf<RootBloc.Child.SettingsRoot>()
+        root.state.value.backStack.size shouldBe 1
+    }
+
+    @Test
+    fun Given_sign_in_deeplink_When_initialized_Then_authentication_shown_with_sign_in_props() {
+        val root = createRoot(DeepLink.SignIn)
+        root.instance() should instanceOf<RootBloc.Child.Authentication>()
+        root.state.value.backStack.size shouldBe 1
+        authProps shouldBe AuthenticationBloc.Props.SignIn
+    }
+
+    @Test
+    fun Given_sign_up_deeplink_When_initialized_Then_authentication_shown_with_sign_up_props() {
+        val root = createRoot(DeepLink.SignUp)
+        root.instance() should instanceOf<RootBloc.Child.Authentication>()
+        root.state.value.backStack.size shouldBe 1
+        authProps shouldBe AuthenticationBloc.Props.SignUp
     }
 }

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/DeepLink.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/DeepLink.kt
@@ -1,0 +1,42 @@
+package com.plusmobileapps.chefmate.root
+
+sealed class DeepLink {
+    data object None : DeepLink()
+
+    data class RecipeDetail(val recipeId: Long) : DeepLink()
+
+    data object Groceries : DeepLink()
+
+    data object MealPlanner : DeepLink()
+
+    data object AppSettings : DeepLink()
+
+    data object SignIn : DeepLink()
+
+    data object SignUp : DeepLink()
+
+    companion object {
+        const val SCHEME: String = "chefmate"
+
+        fun parse(uri: String?): DeepLink {
+            if (uri.isNullOrBlank()) return None
+            val prefix = "$SCHEME://"
+            if (!uri.startsWith(prefix)) return None
+            val rest = uri.substring(prefix.length).trimEnd('/')
+            val segments = rest.split('/').filter { it.isNotEmpty() }
+            val host = segments.firstOrNull() ?: return None
+            return when (host) {
+                "recipe" -> {
+                    val id = segments.getOrNull(1)?.toLongOrNull() ?: return None
+                    RecipeDetail(id)
+                }
+                "groceries" -> Groceries
+                "meal-planner" -> MealPlanner
+                "settings" -> AppSettings
+                "signin" -> SignIn
+                "signup" -> SignUp
+                else -> None
+            }
+        }
+    }
+}

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -51,6 +51,6 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
     }
 
     fun interface Factory {
-        fun create(context: BlocContext): RootBloc
+        fun create(context: BlocContext, deepLink: DeepLink): RootBloc
     }
 }

--- a/docs/navigation-deeplinks.md
+++ b/docs/navigation-deeplinks.md
@@ -1,0 +1,81 @@
+# Navigation Deeplinks
+
+`chefmate://` deeplinks let you cold-start the app directly on a specific screen, which speeds up iteration on screens that are normally several taps deep.
+
+These are **cold-start only**: the deeplink is parsed once during app launch and used as the initial Decompose stack. To re-target a different screen, fully kill the app and re-launch it (see platform instructions below). Process-death restore keeps the user's saved stack — the deeplink does **not** override it.
+
+For the unrelated Supabase email-verification flow (`chefmate://auth/...`), see [DEEP_LINKING_SETUP.md](DEEP_LINKING_SETUP.md).
+
+## Supported URIs
+
+| URI | Lands on |
+|---|---|
+| `chefmate://recipe/{id}` | Recipe detail for the given recipe id (`Long`) |
+| `chefmate://groceries` | Bottom-nav `Groceries` tab |
+| `chefmate://meal-planner` | Bottom-nav `Meals` tab |
+| `chefmate://settings` | App settings root screen (the destination reached via Settings tab → "App Settings") |
+| `chefmate://signin` | Authentication screen in sign-in mode |
+| `chefmate://signup` | Authentication screen in sign-up mode |
+
+Unknown URIs, missing/invalid path segments (`chefmate://recipe`, `chefmate://recipe/abc`), and non-`chefmate://` URIs all fall back to `DeepLink.None` and the app launches normally on the recipes tab.
+
+## Android
+
+The `chefmate://` scheme is registered via an `ACTION_VIEW` intent-filter on `MainActivity` in `client/composeApp/src/androidMain/AndroidManifest.xml`. `MainActivity.onCreate` reads `intent.data` and passes the parsed `DeepLink` to `buildRootBloc`.
+
+```bash
+# Force-stop first so a fresh cold start picks up the new intent
+adb shell am force-stop com.plusmobileapps.chefmate
+
+# Launch with a deeplink
+adb shell am start -W -a android.intent.action.VIEW -d "chefmate://recipe/1"
+adb shell am start -W -a android.intent.action.VIEW -d "chefmate://groceries"
+adb shell am start -W -a android.intent.action.VIEW -d "chefmate://meal-planner"
+adb shell am start -W -a android.intent.action.VIEW -d "chefmate://settings"
+adb shell am start -W -a android.intent.action.VIEW -d "chefmate://signin"
+adb shell am start -W -a android.intent.action.VIEW -d "chefmate://signup"
+```
+
+Without `force-stop`, Android delivers the intent to the already-running activity via `onNewIntent`, which currently only handles share intents — the navigation deeplink is ignored.
+
+## Desktop (JVM)
+
+`main(args: Array<String>)` takes the first CLI argument and parses it as a deeplink.
+
+```bash
+./gradlew :client:composeApp:run --args="chefmate://recipe/1"
+./gradlew :client:composeApp:run --args="chefmate://groceries"
+./gradlew :client:composeApp:run --args="chefmate://meal-planner"
+./gradlew :client:composeApp:run --args="chefmate://settings"
+./gradlew :client:composeApp:run --args="chefmate://signin"
+./gradlew :client:composeApp:run --args="chefmate://signup"
+```
+
+## iOS
+
+The `chefmate` URL scheme is registered in `iosApp/iosApp/Info.plist` under `CFBundleURLTypes`. `AppDelegate.application(_:didFinishLaunchingWithOptions:)` captures `launchOptions[.url]` (excluding the existing `chefmate://import?url=...` share flow) and forwards the URL string to `RootBlocProvider.buildRootBloc(..., deepLinkUrl:)`.
+
+```bash
+# Boot the simulator first if it isn't running
+xcrun simctl boot "iPhone 15"   # adjust to your installed simulator
+
+# Cold-start with a deeplink (simctl terminate ensures the next launch is cold)
+xcrun simctl terminate booted com.plusmobileapps.chefmate
+xcrun simctl openurl booted "chefmate://recipe/1"
+xcrun simctl openurl booted "chefmate://groceries"
+xcrun simctl openurl booted "chefmate://meal-planner"
+xcrun simctl openurl booted "chefmate://settings"
+xcrun simctl openurl booted "chefmate://signin"
+xcrun simctl openurl booted "chefmate://signup"
+```
+
+The `chefmate://import?url=...` share flow still goes through the existing `onOpenURL` handler in `ContentView.swift` and is unaffected.
+
+## Adding a new deeplink
+
+1. Add a new `data object` or `data class` to `DeepLink` in `client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/DeepLink.kt` and a matching branch in `DeepLink.parse`.
+2. Extend `RootBlocImpl.initialStackFor` in `client/root/impl/...` to map the new variant to a `Configuration` (or list of configurations).
+3. If the target lives behind the bottom nav, also update the `initialBottomNavTab` mapping.
+4. Add coverage in `DeepLinkTest` (parser) and `RootBlocTest` (initial stack).
+
+Platform entry points already forward any parsed deeplink, so no changes are required on Android/JVM/iOS for additional URIs.

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -12,10 +12,23 @@ struct iOSApp: App {
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     var backDispatcher: BackDispatcher = BackDispatcherKt.BackDispatcher()
+    private var launchDeepLinkUrl: String?
 
     override init() {
         super.init()
         BugsnagStartup_iosKt.initializeBugsnag()
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        if let url = launchOptions?[.url] as? URL,
+           url.scheme == "chefmate",
+           url.host != "import" {
+            launchDeepLinkUrl = url.absoluteString
+        }
+        return true
     }
 
     lazy var root: RootBloc = RootBlocProvider.shared.buildRootBloc(
@@ -25,6 +38,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             instanceKeeper: nil,
             backHandler: backDispatcher
         ),
-        application: UIApplication.shared
+        application: UIApplication.shared,
+        deepLinkUrl: launchDeepLinkUrl
     )
 }


### PR DESCRIPTION
## Summary
- Adds a `DeepLink` sealed class + `chefmate://` URI parser in `client/root/public`, threaded through `RootBloc.Factory` so cold-start can land on a specific screen.
- Supports: `chefmate://recipe/{id}`, `chefmate://groceries`, `chefmate://meal-planner`, `chefmate://settings` (app settings root), `chefmate://signin`, `chefmate://signup`.
- Wires entry points on Android (`ACTION_VIEW` intent-filter in the manifest, parsed in `MainActivity`), JVM (`main(args)` reads `args[0]`), and iOS (`AppDelegate` captures `launchOptions[.url]` and forwards it through `RootBlocProvider`). The iOS URL scheme was already registered in `Info.plist`.
- Bottom-nav-tab deeplinks (groceries, meal-planner) work via a new `initialTab: Tab?` arg on `BottomNavBloc.Factory`.

## Why
Hitting a specific screen from a cold start (e.g. recipe detail #42) saves a lot of clicking through the bottom nav while iterating.

## How to try it
```bash
# Android (force-stop first so a new cold start happens)
adb shell am force-stop com.plusmobileapps.chefmate
adb shell am start -W -a android.intent.action.VIEW -d "chefmate://recipe/1"

# Desktop / JVM
./gradlew :client:composeApp:run --args="chefmate://meal-planner"

# iOS Simulator
xcrun simctl openurl booted "chefmate://settings"
```

## Notes
- Deeplinks are applied to the **initial** stack only — re-running with a different URI requires a cold start (force-stop on Android). This is intentional for the dev-convenience use case and keeps the surface small. Easy to extend to a runtime `handleDeepLink` later if needed.
- Decompose's stack serializer wins on process-death restore, so a saved stack will not be overwritten by the launch deeplink.

## Test plan
- [x] `:client:root:impl:jvmTest` — added `DeepLinkTest` for the parser + 6 cases in `RootBlocTest` for each supported `DeepLink` variant.
- [x] `:client:bottomnav:impl:jvmTest` — passes.
- [x] Compiles clean on `compileDebugKotlinAndroid` + `linkDebugFrameworkIosSimulatorArm64`.
- [ ] Manual smoke test on Android with `adb shell am start ... chefmate://recipe/1`.
- [ ] Manual smoke test on Desktop with `--args="chefmate://groceries"`.
- [ ] Manual smoke test on iOS Simulator with `xcrun simctl openurl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)