### PR TITLE
feat(featureflag): target flags at specific user ids

### DIFF
--- a/.claude/skills/add-feature-flag.md
+++ b/.claude/skills/add-feature-flag.md
@@ -71,6 +71,11 @@ values ('home_banner_text', 'string', '', true, 0);
 update feature_flags set rollout_percent = 100 where key = 'show_onboarding_v2';
 ```
 
+To force-enable for specific signed-in users on top of the rollout (e.g. QA/beta), set the `user_ids` allowlist — those users get the flag regardless of the rollout bucket (but still subject to `enabled`, `platforms`, and version bounds):
+```sql
+update feature_flags set user_ids = array['<supabase-user-id>'] where key = 'show_onboarding_v2';
+```
+
 ## Step 3 — Read the flag in a Bloc or ViewModel
 
 Inject `FeatureFlags` and expose a `StateFlow`:

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagEvaluator.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagEvaluator.kt
@@ -20,8 +20,16 @@ class FeatureFlagEvaluator {
         if (!versionMatches(row.minVersion, row.maxVersion, context.versionName)) {
             return flag.defaultValue
         }
-        if (!inRollout(flag.key, context.identity, row.rolloutPercent)) return flag.defaultValue
+        if (!isActive(flag.key, context.identity, row)) return flag.defaultValue
         return parseValue(flag, row.valueType, row.value)
+    }
+
+    private fun isActive(flagKey: String, identity: String, row: FeatureFlagRow): Boolean {
+        // Allowlisted users get the flag regardless of the rollout bucket. The list holds
+        // authenticated Supabase user ids, so this only takes effect for signed-in users
+        // (logged-out clients bucket by a device UUID, which is never on the list).
+        if (row.userIds?.contains(identity) == true) return true
+        return inRollout(flagKey, identity, row.rolloutPercent)
     }
 
     private fun platformMatches(allowed: List<String>?, current: Platform): Boolean {

--- a/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagRow.kt
+++ b/client/featureflag/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagRow.kt
@@ -13,4 +13,5 @@ data class FeatureFlagRow(
     val platforms: List<String>? = null,
     @SerialName("min_version") val minVersion: String? = null,
     @SerialName("max_version") val maxVersion: String? = null,
+    @SerialName("user_ids") val userIds: List<String>? = null,
 )

--- a/client/featureflag/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagEvaluatorTest.kt
+++ b/client/featureflag/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/featureflag/impl/FeatureFlagEvaluatorTest.kt
@@ -107,6 +107,73 @@ class FeatureFlagEvaluatorTest {
     }
 
     @Test
+    fun When_user_allowlisted_Then_value_returned_even_outside_rollout() {
+        val row =
+            booleanRow(
+                enabled = true,
+                value = "true",
+                rolloutPercent = 0,
+                userIds = listOf("vip-user"),
+            )
+        evaluator.evaluate(SampleBoolean, row, ctx(identity = "vip-user")) shouldBe true
+    }
+
+    @Test
+    fun When_user_not_allowlisted_Then_rollout_still_applies() {
+        // rolloutPercent 0 means everyone not on the list gets the default.
+        val row =
+            booleanRow(
+                enabled = true,
+                value = "true",
+                rolloutPercent = 0,
+                userIds = listOf("vip-user"),
+            )
+        evaluator.evaluate(SampleBoolean, row, ctx(identity = "other-user")) shouldBe false
+    }
+
+    @Test
+    fun When_user_allowlisted_but_row_disabled_Then_default_returned() {
+        val row =
+            booleanRow(
+                enabled = false,
+                value = "true",
+                rolloutPercent = 100,
+                userIds = listOf("vip-user"),
+            )
+        evaluator.evaluate(SampleBoolean, row, ctx(identity = "vip-user")) shouldBe false
+    }
+
+    @Test
+    fun When_user_allowlisted_but_platform_excluded_Then_default_returned() {
+        val row =
+            booleanRow(
+                enabled = true,
+                value = "true",
+                rolloutPercent = 100,
+                platforms = listOf("IOS"),
+                userIds = listOf("vip-user"),
+            )
+        evaluator.evaluate(SampleBoolean, row, ctx(identity = "vip-user")) shouldBe false
+    }
+
+    @Test
+    fun When_user_allowlisted_but_below_min_version_Then_default_returned() {
+        val row =
+            booleanRow(
+                enabled = true,
+                value = "true",
+                rolloutPercent = 100,
+                minVersion = "1.5.0",
+                userIds = listOf("vip-user"),
+            )
+        evaluator.evaluate(
+            SampleBoolean,
+            row,
+            ctx(identity = "vip-user", versionName = "1.4.3"),
+        ) shouldBe false
+    }
+
+    @Test
     fun When_value_type_mismatch_Then_default_returned() {
         val row =
             FeatureFlagRow(
@@ -167,6 +234,7 @@ class FeatureFlagEvaluatorTest {
         platforms: List<String>? = null,
         minVersion: String? = null,
         maxVersion: String? = null,
+        userIds: List<String>? = null,
     ): FeatureFlagRow =
         FeatureFlagRow(
             key = SampleBoolean.key,
@@ -177,5 +245,6 @@ class FeatureFlagEvaluatorTest {
             platforms = platforms,
             minVersion = minVersion,
             maxVersion = maxVersion,
+            userIds = userIds,
         )
 }

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -16,6 +16,7 @@ create table public.feature_flags (
     platforms text[],
     min_version text,
     max_version text,
+    user_ids text[],
     updated_at timestamptz not null default now()
 );
 
@@ -36,6 +37,7 @@ Writes go through the service role / Studio UI — clients only ever read.
 - `rollout_percent` — % of users for whom the flag is "active". Active users get `value`; the rest get the default. Bucketing is stable per (`key`, identity) and uses FNV-1a 32-bit so Android, iOS, and JVM agree.
 - `platforms` — `null` / empty = all platforms. Otherwise an array of `'ANDROID'` / `'IOS'` / `'JVM'`.
 - `min_version` / `max_version` — optional semver bounds, compared against the app's current `versionName` (only major/minor/patch are used; `-pre` suffixes are ignored).
+- `user_ids` — `null` / empty = no allowlist. Otherwise an array of authenticated Supabase user ids who get the flag **regardless of the rollout bucket** (additive on top of `rollout_percent` — useful for force-enabling QA/beta users on a partial rollout). Allowlisted users still respect `enabled`, `platforms`, and the version bounds. Only takes effect for signed-in users: a logged-out client buckets by a device UUID that is never on the list (see Identity / bucketing below).
 
 ## Adding a flag
 

--- a/supabase/migrations/20260605_add_feature_flag_user_ids.sql
+++ b/supabase/migrations/20260605_add_feature_flag_user_ids.sql
@@ -1,0 +1,8 @@
+-- Adds the `user_ids` allowlist column to `feature_flags`. It holds an array of
+-- authenticated Supabase user ids. Listed users get the flag's `value` regardless
+-- of the rollout bucket (additive on top of `rollout_percent`), but still subject to
+-- `enabled`, `platforms`, and the version bounds. NULL / empty means "no allowlist —
+-- rollout_percent alone decides". Only takes effect for signed-in users, since
+-- logged-out clients bucket by a device UUID that is never on the list.
+
+ALTER TABLE public.feature_flags ADD COLUMN IF NOT EXISTS user_ids TEXT[];


### PR DESCRIPTION
## What

Adds a `user_ids` allowlist to the feature-flag system so a flag can be force-enabled for specific signed-in users — not just a percentage rollout.

Before this, the user id was only used as the *bucketing identity* for `rollout_percent`; there was no way to name a user and turn a flag on for them.

## How it works

- New nullable `user_ids text[]` column on `feature_flags` (decoded into `FeatureFlagRow.userIds`).
- The evaluator is **additive**: listed users get the flag's value regardless of the rollout bucket, *in addition to* whoever falls in `rollout_percent`. Useful for force-enabling QA/beta users on top of a partial rollout.
- Allowlisted users still respect the earlier gates — `enabled` (kill switch), `platforms`, and `min_version`/`max_version`. The allowlist only bypasses the rollout %.
- Only takes effect for **signed-in** users: the evaluation `identity` is the Supabase user id when authenticated, but a device UUID when logged out (which is never on the list).

```kotlin
private fun isActive(flagKey: String, identity: String, row: FeatureFlagRow): Boolean {
    if (row.userIds?.contains(identity) == true) return true
    return inRollout(flagKey, identity, row.rolloutPercent)
}
```

## Backend

Run the migration in `supabase/migrations/20260605_add_feature_flag_user_ids.sql`:

```sql
ALTER TABLE public.feature_flags ADD COLUMN IF NOT EXISTS user_ids TEXT[];
```

Then to target users:

```sql
update feature_flags set user_ids = array['<supabase-user-id>'] where key = 'my_flag';
```

## Tests

Added evaluator cases to `FeatureFlagEvaluatorTest`: allowlisted user gets the flag outside the rollout, non-listed users still follow the rollout, and the allowlist does **not** override `enabled` / `platforms` / version bounds. `:client:featureflag:impl:jvmTest` passes.

## Commits
1. `feat` — row column, evaluator, unit tests, migration
2. `docs` — `feature-flags.md` column reference + `add-feature-flag` skill note

🤖 Generated with [Claude Code](https://claude.com/claude-code)