### PR TITLE
feat(build-logic): add plusLibrary { uiTest = true } flag for impl-robots modules

### DIFF
--- a/.claude/skills/add-compose-multiplatform-test.md
+++ b/.claude/skills/add-compose-multiplatform-test.md
@@ -289,17 +289,16 @@ plugins {
 }
 
 kotlin {
-    sourceSets {
-        commonMain.dependencies {
-            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
-            api(compose.uiTest)
-            implementation(projects.client.recipe.list.public)
-        }
-    }
+    sourceSets { commonMain.dependencies { implementation(projects.client.recipe.list.public) } }
 }
 
-plusLibrary { namespace = "com.plusmobileapps.chefmate.recipe.list.robots" }
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.recipe.list.robots"
+    uiTest = true
+}
 ```
+
+`uiTest = true` is what wires the `compose.uiTest` `api` dependency into `commonMain` — no manual `@OptIn(ExperimentalComposeLibrary::class)` needed.
 
 **Robot class** — takes `ComposeUiTest` in its constructor; an entry-point extension on `ComposeUiTest` is the only way tests construct it:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ The `plusLibrary` extension in each module's `build.gradle.kts` controls convent
 - `enableDi = true` — sets up Metro (kotlin-inject) dependency injection
 - `enableTesting = true` — adds test dependencies (mokkery, turbine, kotest, coroutines-test)
 - `enableDatabaseTesting = true` — adds `client/database/testing` (in-memory SQLDelight) to test dependencies and links sqlite3 for iOS. Use this when tests need a real database via `createTestDatabase()`. Requires `enableTesting = true`.
+- `uiTest = true` — adds `compose.uiTest` as an `api` dependency on `commonMain`. Used by `impl-robots` modules that expose reusable Compose UI test robots. Requires the `compose` plugin to also be applied.
 
 ### BLoC Pattern (Decompose)
 
@@ -135,7 +136,7 @@ See `client/cook/public/.../CookModePreviews.kt` and `client/ui/screenshot-test/
 **Rule: every new feature must ship with a multiplatform Compose UI test using the `impl-robots` pattern.** Robots wrap `ComposeUiTest` with domain-level vocabulary so test cases read as user flows, not semantics-tree lookups. They run on all client targets (Android, iOS, Desktop, Web) because they live in `commonMain`.
 
 **Pattern:**
-1. For a new feature `client/<feature>/<sub>/impl`, create a sibling module `client/<feature>/<sub>/impl-robots` with a `build.gradle.kts` that applies `kmpLibrary` + `compose`, exposes `api(compose.uiTest)`, and `implementation(projects.client.<feature>.<sub>.public)`. See `client/recipe/list/impl-robots/build.gradle.kts` for the minimal shape.
+1. For a new feature `client/<feature>/<sub>/impl`, create a sibling module `client/<feature>/<sub>/impl-robots` with a `build.gradle.kts` that applies `kmpLibrary` + `compose`, sets `plusLibrary { uiTest = true }` (which wires the `compose.uiTest` `api` dependency), and adds `implementation(projects.client.<feature>.<sub>.public)`. See `client/recipe/list/impl-robots/build.gradle.kts` for the minimal shape.
 2. Add `<Feature>Robot.kt` under `src/commonMain/kotlin/.../<feature>/robots/`. Take `ComposeUiTest` in the constructor. Scope every node lookup to a descendant of the screen's root test tag (`hasAnyAncestor(hasTestTag(<Feature>TestTags.SCREEN))`) so titles rendered on other screens don't satisfy matchers. Provide a factory extension (e.g. `fun ComposeUiTest.recipeList() = …`). Return `<Feature>Robot` from every action method for chaining.
 3. Add a test in `client/composeApp/src/commonTest/...` (or the feature's own test module) that runs through `runRootBlocTest { … }` and composes one or more robots into a user flow. Reference example: `client/composeApp/src/commonTest/.../RootNavigationUiTest.kt`.
 4. For async UI states, expose an `awaitDisplayed()` on the robot using `waitUntilExactlyOneExists` — see `client/recipe/core/impl-robots/.../RecipeDetailRobot.kt`.

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KmpLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KmpLibraryConventionPlugin.kt
@@ -7,6 +7,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
+import org.jetbrains.compose.ComposePlugin
+import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
@@ -24,6 +26,10 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
 
                 if (plusLibraryExtension.enableTesting) {
                     applyTesting(enableDatabaseTesting = plusLibraryExtension.enableDatabaseTesting)
+                }
+
+                if (plusLibraryExtension.uiTest) {
+                    applyUiTest()
                 }
             }
 
@@ -130,5 +136,13 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalComposeLibrary::class)
+private fun Project.applyUiTest() {
+    extensions.configure<KotlinMultiplatformExtension> {
+        val compose = ComposePlugin.Dependencies(project)
+        sourceSets.getByName("commonMain").dependencies { api(compose.uiTest) }
     }
 }

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/PlusLibraryExtension.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/PlusLibraryExtension.kt
@@ -16,4 +16,11 @@ open class PlusLibraryExtension {
      * commonTest and links sqlite3 for iOS test binaries. Requires [enableTesting] to also be true.
      */
     var enableDatabaseTesting: Boolean = false
+
+    /**
+     * Flag to enable the Compose UI test dependency. When true, adds `compose.uiTest` as an `api`
+     * dependency on `commonMain`. Intended for `impl-robots` modules that expose reusable Compose
+     * UI test robots. Requires the `compose` plugin to also be applied on the module.
+     */
+    var uiTest: Boolean = false
 }

--- a/client/aichat/impl-robots/build.gradle.kts
+++ b/client/aichat/impl-robots/build.gradle.kts
@@ -3,13 +3,9 @@ plugins {
     alias(libs.plugins.compose)
 }
 
