### PR TITLE
fix(aichat): input inset + relocate the in-flight loading indicator

### DIFF
--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatPreviews.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatPreviews.kt
@@ -97,6 +97,15 @@ val previewAiChatBlocStreaming: AiChatBloc =
         )
     )
 
+/**
+ * Reply in flight before the first token arrives — the latest message is the user's and [isSending]
+ * is true, so the "Gemini is thinking" bubble shows in the model position.
+ */
+val previewAiChatBlocThinking: AiChatBloc =
+    aiChatBloc(
+        AiChatBloc.Model(messages = sampleConversation, canAddRecipe = true, isSending = true)
+    )
+
 /** Error banner state — typical for a missing API key or network failure. */
 val previewAiChatBlocError: AiChatBloc =
     aiChatBloc(
@@ -123,6 +132,12 @@ internal fun AiChatScreenEmptyPreview() {
 @Composable
 internal fun AiChatScreenStreamingPreview() {
     ChefMateTheme { previewAiChatBlocStreaming.Content() }
+}
+
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+internal fun AiChatScreenThinkingPreview() {
+    ChefMateTheme { previewAiChatBlocThinking.Content() }
 }
 
 @Preview(showBackground = true, heightDp = 900)

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatScreen.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatScreen.kt
@@ -507,22 +507,18 @@ private fun AiChatInput(
                     }
                 ),
             trailingIcon = {
+                // The send button is purely enable/disable now — it lights up once there's text to
+                // send. The in-flight indicator lives in the chat log (see ThinkingBubble) where
+                // it's actually visible.
                 IconButton(
                     onClick = onSendClick,
                     enabled = canSend,
                     modifier = Modifier.testTag(AiChatTestTags.SEND_BUTTON),
                 ) {
-                    if (isSending) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(20.dp),
-                            strokeWidth = 2.dp,
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.Send,
-                            contentDescription = stringResource(Res.string.aichat_send),
-                        )
-                    }
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Send,
+                        contentDescription = stringResource(Res.string.aichat_send),
+                    )
                 }
             },
         )

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatScreen.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatScreen.kt
@@ -15,13 +15,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -96,7 +100,7 @@ fun AiChatScreen(bloc: AiChatBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
 
     PlusHeaderContainer(
-        modifier = modifier.fillMaxSize().imePadding().testTag(AiChatTestTags.SCREEN),
+        modifier = modifier.fillMaxSize().testTag(AiChatTestTags.SCREEN),
         data =
             PlusHeaderData.Child(
                 title = Res.string.aichat_title.asTextData(),
@@ -410,6 +414,10 @@ private fun AiChatInput(
             modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface)
+                // Keep the input above the keyboard when open and above the navigation/gesture bar
+                // when closed. Unioning the two insets pads by whichever is larger (the IME inset
+                // already includes the navigation bar) so they never stack.
+                .windowInsetsPadding(WindowInsets.ime.union(WindowInsets.navigationBars))
                 .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatScreen.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatScreen.kt
@@ -124,7 +124,11 @@ fun AiChatScreen(bloc: AiChatBloc, modifier: Modifier = Modifier) {
                 if (state.messages.isEmpty()) {
                     EmptyState(modifier = Modifier.fillMaxSize())
                 } else {
-                    MessageList(messages = state.messages, modifier = Modifier.fillMaxSize())
+                    MessageList(
+                        messages = state.messages,
+                        isSending = state.isSending,
+                        modifier = Modifier.fillMaxSize(),
+                    )
                 }
             }
             state.error?.let { error ->
@@ -161,10 +165,20 @@ fun AiChatScreen(bloc: AiChatBloc, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun MessageList(messages: List<ChatMessage>, modifier: Modifier = Modifier) {
+private fun MessageList(
+    messages: List<ChatMessage>,
+    isSending: Boolean,
+    modifier: Modifier = Modifier,
+) {
     val listState = rememberLazyListState()
     val inspection = LocalInspectionMode.current
     val last = messages.lastOrNull()
+
+    // Until the reply's first token arrives no model row exists yet (the repository defers it), so
+    // surface a "Gemini is thinking" bubble where the reply will land — at the start/bottom of the
+    // log — instead of relying on the tiny spinner that used to live in the send button.
+    val showThinking =
+        isSending && messages.none { it.role == ChatMessage.Role.MODEL && it.isStreaming }
 
     // Capture, the moment the last message first appears, whether it began streaming this session.
     // A reply that streams in is spelled out line by line; an already-complete message (history
@@ -194,6 +208,11 @@ private fun MessageList(messages: List<ChatMessage>, modifier: Modifier = Modifi
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
+        // reverseLayout: the first item renders at the bottom (newest), so the thinking bubble sits
+        // just below the latest user message.
+        if (showThinking) {
+            item(key = "thinking") { ThinkingBubble() }
+        }
         items(messages.asReversed(), key = { it.id }) { message ->
             val isRevealing = revealStreaming && message.id == last?.id
             val displayContent =
@@ -284,6 +303,36 @@ private fun MessageBubble(
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * Shown in the Gemini (start) position while a reply is in flight but no token has arrived yet.
+ * Mirrors a model [MessageBubble] — same role label and bubble styling — with a small spinner in
+ * place of text, so it reads as "Gemini is thinking" rather than a stray indicator on the input.
+ */
+@Composable
+private fun ThinkingBubble(modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxWidth(), horizontalAlignment = Alignment.Start) {
+        Text(
+            text = stringResource(Res.string.aichat_role_gemini),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
+        )
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier.testTag(AiChatTestTags.THINKING_INDICATOR),
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp).size(16.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatTestTags.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatTestTags.kt
@@ -6,6 +6,7 @@ object AiChatTestTags {
     const val SEND_BUTTON = "AiChatSendButton"
     const val HISTORY_BUTTON = "AiChatHistoryButton"
     const val MESSAGE_LIST = "AiChatMessageList"
+    const val THINKING_INDICATOR = "AiChatThinkingIndicator"
     const val ADD_RECIPE_PILL = "AiChatAddRecipePill"
     const val ATTACH_PHOTO_BUTTON = "AiChatAttachPhotoButton"
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTest.kt
@@ -14,6 +14,7 @@ import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocEmpty
 import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocError
 import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocExtracting
 import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocStreaming
+import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocThinking
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
@@ -59,6 +60,13 @@ fun AiChatConversationDarkScreenshot() {
 @Composable
 fun AiChatStreamingLightScreenshot() {
     AiChatScreenshot(bloc = previewAiChatBlocStreaming)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun AiChatThinkingLightScreenshot() {
+    AiChatScreenshot(bloc = previewAiChatBlocThinking)
 }
 
 @PreviewTest

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatThinkingLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatThinkingLightScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d068048243d47d22a1ddf9058aa1b03292d91c2255190d64a42049d16afa23a8
+size 124500


### PR DESCRIPTION
## Summary

Three fixes to the AI Chat screen, each in its own commit.

1. **Input no longer blocked by the gesture bar.** The chat input only had `imePadding()`, so with the keyboard closed it ran under the Android navigation/gesture bar. The input row now pads by the *union* of the IME and navigation-bar insets — whichever is larger — so it clears the gesture bar when closed and the keyboard when open, without double-padding.
2. **Loading indicator moved into the chat.** The only "Gemini is working" cue used to be a tiny, hard-to-see spinner inside the send button. Before the reply's first token arrives there's no model row yet (the repo defers it), so a **thinking bubble** now renders in the Gemini (start) position — same label/styling as a real reply, with a spinner in place of text — and is replaced by the reply bubble once tokens stream in.
3. **Send button is just enable/disable.** Dropped the in-button spinner; the button is the Send icon, enabled only when the input is non-blank and not already sending — clearly greyed out until a message can actually be sent.

## Commits

- `fix(aichat): keep text input above the navigation/gesture bar`
- `feat(aichat): show an in-chat "Gemini is thinking" bubble while awaiting a reply`
- `fix(aichat): disable the send button until there's text to send`
- `test(aichat): snapshot coverage for the thinking state`

## Testing

- `:client:aichat:impl:jvmTest` ✅
- AiChat navigation/UI tests (`:client:composeApp:jvmTest --tests "*AiChat*"`) ✅
- `:client:ui:screenshot-test:validateDebugScreenshotTest` ✅ (new `AiChatThinkingLightScreenshot` reference recorded)

Note: in the static snapshot the spinner shows as a tiny mark because indeterminate progress indicators don't animate in screenshot/inspection mode — it spins normally on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
