### PR TITLE
fix(grocery): make grocery list empty states scrollable in landscape

### DIFF
--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -17,11 +18,14 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
@@ -726,39 +730,44 @@ private fun EmptyGroceryListState(
     modifier: Modifier = Modifier,
 ) {
     val dimens = ChefMateTheme.dimens
-    Column(
-        modifier =
-            modifier
-                .testTag(GroceryListTestTags.EMPTY_STATE)
-                .fillMaxWidth()
-                .padding(horizontal = dimens.paddingExtraLarge),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Icon(
-            imageVector = Icons.Outlined.ShoppingCart,
-            contentDescription = null,
-            modifier = Modifier.size(64.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(Modifier.height(dimens.paddingNormal))
-        Text(
-            text = stringResource(Res.string.grocery_list_empty_title),
-            style = MaterialTheme.typography.titleMedium,
-        )
-        Spacer(Modifier.height(dimens.paddingSmall))
-        Text(
-            text = stringResource(Res.string.grocery_list_empty_description),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(Modifier.height(dimens.paddingLarge))
-        Button(
-            onClick = onBrowseRecipesClicked,
-            modifier = Modifier.testTag(GroceryListTestTags.BROWSE_RECIPES_BUTTON).fillMaxWidth(),
+    // Allow the centered content to scroll when the viewport is too short (e.g. landscape) so
+    // nothing gets cut off; heightIn(min = maxHeight) keeps it vertically centered when it fits.
+    BoxWithConstraints(modifier = modifier.testTag(GroceryListTestTags.EMPTY_STATE)) {
+        Column(
+            modifier =
+                Modifier.verticalScroll(rememberScrollState())
+                    .heightIn(min = maxHeight)
+                    .fillMaxWidth()
+                    .padding(horizontal = dimens.paddingExtraLarge),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
-            Text(stringResource(Res.string.grocery_list_empty_browse_recipes))
+            Icon(
+                imageVector = Icons.Outlined.ShoppingCart,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(dimens.paddingNormal))
+            Text(
+                text = stringResource(Res.string.grocery_list_empty_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(Modifier.height(dimens.paddingSmall))
+            Text(
+                text = stringResource(Res.string.grocery_list_empty_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(dimens.paddingLarge))
+            Button(
+                onClick = onBrowseRecipesClicked,
+                modifier =
+                    Modifier.testTag(GroceryListTestTags.BROWSE_RECIPES_BUTTON).fillMaxWidth(),
+            ) {
+                Text(stringResource(Res.string.grocery_list_empty_browse_recipes))
+            }
         }
     }
 }
@@ -775,46 +784,52 @@ private fun FilteredEmptyGroceryListState(
     modifier: Modifier = Modifier,
 ) {
     val dimens = ChefMateTheme.dimens
-    Column(
-        modifier =
-            modifier
-                .testTag(GroceryListTestTags.FILTERED_EMPTY_STATE)
-                .fillMaxWidth()
-                .padding(horizontal = dimens.paddingExtraLarge),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Icon(
-            imageVector = Icons.Default.FilterList,
-            contentDescription = null,
-            modifier = Modifier.size(64.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(Modifier.height(dimens.paddingNormal))
-        Text(
-            text = stringResource(Res.string.grocery_list_filtered_empty_title),
-            style = MaterialTheme.typography.titleMedium,
-        )
-        Spacer(Modifier.height(dimens.paddingSmall))
-        Text(
-            text = stringResource(Res.string.grocery_list_filtered_empty_description),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(Modifier.height(dimens.paddingLarge))
-        Button(
-            onClick = onClearFiltersClicked,
-            modifier = Modifier.testTag(GroceryListTestTags.CLEAR_FILTERS_BUTTON).fillMaxWidth(),
+    // Allow the centered content to scroll when the viewport is too short (e.g. landscape) so
+    // nothing gets cut off; heightIn(min = maxHeight) keeps it vertically centered when it fits.
+    BoxWithConstraints(modifier = modifier.testTag(GroceryListTestTags.FILTERED_EMPTY_STATE)) {
+        Column(
+            modifier =
+                Modifier.verticalScroll(rememberScrollState())
+                    .heightIn(min = maxHeight)
+                    .fillMaxWidth()
+                    .padding(horizontal = dimens.paddingExtraLarge),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
-            Text(stringResource(Res.string.grocery_list_filtered_empty_clear_filters))
-        }
-        Spacer(Modifier.height(dimens.paddingSmall))
-        OutlinedButton(
-            onClick = onBrowseRecipesClicked,
-            modifier = Modifier.testTag(GroceryListTestTags.BROWSE_RECIPES_BUTTON).fillMaxWidth(),
-        ) {
-            Text(stringResource(Res.string.grocery_list_empty_browse_recipes))
+            Icon(
+                imageVector = Icons.Default.FilterList,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(dimens.paddingNormal))
+            Text(
+                text = stringResource(Res.string.grocery_list_filtered_empty_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(Modifier.height(dimens.paddingSmall))
+            Text(
+                text = stringResource(Res.string.grocery_list_filtered_empty_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(dimens.paddingLarge))
+            Button(
+                onClick = onClearFiltersClicked,
+                modifier =
+                    Modifier.testTag(GroceryListTestTags.CLEAR_FILTERS_BUTTON).fillMaxWidth(),
+            ) {
+                Text(stringResource(Res.string.grocery_list_filtered_empty_clear_filters))
+            }
+            Spacer(Modifier.height(dimens.paddingSmall))
+            OutlinedButton(
+                onClick = onBrowseRecipesClicked,
+                modifier =
+                    Modifier.testTag(GroceryListTestTags.BROWSE_RECIPES_BUTTON).fillMaxWidth(),
+            ) {
+                Text(stringResource(Res.string.grocery_list_empty_browse_recipes))
+            }
         }
     }
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTest.kt
@@ -58,6 +58,15 @@ fun GroceryListEmptyPhonePortraitDarkScreenshot() {
     GroceryListScreenshot(bloc = previewGroceryListBlocEmpty, darkTheme = true)
 }
 
+// Landscape (short viewport): the empty state must stay vertically centered and become
+// scrollable rather than getting cut off — regression coverage for #240.
+@PreviewTest
+@Preview(showBackground = true, widthDp = 740, heightDp = 360)
+@Composable
+fun GroceryListEmptyPhoneLandscapeLightScreenshot() {
+    GroceryListScreenshot(bloc = previewGroceryListBlocEmpty)
+}
+
 // ── Filtered empty state — "Clear filters" + "Browse my recipes" recovery CTAs ──
 
 @PreviewTest
@@ -72,4 +81,13 @@ fun GroceryListFilteredEmptyPhonePortraitLightScreenshot() {
 @Composable
 fun GroceryListFilteredEmptyPhonePortraitDarkScreenshot() {
     GroceryListScreenshot(bloc = previewGroceryListBlocFilteredEmpty, darkTheme = true)
+}
+
+// Landscape (short viewport): the filtered empty state must stay centered and scroll rather than
+// getting cut off — regression coverage for #240.
+@PreviewTest
+@Preview(showBackground = true, widthDp = 740, heightDp = 360)
+@Composable
+fun GroceryListFilteredEmptyPhoneLandscapeLightScreenshot() {
+    GroceryListScreenshot(bloc = previewGroceryListBlocFilteredEmpty)
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListEmptyPhoneLandscapeLightScreenshot_5e5a0bd2_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListEmptyPhoneLandscapeLightScreenshot_5e5a0bd2_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cbbc5e123be53138646fd623f418f121a4c9118a3872d683912ec55391568db
+size 45624

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListFilteredEmptyPhoneLandscapeLightScreenshot_5e5a0bd2_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListFilteredEmptyPhoneLandscapeLightScreenshot_5e5a0bd2_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40334bef1c4357b924bf46eb4f618144b17b44d07b4f775f90afbad5982c8f3d
+size 49546


### PR DESCRIPTION
## Summary

Fixes #240 — the grocery list empty states (both the plain "empty" and the "filtered empty" variants) got cut off in landscape because their content sat in a centered, non-scrolling `Column`, leaving the CTA buttons unreachable.

Both `EmptyGroceryListState` and `FilteredEmptyGroceryListState` are now wrapped in a `BoxWithConstraints` with the inner `Column` using `verticalScroll` + `heightIn(min = maxHeight)` — the canonical "center-when-it-fits, scroll-when-it-doesn't" pattern. Portrait rendering is unchanged.

## Commits
1. `fix(grocery)` — the scroll fix in `GroceryListScreen.kt`.
2. `test(grocery)` — landscape (740×360) snapshot variants for both empty states as regression coverage.

## Testing
- Existing **portrait** snapshot references regenerated **byte-identical**, confirming the change is visually transparent when content fits.
- Two new **landscape** snapshots recorded; `validateDebugScreenshotTest` passes.
- `ktfmtCheck` passes for the edited modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)