### PR TITLE
feat(update): in-app self-update for desktop + release signing

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     strategy:
+      # Don't let one platform's failure cancel the others (e.g. keep building the
+      # Windows MSIX even if the macOS leg fails).
+      fail-fast: false
       matrix:
         include:
           - os: macos-15
@@ -97,14 +100,69 @@ jobs:
           xcrun stapler staple "$DMG"
           rm -f AuthKey.p8
 
+      - name: Build app image for MSIX (Windows)
+        if: runner.os == 'Windows'
+        run: ./gradlew :client:composeApp:createReleaseDistributable
+
+      - name: Package MSIX (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          STORE_IDENTITY_NAME: ${{ secrets.STORE_IDENTITY_NAME }}
+          STORE_PUBLISHER: ${{ secrets.STORE_PUBLISHER }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $img = "client/composeApp/build/compose/binaries/main-release/app/Chef Mate"
+
+          # Resolve the release version (tag on push; build.gradle.kts otherwise) as 4-part x.y.z.0
+          if ($env:GITHUB_REF -like 'refs/tags/v*') {
+            $version = $env:GITHUB_REF_NAME.TrimStart('v')
+          } else {
+            $version = (Select-String 'versionName = "(.+?)"' client/composeApp/build.gradle.kts).Matches[0].Groups[1].Value
+          }
+          $msixVersion = "$version.0"
+
+          # Identity from Store secrets, with placeholders so the MSIX still builds when unset
+          $idName = if ($env:STORE_IDENTITY_NAME) { $env:STORE_IDENTITY_NAME } else { "PlusMobileApps.ChefMate" }
+          $publisher = if ($env:STORE_PUBLISHER) { $env:STORE_PUBLISHER } else { "CN=Plus Mobile Apps" }
+
+          # Substitute manifest tokens and drop it next to the app image
+          (Get-Content packaging/windows/AppxManifest.xml -Raw) `
+            -replace '__IDENTITY_NAME__', $idName `
+            -replace '__PUBLISHER__', $publisher `
+            -replace '__VERSION__', $msixVersion |
+            Set-Content "$img/AppxManifest.xml"
+
+          # Reuse the existing app icon for the required Store logo assets (replace with
+          # correctly-sized PNGs for Store certification).
+          New-Item -ItemType Directory -Force -Path "$img/Assets" | Out-Null
+          $icon = "client/composeApp/src/jvmMain/resources/app-icon.png"
+          Copy-Item $icon "$img/Assets/StoreLogo.png"
+          Copy-Item $icon "$img/Assets/Square150x150Logo.png"
+          Copy-Item $icon "$img/Assets/Square44x44Logo.png"
+
+          $makeappx = (Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\makeappx.exe" |
+                       Sort-Object FullName -Descending | Select-Object -First 1).FullName
+          & $makeappx pack /d "$img" /p "$env:RUNNER_TEMP\ChefMate.msix" /o
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-path }}
 
+      - name: Upload MSIX artifact (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-windows-msix
+          path: ${{ runner.temp }}/ChefMate.msix
+
   release:
     needs: build
+    # Only publish a GitHub Release for tag pushes; a manual workflow_dispatch on a
+    # branch just builds artifacts (e.g. to grab the MSIX) without cutting a release.
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -114,8 +172,66 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Generate update feed
+        # Windows is intentionally omitted: it ships via the Microsoft Store and updates there,
+        # so the in-app updater is inert on Windows and never reads this feed.
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          BASE="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}"
+          DMG=$(cd artifacts && ls *.dmg)
+          DEB=$(cd artifacts && ls *.deb)
+          cat > artifacts/latest.json <<EOF
+          {
+            "version": "${VERSION}",
+            "notesUrl": "https://github.com/${{ github.repository }}/releases/tag/${GITHUB_REF_NAME}",
+            "downloads": {
+              "macos": "${BASE}/${DMG}",
+              "linux": "${BASE}/${DEB}"
+            }
+          }
+          EOF
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*
           generate_release_notes: true
+
+  # Submits the MSIX to the Microsoft Store. Runs only on tag pushes, and each step
+  # no-ops unless STORE_PRODUCT_ID is configured. The very first submission for a new
+  # app must still be made manually in Partner Center to create the listing.
+  publish-store:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: windows-latest
+    env:
+      STORE_PRODUCT_ID: ${{ secrets.STORE_PRODUCT_ID }}
+    steps:
+      - uses: actions/download-artifact@v4
+        if: env.STORE_PRODUCT_ID != ''
+        with:
+          name: desktop-windows-msix
+          path: msix
+
+      # NOTE: verify the action ref against the current MSStore CLI docs before relying on it.
+      - name: Setup MSStore CLI
+        if: env.STORE_PRODUCT_ID != ''
+        uses: microsoft/setup-msstore-cli@v1
+
+      - name: Configure MSStore CLI
+        if: env.STORE_PRODUCT_ID != ''
+        run: >
+          msstore reconfigure
+          --tenantId ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          --sellerId ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          --clientId ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          --clientSecret ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+
+      - name: Publish to Microsoft Store
+        if: env.STORE_PRODUCT_ID != ''
+        shell: pwsh
+        run: |
+          $msix = (Get-ChildItem msix/*.msix | Select-Object -First 1).FullName
+          # -id is the Partner Center app/product id; adjust if your account uses a separate Store ID.
+          msstore publish -i $msix -id $env:STORE_PRODUCT_ID

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/main.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/main.kt
@@ -2,8 +2,14 @@
 
 package com.plusmobileapps.chefmate
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -21,6 +27,9 @@ import com.arkivanov.essenty.backhandler.BackDispatcher
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.plusmobileapps.chefmate.buildconfig.BuildConfig
 import com.plusmobileapps.chefmate.root.DeepLink
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import com.plusmobileapps.chefmate.update.DesktopUpdater
+import com.plusmobileapps.chefmate.update.UpdateBanner
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
@@ -40,6 +49,7 @@ fun main(args: Array<String>) {
     val lifecycle = LifecycleRegistry()
     val backDispatcher = BackDispatcher()
     val appComponent = dev.zacsweers.metro.createGraph<JvmApplicationComponent>()
+    val updater = DesktopUpdater()
 
     val settings = appComponent.settings
     val initialSize =
@@ -103,8 +113,13 @@ fun main(args: Array<String>) {
                 }
         }
 
+        LaunchedEffect(Unit) { updater.checkForUpdates() }
+
         Window(
-            onCloseRequest = ::exitApplication,
+            onCloseRequest = {
+                updater.close()
+                exitApplication()
+            },
             state = windowState,
             title = "Chef Mate",
             icon = painterResource("app-icon.png"),
@@ -116,7 +131,19 @@ fun main(args: Array<String>) {
                 }
             },
         ) {
-            App(rootBloc = rootBloc, toastService = appComponent.toastService)
+            Box(modifier = Modifier.fillMaxSize()) {
+                App(rootBloc = rootBloc, toastService = appComponent.toastService)
+                val updateState by updater.state.collectAsState()
+                ChefMateTheme {
+                    UpdateBanner(
+                        state = updateState,
+                        onDownload = updater::startDownload,
+                        onInstall = updater::install,
+                        onDismiss = updater::dismiss,
+                        modifier = Modifier.align(Alignment.BottomCenter),
+                    )
+                }
+            }
         }
     }
 }

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/update/DesktopUpdater.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/update/DesktopUpdater.kt
@@ -1,0 +1,142 @@
+package com.plusmobileapps.chefmate.update
+
+import co.touchlab.kermit.Logger
+import com.plusmobileapps.chefmate.buildconfig.BuildConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readRemaining
+import java.awt.Desktop
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.io.readByteArray
+import kotlinx.serialization.json.Json
+
+private const val DEFAULT_FEED_URL =
+    "https://github.com/Plus-Mobile-Apps/chef-mate/releases/latest/download/latest.json"
+
+/**
+ * Desktop-only self-update driver. Polls a `latest.json` feed published by CI, and when a newer
+ * version exists, downloads the platform installer and opens it. Signed-installer model — we never
+ * patch jars in place, so the macOS notarization staple stays intact.
+ *
+ * Inert on Windows: that platform ships through the Microsoft Store, which both forbids
+ * self-updating (Store certification policy) and sandboxes the MSIX install so it can't replace
+ * itself anyway. Updates there are the Store's job.
+ */
+class DesktopUpdater(
+    private val currentVersion: String = BuildConfig.VERSION_NAME,
+    private val feedUrl: String = DEFAULT_FEED_URL,
+) {
+    private val log = Logger.withTag("DesktopUpdater")
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val http = HttpClient(CIO)
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val _state = MutableStateFlow<UpdateState>(UpdateState.Idle)
+    val state: StateFlow<UpdateState> = _state.asStateFlow()
+
+    private var available: UpdateState.Available? = null
+
+    /** In-app updates run on macOS and Linux only; Windows defers to the Microsoft Store. */
+    private val isSupported: Boolean = platformKey() != "windows"
+
+    fun checkForUpdates() {
+        if (!isSupported) return
+        scope.launch {
+            runCatching {
+                val feed = json.decodeFromString<UpdateFeed>(http.get(feedUrl).bodyAsText())
+                if (!isNewer(feed.version, currentVersion)) return@runCatching null
+                val url = feed.downloads[platformKey()] ?: return@runCatching null
+                UpdateState.Available(feed.version, url, feed.notesUrl).also { available = it }
+            }
+                .onSuccess { result -> result?.let { _state.value = it } }
+                .onFailure { log.w(it) { "Update check failed" } }
+        }
+    }
+
+    fun startDownload() {
+        val target = available ?: return
+        scope.launch {
+            runCatching { downloadToTemp(target) }
+                .onSuccess { _state.value = UpdateState.Ready(it.absolutePath) }
+                .onFailure {
+                    log.e(it) { "Update download failed" }
+                    _state.value = target // revert to the Available banner so the user can retry
+                }
+        }
+    }
+
+    /** Opens the downloaded installer with the OS handler (mounts the dmg / runs the msi). */
+    fun install() {
+        val ready = _state.value as? UpdateState.Ready ?: return
+        runCatching { Desktop.getDesktop().open(File(ready.installerPath)) }
+            .onFailure { log.e(it) { "Failed to launch installer" } }
+    }
+
+    fun dismiss() {
+        _state.value = UpdateState.Idle
+    }
+
+    fun close() {
+        http.close()
+        scope.cancel()
+    }
+
+    private suspend fun downloadToTemp(target: UpdateState.Available): File {
+        val fileName = target.downloadUrl.substringAfterLast('/')
+        val dest = File(System.getProperty("java.io.tmpdir"), fileName)
+        http.prepareGet(target.downloadUrl).execute { response ->
+            val total = response.headers["Content-Length"]?.toLongOrNull() ?: -1L
+            val channel: ByteReadChannel = response.bodyAsChannel()
+            var read = 0L
+            dest.outputStream().use { out ->
+                while (!channel.isClosedForRead) {
+                    val packet = channel.readRemaining(DEFAULT_BUFFER_SIZE.toLong())
+                    while (!packet.exhausted()) {
+                        val bytes = packet.readByteArray()
+                        out.write(bytes)
+                        read += bytes.size
+                        _state.value =
+                            UpdateState.Downloading(
+                                if (total > 0) (read.toFloat() / total).coerceIn(0f, 1f) else -1f
+                            )
+                    }
+                }
+            }
+        }
+        return dest
+    }
+}
+
+private fun platformKey(): String {
+    val os = System.getProperty("os.name").lowercase()
+    return when {
+        os.contains("mac") || os.contains("darwin") -> "macos"
+        os.contains("win") -> "windows"
+        else -> "linux"
+    }
+}
+
+/** Compares dotted numeric versions (e.g. `1.8.0` > `1.7.1`). Non-numeric parts compare as 0. */
+internal fun isNewer(candidate: String, current: String): Boolean {
+    val c = candidate.split('.').map { it.toIntOrNull() ?: 0 }
+    val n = current.split('.').map { it.toIntOrNull() ?: 0 }
+    for (i in 0 until maxOf(c.size, n.size)) {
+        val a = c.getOrElse(i) { 0 }
+        val b = n.getOrElse(i) { 0 }
+        if (a != b) return a > b
+    }
+    return false
+}

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/update/UpdateBanner.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/update/UpdateBanner.kt
@@ -1,0 +1,85 @@
+package com.plusmobileapps.chefmate.update
+
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+/** Desktop-only self-update banner. Renders nothing when [state] is [UpdateState.Idle]. */
+@Composable
+fun UpdateBanner(
+    state: UpdateState,
+    onDownload: () -> Unit,
+    onInstall: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (state is UpdateState.Idle) return
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = ChefMateTheme.colorScheme.primaryContainer,
+        contentColor = ChefMateTheme.colorScheme.onPrimaryContainer,
+        shadowElevation = 3.dp,
+    ) {
+        Column(modifier = Modifier.padding(ChefMateTheme.dimens.paddingNormal)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = spacedBy(ChefMateTheme.dimens.paddingSmall),
+            ) {
+                Text(
+                    text = bannerText(state),
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = ChefMateTheme.typography.bodyMedium,
+                )
+                when (state) {
+                    is UpdateState.Available -> {
+                        TextButton(onClick = onDownload) { Text("Download") }
+                    }
+                    is UpdateState.Ready -> {
+                        TextButton(onClick = onInstall) { Text("Restart & install") }
+                    }
+                    else -> Unit
+                }
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Default.Close, contentDescription = "Dismiss")
+                }
+            }
+            if (state is UpdateState.Downloading) {
+                if (state.fraction >= 0f) {
+                    LinearProgressIndicator(
+                        progress = { state.fraction },
+                        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                    )
+                } else {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth().padding(top = 8.dp))
+                }
+            }
+        }
+    }
+}
+
+private fun bannerText(state: UpdateState): String =
+    when (state) {
+        is UpdateState.Available -> "Version ${state.version} is available"
+        is UpdateState.Downloading -> "Downloading update…"
+        is UpdateState.Ready -> "Update ready to install"
+        UpdateState.Idle -> ""
+    }

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/update/UpdateModels.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/update/UpdateModels.kt
@@ -1,0 +1,20 @@
+package com.plusmobileapps.chefmate.update
+
+import kotlinx.serialization.Serializable
+
+/** Update feed published by the `desktop-release` workflow as `latest.json`. */
+@Serializable
+data class UpdateFeed(val version: String, val notesUrl: String, val downloads: Map<String, String>)
+
+sealed interface UpdateState {
+    /** No update known, or the banner was dismissed. */
+    data object Idle : UpdateState
+
+    data class Available(val version: String, val downloadUrl: String, val notesUrl: String) :
+        UpdateState
+
+    /** [fraction] is -1f when the server does not send a content length. */
+    data class Downloading(val fraction: Float) : UpdateState
+
+    data class Ready(val installerPath: String) : UpdateState
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,22 +4,34 @@ This project uses **GitHub Actions** for CI and **Fastlane** for mobile build/up
 
 ## Quick Start
 
-To create a release for all platforms:
+The recommended path is the automated **Bump Version** workflow (see [Version Management](#version-management)) — it bumps versions, opens a PR, and tags the release on merge. To release manually, push a tag directly:
 
 ```bash
 git tag v1.0.0
 git push --tags
 ```
 
-This triggers three independent workflows that run in parallel:
+Either way, the tag triggers three independent workflows that run in parallel:
 
 | Platform | Workflow | Destination |
 |----------|----------|-------------|
 | Android | `android-release.yml` | Play Store (internal track) |
 | iOS | `ios-release.yml` | App Store Connect (TestFlight) |
-| Desktop | `desktop-release.yml` | GitHub Releases (DMG, MSI, DEB) |
+| Desktop | `desktop-release.yml` | GitHub Releases (signed DMG + DEB) and `latest.json` update feed |
 
 All workflows also support manual triggering via the "Run workflow" button in the GitHub Actions UI (`workflow_dispatch`).
+
+### Desktop update strategy
+
+Desktop uses **two different update channels** depending on platform:
+
+| Platform | Distribution | Updates |
+|----------|--------------|---------|
+| macOS | Notarized `.dmg` on GitHub Releases | **In-app updater** (`DesktopUpdater`) polls the `latest.json` feed and prompts the user to download + install |
+| Linux | `.deb` on GitHub Releases | **In-app updater** (same feed) |
+| Windows | **Microsoft Store** (MSIX) | **The Store** — the in-app updater is intentionally a no-op on Windows (Store policy forbids self-updating, and the MSIX sandbox can't replace its own install) |
+
+See [Windows: Microsoft Store (MSIX)](#windows-microsoft-store-msix) for the Windows path.
 
 ---
 
@@ -79,6 +91,26 @@ These are read by BuildKonfig at build time. See [buildconfig-setup.md](buildcon
 | `ASC_ISSUER_ID` | App Store Connect API Issuer ID |
 | `ASC_API_KEY` | App Store Connect API private key (`.p8` content, base64-encoded) |
 | `APPLE_TEAM_ID` | Apple Developer Team ID |
+
+#### Desktop Code Signing
+
+**macOS** desktop signing reuses the **existing iOS `MATCH_*` and `ASC_*` secrets** — no desktop-specific secrets are required. The `desktop-release.yml` workflow installs the Developer ID certificate via `fastlane mac certificates` (Fastlane match), resolves the identity into `MACOS_SIGN_IDENTITY` at runtime, signs during `packageReleaseDmg`, and notarizes/staples the DMG with `xcrun notarytool`. See [Desktop macOS code signing](#desktop-macos-code-signing).
+
+**Windows** code signing is **not required** — the Microsoft Store signs MSIX packages on ingestion.
+
+#### Microsoft Store (Partner Center API)
+
+Required only for [automated MSIX submission](#automating-store-submission). Created from an Azure AD application associated with your Partner Center account.
+
+| Secret | Description |
+|--------|-------------|
+| `PARTNER_CENTER_TENANT_ID` | Azure AD tenant ID |
+| `PARTNER_CENTER_CLIENT_ID` | Azure AD application (client) ID |
+| `PARTNER_CENTER_CLIENT_SECRET` | Client secret for that Azure AD application |
+| `PARTNER_CENTER_SELLER_ID` | Seller ID from Partner Center → Account settings |
+| `STORE_PRODUCT_ID` | The Store product/app ID for the reserved app — gates the `publish-store` job |
+| `STORE_IDENTITY_NAME` | Partner Center **Package/Identity Name** — substituted into `AppxManifest.xml` (falls back to a placeholder if unset, so the MSIX still builds) |
+| `STORE_PUBLISHER` | Partner Center **Publisher** `CN=...` string — substituted into `AppxManifest.xml` |
 
 ---
 
@@ -148,11 +180,200 @@ releaseStorePassword=YOUR_STORE_PASSWORD
    `client/composeApp/build.gradle.kts`, so the binary is functionally identical to the old debug
    packaging — it just carries the release marker.
 2. On macOS, signs and notarizes the DMG (see [Code signing](#desktop-macos-code-signing) below)
-3. Uploads each package as a build artifact
-4. Creates a GitHub Release from the tag with all three packages attached
-5. Auto-generates release notes from commits since the last tag
+3. On Windows, also builds the app image (`createReleaseDistributable`) and packs an MSIX via `makeappx`
+4. Uploads each package (and, on Windows, the MSIX) as build artifacts
+5. Generates `latest.json` (the in-app update feed) with the macOS + Linux download URLs — **Windows is intentionally omitted** because it updates via the Store
+6. Creates a GitHub Release from the tag with the packages + `latest.json` attached
+7. Auto-generates release notes from commits since the last tag
+8. On tag pushes, the `publish-store` job submits the MSIX to the Microsoft Store via the MSStore CLI (no-ops until `STORE_PRODUCT_ID` is set)
 
-**Package configuration:** Native distribution settings (package name, version, vendor, platform-specific options) are in `client/composeApp/build.gradle.kts` under the `compose.desktop.application.nativeDistributions` block.
+**Package configuration:** Native distribution settings (package name, version, vendor, platform-specific options) are in `client/composeApp/build.gradle.kts` under the `compose.desktop.application.nativeDistributions` block. The macOS `signing { }` / `notarization { }` blocks are gated on `MACOS_SIGN_IDENTITY` so local `packageDmg` works without a cert.
+
+#### In-app updater (macOS + Linux)
+
+The desktop app embeds `DesktopUpdater` (`client/composeApp/src/jvmMain/.../update/`). On launch it polls the stable feed URL:
+
+```
+https://github.com/Plus-Mobile-Apps/chef-mate/releases/latest/download/latest.json
+```
+
+GitHub always serves `releases/latest/download/<asset>` from the newest non-prerelease release, so no separate hosting is needed. The updater compares the feed `version` against `BuildConfig.VERSION_NAME`; if newer, it surfaces a banner to download the platform installer and open it. It is a **no-op on Windows** by design.
+
+This is a *signed-installer* model (download + run the new signed package), **not** in-place jar patching — patching jars inside the bundle would invalidate the macOS notarization staple.
+
+**`latest.json` shape:**
+
+```json
+{
+  "version": "1.8.0",
+  "notesUrl": "https://github.com/Plus-Mobile-Apps/chef-mate/releases/tag/v1.8.0",
+  "downloads": {
+    "macos": "https://github.com/.../releases/download/v1.8.0/Chef-Mate-1.8.0.dmg",
+    "linux": "https://github.com/.../releases/download/v1.8.0/chef-mate_1.8.0_amd64.deb"
+  }
+}
+```
+
+#### macOS notarization
+
+The `.p12` for `MACOS_CERT_P12_BASE64` is a "Developer ID Application" certificate exported from Keychain Access (include the private key). Export and encode:
+
+```bash
+# In Keychain Access: right-click the "Developer ID Application" cert → Export → .p12
+base64 -i DeveloperID.p12 | pbcopy   # store as MACOS_CERT_P12_BASE64
+```
+
+`APPLE_APP_PASSWORD` is an app-specific password generated at <https://appleid.apple.com> (Sign-In and Security → App-Specific Passwords). Without notarization, Gatekeeper refuses to launch the app ("damaged / cannot be opened").
+
+---
+
+## Windows: Microsoft Store (MSIX)
+
+Windows ships through the **Microsoft Store** as an MSIX package. This is the recommended Windows path because:
+
+- **The Store signs the package for free** on ingestion — no code-signing certificate needed (no ~$10/month or ~$200+/year cert).
+- **The Store handles auto-updates** — which is why the in-app updater no-ops on Windows.
+- SmartScreen trusts Store apps, so users never see "unknown publisher" warnings.
+
+> When creating the product in Partner Center, choose **"MSIX or PWA app"**, *not* "EXE or MSI app". The EXE/MSI option only provides a listing that points at your own self-hosted, self-signed installer — it gives you neither free signing nor Store-managed updates.
+
+### One-time Partner Center setup
+
+1. In [Partner Center](https://partner.microsoft.com/dashboard), create a **new MSIX product** and reserve the app name.
+2. From the product's **Product Identity** page, record three values needed for the manifest:
+   - **Package/Identity Name** (e.g. `12345PlusMobileApps.ChefMate`)
+   - **Publisher** (the `CN=...` string, e.g. `CN=ABCD1234-...`)
+   - **Publisher Display Name** (e.g. `Plus Mobile Apps`)
+3. The **first submission must be done manually** in Partner Center to establish the listing. Automated submission (below) is for subsequent releases.
+
+### Packaging sketch
+
+jpackage / Compose Desktop does **not** emit MSIX, so we package the unpackaged *app image* ourselves. Compose Desktop's `createDistributable` task produces the app image (app + bundled JRE) at:
+
+```
+client/composeApp/build/compose/binaries/main/app/Chef Mate/
+```
+
+The MSIX is then built by laying that directory next to an `AppxManifest.xml` and running `makeappx` (part of the Windows SDK, preinstalled on `windows-latest` runners). **This is wired into `desktop-release.yml`** — the manifest lives at `packaging/windows/AppxManifest.xml` and uses `__TOKEN__` placeholders that the workflow substitutes at build time.
+
+**`packaging/windows/AppxManifest.xml`** (the committed manifest uses tokens; the identity values come from Partner Center, and the version must be 4-part with a `.0` revision):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+    xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+    xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+    xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+
+  <Identity Name="[PACKAGE_IDENTITY_NAME]"
+            Publisher="[CN=PUBLISHER_ID]"
+            Version="1.7.1.0"
+            ProcessorArchitecture="x64" />
+
+  <Properties>
+    <DisplayName>Chef Mate</DisplayName>
+    <PublisherDisplayName>Plus Mobile Apps</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0"
+                        MaxVersionTested="10.0.22621.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+
+  <Applications>
+    <Application Id="ChefMate"
+                 Executable="Chef Mate.exe"
+                 EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+          DisplayName="Chef Mate"
+          Description="Chef Mate - Your AI Cooking Assistant"
+          BackgroundColor="transparent"
+          Square150x150Logo="Assets\Square150x150Logo.png"
+          Square44x44Logo="Assets\Square44x44Logo.png" />
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <!-- Win32 / Desktop Bridge apps require the runFullTrust restricted capability -->
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>
+```
+
+`runFullTrust` is the restricted capability that lets a packaged Win32 app (which a bundled-JRE app is) run unsandboxed. The required logo assets (`StoreLogo`, `Square150x150Logo`, `Square44x44Logo`) are generated in CI by copying the existing app icon — replace these with correctly-sized PNGs before submitting for Store certification.
+
+**Build step** (the `Build app image for MSIX` + `Package MSIX` steps on the Windows leg of `desktop-release.yml`). The packaging step substitutes the manifest tokens, copies the icon into the `Assets`, and packs with `makeappx`:
+
+```yaml
+  - name: Package MSIX (Windows)
+    if: runner.os == 'Windows'
+    shell: pwsh
+    env:
+      STORE_IDENTITY_NAME: ${{ secrets.STORE_IDENTITY_NAME }}
+      STORE_PUBLISHER: ${{ secrets.STORE_PUBLISHER }}
+    run: |
+      # resolve version (tag → x.y.z), substitute __IDENTITY_NAME__/__PUBLISHER__/__VERSION__,
+      # copy icon to Assets\{StoreLogo,Square150x150Logo,Square44x44Logo}.png, then:
+      $makeappx = (Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\makeappx.exe" |
+                   Sort-Object FullName -Descending | Select-Object -First 1).FullName
+      & $makeappx pack /d "$img" /p "$env:RUNNER_TEMP\ChefMate.msix" /o
+```
+
+> Because the MSIX is signed by the Store on submission, you do **not** sign it yourself in CI. (You only need a self-signed cert to *sideload* it for local testing.)
+
+### Automating Store submission
+
+**Yes — this is wired in** via Microsoft's [**MSStore CLI**](https://github.com/microsoft/msstore-cli), driven from the `publish-store` job in `desktop-release.yml`.
+
+**Auth setup (one-time):**
+1. In Partner Center → **Account settings → User management → Azure AD applications**, add (or create) an Azure AD application and grant it the **Manager** role.
+2. Record the **tenant ID**, **client ID**, and create a **client secret**; grab the **seller ID** from Account settings. Store them as the `PARTNER_CENTER_*` secrets listed above.
+3. Set `STORE_PRODUCT_ID` (and `STORE_IDENTITY_NAME` / `STORE_PUBLISHER`). The `publish-store` job no-ops while `STORE_PRODUCT_ID` is unset, so it's safe to leave dormant until you're ready.
+
+**The job** (runs only on tag pushes; each step is gated on `STORE_PRODUCT_ID`):
+
+```yaml
+  publish-store:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: windows-latest
+    env:
+      STORE_PRODUCT_ID: ${{ secrets.STORE_PRODUCT_ID }}
+    steps:
+      - uses: actions/download-artifact@v4
+        if: env.STORE_PRODUCT_ID != ''
+        with: { name: desktop-windows-msix, path: msix }
+      - name: Setup MSStore CLI
+        if: env.STORE_PRODUCT_ID != ''
+        uses: microsoft/setup-msstore-cli@v1
+      - name: Configure MSStore CLI
+        if: env.STORE_PRODUCT_ID != ''
+        run: >
+          msstore reconfigure
+          --tenantId ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          --sellerId ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          --clientId ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          --clientSecret ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+      - name: Publish to Microsoft Store
+        if: env.STORE_PRODUCT_ID != ''
+        shell: pwsh
+        run: |
+          $msix = (Get-ChildItem msix/*.msix | Select-Object -First 1).FullName
+          msstore publish -i $msix -id $env:STORE_PRODUCT_ID
+```
+
+**Caveats / things to verify on first run:**
+- The **first** submission must be made manually in Partner Center; the API updates an existing listing, it doesn't create one.
+- Verify the `microsoft/setup-msstore-cli` action ref and the `msstore publish -id` value (Partner Center product ID vs. Store app ID) against the [current MSStore CLI docs](https://learn.microsoft.com/en-us/windows/apps/publish/msstore-dev-cli/commands) — the CLI is in preview and flags shift.
+- Store **certification review** still applies to each submission and can take hours to a day, so Store releases lag the GitHub Release / mobile releases.
+- The MSIX `Identity/Version` is derived from the release tag, so it increments automatically with the [version bump](#version-management).
+
+> **Status:** the MSIX packaging steps and `publish-store` job are wired into `desktop-release.yml`. The MSIX builds on every run (with placeholder identity until the Store secrets are set); submission only fires on tag pushes once `STORE_PRODUCT_ID` is configured. The unsigned `.msi` is still built as a fallback/sideload artifact.
 
 #### Desktop macOS code signing
 
@@ -406,9 +627,20 @@ Versions are defined in two files across three platforms:
 | iOS | `iosApp/Configuration/Config.xcconfig` | `CURRENT_PROJECT_VERSION` / `MARKETING_VERSION` |
 | Desktop | `client/composeApp/build.gradle.kts` | `packageVersion` (generic + macOS) |
 
-### Bump Script
+### CI version bump (recommended)
 
-Use `scripts/bump-version.sh` to update all version fields at once. Run it with no arguments for interactive mode:
+The normal release path is fully automated and **does not require running anything locally or creating tags by hand**:
+
+1. Trigger the **Bump Version** workflow (`bump-version.yml`) from the GitHub Actions UI (`workflow_dispatch`), choosing `major` / `minor` / `patch` / `custom`.
+2. It updates all version fields (Android, iOS, Desktop) and opens a PR (`chore: bump version to X.Y.Z`).
+3. Merging that PR triggers `build-release.yml`, which creates the `vX.Y.Z` tag and publishes the GitHub Release.
+4. The tag push then triggers `android-release`, `desktop-release`, and `ios-release` (requires `RELEASE_TOKEN`).
+
+See [ci/VERSION_BUMP_SETUP.md](ci/VERSION_BUMP_SETUP.md) for the required `RELEASE_TOKEN` configuration.
+
+### Bump script (local alternative)
+
+For local bumps (e.g. when not using the CI workflow), `scripts/bump-version.sh` updates all version fields at once. Run it with no arguments for interactive mode:
 
 ```bash
 ./scripts/bump-version.sh
@@ -429,10 +661,10 @@ CLI flags are also available for non-interactive use:
 ./scripts/bump-version.sh --version 1.0.0 --build-number 1 # set both
 ```
 
-Run the script before tagging a new release.
-
 ## Known Limitations
 
-- **Windows MSI and Linux DEB are unsigned** — only the macOS DMG is signed/notarized (see [Desktop macOS code signing](#desktop-macos-code-signing)). Windows users may see a SmartScreen warning.
+- **Windows MSI and Linux DEB are unsigned** — only the macOS DMG is signed/notarized (see [Desktop macOS code signing](#desktop-macos-code-signing)). Windows ships via the Microsoft Store (Store-signed), so this only affects the fallback MSI.
+- **MSIX packaging logo assets are placeholders** — CI reuses the app icon for all three Store logos, which won't pass Store certification. Replace with correctly-sized PNGs (see [Windows: Microsoft Store (MSIX)](#windows-microsoft-store-msix)).
+- **MSStore CLI is in preview** — the `publish-store` job's action ref and `publish` flags should be verified against current docs on first real submission.
+- **Store releases lag** — Microsoft Store certification review delays Windows releases relative to the GitHub Release and mobile stores.
 - **R8/ProGuard is disabled** — Android release builds are not minified. Enabling R8 requires ProGuard rules for KMP libraries (Ktor, Supabase, kotlinx.serialization, Decompose).
-- **No CI version bumping** — versions are bumped locally via `scripts/bump-version.sh` before tagging; there is no automatic version increment in CI.

--- a/packaging/windows/AppxManifest.xml
+++ b/packaging/windows/AppxManifest.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  MSIX manifest for the Microsoft Store build of Chef Mate.
+
+  The __TOKENS__ below are substituted by the "Package MSIX" step in
+  .github/workflows/desktop-release.yml before makeappx runs:
+    __IDENTITY_NAME__ -> Partner Center "Package/Identity Name" (STORE_IDENTITY_NAME secret)
+    __PUBLISHER__     -> Partner Center "Publisher" CN string    (STORE_PUBLISHER secret)
+    __VERSION__       -> release version as 4-part x.y.z.0
+
+  When the Store secrets are absent the step falls back to placeholder identity
+  values so the MSIX still builds as an artifact (it just can't be submitted).
+-->
+<Package
+    xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+    xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+    xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+
+  <Identity Name="__IDENTITY_NAME__"
+            Publisher="__PUBLISHER__"
+            Version="__VERSION__"
+            ProcessorArchitecture="x64" />
+
+  <Properties>
+    <DisplayName>Chef Mate+</DisplayName>
+    <PublisherDisplayName>Plus Mobile Apps LLC</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0"
+                        MaxVersionTested="10.0.22621.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+
+  <Applications>
+    <Application Id="ChefMate"
+                 Executable="Chef Mate.exe"
+                 EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+          DisplayName="Chef Mate+"
+          Description="Chef Mate - Your AI Cooking Assistant"
+          BackgroundColor="transparent"
+          Square150x150Logo="Assets\Square150x150Logo.png"
+          Square44x44Logo="Assets\Square44x44Logo.png" />
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <!-- Win32 (Desktop Bridge) apps with a bundled JRE must run unsandboxed -->
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>


### PR DESCRIPTION
## Summary
Establishes the desktop release + update story across all three desktop targets, using the right channel per platform:

- **macOS / Linux** — signed/notarized `.dmg` and `.deb` on GitHub Releases, with an **in-app updater** that polls a `latest.json` feed and prompts to download + install.
- **Windows** — ships via the **Microsoft Store** as an MSIX (Store signs it for free and handles updates), so the in-app updater is a deliberate no-op there.

## What's included
### In-app updater (macOS + Linux)
- `DesktopUpdater` polls `releases/latest/download/latest.json`, semver-compares against `BuildConfig.VERSION_NAME`, streams the platform installer with progress, and opens it. Bottom-overlay banner in `main.kt`. No-op on Windows.

### Release automation (`desktop-release.yml`)
- Publishes `latest.json` (macOS + Linux) on each tag.
- Gated **macOS codesign + notarization** and **Windows `signtool`** (no-op without secrets).
- **MSIX packaging**: builds the app image, substitutes identity/version tokens into `packaging/windows/AppxManifest.xml`, packs with `makeappx`.
- **`publish-store` job**: submits the MSIX via the MSStore CLI on tag pushes (gated on `STORE_PRODUCT_ID`).
- `build` matrix uses `fail-fast: false`; the `release` job only runs on tag pushes.

### Docs
- `docs/deployment.md`: desktop update strategy, signing secrets, the full Microsoft Store / MSIX section, and corrected version-management guidance.

## Validation status
The desktop-release workflow has been run on this branch (`workflow_dispatch`) — **macOS DMG, Linux DEB, Windows MSI, and Windows MSIX all build green**. The MSIX has been iterated against Partner Center package validation until it passed: identity name, publisher, publisher display name, and the reserved display name (`Chef Mate+`) are all set correctly. Identity values come from the `STORE_IDENTITY_NAME` / `STORE_PUBLISHER` secrets (now configured).

## Secrets (all gated)
- **macOS signing:** `MACOS_CERT_P12_BASE64`, `MACOS_CERT_PASSWORD`, `MACOS_SIGN_IDENTITY`, `APPLE_ID`, `APPLE_APP_PASSWORD`, `APPLE_TEAM_ID`
- **Windows (optional, non-Store MSI only):** `WINDOWS_CERT_PFX_BASE64`, `WINDOWS_CERT_PASSWORD`
- **Microsoft Store:** `PARTNER_CENTER_TENANT_ID`, `PARTNER_CENTER_CLIENT_ID`, `PARTNER_CENTER_CLIENT_SECRET`, `PARTNER_CENTER_SELLER_ID`, `STORE_PRODUCT_ID`, `STORE_IDENTITY_NAME` (set), `STORE_PUBLISHER` (set)

## Test plan
- [x] `./gradlew :client:composeApp:compileKotlinJvm`
- [x] Desktop-release workflow builds all four desktop packages incl. MSIX
- [x] MSIX clears Partner Center package validation (manual upload)
- [ ] Smoke-test the updater banner against a live feed with a higher version
- [ ] After configuring Store API secrets: confirm publish-store auto-submits (first submission is manual)

## Known gaps / follow-ups
- **MSIX logo assets are placeholders** (app icon reused) — won't pass Store *certification*. Tracked in #231.
- **runFullTrust** is a restricted capability — justify it inline during Store submission (expected for a bundled-JRE desktop app).
- **Windows Start-menu/tile name is now `Chef Mate+`** (the reserved name). Reserve "Chef Mate" too if you want the tile to read that.
- **Banner not visually verified** and **no snapshot test** (the screenshot-test harness is Android-only and can't reach jvmMain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)