-kotlin {
-    sourceSets {
-        commonMain.dependencies {
-            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)
-            implementation(projects.client.aichat.public)
-        }
-    }
-}
+kotlin { sourceSets { commonMain.dependencies { implementation(projects.client.aichat.public) } } }
 
-plusLibrary { namespace = "com.plusmobileapps.chefmate.aichat.robots" }
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.aichat.robots"
+    uiTest = true
+}

--- a/client/bottomnav/impl-robots/build.gradle.kts
+++ b/client/bottomnav/impl-robots/build.gradle.kts
@@ -4,12 +4,10 @@ plugins {
 }
 
 kotlin {
-    sourceSets {
-        commonMain.dependencies {
-            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)
-            implementation(projects.client.bottomnav.public)
-        }
-    }
+    sourceSets { commonMain.dependencies { implementation(projects.client.bottomnav.public) } }
 }
 
-plusLibrary { namespace = "com.plusmobileapps.chefmate.recipe.bottomnav.robots" }
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.recipe.bottomnav.robots"
+    uiTest = true
+}

--- a/client/recipe/categories/impl-robots/build.gradle.kts
+++ b/client/recipe/categories/impl-robots/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 
 kotlin {
     sourceSets {
-        commonMain.dependencies {
-            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)
-            implementation(projects.client.recipe.categories.public)
-        }
+        commonMain.dependencies { implementation(projects.client.recipe.categories.public) }
     }
 }
 
-plusLibrary { namespace = "com.plusmobileapps.chefmate.recipe.categories.robots" }
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.recipe.categories.robots"
+    uiTest = true
+}

--- a/client/recipe/core/impl-robots/build.gradle.kts
+++ b/client/recipe/core/impl-robots/build.gradle.kts
@@ -4,12 +4,10 @@ plugins {
 }
 
 kotlin {
-    sourceSets {
-        commonMain.dependencies {
-            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)
-            implementation(projects.client.recipe.core.public)
-        }
-    }
+    sourceSets { commonMain.dependencies { implementation(projects.client.recipe.core.public) } }
 }
 
-plusLibrary { namespace = "com.plusmobileapps.chefmate.recipe.core.robots" }
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.recipe.core.robots"
+    uiTest = true
+}

--- a/client/recipe/importer/impl-robots/build.gradle.kts
+++ b/client/recipe/importer/impl-robots/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 
 kotlin {
     sourceSets {
-        commonMain.dependencies {
-            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)
-            implementation(projects.client.recipe.importer.public)
-        }
+        commonMain.dependencies { implementation(projects.client.recipe.importer.public) }
     }
 }
 
-plusLibrary { namespace = "com.plusmobileapps.chefmate.recipe.importer.robots" }
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.recipe.importer.robots"
+    uiTest = true
+}

--- a/client/recipe/list/impl-robots/build.gradle.kts
+++ b/client/recipe/list/impl-robots/build.gradle.kts
@@ -4,12 +4,10 @@ plugins {
 }
 
 kotlin {
-    sourceSets {
-        commonMain.dependencies {
-            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)
-            implementation(projects.client.recipe.list.public)
-        }
-    }
+    sourceSets { commonMain.dependencies { implementation(projects.client.recipe.list.public) } }
 }
 
-plusLibrary { namespace = "com.plusmobileapps.chefmate.recipe.list.robots" }
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.recipe.list.robots"
+    uiTest = true
+}

--- a/client/settings/impl-robots/build.gradle.kts
+++ b/client/settings/impl-robots/build.gradle.kts
@@ -4,12 +4,10 @@ plugins {
 }
 
 kotlin {
-    sourceSets {
-        commonMain.dependencies {
-            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)
-            implementation(projects.client.settings.public)
-        }
-    }
+    sourceSets { commonMain.dependencies { implementation(projects.client.settings.public) } }
 }
 
-plusLibrary { namespace = "com.plusmobileapps.chefmate.settings.robots" }
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.settings.robots"
+    uiTest = true
+}

--- a/client/settings/root/impl-robots/build.gradle.kts
+++ b/client/settings/root/impl-robots/build.gradle.kts
@@ -4,12 +4,10 @@ plugins {
 }
 
 kotlin {
-    sourceSets {
-        commonMain.dependencies {
-            @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)
-            implementation(projects.client.settings.root.public)
-        }
-    }
+    sourceSets { commonMain.dependencies { implementation(projects.client.settings.root.public) } }
 }
 
-plusLibrary { namespace = "com.plusmobileapps.chefmate.settings.root.robots" }
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.settings.root.robots"
+    uiTest = true
+}


### PR DESCRIPTION
## Summary
- Adds a new `uiTest: Boolean` property to the `plusLibrary` extension. When set to `true`, the `KmpLibraryConventionPlugin` adds `compose.uiTest` as an `api` dependency on `commonMain` (with the required `ExperimentalComposeLibrary` opt-in handled centrally).
- Replaces the manual `@OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class) api(compose.uiTest)` line in all 8 `impl-robots` modules with the new flag.
- Updates `CLAUDE.md` and the `add-compose-multiplatform-test` skill so the documented robot module template uses the new flag.

Closes #223

## Test plan
- [x] `./gradlew :client:recipe:list:impl-robots:compileKotlinJvm --rerun-tasks` — succeeds with the new flag in place
- [x] `./gradlew :client:recipe:categories:impl-robots:compileKotlinJvm` — succeeds (covers the newest `impl-robots` module)
- [x] `./gradlew :build-logic:compileKotlin --rerun-tasks` — convention plugin compiles
- [x] `ktfmtCheck` passes on every touched `impl-robots/build.gradle.kts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)