### PR TITLE
refactor(recipe): type recipe-extraction errors with an enum

### DIFF
--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatViewModel.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatViewModel.kt
@@ -8,6 +8,7 @@ import com.plusmobileapps.chefmate.aichat.AiChatNoApiKeyError
 import com.plusmobileapps.chefmate.aichat.ChatMessage
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.PendingRecipePhotoStore
+import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import com.plusmobileapps.chefmate.recipe.data.RecipeImageExtractor
 import com.plusmobileapps.chefmate.text.TextData
@@ -136,9 +137,9 @@ class AiChatViewModel(
                     return@launch
                 val recipe = recipeExtractor.extract(history)
                 _extractedRecipe.tryEmit(AiChatBloc.Output.AddAsRecipe(recipe))
-            } catch (e: GeminiExtractionException) {
+            } catch (e: RecipeExtractionException) {
                 _error.value =
-                    if (e.message == "MISSING_API_KEY") AiChatNoApiKeyError
+                    if (e.error == RecipeExtractionError.MISSING_API_KEY) AiChatNoApiKeyError
                     else AiChatExtractionError
             } catch (_: Throwable) {
                 _error.value = AiChatExtractionError
@@ -170,7 +171,7 @@ class AiChatViewModel(
                 )
             } catch (e: RecipeExtractionException) {
                 _error.value =
-                    if (e.message == "MISSING_API_KEY") AiChatNoApiKeyError
+                    if (e.error == RecipeExtractionError.MISSING_API_KEY) AiChatNoApiKeyError
                     else AiChatExtractionError
             } catch (_: Throwable) {
                 _error.value = AiChatExtractionError

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/GeminiRecipeExtractor.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/GeminiRecipeExtractor.kt
@@ -5,6 +5,7 @@ import com.plusmobileapps.chefmate.aichat.impl.di.GeminiApiKey
 import com.plusmobileapps.chefmate.aichat.impl.di.GeminiHttpClient
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
+import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import com.plusmobileapps.chefmate.recipe.data.RecipeImageExtractor
 import dev.zacsweers.metro.ContributesBinding
@@ -25,9 +26,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
-
-class GeminiExtractionException(message: String, cause: Throwable? = null) :
-    RuntimeException(message, cause)
 
 /**
  * One-shot Gemini call that turns the current chat history into an [ExtractedRecipeData] using
@@ -66,7 +64,7 @@ class RealGeminiRecipeExtractor(
                     parts = listOf(GeminiPart(text = message.content)),
                 )
             }
-        return generate(contents) { code, cause -> throw GeminiExtractionException(code, cause) }
+        return generate(contents)
     }
 
     override suspend fun extractFromImage(bytes: ByteArray, mimeType: String): ExtractedRecipeData {
@@ -87,18 +85,15 @@ class RealGeminiRecipeExtractor(
                         ),
                 )
             )
-        return generate(contents) { code, cause -> throw RecipeExtractionException(code, cause) }
+        return generate(contents)
     }
 
     /**
-     * Shared structured-output call. [fail] maps a stable error code to the caller's exception type
-     * (chat vs. recipe flow) so the two public entry points don't leak each other's exceptions.
+     * Shared structured-output call for both entry points. Failures surface as a
+     * [RecipeExtractionException] carrying a typed [RecipeExtractionError].
      */
-    private suspend fun generate(
-        contents: List<GeminiContent>,
-        fail: (code: String, cause: Throwable?) -> Nothing,
-    ): ExtractedRecipeData {
-        if (apiKey.isBlank()) fail("MISSING_API_KEY", null)
+    private suspend fun generate(contents: List<GeminiContent>): ExtractedRecipeData {
+        if (apiKey.isBlank()) throw RecipeExtractionException(RecipeExtractionError.MISSING_API_KEY)
 
         val request = GeminiRequest(contents = contents, generationConfig = recipeGenerationConfig)
 
@@ -114,19 +109,21 @@ class RealGeminiRecipeExtractor(
                     }
                     .body<GeminiResponse>()
             } catch (e: Throwable) {
-                fail("REQUEST_FAILED", e)
+                throw RecipeExtractionException(RecipeExtractionError.REQUEST_FAILED, e)
             }
 
         val payload =
             response.candidates?.firstOrNull()?.content?.parts?.firstOrNull()?.text
-                ?: fail("EMPTY_RESPONSE", null)
+                ?: throw RecipeExtractionException(RecipeExtractionError.EMPTY_RESPONSE)
 
         val recipe =
             runCatching { json.decodeFromString(RecipeJson.serializer(), payload) }
-                .getOrElse { fail("MALFORMED_JSON", it) }
+                .getOrElse {
+                    throw RecipeExtractionException(RecipeExtractionError.MALFORMED_JSON, it)
+                }
 
         if (recipe.title.isBlank() || recipe.ingredients.isEmpty() || recipe.directions.isEmpty()) {
-            fail("INCOMPLETE_RECIPE", null)
+            throw RecipeExtractionException(RecipeExtractionError.INCOMPLETE_RECIPE)
         }
 
         return ExtractedRecipeData(

--- a/client/aichat/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatViewModelTest.kt
+++ b/client/aichat/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatViewModelTest.kt
@@ -10,6 +10,7 @@ import com.plusmobileapps.chefmate.aichat.AiChatNoApiKeyError
 import com.plusmobileapps.chefmate.aichat.ChatMessage
 import com.plusmobileapps.chefmate.database.testing.createTestDatabase
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
+import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import com.plusmobileapps.chefmate.recipe.data.RecipeImageExtractor
 import com.plusmobileapps.chefmate.recipe.data.testing.FakePendingRecipePhotoStore
@@ -153,7 +154,7 @@ class AiChatViewModelTest {
     fun extractFromImage_surfaces_missing_api_key_error() =
         runTest(dispatcher) {
             everySuspend { imageExtractor.extractFromImage(any(), any()) } throws
-                RecipeExtractionException("MISSING_API_KEY")
+                RecipeExtractionException(RecipeExtractionError.MISSING_API_KEY)
             val viewModel = newViewModel()
 
             viewModel.extractFromImage(byteArrayOf(1), "jpg")
@@ -167,7 +168,7 @@ class AiChatViewModelTest {
     fun extractFromImage_surfaces_generic_error_on_other_failures() =
         runTest(dispatcher) {
             everySuspend { imageExtractor.extractFromImage(any(), any()) } throws
-                RecipeExtractionException("MALFORMED_JSON")
+                RecipeExtractionException(RecipeExtractionError.MALFORMED_JSON)
             val viewModel = newViewModel()
 
             viewModel.extractFromImage(byteArrayOf(1), "jpg")
@@ -191,7 +192,7 @@ class AiChatViewModelTest {
         runTest(dispatcher) {
             everySuspend { geminiClient.streamReply(any()) } returns flow { emit("ok") }
             everySuspend { recipeExtractor.extract(any()) } throws
-                GeminiExtractionException("MISSING_API_KEY")
+                RecipeExtractionException(RecipeExtractionError.MISSING_API_KEY)
             val viewModel = newViewModel()
 
             viewModel.onInputChange("hi")
@@ -206,7 +207,7 @@ class AiChatViewModelTest {
         runTest(dispatcher) {
             everySuspend { geminiClient.streamReply(any()) } returns flow { emit("ok") }
             everySuspend { recipeExtractor.extract(any()) } throws
-                GeminiExtractionException("MALFORMED_JSON")
+                RecipeExtractionException(RecipeExtractionError.MALFORMED_JSON)
             val viewModel = newViewModel()
 
             viewModel.onInputChange("hi")

--- a/client/aichat/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/aichat/impl/GeminiRecipeExtractorImageTest.kt
+++ b/client/aichat/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/aichat/impl/GeminiRecipeExtractorImageTest.kt
@@ -1,5 +1,6 @@
 package com.plusmobileapps.chefmate.aichat.impl
 
+import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
@@ -61,7 +62,7 @@ class GeminiRecipeExtractorImageTest {
             shouldThrow<RecipeExtractionException> {
                 extractor.extractFromImage(imageBytes, "image/jpeg")
             }
-        error.message shouldBe "MISSING_API_KEY"
+        error.error shouldBe RecipeExtractionError.MISSING_API_KEY
     }
 
     @Test
@@ -72,7 +73,7 @@ class GeminiRecipeExtractorImageTest {
             shouldThrow<RecipeExtractionException> {
                 extractor.extractFromImage(imageBytes, "image/jpeg")
             }
-        error.message shouldBe "EMPTY_RESPONSE"
+        error.error shouldBe RecipeExtractionError.EMPTY_RESPONSE
     }
 
     @Test
@@ -83,7 +84,7 @@ class GeminiRecipeExtractorImageTest {
             shouldThrow<RecipeExtractionException> {
                 extractor.extractFromImage(imageBytes, "image/jpeg")
             }
-        error.message shouldBe "MALFORMED_JSON"
+        error.error shouldBe RecipeExtractionError.MALFORMED_JSON
     }
 
     @Test
@@ -97,7 +98,7 @@ class GeminiRecipeExtractorImageTest {
             shouldThrow<RecipeExtractionException> {
                 extractor.extractFromImage(imageBytes, "image/jpeg")
             }
-        error.message shouldBe "INCOMPLETE_RECIPE"
+        error.error shouldBe RecipeExtractionError.INCOMPLETE_RECIPE
     }
 
     @Test
@@ -108,7 +109,7 @@ class GeminiRecipeExtractorImageTest {
             shouldThrow<RecipeExtractionException> {
                 extractor.extractFromImage(imageBytes, "image/jpeg")
             }
-        error.message shouldBe "REQUEST_FAILED"
+        error.error shouldBe RecipeExtractionError.REQUEST_FAILED
     }
 
     /** Wraps [recipeJson] (the structured-output payload) in Gemini's candidate envelope. */

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/FakeGeminiRecipeExtractor.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/FakeGeminiRecipeExtractor.kt
@@ -1,11 +1,11 @@
 package com.plusmobileapps.chefmate.fakes
 
 import com.plusmobileapps.chefmate.aichat.ChatMessage
-import com.plusmobileapps.chefmate.aichat.impl.GeminiExtractionException
 import com.plusmobileapps.chefmate.aichat.impl.GeminiRecipeExtractor
 import com.plusmobileapps.chefmate.aichat.impl.RealGeminiRecipeExtractor
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
+import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import com.plusmobileapps.chefmate.recipe.data.RecipeImageExtractor
 import dev.zacsweers.metro.ContributesBinding
@@ -35,8 +35,8 @@ class FakeGeminiRecipeExtractor : GeminiRecipeExtractor, RecipeImageExtractor {
     var response: ExtractedRecipeData? = null
 
     override suspend fun extract(history: List<ChatMessage>): ExtractedRecipeData =
-        response ?: throw GeminiExtractionException("NO_FAKE_RESPONSE")
+        response ?: throw RecipeExtractionException(RecipeExtractionError.EMPTY_RESPONSE)
 
     override suspend fun extractFromImage(bytes: ByteArray, mimeType: String): ExtractedRecipeData =
-        response ?: throw RecipeExtractionException("NO_FAKE_RESPONSE")
+        response ?: throw RecipeExtractionException(RecipeExtractionError.EMPTY_RESPONSE)
 }

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeImageExtractor.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeImageExtractor.kt
@@ -12,10 +12,23 @@ interface RecipeImageExtractor {
     suspend fun extractFromImage(bytes: ByteArray, mimeType: String): ExtractedRecipeData
 }
 
+/** The distinct ways recipe extraction (from chat text or an image) can fail. */
+enum class RecipeExtractionError {
+    /** No Gemini API key is configured. */
+    MISSING_API_KEY,
+    /** The network request to Gemini failed. */
+    REQUEST_FAILED,
+    /** Gemini returned no usable candidate/content. */
+    EMPTY_RESPONSE,
+    /** Gemini's structured-output payload couldn't be parsed as a recipe. */
+    MALFORMED_JSON,
+    /** A recipe was parsed but is missing required fields (title, ingredients, or directions). */
+    INCOMPLETE_RECIPE,
+}
+
 /**
- * Thrown when image extraction fails. [message] is a stable code (`MISSING_API_KEY`,
- * `REQUEST_FAILED`, `EMPTY_RESPONSE`, `MALFORMED_JSON`, `INCOMPLETE_RECIPE`) that callers map to a
- * user-facing error.
+ * Thrown when recipe extraction fails. [error] is a typed [RecipeExtractionError] so callers can
+ * branch exhaustively (e.g. surface a "missing API key" message) without matching on strings.
  */
-class RecipeExtractionException(message: String, cause: Throwable? = null) :
-    RuntimeException(message, cause)
+class RecipeExtractionException(val error: RecipeExtractionError, cause: Throwable? = null) :
+    RuntimeException(error.name, cause)

--- a/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeImageExtractor.kt
+++ b/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeImageExtractor.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.recipe.data.testing
 
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
+import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import com.plusmobileapps.chefmate.recipe.data.RecipeImageExtractor
 
@@ -16,7 +17,7 @@ class FakeRecipeImageExtractor(var response: ExtractedRecipeData? = null) : Reci
     override suspend fun extractFromImage(bytes: ByteArray, mimeType: String): ExtractedRecipeData {
         calls.add(Call(bytes = bytes, mimeType = mimeType))
         error?.let { throw it }
-        return response ?: throw RecipeExtractionException("NO_FAKE_RESPONSE")
+        return response ?: throw RecipeExtractionException(RecipeExtractionError.EMPTY_RESPONSE)
     }
 
     data class Call(val bytes: ByteArray, val mimeType: String) {

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
@@ -15,6 +15,7 @@ import com.plusmobileapps.chefmate.recipe.data.CategoryRepository
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
 import com.plusmobileapps.chefmate.recipe.data.PendingRecipePhotoStore
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import com.plusmobileapps.chefmate.recipe.data.RecipeImageExtractor
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
@@ -259,7 +260,7 @@ class RecipeListViewModel(
                 _state.update {
                     it.copy(
                         scanError =
-                            if (e.message == "MISSING_API_KEY")
+                            if (e.error == RecipeExtractionError.MISSING_API_KEY)
                                 ResourceString(Res.string.recipe_list_scan_no_api_key)
                             else ResourceString(Res.string.recipe_list_scan_failed)
                     )

--- a/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
+++ b/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
@@ -11,6 +11,7 @@ import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.Category
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import com.plusmobileapps.chefmate.recipe.data.SyncStatus
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeCategoryRepository
@@ -86,7 +87,7 @@ class RecipeListViewModelTest {
 
     @Test
     fun When_scan_fails_with_missing_api_key_Then_scan_error_set() {
-        imageExtractor.error = RecipeExtractionException("MISSING_API_KEY")
+        imageExtractor.error = RecipeExtractionException(RecipeExtractionError.MISSING_API_KEY)
 
         viewModel.scanRecipeFromPhoto(byteArrayOf(1), "jpg")
 
@@ -96,7 +97,7 @@ class RecipeListViewModelTest {
 
     @Test
     fun When_scan_fails_generically_Then_scan_error_set_and_dismissable() {
-        imageExtractor.error = RecipeExtractionException("MALFORMED_JSON")
+        imageExtractor.error = RecipeExtractionException(RecipeExtractionError.MALFORMED_JSON)
 
         viewModel.scanRecipeFromPhoto(byteArrayOf(1), "jpg")
         (viewModel.state.value.scanError != null) shouldBe true


### PR DESCRIPTION
Addresses review feedback from #241 (tracked in #244).

## Feedback
> can failing happen with a stronger type of an enum or a sealed class for flexibility of getting more detail information?

The recipe-extraction path signalled failures with **raw string codes** (`"MISSING_API_KEY"`, `"REQUEST_FAILED"`, …). The producer used a `fail(code: String, …)` lambda and every consumer compared `exception.message == "MISSING_API_KEY"` — stringly-typed, no exhaustiveness, no structured detail.

## Change
- New `RecipeExtractionError` **enum** in `client/recipe/data/public` (next to `RecipeExtractionException`): `MISSING_API_KEY`, `REQUEST_FAILED`, `EMPTY_RESPONSE`, `MALFORMED_JSON`, `INCOMPLETE_RECIPE`.
- `RecipeExtractionException` now carries `val error: RecipeExtractionError` instead of a bare string message.
- `RealGeminiRecipeExtractor.generate(...)` throws the typed exception **directly** — the string-code `fail()` indirection and the parallel `GeminiExtractionException` are gone. Both `extract` (chat text) and `extractFromImage` (vision) share it.
- Consumers (`AiChatViewModel`, `RecipeListViewModel`) and test fakes branch on `e.error` instead of matching strings.

Streaming-reply errors (`GeminiException` in `GeminiClient`) are a separate concern and intentionally left as-is.

## Testing
- `aichat:impl`, `recipe:data:impl`, `recipe:list:impl` unit tests (extractor + view models now assert the typed value).
- Full `composeApp:jvmTest` (DI graph + flow tests) and `ktfmtCheck` on touched modules — all green.
- Pure common-Kotlin change (enum + exception), so it compiles identically on JVM and iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)