### PR TITLE
feat(recipe): multi-select on list + overflow-menu export

### DIFF
--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -114,6 +114,17 @@ class BottomNavBlocImpl(
         viewModel.selectTab(BottomNavBloc.Tab.BROWSER)
     }
 
+    override fun onExportFinished() {
+        // The recipe-list child stays cached in the bottom-nav stack while the user is on the
+        // exporter, so its bloc is still alive and ready to hear "you can drop selection mode now".
+        stack.value.items
+            .map { it.instance }
+            .filterIsInstance<RecipeList>()
+            .firstOrNull()
+            ?.bloc
+            ?.onExportFinished()
+    }
+
     override fun onTabSelected(tab: BottomNavBloc.Tab) {
         val configuration =
             when (tab) {

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -176,6 +176,9 @@ class BottomNavBlocImpl(
             is RecipeListBloc.Output.OpenCookMode -> {
                 this.output.onNext(BottomNavBloc.Output.OpenCookMode(output.recipeId))
             }
+            is RecipeListBloc.Output.OpenExportRecipes -> {
+                this.output.onNext(BottomNavBloc.Output.OpenExportRecipes(output.recipeIds))
+            }
         }
     }
 

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -71,6 +71,12 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
         data class OpenMealPlanner(val props: MealPlannerRootBloc.Props) : Output()
 
         data class OpenCookMode(val recipeId: Long) : Output()
+
+        /**
+         * Forwarded from the recipe list's overflow menu. [recipeIds] is null when the user picked
+         * "Export all recipes" and a non-empty set when they exported a multi-select.
+         */
+        data class OpenExportRecipes(val recipeIds: Set<Long>?) : Output()
     }
 
     fun interface Factory {

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -25,6 +25,12 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
 
     fun handleSharedUrl(url: String)
 
+    /**
+     * Called by the root navigator after a launched-from-list export completes successfully.
+     * Forwards to the recipe-list child so it can drop multi-select mode.
+     */
+    fun onExportFinished()
+
     data class Model(val selectedTab: Tab = Tab.RECIPES, val tabs: List<Tab> = Tab.entries)
 
     enum class Tab {

--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserRootBlocImpl.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserRootBlocImpl.kt
@@ -94,11 +94,7 @@ class BrowserRootBlocImpl(
             is BrowserRootBloc.Presentation.Modal ->
                 PlusHeaderContainer(
                     modifier = modifier,
-                    data =
-                        PlusHeaderData.Modal(
-                            title = FixedString(""),
-                            onCloseClick = p.onClose,
-                        ),
+                    data = PlusHeaderData.Modal(title = FixedString(""), onCloseClick = p.onClose),
                     scrollEnabled = false,
                     maxContentWidth = Dp.Unspecified,
                     content = { BrowserRootScreen(bloc = this@BrowserRootBlocImpl) },

--- a/client/recipe/categories/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/categories/impl/ui/RecipeCategoriesScreen.kt
+++ b/client/recipe/categories/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/categories/impl/ui/RecipeCategoriesScreen.kt
@@ -359,9 +359,7 @@ private fun CategoryList(
             )
         }
         if (userItems.isEmpty()) {
-            item(key = "user-empty") {
-                EmptyUserSectionHint()
-            }
+            item(key = "user-empty") { EmptyUserSectionHint() }
         } else {
             items(userItems, key = { it.rowKey() }) { item ->
                 CategoryRow(

--- a/client/recipe/exporter/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/impl/ExportRecipesBlocImpl.kt
+++ b/client/recipe/exporter/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/impl/ExportRecipesBlocImpl.kt
@@ -13,11 +13,11 @@ import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc.Model
 import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc.Output
 import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc.PendingSave
 import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc.Phase
+import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc.Props
 import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesScreen
 import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
-import dev.zacsweers.metro.Provider
 import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
@@ -27,11 +27,12 @@ import kotlinx.coroutines.flow.StateFlow
 )
 class ExportRecipesBlocImpl(
     @Assisted context: BlocContext,
+    @Assisted private val props: Props,
     @Assisted private val output: Consumer<Output>,
-    viewModelFactory: Provider<ExportRecipesViewModel>,
+    viewModelFactory: ExportRecipesViewModel.Factory,
 ) : ExportRecipesBloc, BlocContext by context {
 
-    private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
+    private val viewModel = instanceKeeper.getViewModel { viewModelFactory.create(props) }
 
     override val state: StateFlow<Model> = viewModel.state.mapState { it.toBlocModel() }
 

--- a/client/recipe/exporter/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/impl/ExportRecipesBlocImpl.kt
+++ b/client/recipe/exporter/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/impl/ExportRecipesBlocImpl.kt
@@ -47,7 +47,8 @@ class ExportRecipesBlocImpl(
     override fun onStartOver() = viewModel.onStartOver()
 
     override fun onBack() {
-        output.onNext(Output.Back)
+        val isFromDone = viewModel.state.value.stage is ExportRecipesViewModel.Stage.Done
+        output.onNext(if (isFromDone) Output.Finished else Output.Back)
     }
 
     @Composable

--- a/client/recipe/exporter/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/impl/ExportRecipesViewModel.kt
+++ b/client/recipe/exporter/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/impl/ExportRecipesViewModel.kt
@@ -10,11 +10,14 @@ import com.plusmobileapps.chefmate.di.IO
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
-import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,8 +27,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-@Inject
+@AssistedInject
 class ExportRecipesViewModel(
+    @Assisted private val props: ExportRecipesBloc.Props,
     @Main mainContext: CoroutineContext,
     @IO private val ioContext: CoroutineContext,
     private val repository: RecipeRepository,
@@ -61,12 +65,17 @@ class ExportRecipesViewModel(
                         )
                     return@launch
                 }
-            if (recipes.isEmpty()) {
+            val scoped =
+                when (val p = props) {
+                    is ExportRecipesBloc.Props.All -> recipes
+                    is ExportRecipesBloc.Props.Selected -> recipes.filter { it.id in p.recipeIds }
+                }
+            if (scoped.isEmpty()) {
                 _state.value = State(stage = Stage.Empty)
                 return@launch
             }
-            loadedRecipes = recipes.associateBy { it.id.toString() }
-            val items = recipes.map { it.toItem(selected = true) }
+            loadedRecipes = scoped.associateBy { it.id.toString() }
+            val items = scoped.map { it.toItem(selected = true) }
             _state.value = State(stage = Stage.Review(items))
         }
     }
@@ -194,6 +203,11 @@ class ExportRecipesViewModel(
      * the public BLoC contract; the BLoC adapts this into its own `PendingSave` when mapping state.
      */
     class PendingArchive(val token: Long, val fileName: String, val archive: ByteArray)
+
+    @AssistedFactory
+    fun interface Factory {
+        fun create(props: ExportRecipesBloc.Props): ExportRecipesViewModel
+    }
 
     private companion object {
         const val TAG = "ExportRecipesViewModel"

--- a/client/recipe/exporter/impl/src/jvmTest/kotlin/com/plusmobileapps/chefmate/recipe/exporter/impl/ExportRecipesBlocImplTest.kt
+++ b/client/recipe/exporter/impl/src/jvmTest/kotlin/com/plusmobileapps/chefmate/recipe/exporter/impl/ExportRecipesBlocImplTest.kt
@@ -1,0 +1,83 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+
+package com.plusmobileapps.chefmate.recipe.exporter.impl
+
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
+import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
+import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.plusmobileapps.chefmate.testing.TestConsumer
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+class ExportRecipesBlocImplTest {
+
+    private val context = TestBlocContext.create()
+    private val output = TestConsumer<ExportRecipesBloc.Output>()
+    private val seeded =
+        MutableStateFlow(listOf(recipe(1L, "Garlic Noodles"), recipe(2L, "Lentil Curry")))
+    private val repository = FakeRecipeRepository(seeded)
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    private fun createBloc(
+        props: ExportRecipesBloc.Props = ExportRecipesBloc.Props.All
+    ): ExportRecipesBlocImpl =
+        ExportRecipesBlocImpl(
+            context = context,
+            props = props,
+            output = output,
+            viewModelFactory = { p ->
+                ExportRecipesViewModel(
+                    props = p,
+                    mainContext = dispatcher,
+                    ioContext = dispatcher,
+                    repository = repository,
+                )
+            },
+        )
+
+    @Test
+    fun When_back_from_review_stage_Then_emits_Back() {
+        val bloc = createBloc()
+        bloc.onBack()
+        output.lastValue shouldBe ExportRecipesBloc.Output.Back
+    }
+
+    @Test
+    fun When_back_from_done_stage_Then_emits_Finished() {
+        val bloc = createBloc()
+        bloc.onExportClicked()
+        bloc.onSaveCompleted(saved = true)
+
+        bloc.onBack()
+
+        output.lastValue shouldBe ExportRecipesBloc.Output.Finished
+    }
+
+    @Test
+    fun When_back_from_error_stage_Then_emits_Back() {
+        val bloc = createBloc()
+        bloc.onExportClicked()
+        bloc.onSaveCompleted(saved = false) // cancel → Error stage
+
+        bloc.onBack()
+
+        output.lastValue shouldBe ExportRecipesBloc.Output.Back
+    }
+
+    private fun recipe(id: Long, title: String): Recipe =
+        Recipe.Empty.copy(
+            id = id,
+            title = title,
+            ingredients = "salt\npepper",
+            directions = "Mix.\nServe.",
+            createdAt = Instant.DISTANT_PAST,
+            updatedAt = Instant.DISTANT_PAST,
+        )
+}

--- a/client/recipe/exporter/impl/src/jvmTest/kotlin/com/plusmobileapps/chefmate/recipe/exporter/impl/ExportRecipesViewModelTest.kt
+++ b/client/recipe/exporter/impl/src/jvmTest/kotlin/com/plusmobileapps/chefmate/recipe/exporter/impl/ExportRecipesViewModelTest.kt
@@ -5,6 +5,7 @@ package com.plusmobileapps.chefmate.recipe.exporter.impl
 
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
+import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
 import com.plusmobileapps.chefmate.recipe.exporter.impl.ExportRecipesViewModel.Stage
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -28,8 +29,9 @@ class ExportRecipesViewModelTest {
     private val repository = FakeRecipeRepository(seededRecipes)
     private val dispatcher = UnconfinedTestDispatcher()
 
-    private fun createViewModel() =
+    private fun createViewModel(props: ExportRecipesBloc.Props = ExportRecipesBloc.Props.All) =
         ExportRecipesViewModel(
+            props = props,
             mainContext = dispatcher,
             ioContext = dispatcher,
             repository = repository,
@@ -42,6 +44,21 @@ class ExportRecipesViewModelTest {
         val review = vm.state.value.stage.shouldBeInstanceOf<Stage.Review>()
         review.items.map { it.title } shouldBe listOf("Garlic Noodles", "Lentil Curry")
         review.items.all { it.selected } shouldBe true
+    }
+
+    @Test
+    fun When_props_selected_Then_only_matching_recipes_shown() {
+        val vm = createViewModel(props = ExportRecipesBloc.Props.Selected(recipeIds = setOf(2L)))
+
+        val review = vm.state.value.stage.shouldBeInstanceOf<Stage.Review>()
+        review.items.map { it.title } shouldBe listOf("Lentil Curry")
+        review.items.all { it.selected } shouldBe true
+    }
+
+    @Test
+    fun When_props_selected_excludes_everything_Then_empty_stage_shown() {
+        val vm = createViewModel(props = ExportRecipesBloc.Props.Selected(recipeIds = setOf(9999L)))
+        vm.state.value.stage shouldBe Stage.Empty
     }
 
     @Test

--- a/client/recipe/exporter/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/ExportRecipesBloc.kt
+++ b/client/recipe/exporter/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/ExportRecipesBloc.kt
@@ -6,6 +6,7 @@ import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.ui.BlocScreen
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.Serializable
 
 interface ExportRecipesBloc : BackHandlerOwner, BlocScreen {
     val state: StateFlow<Model>
@@ -76,7 +77,20 @@ interface ExportRecipesBloc : BackHandlerOwner, BlocScreen {
         data object Back : Output()
     }
 
+    /**
+     * Controls which recipes the bloc loads:
+     * - [All] loads every recipe in the local cache pre-selected (the Settings → Backup flow).
+     * - [Selected] restricts the review list to the given ids — used when the user multi-selects on
+     *   the recipe list and launches export from the overflow menu.
+     */
+    @Serializable
+    sealed class Props {
+        @Serializable data object All : Props()
+
+        @Serializable data class Selected(val recipeIds: Set<Long>) : Props()
+    }
+
     fun interface Factory {
-        fun create(context: BlocContext, output: Consumer<Output>): ExportRecipesBloc
+        fun create(context: BlocContext, props: Props, output: Consumer<Output>): ExportRecipesBloc
     }
 }

--- a/client/recipe/exporter/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/ExportRecipesBloc.kt
+++ b/client/recipe/exporter/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/ExportRecipesBloc.kt
@@ -74,7 +74,15 @@ interface ExportRecipesBloc : BackHandlerOwner, BlocScreen {
     }
 
     sealed class Output {
+        /** User backed out of the exporter from any stage other than [Phase.Done]. */
         data object Back : Output()
+
+        /**
+         * User left the exporter from the [Phase.Done] screen — the archive was actually written.
+         * Distinct from [Back] so the parent navigator can react (e.g. clear the recipe-list
+         * selection that launched the export).
+         */
+        data object Finished : Output()
     }
 
     /**

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
@@ -152,7 +152,13 @@ class RecipeListBlocImpl(
         val state = viewModel.state.value
         val ids = if (state.isSelectionMode) state.selectedRecipeIds else null
         output.onNext(Output.OpenExportRecipes(ids))
-        if (state.isSelectionMode) viewModel.exitSelectionMode()
+        // Selection mode persists across the trip to the exporter so the user can come back to the
+        // same picks if they bail out. It only clears via [onExportFinished] when the exporter
+        // signals a successful save.
+    }
+
+    override fun onExportFinished() {
+        viewModel.exitSelectionMode()
     }
 
     @Composable

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
@@ -52,11 +52,17 @@ class RecipeListBlocImpl(
                 isSearchActive = it.isSearchActive,
                 cookingRecipeCount = it.cookingRecipeIds.size,
                 showDoneCookingDialog = it.showDoneCookingDialog,
+                isSelectionMode = it.isSelectionMode,
+                selectedRecipeIds = it.selectedRecipeIds,
             )
         }
 
     override fun onRecipeClicked(recipe: RecipeListItem) {
-        output.onNext(Output.OpenRecipe(recipe.id))
+        if (viewModel.state.value.isSelectionMode) {
+            viewModel.toggleRecipeSelected(recipe.id)
+        } else {
+            output.onNext(Output.OpenRecipe(recipe.id))
+        }
     }
 
     override fun onAddRecipeClicked() {
@@ -124,6 +130,29 @@ class RecipeListBlocImpl(
 
     override fun onDoneCookingDismissed() {
         viewModel.dismissDoneCookingDialog()
+    }
+
+    override fun onEnterSelectionMode() {
+        viewModel.enterSelectionMode()
+    }
+
+    override fun onExitSelectionMode() {
+        viewModel.exitSelectionMode()
+    }
+
+    override fun onToggleRecipeSelected(recipe: RecipeListItem) {
+        viewModel.toggleRecipeSelected(recipe.id)
+    }
+
+    override fun onToggleSelectAllVisible() {
+        viewModel.toggleSelectAllVisible()
+    }
+
+    override fun onExportClicked() {
+        val state = viewModel.state.value
+        val ids = if (state.isSelectionMode) state.selectedRecipeIds else null
+        output.onNext(Output.OpenExportRecipes(ids))
+        if (state.isSelectionMode) viewModel.exitSelectionMode()
     }
 
     @Composable

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
@@ -198,6 +198,38 @@ class RecipeListViewModel(
         }
     }
 
+    fun enterSelectionMode() {
+        _state.update { it.copy(isSelectionMode = true, selectedRecipeIds = emptySet()) }
+    }
+
+    fun exitSelectionMode() {
+        _state.update { it.copy(isSelectionMode = false, selectedRecipeIds = emptySet()) }
+    }
+
+    fun toggleRecipeSelected(recipeId: Long) {
+        _state.update {
+            val next =
+                if (recipeId in it.selectedRecipeIds) it.selectedRecipeIds - recipeId
+                else it.selectedRecipeIds + recipeId
+            it.copy(selectedRecipeIds = next)
+        }
+    }
+
+    /**
+     * Selects every recipe currently visible; if all are already selected, clears the selection.
+     */
+    fun toggleSelectAllVisible() {
+        _state.update { state ->
+            val visibleIds = state.displayRecipes.map { it.id }.toSet()
+            val allVisibleSelected =
+                visibleIds.isNotEmpty() && state.selectedRecipeIds.containsAll(visibleIds)
+            val next =
+                if (allVisibleSelected) state.selectedRecipeIds - visibleIds
+                else state.selectedRecipeIds + visibleIds
+            state.copy(selectedRecipeIds = next)
+        }
+    }
+
     data class State(
         val isLoading: Boolean = true,
         val isSyncing: Boolean = false,
@@ -211,6 +243,8 @@ class RecipeListViewModel(
         val searchQuery: String = "",
         val cookingRecipeIds: List<Long> = emptyList(),
         val showDoneCookingDialog: Boolean = false,
+        val isSelectionMode: Boolean = false,
+        val selectedRecipeIds: Set<Long> = emptySet(),
     ) {
         val isSearchActive: Boolean
             get() = searchQuery.isNotBlank()

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
@@ -97,6 +97,16 @@ private fun recipeListBloc(model: RecipeListBloc.Model): RecipeListBloc =
 
         override fun onDoneCookingDismissed() = Unit
 
+        override fun onEnterSelectionMode() = Unit
+
+        override fun onExitSelectionMode() = Unit
+
+        override fun onToggleRecipeSelected(recipe: RecipeListItem) = Unit
+
+        override fun onToggleSelectAllVisible() = Unit
+
+        override fun onExportClicked() = Unit
+
         @Composable override fun Content(modifier: Modifier) = RecipeListScreen(this, modifier)
     }
 
@@ -129,6 +139,28 @@ val previewRecipeListBlocCategoryFiltered: RecipeListBloc =
         )
     )
 
+/** Recipe list in multi-select mode with two recipes picked — exercises the selection top bar. */
+val previewRecipeListBlocSelectionMode: RecipeListBloc =
+    recipeListBloc(
+        RecipeListBloc.Model(
+            recipes = sampleRecipes,
+            totalRecipeCount = sampleRecipes.size,
+            isSelectionMode = true,
+            selectedRecipeIds = setOf(1L, 3L),
+        )
+    )
+
+/** Multi-select mode with no recipes picked — locks in the disabled export icon state. */
+val previewRecipeListBlocSelectionModeEmpty: RecipeListBloc =
+    recipeListBloc(
+        RecipeListBloc.Model(
+            recipes = sampleRecipes,
+            totalRecipeCount = sampleRecipes.size,
+            isSelectionMode = true,
+            selectedRecipeIds = emptySet(),
+        )
+    )
+
 @Preview(showBackground = true, heightDp = 1100)
 @Composable
 internal fun RecipeListPreview() {
@@ -145,4 +177,10 @@ internal fun RecipeListCookingPreview() {
 @Composable
 internal fun RecipeListCookingTabletPreview() {
     ChefMateTheme { RecipeListScreen(bloc = previewRecipeListBlocCooking) }
+}
+
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+internal fun RecipeListSelectionPreview() {
+    ChefMateTheme { RecipeListScreen(bloc = previewRecipeListBlocSelectionMode) }
 }

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
@@ -107,6 +107,8 @@ private fun recipeListBloc(model: RecipeListBloc.Model): RecipeListBloc =
 
         override fun onExportClicked() = Unit
 
+        override fun onExportFinished() = Unit
+
         @Composable override fun Content(modifier: Modifier) = RecipeListScreen(this, modifier)
     }
 

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListScreen.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListScreen.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.recipe.list.impl.ui
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -31,14 +32,18 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SoupKitchen
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.Circle
 import androidx.compose.material.icons.outlined.CloudDone
 import androidx.compose.material.icons.outlined.CloudOff
 import androidx.compose.material.icons.outlined.LocalFireDepartment
@@ -52,6 +57,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilterChip
@@ -62,6 +69,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -117,10 +125,18 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_list_filter
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_filter_rated
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_item_calories
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_item_servings
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_menu_export_all
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_menu_select
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_more_actions
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_clear
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_empty
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_placeholder
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_count
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_deselect_all
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_exit
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_export
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_select_all
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_sort_a_to_z
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_sort_and_filter
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_sort_by
@@ -173,69 +189,122 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
             }
     }
 
-    Box(modifier = modifier.fillMaxSize().testTag(RecipeListTestTags.SCREEN)) {
-        PlusNavContainer(
-            modifier = modifier.fillMaxSize(),
-            data =
-                PlusHeaderData.Parent(
-                    title = Res.string.recipe_list_title.asTextData(),
-                    trailingAccessory =
-                        PlusHeaderData.TrailingAccessory.Custom {
-                            IconButton(
-                                onClick = {
-                                    showSearchBar = !showSearchBar
-                                    if (!showSearchBar) bloc.onSearchQueryChanged("")
-                                }
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Search,
-                                    contentDescription =
-                                        stringResource(Res.string.recipe_list_search),
-                                )
+    val headerData =
+        if (state.isSelectionMode) {
+            PlusHeaderData.Parent(
+                title =
+                    PhraseModel(
+                        Res.string.recipe_list_selection_count,
+                        "count" to FixedString(state.selectedRecipeIds.size.toString()),
+                    ),
+                trailingAccessory =
+                    PlusHeaderData.TrailingAccessory.Custom {
+                        val allSelected =
+                            state.recipes.isNotEmpty() &&
+                                state.recipes.all { it.id in state.selectedRecipeIds }
+                        IconButton(onClick = bloc::onToggleSelectAllVisible) {
+                            Icon(
+                                imageVector =
+                                    if (allSelected) Icons.Default.CheckCircle
+                                    else Icons.Outlined.Circle,
+                                contentDescription =
+                                    stringResource(
+                                        if (allSelected) {
+                                            Res.string.recipe_list_selection_deselect_all
+                                        } else {
+                                            Res.string.recipe_list_selection_select_all
+                                        }
+                                    ),
+                            )
+                        }
+                        IconButton(
+                            onClick = bloc::onExportClicked,
+                            enabled = state.selectedRecipeIds.isNotEmpty(),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.FileDownload,
+                                contentDescription =
+                                    stringResource(Res.string.recipe_list_selection_export),
+                            )
+                        }
+                        IconButton(onClick = bloc::onExitSelectionMode) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription =
+                                    stringResource(Res.string.recipe_list_selection_exit),
+                            )
+                        }
+                    },
+            )
+        } else {
+            PlusHeaderData.Parent(
+                title = Res.string.recipe_list_title.asTextData(),
+                trailingAccessory =
+                    PlusHeaderData.TrailingAccessory.Custom {
+                        IconButton(
+                            onClick = {
+                                showSearchBar = !showSearchBar
+                                if (!showSearchBar) bloc.onSearchQueryChanged("")
                             }
-                            IconButton(onClick = bloc::onToggleViewMode) {
-                                Icon(
-                                    imageVector =
-                                        if (state.isGridView) Icons.AutoMirrored.Filled.ViewList
-                                        else Icons.Default.GridView,
-                                    contentDescription =
-                                        stringResource(
-                                            if (state.isGridView) {
-                                                Res.string.recipe_list_view_list
-                                            } else {
-                                                Res.string.recipe_list_view_grid
-                                            }
-                                        ),
-                                )
-                            }
-                            IconButton(onClick = { showSortFilterSheet = true }) {
-                                val filterCount = state.totalActiveFilterCount
-                                if (filterCount > 0) {
-                                    BadgedBox(badge = { Badge { Text("$filterCount") } }) {
-                                        Icon(
-                                            imageVector = Icons.Default.FilterList,
-                                            contentDescription =
-                                                stringResource(Res.string.recipe_list_filter),
-                                            tint = MaterialTheme.colorScheme.primary,
-                                        )
-                                    }
-                                } else {
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Search,
+                                contentDescription = stringResource(Res.string.recipe_list_search),
+                            )
+                        }
+                        IconButton(onClick = bloc::onToggleViewMode) {
+                            Icon(
+                                imageVector =
+                                    if (state.isGridView) Icons.AutoMirrored.Filled.ViewList
+                                    else Icons.Default.GridView,
+                                contentDescription =
+                                    stringResource(
+                                        if (state.isGridView) {
+                                            Res.string.recipe_list_view_list
+                                        } else {
+                                            Res.string.recipe_list_view_grid
+                                        }
+                                    ),
+                            )
+                        }
+                        IconButton(onClick = { showSortFilterSheet = true }) {
+                            val filterCount = state.totalActiveFilterCount
+                            if (filterCount > 0) {
+                                BadgedBox(badge = { Badge { Text("$filterCount") } }) {
                                     Icon(
                                         imageVector = Icons.Default.FilterList,
                                         contentDescription =
                                             stringResource(Res.string.recipe_list_filter),
+                                        tint = MaterialTheme.colorScheme.primary,
                                     )
                                 }
-                            }
-                            IconButton(onClick = bloc::onAddRecipeClicked) {
+                            } else {
                                 Icon(
-                                    imageVector = Icons.Default.Add,
+                                    imageVector = Icons.Default.FilterList,
                                     contentDescription =
-                                        stringResource(Res.string.recipe_list_add_recipe),
+                                        stringResource(Res.string.recipe_list_filter),
                                 )
                             }
-                        },
-                ),
+                        }
+                        IconButton(onClick = bloc::onAddRecipeClicked) {
+                            Icon(
+                                imageVector = Icons.Default.Add,
+                                contentDescription =
+                                    stringResource(Res.string.recipe_list_add_recipe),
+                            )
+                        }
+                        OverflowMenu(
+                            onSelectClicked = bloc::onEnterSelectionMode,
+                            onExportAllClicked = bloc::onExportClicked,
+                        )
+                    },
+            )
+        }
+
+    Box(modifier = modifier.fillMaxSize().testTag(RecipeListTestTags.SCREEN)) {
+        PlusNavContainer(
+            modifier = modifier.fillMaxSize(),
+            data = headerData,
             scrollEnabled = false,
             content = {
                 AnimatedVisibility(
@@ -284,6 +353,8 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                                 state = gridState,
                                 bottomContentPadding =
                                     if (state.cookingRecipeCount > 0) FabStackReserve else 0.dp,
+                                isSelectionMode = state.isSelectionMode,
+                                selectedRecipeIds = state.selectedRecipeIds,
                             )
                         }
                         else -> {
@@ -294,6 +365,8 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                                 state = listState,
                                 bottomContentPadding =
                                     if (state.cookingRecipeCount > 0) FabStackReserve else 0.dp,
+                                isSelectionMode = state.isSelectionMode,
+                                selectedRecipeIds = state.selectedRecipeIds,
                             )
                         }
                     }
@@ -390,6 +463,37 @@ private fun DoneCookingDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
             }
         },
     )
+}
+
+@Composable
+private fun OverflowMenu(onSelectClicked: () -> Unit, onExportAllClicked: () -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = stringResource(Res.string.recipe_list_more_actions),
+            )
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.recipe_list_menu_select)) },
+                leadingIcon = { Icon(Icons.Default.Check, contentDescription = null) },
+                onClick = {
+                    expanded = false
+                    onSelectClicked()
+                },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.recipe_list_menu_export_all)) },
+                leadingIcon = { Icon(Icons.Default.FileDownload, contentDescription = null) },
+                onClick = {
+                    expanded = false
+                    onExportAllClicked()
+                },
+            )
+        }
+    }
 }
 
 // region Sort & Filter Bottom Sheet
