### PR TITLE
fix(root): wrap nav stack in Surface to fix predictive-back white flash

### DIFF
--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -3,6 +3,7 @@
 package com.plusmobileapps.chefmate.root
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -23,25 +24,30 @@ import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 fun RootScreen(rootBloc: RootBloc, modifier: Modifier = Modifier) {
     val stack by rootBloc.state.subscribeAsState()
     ChefMateTheme {
-        Children(
-            modifier = modifier.fillMaxSize(),
-            stack = stack,
-            animation =
-                backAnimation(
-                    backHandler = rootBloc.backHandler,
-                    onBack = rootBloc::onBackClicked,
-                    fallbackAnimation =
-                        stackAnimation { child, otherChild, _ ->
-                            if (child.instance.isModal() || otherChild.instance.isModal()) {
-                                verticalSlide()
-                            } else {
-                                slide()
-                            }
-                        },
-                    isModal = { it.isModal() },
-                ),
-        ) { child ->
-            child.instance.Content()
+        // Surface paints the theme background behind the navigation stack so the
+        // Android predictive-back gesture reveals the themed color (white in light,
+        // black in dark) instead of the Activity's hardcoded light window background.
+        Surface(modifier = modifier.fillMaxSize()) {
+            Children(
+                modifier = Modifier.fillMaxSize(),
+                stack = stack,
+                animation =
+                    backAnimation(
+                        backHandler = rootBloc.backHandler,
+                        onBack = rootBloc::onBackClicked,
+                        fallbackAnimation =
+                            stackAnimation { child, otherChild, _ ->
+                                if (child.instance.isModal() || otherChild.instance.isModal()) {
+                                    verticalSlide()
+                                } else {
+                                    slide()
+                                }
+                            },
+                        isModal = { it.isModal() },
+                    ),
+            ) { child ->
+                child.instance.Content()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- The Android predictive-back gesture was flashing white in dark mode (#230).
- Root cause: the Activity is themed `@android:style/Theme.Material.Light.NoActionBar`, so the Android window background is hardcoded to white. During the predictive-back gesture, Decompose scales/clips the exiting screen with rounded corners — and the area outside those corners falls through transparent Compose layers to that white window background.
- Fix: wrap `Children` in a Material3 `Surface` inside `ChefMateTheme` so the themed background color (`colorScheme.background` — white in light, dark in dark) sits behind the navigation stack and is what gets revealed during the gesture.

## Test plan

- [ ] Run on Android in dark mode, navigate into a child screen (e.g. open a recipe), swipe back from the edge — the revealed area should be dark, not white.
- [ ] Run on Android in light mode, repeat — the revealed area should remain light.
- [ ] Sanity-check iOS / Desktop still render normally.

Fixes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)