### PR TITLE
feat(grocery): empty state when filters match no items

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ For iOS, open `/iosApp` in Xcode or use the IDE run configuration.
 - **Never `git push` without an explicit request from the user in the current message.** "Commit it" / "save this" / "go ahead" authorize a commit but not a push. The push is always a separate, user-requested action.
 - **Never bundle `git push` into the same Bash invocation as `git add` / `git commit`.** Run the commit on its own and stop. The user will issue a separate "push" instruction when they're ready.
 - **When opening a PR, split work into multiple commits by concern type so reviewers can step through them.** A typical order: refactors/renames first (no behavior change), then the feature or fix, then tests, then docs / strings / generated artifacts. One concern per commit, each with a conventional-commit subject (`refactor(recipe): …`, `feat(recipe): …`, `test(recipe): …`, `docs: …`). If a change is genuinely one concern, one commit is fine — don't manufacture splits.
+- **For feature work, split commits along the testing layers (see Architecture below):**
+  1. **One commit per BLoC, bundling that BLoC's unit tests with it.** Each BLoC (interface + impl + ViewModel) ships in the same commit as its `impl/src/commonTest` unit tests. If a PR touches several BLoCs, give each its own commit.
+  2. **Snapshots in their own commit.** The `<Feature>Previews.kt` previews, the `screenshot-test` `@PreviewTest` wrappers, and the recorded reference PNGs go together in a single dedicated commit, separate from the BLoC logic.
+  3. **Automation tests last.** Robot UI tests and the `impl-robots` modules that back them (the `<Feature>Robot.kt` classes and the `runRootBlocTest { … }` flow tests) come in the final commit.
 
 ## Architecture
 

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
@@ -141,6 +141,10 @@ class GroceryListBlocImpl(
         viewModel.onApplySortAndFilter(sort, filter, recipeFilter)
     }
 
+    override fun onClearFiltersClicked() {
+        viewModel.onClearFiltersClicked()
+    }
+
     override fun onDeleteClicked() {
         viewModel.onDeleteClicked()
     }

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
@@ -217,6 +217,17 @@ class GroceryListViewModel(
         _state.update { it.copy(sort = sort, filter = filter, recipeFilter = recipeFilter) }
     }
 
+    /**
+     * Resets the purchase and recipe filters to their defaults while preserving the chosen sort
+     * order (sort never removes items, so it can't be the cause of an empty filtered list).
+     */
+    fun onClearFiltersClicked() {
+        _filter.value = GroceryFilter.ALL
+        _recipeFilter.value = null
+        filterPref = GroceryFilter.ALL.name
+        _state.update { it.copy(filter = GroceryFilter.ALL, recipeFilter = null) }
+    }
+
     fun onDeleteClicked() {
         _state.update { it.copy(showDeleteDialog = true) }
     }

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListPreviews.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListPreviews.kt
@@ -98,6 +98,8 @@ private fun groceryListBloc(
             recipeFilter: String?,
         ) = Unit
 
+        override fun onClearFiltersClicked() = Unit
+
         override fun onDeleteClicked() = Unit
 
         override fun onDeleteDismissed() = Unit
@@ -132,6 +134,23 @@ val previewGroceryListBloc: GroceryListBloc =
 val previewGroceryListBlocEmpty: GroceryListBloc =
     groceryListBloc(GroceryListBloc.Model(lists = listOf(sampleList), selectedList = sampleList))
 
