### PR TITLE
feat(profile): add user profile management

### DIFF
--- a/client/auth/data/impl/build.gradle.kts
+++ b/client/auth/data/impl/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
             implementation(libs.supabase.auth)
             implementation(libs.supabase.postgrest)
             implementation(libs.supabase.storage)
+            implementation(libs.supabase.functions)
         }
         jvmMain.dependencies { implementation(libs.ktor.client.cio) }
         androidMain.dependencies { implementation(libs.ktor.client.cio) }

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
@@ -18,6 +18,7 @@ import io.github.jan.supabase.auth.providers.builtin.Email
 import io.github.jan.supabase.auth.providers.builtin.OTP
 import io.github.jan.supabase.auth.status.SessionStatus
 import io.github.jan.supabase.auth.user.UserInfo
+import io.github.jan.supabase.functions.functions
 import kotlin.coroutines.CoroutineContext
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -28,8 +29,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 
 @Inject
 @SingleIn(AppScope::class)
@@ -201,6 +204,31 @@ class SupabaseAuthenticationRepository(
             println("Error signing out: ${e.message}")
         }
     }
+
+    override suspend fun updateProfile(displayName: String, avatarUrl: String?): Result<Unit> =
+        try {
+            supabaseClient.auth.updateUser {
+                data = buildJsonObject {
+                    put("name", displayName)
+                    avatarUrl?.let { put("avatar_url", it) }
+                }
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) { "Failed to update profile" }
+            Result.failure(e)
+        }
+
+    override suspend fun deleteAccount(): Result<Unit> =
+        try {
+            // The client SDK can't delete auth users, so the actual deletion happens in a
+            // service-role Edge Function. It reads the caller's JWT and admin-deletes that user.
+            supabaseClient.functions.invoke("delete-account")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) { "Failed to delete account" }
+            Result.failure(e)
+        }
 
     override suspend fun sendPasswordResetEmail(email: String): Result<Unit> =
         try {

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseModule.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseModule.kt
@@ -10,6 +10,7 @@ import dev.zacsweers.metro.SingleIn
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.functions.Functions
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.storage.Storage
 
@@ -35,6 +36,7 @@ interface SupabaseModule {
             install(Auth)
             install(Postgrest)
             install(Storage)
+            install(Functions)
         }
     }
 }

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseProfilePhotoStorage.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseProfilePhotoStorage.kt
@@ -1,0 +1,64 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package com.plusmobileapps.chefmate.auth.data.impl
+
+import co.touchlab.kermit.Logger
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.data.ProfilePhotoStorage
+import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.storage.storage
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class SupabaseProfilePhotoStorage(
+    private val supabaseClient: SupabaseClient,
+    private val authRepository: AuthenticationRepository,
+) : ProfilePhotoStorage {
+
+    override suspend fun uploadPhoto(bytes: ByteArray, fileExtension: String): String {
+        // A real user is always signed in by the time they reach the profile screen, but keep the
+        // same lazy session guarantee as recipe photos so the call never races a missing session.
+        authRepository.ensureSession().getOrElse {
+            throw IllegalStateException(
+                "Cannot upload avatar: failed to acquire Supabase session",
+                it,
+            )
+        }
+        val ownerFolder =
+            (authRepository.state.value as? AuthState.Authenticated)?.user?.userId
+                ?: error("Cannot upload avatar: no Supabase session")
+        val bucket = supabaseClient.storage.from(BUCKET_NAME)
+        val sanitizedExtension = fileExtension.trimStart('.').lowercase().ifBlank { "jpg" }
+        // Randomize the filename so caches (Supabase CDN, Coil) don't serve a stale avatar after an
+        // update; the old object is cleaned up best-effort by callers via deletePhoto.
+        val path = "$ownerFolder/${Uuid.random()}.$sanitizedExtension"
+        bucket.upload(path = path, data = bytes) { upsert = true }
+        return bucket.publicUrl(path)
+    }
+
+    override suspend fun deletePhoto(publicUrl: String) {
+        val needle = "/$BUCKET_NAME/"
+        if (!publicUrl.contains(needle)) return
+        val path = publicUrl.substringAfter(needle)
+        if (path.isBlank()) return
+        try {
+            supabaseClient.storage.from(BUCKET_NAME).delete(path)
+        } catch (t: Throwable) {
+            Logger.w(throwable = t, tag = "SupabaseProfilePhotoStorage") {
+                "Failed to delete avatar at $path"
+            }
+        }
+    }
+
+    private companion object {
+        const val BUCKET_NAME = "avatars"
+    }
+}

