### PR TITLE
fix(recipebook): crash reading books seeded with SQLite datetime timestamps

### DIFF
--- a/client/database/core/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/5.sqm
+++ b/client/database/core/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/5.sqm
@@ -30,8 +30,11 @@ CREATE TABLE RecipeBookRecipe (
 
 CREATE INDEX idx_recipe_book_recipe_recipe ON RecipeBookRecipe(recipeId);
 
--- Seed the single local default book.
-INSERT INTO RecipeBook (name, isDefault) VALUES ('My Recipes', 1);
+-- Seed the single local default book. Timestamps are written in ISO-8601 (matching
+-- kotlin.time.Instant.toString()); the column default datetime('now') would produce a
+-- space-separated SQLite datetime that Instant.parse can't read.
+INSERT INTO RecipeBook (name, isDefault, createdAt, updatedAt)
+VALUES ('My Recipes', 1, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'));
 
 -- Link every existing recipe to the default book.
 INSERT INTO RecipeBookRecipe (recipeBookId, recipeId)

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImpl.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImpl.kt
@@ -310,10 +310,18 @@ class RecipeBookRepositoryImpl(
             name = name,
             isDefault = isDefault,
             syncStatus = syncStatus,
-            createdAt = Instant.parse(createdAt),
-            updatedAt = Instant.parse(updatedAt),
+            createdAt = parseTimestamp(createdAt),
+            updatedAt = parseTimestamp(updatedAt),
         )
     }
+
+    /**
+     * Books seeded by an upgrade migration's column default carry a SQLite datetime (`"2026-06-08
+     * 22:11:24"` — space-separated, UTC, no offset), which [Instant.parse] rejects. Normalise that
+     * shape to ISO-8601 before parsing so those rows don't crash on read.
+     */
+    private fun parseTimestamp(value: String): Instant =
+        Instant.parse(if (value.contains('T')) value else "${value.replace(' ', 'T')}Z")
 
     private companion object {
         const val TAG = "RecipeBookRepositoryImpl"

--- a/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImplTest.kt
+++ b/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImplTest.kt
@@ -12,6 +12,7 @@ import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteRecipeBook
 import com.plusmobileapps.chefmate.util.testing.FakeDateTimeUtil
 import com.plusmobileapps.chefmate.util.testing.FakeUnique
 import com.russhwolf.settings.MapSettings
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -57,6 +58,27 @@ class RecipeBookRepositoryImplTest {
             val defaultId = repo.getDefaultBookId()
 
             repo.activeBookId.value shouldBe defaultId
+        }
+
+    @Test
+    fun reads_books_seeded_with_sqlite_datetime_timestamps() =
+        runTest(testDispatcher) {
+            // A book seeded by the upgrade migration's column default carries a SQLite datetime
+            // ("2026-06-08 22:11:24"), which Instant.parse rejects. Reading it must not crash.
+            db.recipeBookQueries.create(
+                name = "Imported",
+                isDefault = false,
+                createdAt = "2026-06-08 22:11:24",
+                updatedAt = "2026-06-08 22:11:24",
+                clientId = "client-1",
+                ownerId = null,
+            )
+            val repo = repository()
+
+            repo.getRecipeBooks().test {
+                val books = awaitItem()
+                books.map { it.name } shouldContain "Imported"
+            }
         }
 
     @Test


### PR DESCRIPTION
## What

Fixes an `InstantFormatException` crash that started after recipe books merged (1.8.0). Users who **upgraded** from a pre–recipe-book DB crash whenever recipe books are read:

```
kotlin.time.InstantFormatException: The input string is too short when parsing
an Instant from "2026-06-08 22:11:24"
  at RecipeBookRepositoryImpl.toRecipeBook(RecipeBookRepositoryImpl.kt:313)
```

## Why

Migration `5.sqm` seeds the default book without `createdAt`/`updatedAt`:

```sql
INSERT INTO RecipeBook (name, isDefault) VALUES ('My Recipes', 1);
```

So the timestamps fall back to the column default `DEFAULT (datetime('now'))`. SQLite renders that as `"2026-06-08 22:11:24"` — space-separated, no `T`, no offset — which `kotlin.time.Instant.parse` rejects. `getRecipeBooks()` then throws on the first emission.

Fresh installs were unaffected: they build from the current schema via `Schema.create` and seed through `ensureDefaultBookId`, which writes proper ISO-8601 (`dateTimeUtil.now.toString()`). That's why existing tests passed and it slipped through — only the migration path produces the bad row.

## Changes

- **`toRecipeBook`** now parses tolerantly: a stored value without `T` is normalised from the SQLite datetime shape to ISO-8601 (`replace(' ', 'T')` + `Z`) before `Instant.parse`. This is the fix that actually rescues users who **already** have the bad row — a migration can't retroactively repair them.
- **Migration `5.sqm`** seed now writes explicit ISO timestamps (`strftime('%Y-%m-%dT%H:%M:%SZ','now')`), so anyone upgrading from here on never generates the malformed row (and never pushes a bad timestamp to remote sync). DDL is unchanged, so migration verification stays green.
- **Regression test** inserts a book with `"2026-06-08 22:11:24"` and asserts `getRecipeBooks()` reads it without crashing.

## Verification

- `:client:recipebook:data:impl:jvmTest` — passing
- `:client:database:core:verifyCommonMainDatabaseMigration` — passing
- `ktfmtFormat` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)