+/**
+ * Empty list because the active filter matched nothing — exercises the filtered-empty state with
+ * its "Clear filters" + "Browse my recipes" recovery CTAs. Distinct from
+ * [previewGroceryListBlocEmpty], which only renders when no filter is applied.
+ */
+val previewGroceryListBlocFilteredEmpty: GroceryListBloc =
+    groceryListBloc(
+        GroceryListBloc.Model(
+            groupedItems = emptyList(),
+            filter = GroceryFilter.PURCHASED,
+            availableRecipes = listOf("Pancakes"),
+            hasNoRecipeItems = true,
+            lists = listOf(sampleList),
+            selectedList = sampleList,
+        )
+    )
+
 @Preview(showBackground = true, heightDp = 1100)
 @Composable
 internal fun GroceryListPreview() {
@@ -142,4 +161,10 @@ internal fun GroceryListPreview() {
 @Composable
 internal fun GroceryListEmptyPreview() {
     ChefMateTheme { GroceryListScreen(bloc = previewGroceryListBlocEmpty) }
+}
+
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+internal fun GroceryListFilteredEmptyPreview() {
+    ChefMateTheme { GroceryListScreen(bloc = previewGroceryListBlocFilteredEmpty) }
 }

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -102,6 +103,9 @@ import chefmate.client.grocery.core.public.generated.resources.grocery_list
 import chefmate.client.grocery.core.public.generated.resources.grocery_list_empty_browse_recipes
 import chefmate.client.grocery.core.public.generated.resources.grocery_list_empty_description
 import chefmate.client.grocery.core.public.generated.resources.grocery_list_empty_title
+import chefmate.client.grocery.core.public.generated.resources.grocery_list_filtered_empty_clear_filters
+import chefmate.client.grocery.core.public.generated.resources.grocery_list_filtered_empty_description
+import chefmate.client.grocery.core.public.generated.resources.grocery_list_filtered_empty_title
 import chefmate.client.grocery.core.public.generated.resources.grocery_select_list
 import chefmate.client.grocery.core.public.generated.resources.grocery_sort_aisle
 import chefmate.client.grocery.core.public.generated.resources.grocery_sort_alphabetical
@@ -209,13 +213,19 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
                 onRefresh = bloc::onSyncClicked,
                 modifier = Modifier.weight(1f),
             ) {
-                val showEmptyState =
-                    state.groupedItems.isEmpty() &&
-                        state.filter == GroceryListBloc.GroceryFilter.ALL &&
-                        state.recipeFilter == null &&
-                        !state.isSyncing
+                val hasNoItems = state.groupedItems.isEmpty()
+                val filtersApplied =
+                    state.filter != GroceryListBloc.GroceryFilter.ALL || state.recipeFilter != null
+                val showEmptyState = hasNoItems && !filtersApplied && !state.isSyncing
+                val showFilteredEmptyState = hasNoItems && filtersApplied && !state.isSyncing
                 if (showEmptyState) {
                     EmptyGroceryListState(
+                        onBrowseRecipesClicked = bloc::onBrowseRecipesClicked,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                } else if (showFilteredEmptyState) {
+                    FilteredEmptyGroceryListState(
+                        onClearFiltersClicked = bloc::onClearFiltersClicked,
                         onBrowseRecipesClicked = bloc::onBrowseRecipesClicked,
                         modifier = Modifier.fillMaxSize(),
                     )
@@ -715,8 +725,13 @@ private fun EmptyGroceryListState(
     onBrowseRecipesClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val dimens = ChefMateTheme.dimens
     Column(
-        modifier = modifier.fillMaxWidth().padding(horizontal = 32.dp),
+        modifier =
+            modifier
+                .testTag(GroceryListTestTags.EMPTY_STATE)
+                .fillMaxWidth()
+                .padding(horizontal = dimens.paddingExtraLarge),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -726,20 +741,79 @@ private fun EmptyGroceryListState(
             modifier = Modifier.size(64.dp),
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(dimens.paddingNormal))
         Text(
             text = stringResource(Res.string.grocery_list_empty_title),
             style = MaterialTheme.typography.titleMedium,
         )
-        Spacer(Modifier.height(8.dp))
+        Spacer(Modifier.height(dimens.paddingSmall))
         Text(
             text = stringResource(Res.string.grocery_list_empty_description),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
-        Spacer(Modifier.height(24.dp))
-        Button(onClick = onBrowseRecipesClicked, modifier = Modifier.fillMaxWidth()) {
+        Spacer(Modifier.height(dimens.paddingLarge))
+        Button(
+            onClick = onBrowseRecipesClicked,
+            modifier = Modifier.testTag(GroceryListTestTags.BROWSE_RECIPES_BUTTON).fillMaxWidth(),
+        ) {
+            Text(stringResource(Res.string.grocery_list_empty_browse_recipes))
+        }
+    }
+}
+
+/**
+ * Shown when the list has items but the active purchase/recipe filters leave nothing visible. Lets
+ * the user recover by clearing filters (primary) or jumping to recipes (secondary) instead of
+ * staring at a blank screen.
+ */
+@Composable
+private fun FilteredEmptyGroceryListState(
+    onClearFiltersClicked: () -> Unit,
+    onBrowseRecipesClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dimens = ChefMateTheme.dimens
+    Column(
+        modifier =
+            modifier
+                .testTag(GroceryListTestTags.FILTERED_EMPTY_STATE)
+                .fillMaxWidth()
+                .padding(horizontal = dimens.paddingExtraLarge),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.FilterList,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(dimens.paddingNormal))
+        Text(
+            text = stringResource(Res.string.grocery_list_filtered_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Spacer(Modifier.height(dimens.paddingSmall))
+        Text(
+            text = stringResource(Res.string.grocery_list_filtered_empty_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(dimens.paddingLarge))
+        Button(
+            onClick = onClearFiltersClicked,
+            modifier = Modifier.testTag(GroceryListTestTags.CLEAR_FILTERS_BUTTON).fillMaxWidth(),
+        ) {
+            Text(stringResource(Res.string.grocery_list_filtered_empty_clear_filters))
+        }
+        Spacer(Modifier.height(dimens.paddingSmall))
+        OutlinedButton(
+            onClick = onBrowseRecipesClicked,
+            modifier = Modifier.testTag(GroceryListTestTags.BROWSE_RECIPES_BUTTON).fillMaxWidth(),
+        ) {
             Text(stringResource(Res.string.grocery_list_empty_browse_recipes))
         }
     }

--- a/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
+++ b/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
@@ -343,6 +343,44 @@ class GroceryListBlocTest {
     }
 
     @Test
+    fun When_clear_filters_clicked_Then_filters_reset_but_sort_preserved() = runTest {
+        val items =
+            listOf(
+                GroceryItem(
+                    id = 1,
+                    name = "Flour",
+                    displayName = "Flour",
+                    category = GroceryCategory.BAKING,
+                    isChecked = false,
+                    recipeName = "Chocolate Cake",
+                ),
+                GroceryItem(
+                    id = 2,
+                    name = "Salt",
+                    displayName = "Salt",
+                    category = GroceryCategory.SPICES,
+                    isChecked = true,
+                ),
+            )
+        groceries.emit(items)
+        // Apply a sort + a purchase filter + a recipe filter that together hide everything.
+        bloc.onApplySortAndFilter(
+            GroceryListBloc.GrocerySort.ALPHABETICAL,
+            GroceryListBloc.GroceryFilter.UNPURCHASED,
+            recipeFilter = "Chocolate Cake",
+        )
+        bloc.onClearFiltersClicked()
+        bloc.state.test {
+            val result = awaitItem()
+            result.filter shouldBe GroceryListBloc.GroceryFilter.ALL
+            result.recipeFilter shouldBe null
+            // Sort is intentionally preserved — it never causes an empty filtered list.
+            result.sort shouldBe GroceryListBloc.GrocerySort.ALPHABETICAL
+            result.groupedItems.flatMap { it.items }.size shouldBe 2
+        }
+    }
+
+    @Test
     fun When_browse_recipes_clicked_Then_open_recipes_output_emitted() = runTest {
         bloc.onBrowseRecipesClicked()
         output.lastValue shouldBe GroceryListBloc.Output.OpenRecipes

--- a/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
@@ -58,4 +58,7 @@
     <string name="grocery_list_empty_title">Your grocery list is empty</string>
     <string name="grocery_list_empty_description">Add items below, or pull ingredients in from one of your recipes.</string>
     <string name="grocery_list_empty_browse_recipes">Browse my recipes</string>
+    <string name="grocery_list_filtered_empty_title">No items match your filters</string>
+    <string name="grocery_list_filtered_empty_description">Nothing here matches the filters you’ve applied. Clear them to see everything, or pull in ingredients from one of your recipes.</string>
+    <string name="grocery_list_filtered_empty_clear_filters">Clear filters</string>
 </resources>

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
@@ -44,6 +44,8 @@ interface GroceryListBloc : BlocScreen {
 
     fun onApplySortAndFilter(sort: GrocerySort, filter: GroceryFilter, recipeFilter: String? = null)
 
+    fun onClearFiltersClicked()
+
     fun onDeleteClicked()
 
     fun onDeleteDismissed()

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListTestTags.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListTestTags.kt
@@ -2,4 +2,8 @@ package com.plusmobileapps.chefmate.grocery.core.list
 
 object GroceryListTestTags {
     const val SCREEN = "grocery_list_screen"
+    const val EMPTY_STATE = "grocery_list_empty_state"
+    const val FILTERED_EMPTY_STATE = "grocery_list_filtered_empty_state"
+    const val CLEAR_FILTERS_BUTTON = "grocery_list_clear_filters_button"
+    const val BROWSE_RECIPES_BUTTON = "grocery_list_browse_recipes_button"
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.android.tools.screenshot.PreviewTest
 import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBloc
 import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBlocEmpty
+import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBlocFilteredEmpty
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -55,4 +56,20 @@ fun GroceryListEmptyPhonePortraitLightScreenshot() {
 @Composable
 fun GroceryListEmptyPhonePortraitDarkScreenshot() {
     GroceryListScreenshot(bloc = previewGroceryListBlocEmpty, darkTheme = true)
+}
+
+// ── Filtered empty state — "Clear filters" + "Browse my recipes" recovery CTAs ──
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun GroceryListFilteredEmptyPhonePortraitLightScreenshot() {
+    GroceryListScreenshot(bloc = previewGroceryListBlocFilteredEmpty)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun GroceryListFilteredEmptyPhonePortraitDarkScreenshot() {
+    GroceryListScreenshot(bloc = previewGroceryListBlocFilteredEmpty, darkTheme = true)
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListFilteredEmptyPhonePortraitDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListFilteredEmptyPhonePortraitDarkScreenshot_805fa67c_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79b763ac5d81bbf8b2e483d1ec101871bf288c7a02e2d55f614014bc32c42e8c
+size 69557

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListFilteredEmptyPhonePortraitLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListFilteredEmptyPhonePortraitLightScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82862e2943424372e703ae20cde056cff79b7f9138c5f9699017a13249ba2828
+size 69470


### PR DESCRIPTION
## Summary

Adds a dedicated empty state to the grocery list for when a purchase or recipe **filter** is applied but no items match. Previously the screen rendered a blank list with no explanation or way out.

The new state shows an explanatory message plus two recovery actions:
- **Clear filters** (primary) — resets the purchase and recipe filters back to defaults. Sort is intentionally preserved since it never removes items and so can't be the cause of an empty filtered list.
- **Browse my recipes** (secondary) — reuses the existing `OpenRecipes` output to jump to recipes.

This sits alongside the existing "your list is genuinely empty" state, which only renders when no filter is active.

## Changes

- `GroceryListBloc`: new `onClearFiltersClicked()` handler; `GroceryListViewModel` resets `filter`/`recipeFilter` while keeping `sort`.
- `GroceryListScreen`: split the empty branch into `EmptyGroceryListState` (no filter) and the new `FilteredEmptyGroceryListState` (filter applied, no matches). Spacing migrated to `ChefMateTheme.dimens` tokens.
- New strings + test tags for both empty states.
- Bloc unit test for the clear-filters reset, and light/dark snapshot references for the filtered-empty state.

## Screenshots

| Light | Dark |
|---|---|
| `GroceryListFilteredEmptyPhonePortraitLightScreenshot` | `GroceryListFilteredEmptyPhonePortraitDarkScreenshot` |

## Testing

- `./gradlew :client:grocery:core:impl:testAndroidHostTest` ✅
- `./gradlew :client:ui:screenshot-test:updateDebugScreenshotTest` (references recorded + visually inspected) ✅
- `ktfmtCheck` clean for touched modules ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)