--- a/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
+++ b/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
@@ -24,6 +24,21 @@ interface AuthenticationRepository {
 
     suspend fun signOut()
 
+    /**
+     * Updates the signed-in user's profile metadata. [avatarUrl] is only written when non-null, so
+     * passing `null` leaves an existing avatar untouched. The Supabase session collector mirrors
+     * the updated metadata back into [state], so callers don't need to refresh manually.
+     */
+    suspend fun updateProfile(displayName: String, avatarUrl: String?): Result<Unit>
+
+    /**
+     * Permanently deletes the signed-in user's remote account. The actual deletion runs in a
+     * service-role Supabase Edge Function (`delete-account`) because the client SDK can't delete
+     * auth users. Callers are responsible for the subsequent sign-out + local-data wipe (see
+     * `DeleteAccountUseCase`).
+     */
+    suspend fun deleteAccount(): Result<Unit>
+
     suspend fun sendPasswordResetEmail(email: String): Result<Unit>
 
     suspend fun sendSignInOtp(email: String): Result<Unit>

--- a/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/ProfilePhotoStorage.kt
+++ b/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/ProfilePhotoStorage.kt
@@ -1,0 +1,15 @@
+package com.plusmobileapps.chefmate.auth.data
+
+interface ProfilePhotoStorage {
+    /**
+     * Uploads the user's avatar to the `avatars` bucket and returns its public URL. Overwrites any
+     * existing avatar for the user (one avatar per account).
+     */
+    suspend fun uploadPhoto(bytes: ByteArray, fileExtension: String): String
+
+    /**
+     * Best-effort delete of a previously uploaded avatar. URLs that don't point at the avatars
+     * bucket are ignored; failures are swallowed so caller flows aren't disrupted.
+     */
+    suspend fun deletePhoto(publicUrl: String)
+}

--- a/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
+++ b/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
@@ -19,6 +19,17 @@ class FakeAuthenticationRepository : AuthenticationRepository {
     var verifyEmailOtpResult: Result<Unit> = Result.success(Unit)
     var resendOtpResult: Result<Unit> = Result.success(Unit)
     var ensureSessionResult: Result<Unit> = Result.success(Unit)
+    var updateProfileResult: Result<Unit> = Result.success(Unit)
+    var deleteAccountResult: Result<Unit> = Result.success(Unit)
+
+    var lastUpdatedDisplayName: String? = null
+        private set
+
+    var lastUpdatedAvatarUrl: String? = null
+        private set
+
+    var deleteAccountCallCount: Int = 0
+        private set
 
     var ensureSessionCallCount: Int = 0
         private set
@@ -67,6 +78,30 @@ class FakeAuthenticationRepository : AuthenticationRepository {
 
     override suspend fun signOut() {
         _state.value = AuthState.Unauthenticated
+    }
+
+    override suspend fun updateProfile(displayName: String, avatarUrl: String?): Result<Unit> {
+        lastUpdatedDisplayName = displayName
+        lastUpdatedAvatarUrl = avatarUrl
+        return updateProfileResult.also { result ->
+            if (result.isSuccess) {
+                (_state.value as? AuthState.Authenticated)?.let { authenticated ->
+                    _state.value =
+                        AuthState.Authenticated(
+                            authenticated.user.copy(
+                                userName = displayName,
+                                userProfileImageUrl =
+                                    avatarUrl ?: authenticated.user.userProfileImageUrl,
+                            )
+                        )
+                }
+            }
+        }
+    }
+
+    override suspend fun deleteAccount(): Result<Unit> {
+        deleteAccountCallCount += 1
+        return deleteAccountResult
     }
 
     override suspend fun sendPasswordResetEmail(email: String): Result<Unit> =

--- a/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeProfilePhotoStorage.kt
+++ b/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeProfilePhotoStorage.kt
@@ -1,0 +1,24 @@
+package com.plusmobileapps.chefmate.auth.data.testing
+
+import com.plusmobileapps.chefmate.auth.data.ProfilePhotoStorage
+
+class FakeProfilePhotoStorage : ProfilePhotoStorage {
+    var uploadResult: String = "https://example.com/avatars/test/avatar.jpg"
+    var uploadError: Throwable? = null
+
+    var lastUploadedBytes: ByteArray? = null
+        private set
+
+    var deletedUrls: MutableList<String> = mutableListOf()
+        private set
+
+    override suspend fun uploadPhoto(bytes: ByteArray, fileExtension: String): String {
+        lastUploadedBytes = bytes
+        uploadError?.let { throw it }
+        return uploadResult
+    }
+
+    override suspend fun deletePhoto(publicUrl: String) {
+        deletedUrls.add(publicUrl)
+    }
+}

--- a/client/auth/usecase/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImpl.kt
+++ b/client/auth/usecase/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImpl.kt
@@ -1,0 +1,26 @@
+package com.plusmobileapps.chefmate.auth.usecase.impl
+
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.DeleteAccountUseCase
+import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
+import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DeleteAccountUseCaseImpl(
+    private val authenticationRepository: AuthenticationRepository,
+    private val signOutUseCase: SignOutUseCase,
+) : DeleteAccountUseCase {
+    override suspend fun invoke(): Result<Unit> {
+        // Delete the remote account first. Only if that succeeds do we tear down the local session
+        // and data — otherwise we'd leave the user signed out with their cloud account intact.
+        val result = authenticationRepository.deleteAccount()
+        if (result.isFailure) return result
+        signOutUseCase()
+        return Result.success(Unit)
+    }
+}

--- a/client/auth/usecase/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImplTest.kt
+++ b/client/auth/usecase/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImplTest.kt
@@ -1,0 +1,41 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.auth.usecase.impl
+
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class DeleteAccountUseCaseImplTest {
+
+    private val authenticationRepository = FakeAuthenticationRepository()
+    private var signedOut = false
+    private val signOutUseCase = SignOutUseCase { signedOut = true }
+
+    private val useCase =
+        DeleteAccountUseCaseImpl(
+            authenticationRepository = authenticationRepository,
+            signOutUseCase = signOutUseCase,
+        )
+
+    @Test
+    fun When_remote_deletion_succeeds_Then_user_is_signed_out() = runTest {
+        val result = useCase()
+
+        result.isSuccess shouldBe true
+        authenticationRepository.deleteAccountCallCount shouldBe 1
+        signedOut shouldBe true
+    }
+
+    @Test
+    fun When_remote_deletion_fails_Then_user_is_not_signed_out() = runTest {
+        authenticationRepository.deleteAccountResult = Result.failure(RuntimeException("boom"))
+
+        val result = useCase()
+
+        result.isFailure shouldBe true
+        signedOut shouldBe false
+    }
+}

--- a/client/auth/usecase/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/DeleteAccountUseCase.kt
+++ b/client/auth/usecase/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/DeleteAccountUseCase.kt
@@ -1,0 +1,10 @@
+package com.plusmobileapps.chefmate.auth.usecase
+
+/**
+ * Deletes the signed-in user's remote account, then signs out and wipes all local data. Returns a
+ * failure if the remote deletion fails so callers can surface an error and leave the user signed
+ * in.
+ */
+fun interface DeleteAccountUseCase {
+    suspend operator fun invoke(): Result<Unit>
+}

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -26,6 +26,7 @@ import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Child.Meals
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Child.RecipeList
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Child.Settings
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Output.OpenAppSettings
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Output.OpenManageProfile
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Output.OpenSignIn
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Output.OpenSignUp
 import com.plusmobileapps.chefmate.recipe.bottomnav.impl.ui.BottomNavigationScreen
@@ -235,6 +236,7 @@ class BottomNavBlocImpl(
         when (output) {
             SettingsBloc.Output.OpenSignIn -> OpenSignIn
             SettingsBloc.Output.OpenSignUp -> OpenSignUp
+            SettingsBloc.Output.OpenManageProfile -> OpenManageProfile
             SettingsBloc.Output.OpenAppSettings -> OpenAppSettings
             SettingsBloc.Output.OpenAiChat -> BottomNavBloc.Output.OpenAiChat
             SettingsBloc.Output.OpenDeveloperSettings -> BottomNavBloc.Output.OpenDeveloperSettings

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -73,6 +73,8 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
 
         data object OpenSignUp : Output()
 
+        data object OpenManageProfile : Output()
+
         data object OpenAppSettings : Output()
 
         data object OpenAiChat : Output()

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -104,6 +104,7 @@ kotlin {
             api(projects.client.recipe.importer.impl)
             api(projects.client.recipebook.data.impl)
             api(projects.client.recipebook.edit.impl)
+            api(projects.client.profile.impl)
             api(projects.client.util.impl)
             api(projects.client.settings.impl)
             api(projects.client.settings.root.impl)
@@ -151,6 +152,7 @@ kotlin {
             implementation(projects.client.recipe.list.implRobots)
             implementation(projects.client.settings.implRobots)
             implementation(projects.client.settings.root.implRobots)
+            implementation(projects.client.profile.implRobots)
         }
         val jvmTest by getting {
             dependencies {

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/ManageProfileNavigationUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/ManageProfileNavigationUiTest.kt
@@ -1,0 +1,31 @@
+package com.plusmobileapps.chefmate.tests
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.profile.robots.manageProfile
+import com.plusmobileapps.chefmate.recipe.bottomnav.robots.bottomNav
+import com.plusmobileapps.chefmate.settings.robots.more
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ManageProfileNavigationUiTest {
+
+    @Test
+    fun opening_manage_profile_from_more_tab_shows_the_screen() = runRootBlocTest {
+        bottomNav().clickMoreTab()
+        more().awaitDisplayed().clickManageProfileRow()
+
+        manageProfile().awaitDisplayed().assertDisplayed()
+    }
+
+    @Test
+    fun saving_profile_returns_to_more_tab() = runRootBlocTest {
+        bottomNav().clickMoreTab()
+        more().awaitDisplayed().clickManageProfileRow()
+
+        manageProfile().awaitDisplayed().setDisplayName("Renamed Chef").tapSave()
+
+        // Saving pops back to the More tab.
+        more().awaitDisplayed()
+    }
+}

--- a/client/profile/impl-robots/build.gradle.kts
+++ b/client/profile/impl-robots/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin { sourceSets { commonMain.dependencies { implementation(projects.client.profile.public) } } }
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.profile.robots"
+    uiTest = true
+}

--- a/client/profile/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/robots/ManageProfileRobot.kt
+++ b/client/profile/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/robots/ManageProfileRobot.kt
@@ -1,0 +1,54 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package com.plusmobileapps.chefmate.profile.robots
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import com.plusmobileapps.chefmate.profile.ManageProfileTestTags
+
+/**
+ * Robot for the Manage Profile screen. Every lookup is scoped to a descendant of
+ * [ManageProfileTestTags.SCREEN] so titles rendered on other screens don't satisfy matchers.
+ *
+ * Construct via [manageProfile] from inside a `runComposeUiTest { … }` block.
+ */
+class ManageProfileRobot(private val test: ComposeUiTest) {
+
+    private val onScreen = hasAnyAncestor(hasTestTag(ManageProfileTestTags.SCREEN))
+
+    fun awaitDisplayed(): ManageProfileRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(ManageProfileTestTags.SCREEN))
+    }
+
+    fun setDisplayName(name: String): ManageProfileRobot = apply {
+        // The test tag sits on the PlusTextField wrapper; the editable node is the descendant that
+        // owns the set-text action.
+        test
+            .onNode(
+                hasSetTextAction() and
+                    hasAnyAncestor(hasTestTag(ManageProfileTestTags.DISPLAY_NAME))
+            )
+            .performTextReplacement(name)
+    }
+
+    fun tapSave(): ManageProfileRobot = apply {
+        test.onNode(hasTestTag(ManageProfileTestTags.SAVE) and onScreen).performClick()
+    }
+
+    fun tapDeleteAccount(): ManageProfileRobot = apply {
+        test.onNode(hasTestTag(ManageProfileTestTags.DELETE_ACCOUNT) and onScreen).performClick()
+    }
+
+    fun assertDisplayed(): ManageProfileRobot = apply {
+        test.onNode(hasTestTag(ManageProfileTestTags.SCREEN)).assertIsDisplayed()
+    }
+}
+
+fun ComposeUiTest.manageProfile(): ManageProfileRobot = ManageProfileRobot(this)

--- a/client/profile/impl/build.gradle.kts
+++ b/client/profile/impl/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.profile.public)
+            implementation(projects.client.text.public)
+            implementation(projects.client.ui.public)
+            implementation(projects.client.util.public)
+            implementation(libs.arkivanov.decompose.core)
+            implementation(libs.arkivanov.decompose.compose.extensions)
+            implementation(projects.client.shared)
+            implementation(projects.client.auth.data.public)
+            implementation(projects.client.auth.usecase.public)
+            implementation(compose.components.resources)
+        }
+        commonTest.dependencies { implementation(projects.client.auth.data.testing) }
+    }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.profile.impl"
+    enableDi = true
+    enableTesting = true
+}

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImpl.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImpl.kt
@@ -1,0 +1,81 @@
+package com.plusmobileapps.chefmate.profile.impl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.getViewModel
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Model
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Output
+import com.plusmobileapps.chefmate.profile.impl.ui.ManageProfileScreen
+import com.plusmobileapps.chefmate.util.PickedImage
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.Provider
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = ManageProfileBloc.Factory::class,
+)
+class ManageProfileBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<Output>,
+    viewModelFactory: Provider<ManageProfileViewModel>,
+) : ManageProfileBloc, BlocContext by context {
+
+    private val scope = createScope()
+
+    private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
+
+    override val state: StateFlow<Model> = viewModel.state
+
+    init {
+        scope.launch {
+            viewModel.outputs.collect {
+                when (it) {
+                    ManageProfileViewModel.Output.Saved -> output.onNext(Output.Back)
+                    ManageProfileViewModel.Output.Deleted -> output.onNext(Output.AccountDeleted)
+                }
+            }
+        }
+    }
+
+    override fun onBack() {
+        output.onNext(Output.Back)
+    }
+
+    override fun onDisplayNameChanged(displayName: String) {
+        viewModel.setDisplayName(displayName)
+    }
+
+    override fun onPhotoPicked(image: PickedImage) {
+        viewModel.setPhoto(image)
+    }
+
+    override fun onSaveClicked() {
+        viewModel.save()
+    }
+
+    override fun onDeleteAccountClicked() {
+        viewModel.showDeleteDialog()
+    }
+
+    override fun onDeleteConfirmed() {
+        viewModel.deleteAccount()
+    }
+
+    override fun onDeleteDismissed() {
+        viewModel.dismissDeleteDialog()
+    }
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        ManageProfileScreen(bloc = this, modifier = modifier)
+    }
+}

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
@@ -1,0 +1,124 @@
+package com.plusmobileapps.chefmate.profile.impl
+
+import chefmate.client.profile.public.generated.resources.Res
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_error
+import chefmate.client.profile.public.generated.resources.manage_profile_save_error
+import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.data.ProfilePhotoStorage
+import com.plusmobileapps.chefmate.auth.usecase.DeleteAccountUseCase
+import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Model
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.util.PickedImage
+import dev.zacsweers.metro.Inject
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@Inject
+class ManageProfileViewModel(
+    @Main mainContext: CoroutineContext,
+    private val authenticationRepository: AuthenticationRepository,
+    private val profilePhotoStorage: ProfilePhotoStorage,
+    private val deleteAccountUseCase: DeleteAccountUseCase,
+) : ViewModel(mainContext) {
+
+    private val _state = MutableStateFlow(initialState())
+    val state: StateFlow<Model> = _state.asStateFlow()
+
+    /** Emitted when the screen should pop: after a successful save or account deletion. */
+    private val _outputs = Channel<Output>(Channel.BUFFERED)
+    val outputs: Flow<Output> = _outputs.receiveAsFlow()
+
+    private val pickedImage = MutableStateFlow<PickedImage?>(null)
+
+    private fun initialState(): Model {
+        val user = (authenticationRepository.state.value as? AuthState.Authenticated)?.user
+        return Model(
+            displayName = user?.userName.orEmpty(),
+            email = user?.userEmail.orEmpty(),
+            photoUrl = user?.userProfileImageUrl,
+        )
+    }
+
+    fun setDisplayName(displayName: String) {
+        _state.update { it.copy(displayName = displayName, saveError = null) }
+    }
+
+    fun setPhoto(image: PickedImage) {
+        pickedImage.value = image
+        _state.update { it.copy(pickedPhoto = image.bytes, saveError = null) }
+    }
+
+    fun save() {
+        val current = _state.value
+        if (!current.canSave) return
+        _state.update { it.copy(isSaving = true, saveError = null) }
+        scope.launch {
+            val avatarUrl =
+                pickedImage.value?.let { picked ->
+                    runCatching {
+                            profilePhotoStorage.uploadPhoto(picked.bytes, picked.fileExtension)
+                        }
+                        .getOrElse {
+                            _state.update {
+                                it.copy(
+                                    isSaving = false,
+                                    saveError = Res.string.manage_profile_save_error.asTextData(),
+                                )
+                            }
+                            return@launch
+                        }
+                }
+            authenticationRepository
+                .updateProfile(displayName = current.displayName.trim(), avatarUrl = avatarUrl)
+                .onSuccess { _outputs.send(Output.Saved) }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            isSaving = false,
+                            saveError = Res.string.manage_profile_save_error.asTextData(),
+                        )
+                    }
+                }
+        }
+    }
+
+    fun showDeleteDialog() {
+        _state.update { it.copy(showDeleteDialog = true, deleteError = null) }
+    }
+
+    fun dismissDeleteDialog() {
+        _state.update { it.copy(showDeleteDialog = false) }
+    }
+
+    fun deleteAccount() {
+        _state.update { it.copy(showDeleteDialog = false, isDeleting = true, deleteError = null) }
+        scope.launch {
+            deleteAccountUseCase()
+                .onSuccess { _outputs.send(Output.Deleted) }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            isDeleting = false,
+                            deleteError = Res.string.manage_profile_delete_error.asTextData(),
+                        )
+                    }
+                }
+        }
+    }
+
+    sealed interface Output {
+        data object Saved : Output
+
+        data object Deleted : Output
+    }
+}

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfilePreviews.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfilePreviews.kt
@@ -1,0 +1,71 @@
+package com.plusmobileapps.chefmate.profile.impl.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Model
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import com.plusmobileapps.chefmate.util.PickedImage
+import kotlinx.coroutines.flow.MutableStateFlow
+
+private fun manageProfileBloc(model: Model): ManageProfileBloc =
+    object : ManageProfileBloc {
+        override val state = MutableStateFlow(model)
+
+        override fun onBack() = Unit
+
+        override fun onDisplayNameChanged(displayName: String) = Unit
+
+        override fun onPhotoPicked(image: PickedImage) = Unit
+
+        override fun onSaveClicked() = Unit
+
+        override fun onDeleteAccountClicked() = Unit
+
+        override fun onDeleteConfirmed() = Unit
+
+        override fun onDeleteDismissed() = Unit
+
+        @Composable
+        override fun Content(modifier: Modifier) {
+            ManageProfileScreen(bloc = this, modifier = modifier)
+        }
+    }
+
+val previewManageProfileBloc: ManageProfileBloc =
+    manageProfileBloc(
+        Model(displayName = "Julia Child", email = "julia@example.com", photoUrl = null)
+    )
+
+val previewManageProfileSavingBloc: ManageProfileBloc =
+    manageProfileBloc(
+        Model(displayName = "Julia Child", email = "julia@example.com", isSaving = true)
+    )
+
+val previewManageProfileDeleteDialogBloc: ManageProfileBloc =
+    manageProfileBloc(
+        Model(displayName = "Julia Child", email = "julia@example.com", showDeleteDialog = true)
+    )
+
+val previewManageProfileErrorBloc: ManageProfileBloc =
+    manageProfileBloc(
+        Model(
+            displayName = "Julia Child",
+            email = "julia@example.com",
+            deleteError = FixedString("Couldn’t delete your account. Please try again."),
+        )
+    )
+
+@Preview
+@Composable
+internal fun ManageProfilePreview() {
+    ChefMateTheme { previewManageProfileBloc.Content(Modifier) }
+}
+
+@Preview
+@Composable
+internal fun ManageProfileDeleteDialogPreview() {
+    ChefMateTheme { previewManageProfileDeleteDialogBloc.Content(Modifier) }
+}

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfileScreen.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfileScreen.kt
@@ -1,0 +1,191 @@
+package com.plusmobileapps.chefmate.profile.impl.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import chefmate.client.profile.public.generated.resources.Res
+import chefmate.client.profile.public.generated.resources.manage_profile_avatar_content_description
+import chefmate.client.profile.public.generated.resources.manage_profile_change_photo
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_account
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_cancel
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_confirm
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_message
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_title
+import chefmate.client.profile.public.generated.resources.manage_profile_display_name_hint
+import chefmate.client.profile.public.generated.resources.manage_profile_display_name_label
+import chefmate.client.profile.public.generated.resources.manage_profile_email_label
+import chefmate.client.profile.public.generated.resources.manage_profile_save
+import chefmate.client.profile.public.generated.resources.manage_profile_title
+import coil3.compose.AsyncImage
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
+import com.plusmobileapps.chefmate.profile.ManageProfileTestTags
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusButton
+import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
+import com.plusmobileapps.chefmate.ui.components.PlusDialog
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusTextField
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import com.plusmobileapps.chefmate.util.rememberImagePickerLauncher
+
+@Composable
+fun ManageProfileScreen(bloc: ManageProfileBloc, modifier: Modifier = Modifier) {
+    val state by bloc.state.collectAsState()
+
+    val pickPhoto = rememberImagePickerLauncher { picked -> picked?.let(bloc::onPhotoPicked) }
+
+    if (state.showDeleteDialog) {
+        PlusDialog(
+            title = Res.string.manage_profile_delete_dialog_title.asTextData(),
+            message = Res.string.manage_profile_delete_dialog_message.asTextData(),
+            confirmButtonText = Res.string.manage_profile_delete_dialog_confirm.asTextData(),
+            dismissButtonText = Res.string.manage_profile_delete_dialog_cancel.asTextData(),
+            onConfirmClick = bloc::onDeleteConfirmed,
+            onDismissRequest = bloc::onDeleteDismissed,
+        )
+    }
+
+    PlusHeaderContainer(
+        modifier = modifier.testTag(ManageProfileTestTags.SCREEN),
+        data =
+            PlusHeaderData.Child(
+                title = Res.string.manage_profile_title.asTextData(),
+                onBackClick = bloc::onBack,
+            ),
+        content = {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal),
+            ) {
+                Avatar(
+                    pickedPhoto = state.pickedPhoto,
+                    photoUrl = state.photoUrl,
+                    onClick = pickPhoto,
+                )
+                Text(
+                    Res.string.manage_profile_change_photo.asTextData().localized(),
+                    style = ChefMateTheme.typography.labelLarge,
+                    color = ChefMateTheme.colorScheme.primary,
+                    modifier = Modifier.clickable(onClick = pickPhoto),
+                )
+
+                PlusTextField(
+                    value = state.displayName,
+                    onValueChange = bloc::onDisplayNameChanged,
+                    modifier = Modifier.fillMaxWidth().testTag(ManageProfileTestTags.DISPLAY_NAME),
+                    label = {
+                        Text(Res.string.manage_profile_display_name_label.asTextData().localized())
+                    },
+                    placeholder = {
+                        Text(Res.string.manage_profile_display_name_hint.asTextData().localized())
+                    },
+                    singleLine = true,
+                    enabled = !state.isSaving && !state.isDeleting,
+                    error = state.saveError,
+                )
+
+                PlusTextField(
+                    value = state.email,
+                    onValueChange = {},
+                    modifier = Modifier.fillMaxWidth(),
+                    label = {
+                        Text(Res.string.manage_profile_email_label.asTextData().localized())
+                    },
+                    singleLine = true,
+                    enabled = false,
+                    readOnly = true,
+                )
+
+                PlusButton(
+                    text = Res.string.manage_profile_save.asTextData(),
+                    modifier = Modifier.fillMaxWidth().testTag(ManageProfileTestTags.SAVE),
+                    enabled = state.canSave,
+                    isLoading = state.isSaving,
+                    onClick = bloc::onSaveClicked,
+                )
+
+                state.deleteError?.let { error ->
+                    Text(
+                        error.localized(),
+                        style = ChefMateTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+
+                PlusButton(
+                    text = Res.string.manage_profile_delete_account.asTextData(),
+                    variant = PlusButtonVariant.DESTRUCTIVE,
+                    modifier =
+                        Modifier.fillMaxWidth().testTag(ManageProfileTestTags.DELETE_ACCOUNT),
+                    enabled = !state.isSaving && !state.isDeleting,
+                    isLoading = state.isDeleting,
+                    onClick = bloc::onDeleteAccountClicked,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun Avatar(
+    pickedPhoto: ByteArray?,
+    photoUrl: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val contentDescription =
+        Res.string.manage_profile_avatar_content_description.asTextData().localized()
+    val avatarModifier =
+        modifier
+            .size(AVATAR_SIZE)
+            .clip(CircleShape)
+            .clickable(onClick = onClick)
+            .testTag(ManageProfileTestTags.AVATAR)
+    val model: Any? = pickedPhoto ?: photoUrl
+    if (model != null) {
+        AsyncImage(
+            model = model,
+            contentDescription = contentDescription,
+            modifier = avatarModifier,
+            contentScale = ContentScale.Crop,
+        )
+    } else {
+        Box(
+            modifier = avatarModifier.background(MaterialTheme.colorScheme.surfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Person,
+                contentDescription = contentDescription,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(ChefMateTheme.dimens.paddingExtraLarge),
+            )
+        }
+    }
+}
+
+private val AVATAR_SIZE = 96.dp

--- a/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
+++ b/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
@@ -1,0 +1,129 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.profile.impl
+
+import app.cash.turbine.test
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.ChefMateUser
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.auth.data.testing.FakeProfilePhotoStorage
+import com.plusmobileapps.chefmate.auth.usecase.DeleteAccountUseCase
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
+import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.plusmobileapps.chefmate.testing.TestConsumer
+import com.plusmobileapps.chefmate.util.PickedImage
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class ManageProfileBlocImplTest {
+
+    private val context = TestBlocContext.create()
+    private val output = TestConsumer<ManageProfileBloc.Output>()
+    private val authRepository =
+        FakeAuthenticationRepository().apply {
+            setState(
+                AuthState.Authenticated(
+                    ChefMateUser(
+                        userId = "id-1",
+                        userName = "Original Name",
+                        userEmail = "chef@example.com",
+                        userProfileImageUrl = null,
+                    )
+                )
+            )
+        }
+    private val photoStorage = FakeProfilePhotoStorage()
+    private var deleteCalled = false
+    private val deleteAccountUseCase = DeleteAccountUseCase {
+        deleteCalled = true
+        Result.success(Unit)
+    }
+
+    private val bloc by lazy {
+        ManageProfileBlocImpl(
+            context = context,
+            output = output,
+            viewModelFactory = {
+                ManageProfileViewModel(
+                    mainContext = context.mainContext,
+                    authenticationRepository = authRepository,
+                    profilePhotoStorage = photoStorage,
+                    deleteAccountUseCase = deleteAccountUseCase,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun When_opened_Then_state_is_seeded_from_signed_in_user() {
+        bloc.state.value.displayName shouldBe "Original Name"
+        bloc.state.value.email shouldBe "chef@example.com"
+    }
+
+    @Test
+    fun When_name_changed_and_saved_Then_profile_is_updated_and_back_emitted() = runTest {
+        bloc.onDisplayNameChanged("New Name")
+        bloc.onSaveClicked()
+
+        authRepository.lastUpdatedDisplayName shouldBe "New Name"
+        output.lastValue shouldBe ManageProfileBloc.Output.Back
+    }
+
+    @Test
+    fun When_photo_picked_and_saved_Then_photo_uploaded_and_url_sent() = runTest {
+        photoStorage.uploadResult = "https://example.com/avatars/id-1/avatar.png"
+        bloc.onPhotoPicked(PickedImage(bytes = byteArrayOf(1, 2, 3), fileExtension = "png"))
+        bloc.onSaveClicked()
+
+        photoStorage.lastUploadedBytes shouldBe byteArrayOf(1, 2, 3)
+        authRepository.lastUpdatedAvatarUrl shouldBe "https://example.com/avatars/id-1/avatar.png"
+    }
+
+    @Test
+    fun When_save_fails_Then_save_error_is_surfaced() = runTest {
+        authRepository.updateProfileResult = Result.failure(RuntimeException("boom"))
+
+        bloc.state.test {
+            awaitItem() // seeded
+            bloc.onSaveClicked()
+
+            var item = awaitItem()
+            while (item.saveError == null) item = awaitItem()
+            item.isSaving shouldBe false
+            cancelAndIgnoreRemainingEvents()
+        }
+        output.values.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun When_delete_clicked_Then_dialog_is_shown() = runTest {
+        bloc.state.test {
+            awaitItem()
+            bloc.onDeleteAccountClicked()
+            awaitItem().showDeleteDialog shouldBe true
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun When_delete_dismissed_Then_dialog_is_hidden() = runTest {
+        bloc.state.test {
+            awaitItem()
+            bloc.onDeleteAccountClicked()
+            awaitItem().showDeleteDialog shouldBe true
+            bloc.onDeleteDismissed()
+            awaitItem().showDeleteDialog shouldBe false
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun When_delete_confirmed_Then_account_deleted_and_output_emitted() = runTest {
+        bloc.onDeleteAccountClicked()
+        bloc.onDeleteConfirmed()
+
+        deleteCalled shouldBe true
+        output.lastValue shouldBe ManageProfileBloc.Output.AccountDeleted
+    }
+}

--- a/client/profile/public/build.gradle.kts
+++ b/client/profile/public/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.arkivanov.decompose.core)
+            implementation(projects.client.shared)
+            api(projects.client.text.public)
+            api(projects.client.util.public)
+            implementation(projects.client.ui.public)
+            implementation(compose.components.resources)
+        }
+    }
+}
+
+compose { resources { publicResClass = true } }
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.profile" }

--- a/client/profile/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/profile/public/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,16 @@
+<resources>
+    <string name="manage_profile_title">Manage Profile</string>
+    <string name="manage_profile_display_name_label">Display name</string>
+    <string name="manage_profile_display_name_hint">Enter your name</string>
+    <string name="manage_profile_email_label">Email</string>
+    <string name="manage_profile_change_photo">Change photo</string>
+    <string name="manage_profile_avatar_content_description">Profile photo</string>
+    <string name="manage_profile_save">Save</string>
+    <string name="manage_profile_save_error">Couldn’t save your profile. Please try again.</string>
+    <string name="manage_profile_delete_account">Delete Account</string>
+    <string name="manage_profile_delete_dialog_title">Delete account?</string>
+    <string name="manage_profile_delete_dialog_message">This permanently deletes your account and all of your recipes, groceries, and meal plans. This can’t be undone.</string>
+    <string name="manage_profile_delete_dialog_confirm">Delete</string>
+    <string name="manage_profile_delete_dialog_cancel">Cancel</string>
+    <string name="manage_profile_delete_error">Couldn’t delete your account. Please try again.</string>
+</resources>

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileBloc.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileBloc.kt
@@ -1,0 +1,91 @@
+package com.plusmobileapps.chefmate.profile
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.ui.BlocScreen
+import com.plusmobileapps.chefmate.util.PickedImage
+import kotlinx.coroutines.flow.StateFlow
+
+interface ManageProfileBloc : BlocScreen {
+    val state: StateFlow<Model>
+
+    fun onBack()
+
+    fun onDisplayNameChanged(displayName: String)
+
+    fun onPhotoPicked(image: PickedImage)
+
+    fun onSaveClicked()
+
+    fun onDeleteAccountClicked()
+
+    fun onDeleteConfirmed()
+
+    fun onDeleteDismissed()
+
+    data class Model(
+        val displayName: String = "",
+        val email: String = "",
+        /** Remote avatar URL, shown when no fresh photo has been picked this session. */
+        val photoUrl: String? = null,
+        /** Bytes of a just-picked photo, previewed before it's uploaded on save. */
+        val pickedPhoto: ByteArray? = null,
+        val isSaving: Boolean = false,
+        val saveError: TextData? = null,
+        val showDeleteDialog: Boolean = false,
+        val isDeleting: Boolean = false,
+        val deleteError: TextData? = null,
+    ) {
+        /** Save is enabled once a non-blank name exists and no save/delete is in flight. */
+        val canSave: Boolean
+            get() = displayName.isNotBlank() && !isSaving && !isDeleting
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Model) return false
+            if (displayName != other.displayName) return false
+            if (email != other.email) return false
+            if (photoUrl != other.photoUrl) return false
+            if (!pickedPhoto.contentEqualsNullable(other.pickedPhoto)) return false
+            if (isSaving != other.isSaving) return false
+            if (saveError != other.saveError) return false
+            if (showDeleteDialog != other.showDeleteDialog) return false
+            if (isDeleting != other.isDeleting) return false
+            if (deleteError != other.deleteError) return false
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = displayName.hashCode()
+            result = 31 * result + email.hashCode()
+            result = 31 * result + (photoUrl?.hashCode() ?: 0)
+            result = 31 * result + (pickedPhoto?.contentHashCode() ?: 0)
+            result = 31 * result + isSaving.hashCode()
+            result = 31 * result + (saveError?.hashCode() ?: 0)
+            result = 31 * result + showDeleteDialog.hashCode()
+            result = 31 * result + isDeleting.hashCode()
+            result = 31 * result + (deleteError?.hashCode() ?: 0)
+            return result
+        }
+
+        private fun ByteArray?.contentEqualsNullable(other: ByteArray?): Boolean =
+            when {
+                this == null && other == null -> true
+                this == null || other == null -> false
+                else -> this.contentEquals(other)
+            }
+    }
+
+    sealed class Output {
+        /** Pop back to the More tab (also emitted after a successful save). */
+        data object Back : Output()
+
+        /** The account was deleted; the host pops and the More tab re-renders unauthenticated. */
+        data object AccountDeleted : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): ManageProfileBloc
+    }
+}

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileTestTags.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileTestTags.kt
@@ -1,0 +1,9 @@
+package com.plusmobileapps.chefmate.profile
+
+object ManageProfileTestTags {
+    const val SCREEN = "manage_profile_screen"
+    const val AVATAR = "manage_profile_avatar"
+    const val DISPLAY_NAME = "manage_profile_display_name"
+    const val SAVE = "manage_profile_save"
+    const val DELETE_ACCOUNT = "manage_profile_delete_account"
+}

--- a/client/root/impl/build.gradle.kts
+++ b/client/root/impl/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             implementation(projects.client.cook.public)
             implementation(projects.client.featureflag.public)
             implementation(projects.client.grocery.core.public)
+            implementation(projects.client.profile.public)
             implementation(projects.client.recipe.core.public)
             implementation(projects.client.recipe.exporter.public)
             implementation(projects.client.recipebook.edit.public)

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -20,6 +20,7 @@ import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.featureflag.FeatureFlags
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
@@ -47,6 +48,7 @@ class RootBlocImpl(
     private val authentication: AuthenticationBloc.Factory,
     private val otpBloc: OtpBloc.Factory,
     private val settingsRoot: SettingsRootBloc.Factory,
+    private val manageProfile: ManageProfileBloc.Factory,
     private val developerSettings: DeveloperSettingsBloc.Factory,
     private val cookMode: CookModeBloc.Factory,
     private val featureFlags: FeatureFlags,
@@ -183,6 +185,15 @@ class RootBlocImpl(
                         settingsRoot.create(context = context, output = ::handleSettingsRootOutput)
                 )
 
+            Configuration.ManageProfile ->
+                RootBloc.Child.ManageProfile(
+                    bloc =
+                        manageProfile.create(
+                            context = context,
+                            output = ::handleManageProfileOutput,
+                        )
+                )
+
             Configuration.DeveloperSettings ->
                 RootBloc.Child.DeveloperSettings(
                     bloc =
@@ -282,6 +293,10 @@ class RootBlocImpl(
                 navigation.bringToFront(Configuration.MealPlanner(output.props))
             }
 
+            BottomNavBloc.Output.OpenManageProfile -> {
+                navigation.bringToFront(Configuration.ManageProfile)
+            }
+
             BottomNavBloc.Output.OpenAppSettings -> {
                 navigation.bringToFront(Configuration.SettingsRoot)
             }
@@ -333,6 +348,15 @@ class RootBlocImpl(
     private fun handleSettingsRootOutput(output: SettingsRootBloc.Output) {
         when (output) {
             SettingsRootBloc.Output.Back -> navigation.pop()
+        }
+    }
+
+    private fun handleManageProfileOutput(output: ManageProfileBloc.Output) {
+        when (output) {
+            // Both pop back to the More tab; on deletion the More tab re-renders unauthenticated
+            // on its own once the auth state flips.
+            ManageProfileBloc.Output.Back,
+            ManageProfileBloc.Output.AccountDeleted -> navigation.pop()
         }
     }
 
@@ -451,6 +475,8 @@ class RootBlocImpl(
         @Serializable data class MealPlanner(val props: MealPlannerRootBloc.Props) : Configuration()
 
         @Serializable data object SettingsRoot : Configuration()
+
+        @Serializable data object ManageProfile : Configuration()
 
         @Serializable data object DeveloperSettings : Configuration()
 

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -31,6 +31,9 @@ class RootBlocTest {
     var recipeOutput: Consumer<RecipeRootBloc.Output> = Consumer {}
     var recipeProps: RecipeRootBloc.Props? = null
     var settingsRootOutput: Consumer<SettingsRootBloc.Output> = Consumer {}
+    var manageProfileOutput:
+        Consumer<com.plusmobileapps.chefmate.profile.ManageProfileBloc.Output> =
+        Consumer {}
     var developerSettingsOutput:
         Consumer<com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc.Output> =
         Consumer {}
@@ -83,6 +86,10 @@ class RootBlocTest {
             },
             settingsRoot = { _, output ->
                 settingsRootOutput = output
+                mock()
+            },
+            manageProfile = { _, output ->
+                manageProfileOutput = output
                 mock()
             },
             developerSettings = { _, output ->

--- a/client/root/public/build.gradle.kts
+++ b/client/root/public/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             api(projects.client.developerSettings.public)
             api(projects.client.featureflag.public)
             api(projects.client.grocery.core.public)
+            api(projects.client.profile.public)
             api(projects.client.recipe.core.public)
             api(projects.client.recipe.exporter.public)
             api(projects.client.recipebook.edit.public)

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -12,6 +12,7 @@ import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
@@ -39,6 +40,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class MealPlanner(val bloc: MealPlannerRootBloc) : Child(), BlocScreen by bloc
 
         data class SettingsRoot(val bloc: SettingsRootBloc) : Child(), BlocScreen by bloc
+
+        data class ManageProfile(val bloc: ManageProfileBloc) : Child(), BlocScreen by bloc
 
         data class DeveloperSettings(val bloc: DeveloperSettingsBloc) : Child(), BlocScreen by bloc
 

--- a/client/settings/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/robots/MoreRobot.kt
+++ b/client/settings/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/robots/MoreRobot.kt
@@ -28,6 +28,8 @@ class MoreRobot(private val test: ComposeUiTest) {
 
     fun clickAppSettingsRow(): MoreRobot = clickRow("Settings")
 
+    fun clickManageProfileRow(): MoreRobot = clickRow("Manage Profile")
+
     private fun clickRow(label: String): MoreRobot = apply {
         test.waitUntilExactlyOneExists(hasText(label) and onScreen)
         test.onNode(hasText(label) and onScreen).performClick()

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -67,6 +67,10 @@ class SettingsBlocImpl(
         viewModel.dismissSignOutConfirmationDialog()
     }
 
+    override fun onManageProfileClicked() {
+        output.onNext(Output.OpenManageProfile)
+    }
+
     override fun onUrlClicked(url: String) {
         output.onNext(Output.OpenUrl(url))
     }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/ui/SettingsScreen.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/ui/SettingsScreen.kt
@@ -33,6 +33,7 @@ import chefmate.client.settings.public.generated.resources.Res
 import chefmate.client.settings.public.generated.resources.about
 import chefmate.client.settings.public.generated.resources.developer_settings
 import chefmate.client.settings.public.generated.resources.greeting_authenticated
+import chefmate.client.settings.public.generated.resources.manage_profile
 import chefmate.client.settings.public.generated.resources.more
 import chefmate.client.settings.public.generated.resources.privacy_policy
 import chefmate.client.settings.public.generated.resources.settings
@@ -100,6 +101,11 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
                         GreetingSection(greeting = greeting)
                         HorizontalDivider()
                     }
+                    SettingsRow(
+                        name = Res.string.manage_profile.asTextData(),
+                        onClick = bloc::onManageProfileClicked,
+                    )
+                    HorizontalDivider()
                     SettingsRow(
                         name = Res.string.sign_out.asTextData(),
                         onClick = bloc::onSignOutClicked,
@@ -276,6 +282,8 @@ private val previewBlocUnauthenticated =
 
         override fun onSignOutDismissed() = Unit
 
+        override fun onManageProfileClicked() = Unit
+
         override fun onUrlClicked(url: String) = Unit
 
         override fun onAppSettingsClicked() = Unit
@@ -312,6 +320,8 @@ private val previewBlocAuthenticated =
 
         override fun onSignOutDismissed() = Unit
 
+        override fun onManageProfileClicked() = Unit
+
         override fun onUrlClicked(url: String) = Unit
 
         override fun onAppSettingsClicked() = Unit
@@ -343,6 +353,8 @@ private val previewBlocAnonymous =
         override fun onSignOutConfirmed() = Unit
 
         override fun onSignOutDismissed() = Unit
+
+        override fun onManageProfileClicked() = Unit
 
         override fun onUrlClicked(url: String) = Unit
 

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="sign_in">Sign In</string>
     <string name="sign_out">Sign Out</string>
     <string name="sign_up">Sign Up</string>
+    <string name="manage_profile">Manage Profile</string>
     <string name="greeting_authenticated">Hello {name}!</string>
     <string name="email_verification_required">Please check your email ({email}) to verify your account before signing in.</string>
     <string name="settings_guest_banner">You’re using ChefMate as a guest. Sign up to back up your recipes across devices.</string>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -19,6 +19,8 @@ interface SettingsBloc : BlocScreen {
 
     fun onSignOutDismissed()
 
+    fun onManageProfileClicked()
+
     fun onUrlClicked(url: String)
 
     fun onAppSettingsClicked()
@@ -48,6 +50,8 @@ interface SettingsBloc : BlocScreen {
         data object OpenSignUp : Output()
 
         data object OpenSignIn : Output()
+
+        data object OpenManageProfile : Output()
 
         data object OpenAppSettings : Output()
 

--- a/client/ui/screenshot-test/build.gradle.kts
+++ b/client/ui/screenshot-test/build.gradle.kts
@@ -60,6 +60,8 @@ dependencies {
     implementation(project(":client:settings:public"))
     implementation(project(":client:settings:impl"))
     implementation(project(":client:settings:root:public"))
+    implementation(project(":client:profile:public"))
+    implementation(project(":client:profile:impl"))
     implementation(libs.arkivanov.decompose.core)
 
     screenshotTestImplementation(libs.screenshot.validation.api)

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTest.kt
@@ -1,0 +1,39 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.profile.impl.ui.previewManageProfileBloc
+import com.plusmobileapps.chefmate.profile.impl.ui.previewManageProfileDeleteDialogBloc
+import com.plusmobileapps.chefmate.profile.impl.ui.previewManageProfileSavingBloc
+import com.plusmobileapps.chefmate.ui.Content
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun ManageProfileLightScreenshot() {
+    ChefMateTheme { previewManageProfileBloc.Content() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun ManageProfileDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) { previewManageProfileBloc.Content() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun ManageProfileSavingScreenshot() {
+    ChefMateTheme { previewManageProfileSavingBloc.Content() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun ManageProfileDeleteDialogScreenshot() {
+    ChefMateTheme { previewManageProfileDeleteDialogBloc.Content() }
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDarkScreenshot_907cdd58_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDarkScreenshot_907cdd58_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8dc5cd84b7e9a6e6c296a5a70b6927dc7862283325b7173dc6475dfacf6467a
+size 55224

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDeleteDialogScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDeleteDialogScreenshot_e0e29121_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:901a89720ccb77fadad986e1ea3ff4af669adecce3797f57a88af97fc4c0240d
+size 89102

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileLightScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileLightScreenshot_e0e29121_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02722416ecf8838ca689e462e04dc0b57eb4b5bbaf7d4dc4f85cbf881f31abdf
+size 53646

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileSavingScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileSavingScreenshot_e0e29121_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:370444ae2dace00e7966e9350b7e0a5e533ee41de887745f4d8afb5a9ffc7575
+size 49915

--- a/docs/supabase-avatars-setup.sql
+++ b/docs/supabase-avatars-setup.sql
@@ -1,0 +1,62 @@
+-- Supabase Storage setup for profile photo (avatar) uploads.
+-- Paste this into the Supabase SQL editor for each environment (dev, prod, ...).
+-- Idempotent: every `create policy` is preceded by `drop policy if exists`, so this
+-- file is safe to re-run when the setup changes.
+-- Notes:
+--   * storage.objects already has RLS enabled by default.
+--   * Avatars are written by SupabaseProfilePhotoStorage.kt under "<userId>/<uuid>.<ext>",
+--     mirroring the recipe-photos bucket. Only real (non-anonymous) signed-in users reach
+--     the Manage Profile screen, so every upload has a real auth.uid().
+
+-- 1. Create the bucket (public, 5 MB cap, image MIME types only).
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'avatars',
+  'avatars',
+  true,
+  5242880, -- 5 MB
+  array['image/jpeg', 'image/png', 'image/webp', 'image/heic']
+)
+on conflict (id) do update set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+-- 2. Public read so Coil can load avatars via bucket.publicUrl(path).
+drop policy if exists "avatars_public_read" on storage.objects;
+create policy "avatars_public_read"
+on storage.objects for select
+to public
+using (bucket_id = 'avatars');
+
+-- 3. Authenticated users can only write inside their own folder.
+drop policy if exists "avatars_owner_insert" on storage.objects;
+create policy "avatars_owner_insert"
+on storage.objects for insert
+to authenticated
+with check (
+  bucket_id = 'avatars'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+drop policy if exists "avatars_owner_update" on storage.objects;
+create policy "avatars_owner_update"
+on storage.objects for update
+to authenticated
+using (
+  bucket_id = 'avatars'
+  and (storage.foldername(name))[1] = auth.uid()::text
+)
+with check (
+  bucket_id = 'avatars'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+drop policy if exists "avatars_owner_delete" on storage.objects;
+create policy "avatars_owner_delete"
+on storage.objects for delete
+to authenticated
+using (
+  bucket_id = 'avatars'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -129,6 +129,7 @@ supabase-client = { module = "io.github.jan-tennert.supabase:supabase-kt", versi
 supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
 supabase-postgrest = { module = "io.github.jan-tennert.supabase:postgrest-kt", version.ref = "supabase" }
 supabase-storage = { module = "io.github.jan-tennert.supabase:storage-kt", version.ref = "supabase" }
+supabase-functions = { module = "io.github.jan-tennert.supabase:functions-kt", version.ref = "supabase" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 [plugins]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -110,6 +110,12 @@ include(":client:recipe:categories:impl-robots")
 
 include(":client:recipe:categories:public")
 
+include(":client:profile:impl")
+
+include(":client:profile:impl-robots")
+
+include(":client:profile:public")
+
 include(":client:recipe:core:impl")
 
 include(":client:recipe:core:impl-robots")

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,87 @@
+// Supabase Edge Function: delete-account
+//
+// Permanently deletes the *calling* user's account. The client SDK can't delete auth users, so the
+// app invokes this function (see SupabaseAuthenticationRepository.deleteAccount). It:
+//   1. Reads the caller's JWT from the Authorization header.
+//   2. Resolves the user with an anon-key client (RLS-scoped to that user).
+//   3. Deletes the user with a service-role client (admin.deleteUser).
+//
+// App tables (recipes, groceries, meals, categories, …) must declare their owner FK to
+// auth.users(id) with ON DELETE CASCADE so the user's rows are removed alongside the auth row.
+// Storage objects under the user's folder in the `recipe-photos` / `avatars` buckets are best-effort
+// removed here too.
+//
+// Deploy:  supabase functions deploy delete-account
+// Secrets: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are injected automatically by Supabase.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return json({ error: "Missing Authorization header" }, 401);
+    }
+
+    // Resolve the caller from their JWT.
+    const userClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+    const {
+      data: { user },
+      error: userError,
+    } = await userClient.auth.getUser();
+
+    if (userError || !user) {
+      return json({ error: "Invalid or expired session" }, 401);
+    }
+
+    const admin = createClient(supabaseUrl, serviceRoleKey);
+
+    // Best-effort: remove the user's storage objects before deleting the auth row. Failures here
+    // don't block account deletion — orphaned objects can be swept later.
+    for (const bucket of ["recipe-photos", "avatars"]) {
+      try {
+        const { data: files } = await admin.storage.from(bucket).list(user.id);
+        if (files && files.length > 0) {
+          await admin.storage
+            .from(bucket)
+            .remove(files.map((f) => `${user.id}/${f.name}`));
+        }
+      } catch (_) {
+        // ignore storage cleanup failures
+      }
+    }
+
+    // Delete the auth user. App-table rows cascade via ON DELETE CASCADE FKs to auth.users.
+    const { error: deleteError } = await admin.auth.admin.deleteUser(user.id);
+    if (deleteError) {
+      return json({ error: deleteError.message }, 500);
+    }
+
+    return new Response(null, { status: 204, headers: corsHeaders });
+  } catch (e) {
+    return json({ error: String(e) }, 500);
+  }
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
Closes #52

## What

Adds a **Manage Profile** entry to the More tab for real (non-anonymous) signed-in users. The screen lets the user:

- Change their **display name**
- Change their **profile photo**
- See their (read-only) **email**
- **Delete their account** — behind a confirmation dialog. On confirm, the remote Supabase user is deleted, the user is signed out, and all local data (recipes, groceries, meals, AI chat, categories) is wiped.

The row is hidden for anonymous/guest sessions (consistent with how Sign Out is already hidden for them).

## How

Follows the repo's BLoC + three-module pattern. The screen is a full-screen page hosted at the **Root** stack (like `SettingsRoot`/`DeveloperSettings`), reached via an output that bubbles `SettingsBloc → BottomNavBloc → RootBloc`.

- **Auth layer**: `AuthenticationRepository.updateProfile` / `deleteAccount`; new `ProfilePhotoStorage` (`avatars` bucket); `DeleteAccountUseCase` (deletes remote, then reuses `SignOutUseCase` for the local wipe).
- **Account deletion** runs in a service-role `delete-account` Supabase **edge function** (the client SDK can't delete auth users), invoked via `functions-kt`.
- **Profile photo** uploads to a new public `avatars` storage bucket.

## Commits

Split by concern: auth foundation → profile feature + nav → snapshots → robot/UI flow test → supabase backend.

## Screenshots

| Light | Delete dialog |
|---|---|
| Manage Profile with avatar placeholder, display name, read-only email, Save + destructive Delete Account | Confirmation dialog over the screen |

Recorded reference PNGs are included for default, saving, delete-dialog, and dark variants.

## ⚠️ Deploy steps (backend, not in this repo's CI)

1. Deploy the edge function: `supabase functions deploy delete-account`
2. Run `docs/supabase-avatars-setup.sql` in each environment to create the `avatars` bucket + RLS policies.
3. Ensure app tables (recipes/groceries/meals/categories) have `ON DELETE CASCADE` FKs to `auth.users` so a deleted user's rows are removed.

## Testing

- `:client:auth:usecase:impl` + `:client:profile:impl` unit tests
- `ManageProfileNavigationUiTest` (runRootBlocTest flow)
- Screenshot references recorded + `validateDebugScreenshotTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)