@@ -760,6 +864,8 @@ private fun RecipeGrid(
     modifier: Modifier = Modifier,
     state: LazyGridState = rememberLazyGridState(),
     bottomContentPadding: androidx.compose.ui.unit.Dp = 0.dp,
+    isSelectionMode: Boolean = false,
+    selectedRecipeIds: Set<Long> = emptySet(),
 ) {
     LazyVerticalGrid(
         columns = GridCells.Adaptive(minSize = 160.dp),
@@ -777,7 +883,12 @@ private fun RecipeGrid(
     ) {
         items(recipes.size, key = { recipes[it].id }) { index ->
             val recipe = recipes[index]
-            RecipeGridItem(recipe = recipe, onClick = { onRecipeClicked(recipe) })
+            RecipeGridItem(
+                recipe = recipe,
+                onClick = { onRecipeClicked(recipe) },
+                isSelectionMode = isSelectionMode,
+                isSelected = recipe.id in selectedRecipeIds,
+            )
         }
     }
 }
@@ -787,18 +898,35 @@ private fun RecipeGridItem(
     recipe: RecipeListItem,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isSelectionMode: Boolean = false,
+    isSelected: Boolean = false,
 ) {
     Card(
         onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         colors =
-            CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+            CardDefaults.cardColors(
+                containerColor =
+                    if (isSelectionMode && isSelected) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerLow
+                    }
+            ),
     ) {
-        RecipeImage(
-            imageUrl = recipe.imageUrl,
-            contentDescription = recipe.title,
-            modifier = Modifier.fillMaxWidth().aspectRatio(1.2f),
-        )
+        Box {
+            RecipeImage(
+                imageUrl = recipe.imageUrl,
+                contentDescription = recipe.title,
+                modifier = Modifier.fillMaxWidth().aspectRatio(1.2f),
+            )
+            if (isSelectionMode) {
+                SelectionBadge(
+                    isSelected = isSelected,
+                    modifier = Modifier.align(Alignment.TopEnd).padding(6.dp),
+                )
+            }
+        }
         Column(
             modifier = Modifier.padding(12.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -822,6 +950,30 @@ private fun RecipeGridItem(
     }
 }
 
+/**
+ * Filled-circle checkmark when selected, hollow circle when not — small enough to overlay a recipe
+ * image without overpowering it.
+ */
+@Composable
+private fun SelectionBadge(isSelected: Boolean, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.size(24.dp),
+        shape = androidx.compose.foundation.shape.CircleShape,
+        color =
+            if (isSelected) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+    ) {
+        Icon(
+            imageVector = if (isSelected) Icons.Default.Check else Icons.Outlined.Circle,
+            contentDescription = null,
+            tint =
+                if (isSelected) MaterialTheme.colorScheme.onPrimary
+                else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(2.dp),
+        )
+    }
+}
+
 // endregion
 
 // region List View
@@ -833,6 +985,8 @@ private fun RecipeList(
     modifier: Modifier = Modifier,
     state: LazyListState = rememberLazyListState(),
     bottomContentPadding: androidx.compose.ui.unit.Dp = 0.dp,
+    isSelectionMode: Boolean = false,
+    selectedRecipeIds: Set<Long> = emptySet(),
 ) {
     LazyColumn(
         state = state,
@@ -841,7 +995,12 @@ private fun RecipeList(
     ) {
         items(recipes.size, key = { recipes[it].id }) { index ->
             val recipe = recipes[index]
-            RecipeListItemContent(recipe = recipe, onClick = { onRecipeClicked(recipe) })
+            RecipeListItemContent(
+                recipe = recipe,
+                onClick = { onRecipeClicked(recipe) },
+                isSelectionMode = isSelectionMode,
+                isSelected = recipe.id in selectedRecipeIds,
+            )
         }
     }
 }
@@ -855,12 +1014,32 @@ private fun RecipeListItemContent(
     recipe: RecipeListItem,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isSelectionMode: Boolean = false,
+    isSelected: Boolean = false,
 ) {
+    val background =
+        if (isSelectionMode && isSelected) MaterialTheme.colorScheme.primaryContainer
+        else androidx.compose.ui.graphics.Color.Transparent
     Row(
-        modifier = modifier.fillMaxWidth().clickable(onClick = onClick).padding(16.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .background(background)
+                .padding(16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        if (isSelectionMode) {
+            Icon(
+                imageVector = if (isSelected) Icons.Default.CheckCircle else Icons.Outlined.Circle,
+                contentDescription = null,
+                tint =
+                    if (isSelected) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(24.dp),
+            )
+        }
         RecipeImage(
             imageUrl = recipe.imageUrl,
             contentDescription = recipe.title,

--- a/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImplTest.kt
+++ b/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImplTest.kt
@@ -227,6 +227,80 @@ class RecipeListBlocImplTest {
     }
 
     @Test
+    fun When_export_clicked_outside_selection_mode_Then_OpenExportRecipes_with_null_ids() {
+        bloc.onExportClicked()
+        output.lastValue shouldBe RecipeListBloc.Output.OpenExportRecipes(recipeIds = null)
+    }
+
+    @Test
+    fun When_enter_selection_mode_Then_state_flips_with_empty_selection() = runTest {
+        bloc.state.test {
+            awaitItem().isSelectionMode shouldBe false
+            bloc.onEnterSelectionMode()
+            val next = awaitItem()
+            next.isSelectionMode shouldBe true
+            next.selectedRecipeIds shouldBe emptySet()
+        }
+    }
+
+    @Test
+    fun When_recipe_clicked_in_selection_mode_Then_toggles_selection_no_navigation() = runTest {
+        bloc.state.test {
+            awaitItem() // initial
+            recipes.value = listOf(recipe(1))
+            awaitItem() // recipes loaded
+            bloc.onEnterSelectionMode()
+            awaitItem() // entered selection mode
+
+            bloc.onRecipeClicked(listItem(id = 1))
+            awaitItem().selectedRecipeIds shouldBe setOf(1L)
+
+            bloc.onRecipeClicked(listItem(id = 1))
+            awaitItem().selectedRecipeIds shouldBe emptySet()
+        }
+        output.values shouldBe emptyList()
+    }
+
+    @Test
+    fun When_export_clicked_with_selection_Then_OpenExportRecipes_carries_ids_and_exits_mode() =
+        runTest {
+            bloc.state.test {
+                awaitItem()
+                recipes.value = listOf(recipe(1), recipe(2))
+                awaitItem()
+                bloc.onEnterSelectionMode()
+                awaitItem()
+                bloc.onToggleRecipeSelected(listItem(id = 1))
+                awaitItem()
+                bloc.onToggleRecipeSelected(listItem(id = 2))
+                awaitItem()
+
+                bloc.onExportClicked()
+                val after = awaitItem()
+                after.isSelectionMode shouldBe false
+                after.selectedRecipeIds shouldBe emptySet()
+            }
+            output.lastValue shouldBe RecipeListBloc.Output.OpenExportRecipes(setOf(1L, 2L))
+        }
+
+    @Test
+    fun When_toggle_select_all_visible_Then_selects_all_then_clears() = runTest {
+        bloc.state.test {
+            awaitItem()
+            recipes.value = listOf(recipe(1), recipe(2), recipe(3))
+            awaitItem()
+            bloc.onEnterSelectionMode()
+            awaitItem()
+
+            bloc.onToggleSelectAllVisible()
+            awaitItem().selectedRecipeIds shouldBe setOf(1L, 2L, 3L)
+
+            bloc.onToggleSelectAllVisible()
+            awaitItem().selectedRecipeIds shouldBe emptySet()
+        }
+    }
+
+    @Test
     fun When_recipes_loaded_Then_totalRecipeCount_reflects_unfiltered_count() = runTest {
         bloc.state.test {
             awaitItem()

--- a/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImplTest.kt
+++ b/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImplTest.kt
@@ -262,7 +262,7 @@ class RecipeListBlocImplTest {
     }
 
     @Test
-    fun When_export_clicked_with_selection_Then_OpenExportRecipes_carries_ids_and_exits_mode() =
+    fun When_export_clicked_with_selection_Then_OpenExportRecipes_carries_ids_and_selection_persists() =
         runTest {
             bloc.state.test {
                 awaitItem()
@@ -276,12 +276,32 @@ class RecipeListBlocImplTest {
                 awaitItem()
 
                 bloc.onExportClicked()
-                val after = awaitItem()
-                after.isSelectionMode shouldBe false
-                after.selectedRecipeIds shouldBe emptySet()
+                // No new emission expected — selection mode and the picked ids stay put so the
+                // user can come back to the same selection if they bail out of the exporter.
+                expectNoEvents()
             }
             output.lastValue shouldBe RecipeListBloc.Output.OpenExportRecipes(setOf(1L, 2L))
+            bloc.state.value.isSelectionMode shouldBe true
+            bloc.state.value.selectedRecipeIds shouldBe setOf(1L, 2L)
         }
+
+    @Test
+    fun When_export_finished_called_after_selection_Then_selection_mode_exits() = runTest {
+        bloc.state.test {
+            awaitItem()
+            recipes.value = listOf(recipe(1), recipe(2))
+            awaitItem()
+            bloc.onEnterSelectionMode()
+            awaitItem()
+            bloc.onToggleRecipeSelected(listItem(id = 1))
+            awaitItem()
+
+            bloc.onExportFinished()
+            val after = awaitItem()
+            after.isSelectionMode shouldBe false
+            after.selectedRecipeIds shouldBe emptySet()
+        }
+    }
 
     @Test
     fun When_toggle_select_all_visible_Then_selects_all_then_clears() = runTest {

--- a/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
@@ -64,6 +64,16 @@
     <string name="recipe_sync_syncing">Syncing</string>
     <string name="recipe_sync_synced">Synced</string>
 
+    <!-- Overflow Menu / Selection Mode -->
+    <string name="recipe_list_more_actions">More actions</string>
+    <string name="recipe_list_menu_select">Select recipes</string>
+    <string name="recipe_list_menu_export_all">Export all recipes</string>
+    <string name="recipe_list_selection_count">{count} selected</string>
+    <string name="recipe_list_selection_exit">Exit selection</string>
+    <string name="recipe_list_selection_select_all">Select all</string>
+    <string name="recipe_list_selection_deselect_all">Deselect all</string>
+    <string name="recipe_list_selection_export">Export selected</string>
+
     <!-- Cooking Session -->
     <string name="recipe_list_continue_cooking">Continue cooking</string>
     <string name="recipe_list_done_cooking">Done cooking</string>

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
@@ -47,6 +47,16 @@ interface RecipeListBloc : BlocScreen {
 
     fun onDoneCookingDismissed()
 
+    fun onEnterSelectionMode()
+
+    fun onExitSelectionMode()
+
+    fun onToggleRecipeSelected(recipe: RecipeListItem)
+
+    fun onToggleSelectAllVisible()
+
+    fun onExportClicked()
+
     data class Model(
         val recipes: List<RecipeListItem> = emptyList(),
         val totalRecipeCount: Int = 0,
@@ -64,6 +74,8 @@ interface RecipeListBloc : BlocScreen {
         val isSearchActive: Boolean = false,
         val cookingRecipeCount: Int = 0,
         val showDoneCookingDialog: Boolean = false,
+        val isSelectionMode: Boolean = false,
+        val selectedRecipeIds: Set<Long> = emptySet(),
     ) {
         /** Total number of active filter chips: legacy filters + preset + user category filters. */
         val totalActiveFilterCount: Int
@@ -78,6 +90,13 @@ interface RecipeListBloc : BlocScreen {
         object OpenBrowser : Output()
 
         data class OpenCookMode(val recipeId: Long) : Output()
+
+        /**
+         * Open the recipe-exporter screen. [recipeIds] is null when the user picked "Export all
+         * recipes" from the overflow menu, and a non-empty set when they launched export from
+         * selection mode.
+         */
+        data class OpenExportRecipes(val recipeIds: Set<Long>?) : Output()
     }
 
     interface Factory {

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
@@ -57,6 +57,14 @@ interface RecipeListBloc : BlocScreen {
 
     fun onExportClicked()
 
+    /**
+     * Called by the parent navigator after the exporter signals a successful save. Drops the screen
+     * out of multi-select mode so the user lands back on a clean list. A *cancelled* trip to the
+     * exporter (back/dismiss with nothing exported) does **not** call this — the selection is
+     * preserved so the user can try again.
+     */
+    fun onExportFinished()
+
     data class Model(
         val recipes: List<RecipeListItem> = emptyList(),
         val totalRecipeCount: Int = 0,

--- a/client/root/impl/build.gradle.kts
+++ b/client/root/impl/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
             implementation(projects.client.featureflag.public)
             implementation(projects.client.grocery.core.public)
             implementation(projects.client.recipe.core.public)
+            implementation(projects.client.recipe.exporter.public)
             implementation(projects.client.settings.root.public)
             implementation(projects.client.auth.ui.public)
             implementation(libs.kotlinx.serialization.json)

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -305,6 +305,16 @@ class RootBlocImpl(
     private fun handleExportRecipesOutput(output: ExportRecipesBloc.Output) {
         when (output) {
             ExportRecipesBloc.Output.Back -> navigation.pop()
+            ExportRecipesBloc.Output.Finished -> {
+                navigation.pop()
+                // Tell the recipe list to drop multi-select mode now that the archive was written.
+                stack.value.items
+                    .map { it.instance }
+                    .filterIsInstance<RootBloc.Child.BottomNavigation>()
+                    .firstOrNull()
+                    ?.bloc
+                    ?.onExportFinished()
+            }
         }
     }
 

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -25,6 +25,7 @@ import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc.Props.Detail
+import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
 import com.plusmobileapps.chefmate.root.RootBloc.Child.BottomNavigation
 import com.plusmobileapps.chefmate.root.RootBlocImpl.Configuration.GroceryDetail
 import com.plusmobileapps.chefmate.root.RootBlocImpl.Configuration.RecipeRoot
@@ -53,6 +54,7 @@ class RootBlocImpl(
     private val featureFlags: FeatureFlags,
     private val featureFlagsBlocFactory: FeatureFlagsBloc.Factory,
     private val aiChat: AiChatBloc.Factory,
+    private val exportRecipes: ExportRecipesBloc.Factory,
 ) : RootBloc, BlocContext by context {
 
     init {
@@ -224,6 +226,18 @@ class RootBlocImpl(
                 RootBloc.Child.AiChat(
                     bloc = aiChat.create(context = context, output = ::handleAiChatOutput)
                 )
+
+            is Configuration.ExportRecipes ->
+                RootBloc.Child.ExportRecipes(
+                    bloc =
+                        exportRecipes.create(
+                            context = context,
+                            props =
+                                config.recipeIds?.let { ExportRecipesBloc.Props.Selected(it) }
+                                    ?: ExportRecipesBloc.Props.All,
+                            output = ::handleExportRecipesOutput,
+                        )
+                )
         }
 
     private fun handleBottomNavOutput(output: BottomNavBloc.Output) {
@@ -281,6 +295,16 @@ class RootBlocImpl(
             is BottomNavBloc.Output.OpenCookMode -> {
                 navigation.bringToFront(Configuration.CookMode(output.recipeId))
             }
+
+            is BottomNavBloc.Output.OpenExportRecipes -> {
+                navigation.bringToFront(Configuration.ExportRecipes(output.recipeIds))
+            }
+        }
+    }
+
+    private fun handleExportRecipesOutput(output: ExportRecipesBloc.Output) {
+        when (output) {
+            ExportRecipesBloc.Output.Back -> navigation.pop()
         }
     }
 
@@ -417,5 +441,7 @@ class RootBlocImpl(
         @Serializable data class CookMode(val recipeId: Long) : Configuration()
 
         @Serializable data object AiChat : Configuration()
+
+        @Serializable data class ExportRecipes(val recipeIds: Set<Long>?) : Configuration()
     }
 }

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -16,6 +16,7 @@ import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
+import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
 import com.plusmobileapps.chefmate.settings.root.SettingsRootBloc
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import dev.mokkery.MockMode
@@ -41,6 +42,8 @@ class RootBlocTest {
     var otpOutput: Consumer<OtpBloc.Output> = Consumer {}
     var otpProps: OtpBloc.Props? = null
     var aiChatOutput: Consumer<AiChatBloc.Output> = Consumer {}
+    var exportRecipesOutput: Consumer<ExportRecipesBloc.Output> = Consumer {}
+    var exportRecipesProps: ExportRecipesBloc.Props? = null
     var bottomNavInitialTab: BottomNavBloc.Tab? = null
 
     fun createRoot(
@@ -99,6 +102,11 @@ class RootBlocTest {
             featureFlagsBlocFactory = { _, _ -> mock() },
             aiChat = { _, output ->
                 aiChatOutput = output
+                mock()
+            },
+            exportRecipes = { _, props, output ->
+                exportRecipesProps = props
+                exportRecipesOutput = output
                 mock()
             },
         )
@@ -337,5 +345,26 @@ class RootBlocTest {
         root.instance() should instanceOf<RootBloc.Child.Authentication>()
         root.state.value.backStack.size shouldBe 1
         authProps shouldBe AuthenticationBloc.Props.SignUp
+    }
+
+    @Test
+    fun When_bottom_nav_outputs_export_all_Then_export_recipes_is_shown_with_All_props() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenExportRecipes(recipeIds = null))
+        rootBloc.instance() should instanceOf<RootBloc.Child.ExportRecipes>()
+        exportRecipesProps shouldBe ExportRecipesBloc.Props.All
+    }
+
+    @Test
+    fun When_bottom_nav_outputs_export_selection_Then_export_recipes_uses_Selected_props() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenExportRecipes(recipeIds = setOf(1L, 2L)))
+        rootBloc.instance() should instanceOf<RootBloc.Child.ExportRecipes>()
+        exportRecipesProps shouldBe ExportRecipesBloc.Props.Selected(setOf(1L, 2L))
+    }
+
+    @Test
+    fun Given_export_recipes_When_back_Then_bottom_nav_is_shown() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenExportRecipes(recipeIds = null))
+        exportRecipesOutput.onNext(ExportRecipesBloc.Output.Back)
+        rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
     }
 }

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -56,7 +56,7 @@ class RootBlocTest {
             bottomNav = { _, output, initialTab ->
                 bottomNavOutput = output
                 bottomNavInitialTab = initialTab
-                mock()
+                mock(MockMode.autoUnit)
             },
             browserRootBlocFactory =
                 object : BrowserRootBloc.Factory {
@@ -366,5 +366,21 @@ class RootBlocTest {
         bottomNavOutput.onNext(BottomNavBloc.Output.OpenExportRecipes(recipeIds = null))
         exportRecipesOutput.onNext(ExportRecipesBloc.Output.Back)
         rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+    }
+
+    @Test
+    fun Given_export_recipes_When_finished_Then_bottom_nav_is_shown_and_notified() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenExportRecipes(recipeIds = setOf(1L)))
+        val bottomNavChild =
+            rootBloc.state.value.items
+                .map { it.instance }
+                .filterIsInstance<RootBloc.Child.BottomNavigation>()
+                .first()
+                .bloc
+
+        exportRecipesOutput.onNext(ExportRecipesBloc.Output.Finished)
+
+        rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+        dev.mokkery.verify { bottomNavChild.onExportFinished() }
     }
 }

--- a/client/root/public/build.gradle.kts
+++ b/client/root/public/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
             api(projects.client.featureflag.public)
             api(projects.client.grocery.core.public)
             api(projects.client.recipe.core.public)
+            api(projects.client.recipe.exporter.public)
             api(projects.client.auth.ui.public)
             api(projects.client.settings.root.public)
             api(libs.arkivanov.decompose.core)

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -16,6 +16,7 @@ import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
+import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
 import com.plusmobileapps.chefmate.settings.root.SettingsRootBloc
 import com.plusmobileapps.chefmate.ui.BlocScreen
 
@@ -48,6 +49,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class CookMode(val bloc: CookModeBloc) : Child(), BlocScreen by bloc
 
         data class AiChat(val bloc: AiChatBloc) : Child(), BlocScreen by bloc
+
+        data class ExportRecipes(val bloc: ExportRecipesBloc) : Child(), BlocScreen by bloc
     }
 
     fun interface Factory {

--- a/client/settings/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/impl/SettingsRootBlocImpl.kt
+++ b/client/settings/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/impl/SettingsRootBlocImpl.kt
@@ -138,7 +138,10 @@ class SettingsRootBlocImpl(
 
     private fun handleExportRecipesOutput(output: ExportRecipesBloc.Output) {
         when (output) {
-            ExportRecipesBloc.Output.Back -> navigation.pop()
+            // Settings hosts the exporter without any list-side selection, so success and cancel
+            // both just pop back to the Backup screen.
+            ExportRecipesBloc.Output.Back,
+            ExportRecipesBloc.Output.Finished -> navigation.pop()
         }
     }
 

--- a/client/settings/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/impl/SettingsRootBlocImpl.kt
+++ b/client/settings/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/impl/SettingsRootBlocImpl.kt
@@ -95,6 +95,7 @@ class SettingsRootBlocImpl(
                     bloc =
                         exportRecipes.create(
                             context = context,
+                            props = ExportRecipesBloc.Props.All,
                             output = ::handleExportRecipesOutput,
                         )
                 )

--- a/client/settings/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/root/impl/SettingsRootBlocImplTest.kt
+++ b/client/settings/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/root/impl/SettingsRootBlocImplTest.kt
@@ -43,7 +43,7 @@ class SettingsRootBlocImplTest {
                 importRecipesOutput = output
                 mock()
             },
-            exportRecipes = { _, output ->
+            exportRecipes = { _, _, output ->
                 exportRecipesOutput = output
                 mock()
             },

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTest.kt
@@ -11,6 +11,8 @@ import com.android.tools.screenshot.PreviewTest
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBloc
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocCooking
+import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocSelectionMode
+import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocSelectionModeEmpty
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
@@ -64,3 +66,26 @@ fun RecipeListCookingPhonePortraitDarkScreenshot() {
 // uses Modifier.align(BottomEnd) + 16.dp padding regardless of canvas size — there's no
 // responsive-layout branching to cover, and the FAB shadow rendered slightly differently
 // across Mac arm64 / Linux x64 (1–2 px subpixel AA), causing CI flakiness.
+
+// ── Multi-select mode ──────────────────────────────────────────────────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun RecipeListSelectionLightScreenshot() {
+    RecipeListScreenshot(bloc = previewRecipeListBlocSelectionMode)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun RecipeListSelectionDarkScreenshot() {
+    RecipeListScreenshot(bloc = previewRecipeListBlocSelectionMode, darkTheme = true)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun RecipeListSelectionEmptyScreenshot() {
+    RecipeListScreenshot(bloc = previewRecipeListBlocSelectionModeEmpty)
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeCategoryFilterScreenshotTestKt/RecipeListCategoryFilteredDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeCategoryFilterScreenshotTestKt/RecipeListCategoryFilteredDarkScreenshot_805fa67c_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:289a9486f2dabe493575ad4df66e8a55efd9857fa660fdc2e374cb26fb0db4bd
-size 111421
+oid sha256:7242591ec6d57bee2fdf0a1ce1d70cef6968dc48cb8b1bb3d00d02ff706c764e
+size 112006

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeCategoryFilterScreenshotTestKt/RecipeListCategoryFilteredLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeCategoryFilterScreenshotTestKt/RecipeListCategoryFilteredLightScreenshot_73588fdf_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e11ce453c6000d5e7c532d1391e875b13df9f358230fb9afd310e0d2fd3b4c1
-size 110907
+oid sha256:b0b202fc3a0dec1ec9462ed14fd11156df8f5edaf96aaf1f95a8010895876e5f
+size 111446

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListCookingPhonePortraitDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListCookingPhonePortraitDarkScreenshot_805fa67c_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:320859f0bb1a4a9f39bbe3cbba7b7a06e00a8a94e60df63f5adc3518af6dfb9a
-size 126954
+oid sha256:3d7f3c18249b9578aa1829c2f75dbe4f528d3f84bc620f3e10ba7085950a1e44
+size 127541

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListCookingPhonePortraitLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListCookingPhonePortraitLightScreenshot_73588fdf_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea4259bbd83fe8dad9df648edb36753a87c8e514f76fbfbef25eeb97e61f3b9d
-size 132144
+oid sha256:a780766e750d5f57e9542eabd7026299166eef5ffa629c53242e028b3685f9eb
+size 132675

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListPhonePortraitDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListPhonePortraitDarkScreenshot_805fa67c_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff9e74127e7520bc564a330bf899265be08d65f04158299d28524d9f7cf306d6
-size 110448
+oid sha256:480341baf127bfa87255c70a22dcdcd67e2d198a16e0daf71b5e2d483c709ae3
+size 111016

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListPhonePortraitLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListPhonePortraitLightScreenshot_73588fdf_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b5e4145562dd975f36454c39e2fd9eb40578b50cbb2eb9684d26cbdbeadd069
-size 109934
+oid sha256:ad952fa5dc70497d034d05dfce397d56d25f92862a4c1dc01629c402dd46ac18
+size 110457

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionDarkScreenshot_805fa67c_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7aa4ab89ed4f874e82f57a097ea8993a124942a0db173526ca4891bd23f5ae0
+size 116474

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionEmptyScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionEmptyScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80bce34aeec0c687b73f6ae10878df8b6b3048fde6e88e98b3343b6be365408a
+size 117403

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionLightScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6413d8090fdb2e81827aa70797e5e2931c6f7327adab7387794e7100d95f359
+size 116912


### PR DESCRIPTION
## Summary
- Recipe-list top bar gets a ⋮ overflow menu with **Select recipes** (enters multi-select mode) and **Export all recipes** (opens the existing exporter with every recipe pre-selected).
- In multi-select mode, the title becomes "N selected" and the trailing icons swap to: select-all toggle, Export (disabled until something is picked), and a Close button to exit. Tapping a recipe toggles selection instead of opening detail.
- Hitting Export from selection mode opens the exporter scoped to just the picked recipes via a new `ExportRecipesBloc.Props.Selected(recipeIds)`. Settings → Backup → Export still works unchanged (it passes `Props.All`).

## Implementation notes
- New navigation hop: `RecipeListBloc.Output.OpenExportRecipes(recipeIds: Set<Long>?)` → `BottomNavBloc.Output.OpenExportRecipes` → new `RootBlocImpl.Configuration.ExportRecipes` top-level destination. Keeps the embedded settings-backup flow untouched.
- Exporter VM became `@AssistedInject` with a Factory taking `ExportRecipesBloc.Props` so the same VM serves both call sites — null/All vs. Selected just changes which recipes get loaded.
- Pulled the unrelated ktfmt-format-only diffs into their own `chore(format)` commit so feature commits stay clean.

## Test plan
- [x] `./gradlew :client:recipe:list:impl:jvmTest :client:recipe:exporter:impl:jvmTest :client:settings:root:impl:jvmTest :client:root:impl:jvmTest` — all green
- [x] `./gradlew :client:ui:screenshot-test:validateDebugScreenshotTest` — passes with new selection-mode references + refreshed top-bar references
- [ ] Manual: launch on Desktop, enter selection mode from ⋮, multi-select two recipes, tap export, confirm the save sheet only contains those two
- [ ] Manual: from ⋮, tap "Export all recipes" — confirm exporter shows everything pre-selected like before
- [ ] Manual: Settings → Backup → Export Recipes — confirm unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)