### PR TITLE
Add manage profile name and email

### DIFF
--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
@@ -28,8 +28,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 
 @Inject
 @SingleIn(AppScope::class)
@@ -201,6 +203,19 @@ class SupabaseAuthenticationRepository(
             println("Error signing out: ${e.message}")
         }
     }
+
+    override suspend fun updateProfile(displayName: String): Result<Unit> =
+        try {
+            supabaseClient.auth.updateUser {
+                data = buildJsonObject {
+                    put("name", displayName)
+                }
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) { "Failed to update profile" }
+            Result.failure(e)
+        }
 
     override suspend fun sendPasswordResetEmail(email: String): Result<Unit> =
         try {

--- a/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
+++ b/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
@@ -24,6 +24,8 @@ interface AuthenticationRepository {
 
     suspend fun signOut()
 
+    suspend fun updateProfile(displayName: String): Result<Unit>
+
     suspend fun sendPasswordResetEmail(email: String): Result<Unit>
 
     suspend fun sendSignInOtp(email: String): Result<Unit>

--- a/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
+++ b/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
@@ -19,6 +19,9 @@ class FakeAuthenticationRepository : AuthenticationRepository {
     var verifyEmailOtpResult: Result<Unit> = Result.success(Unit)
     var resendOtpResult: Result<Unit> = Result.success(Unit)
     var ensureSessionResult: Result<Unit> = Result.success(Unit)
+    var updateProfileResult: Result<Unit> = Result.success(Unit)
+    var lastUpdatedDisplayName: String? = null
+        private set
 
     var ensureSessionCallCount: Int = 0
         private set
@@ -67,6 +70,18 @@ class FakeAuthenticationRepository : AuthenticationRepository {
 
     override suspend fun signOut() {
         _state.value = AuthState.Unauthenticated
+    }
+
+    override suspend fun updateProfile(displayName: String): Result<Unit> {
+        lastUpdatedDisplayName = displayName
+        return updateProfileResult.also { result ->
+            if (result.isSuccess) {
+                (_state.value as? AuthState.Authenticated)?.let { authenticated ->
+                    _state.value =
+                        AuthState.Authenticated(authenticated.user.copy(userName = displayName))
+                }
+            }
+        }
     }
 
     override suspend fun sendPasswordResetEmail(email: String): Result<Unit> =

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -26,6 +26,7 @@ import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Child.Meals
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Child.RecipeList
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Child.Settings
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Output.OpenAppSettings
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Output.OpenManageProfile
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Output.OpenSignIn
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Output.OpenSignUp
 import com.plusmobileapps.chefmate.recipe.bottomnav.impl.ui.BottomNavigationScreen
@@ -235,6 +236,7 @@ class BottomNavBlocImpl(
         when (output) {
             SettingsBloc.Output.OpenSignIn -> OpenSignIn
             SettingsBloc.Output.OpenSignUp -> OpenSignUp
+            SettingsBloc.Output.OpenManageProfile -> OpenManageProfile
             SettingsBloc.Output.OpenAppSettings -> OpenAppSettings
             SettingsBloc.Output.OpenAiChat -> BottomNavBloc.Output.OpenAiChat
             SettingsBloc.Output.OpenDeveloperSettings -> BottomNavBloc.Output.OpenDeveloperSettings

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -73,6 +73,8 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
 
         data object OpenSignUp : Output()
 
+        data object OpenManageProfile : Output()
+
         data object OpenAppSettings : Output()
 
         data object OpenAiChat : Output()

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -104,6 +104,7 @@ kotlin {
             api(projects.client.recipe.importer.impl)
             api(projects.client.recipebook.data.impl)
             api(projects.client.recipebook.edit.impl)
+            api(projects.client.profile.impl)
             api(projects.client.util.impl)
             api(projects.client.settings.impl)
             api(projects.client.settings.root.impl)
@@ -151,6 +152,7 @@ kotlin {
             implementation(projects.client.recipe.list.implRobots)
             implementation(projects.client.settings.implRobots)
             implementation(projects.client.settings.root.implRobots)
+            implementation(projects.client.profile.implRobots)
         }
         val jvmTest by getting {
             dependencies {

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/ManageProfileNavigationUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/ManageProfileNavigationUiTest.kt
@@ -1,0 +1,31 @@
+package com.plusmobileapps.chefmate.tests
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.profile.robots.manageProfile
+import com.plusmobileapps.chefmate.recipe.bottomnav.robots.bottomNav
+import com.plusmobileapps.chefmate.settings.robots.more
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ManageProfileNavigationUiTest {
+
+    @Test
+    fun opening_manage_profile_from_more_tab_shows_the_screen() = runRootBlocTest {
+        bottomNav().clickMoreTab()
+        more().awaitDisplayed().clickManageProfileRow()
+
+        manageProfile().awaitDisplayed().assertDisplayed()
+    }
+
+    @Test
+    fun saving_profile_returns_to_more_tab() = runRootBlocTest {
+        bottomNav().clickMoreTab()
+        more().awaitDisplayed().clickManageProfileRow()
+
+        manageProfile().awaitDisplayed().setDisplayName("Renamed Chef").tapSave()
+
+        // Saving pops back to the More tab.
+        more().awaitDisplayed()
+    }
+}

--- a/client/profile/impl-robots/build.gradle.kts
+++ b/client/profile/impl-robots/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin { sourceSets { commonMain.dependencies { implementation(projects.client.profile.public) } } }
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.profile.robots"
+    uiTest = true
+}

--- a/client/profile/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/robots/ManageProfileRobot.kt
+++ b/client/profile/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/robots/ManageProfileRobot.kt
@@ -1,0 +1,50 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package com.plusmobileapps.chefmate.profile.robots
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import com.plusmobileapps.chefmate.profile.ManageProfileTestTags
+
+/**
+ * Robot for the Manage Profile screen. Every lookup is scoped to a descendant of
+ * [ManageProfileTestTags.SCREEN] so titles rendered on other screens don't satisfy matchers.
+ *
+ * Construct via [manageProfile] from inside a `runComposeUiTest { … }` block.
+ */
+class ManageProfileRobot(private val test: ComposeUiTest) {
+
+    private val onScreen = hasAnyAncestor(hasTestTag(ManageProfileTestTags.SCREEN))
+
+    fun awaitDisplayed(): ManageProfileRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(ManageProfileTestTags.SCREEN))
+    }
+
+    fun setDisplayName(name: String): ManageProfileRobot = apply {
+        // The test tag sits on the PlusTextField wrapper; the editable node is the descendant that
+        // owns the set-text action.
+        test
+            .onNode(
+                hasSetTextAction() and
+                    hasAnyAncestor(hasTestTag(ManageProfileTestTags.DISPLAY_NAME))
+            )
+            .performTextReplacement(name)
+    }
+
+    fun tapSave(): ManageProfileRobot = apply {
+        test.onNode(hasTestTag(ManageProfileTestTags.SAVE) and onScreen).performClick()
+    }
+
+    fun assertDisplayed(): ManageProfileRobot = apply {
+        test.onNode(hasTestTag(ManageProfileTestTags.SCREEN)).assertIsDisplayed()
+    }
+}
+
+fun ComposeUiTest.manageProfile(): ManageProfileRobot = ManageProfileRobot(this)

--- a/client/profile/impl/build.gradle.kts
+++ b/client/profile/impl/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.profile.public)
+            implementation(projects.client.text.public)
+            implementation(projects.client.ui.public)
+            implementation(libs.arkivanov.decompose.core)
+            implementation(libs.arkivanov.decompose.compose.extensions)
+            implementation(projects.client.shared)
+            implementation(projects.client.auth.data.public)
+            implementation(compose.components.resources)
+        }
+        commonTest.dependencies { implementation(projects.client.auth.data.testing) }
+    }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.profile.impl"
+    enableDi = true
+    enableTesting = true
+}

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImpl.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImpl.kt
@@ -1,0 +1,63 @@
+package com.plusmobileapps.chefmate.profile.impl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.getViewModel
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Model
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Output
+import com.plusmobileapps.chefmate.profile.impl.ui.ManageProfileScreen
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.Provider
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = ManageProfileBloc.Factory::class,
+)
+class ManageProfileBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<Output>,
+    viewModelFactory: Provider<ManageProfileViewModel>,
+) : ManageProfileBloc, BlocContext by context {
+
+    private val scope = createScope()
+
+    private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
+
+    override val state: StateFlow<Model> = viewModel.state
+
+    init {
+        scope.launch {
+            viewModel.outputs.collect {
+                when (it) {
+                    ManageProfileViewModel.Output.Saved -> output.onNext(Output.Back)
+                }
+            }
+        }
+    }
+
+    override fun onBack() {
+        output.onNext(Output.Back)
+    }
+
+    override fun onDisplayNameChanged(displayName: String) {
+        viewModel.setDisplayName(displayName)
+    }
+
+    override fun onSaveClicked() {
+        viewModel.save()
+    }
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        ManageProfileScreen(bloc = this, modifier = modifier)
+    }
+}

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
@@ -1,0 +1,68 @@
+package com.plusmobileapps.chefmate.profile.impl
+
+import chefmate.client.profile.public.generated.resources.Res
+import chefmate.client.profile.public.generated.resources.manage_profile_save_error
+import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Model
+import com.plusmobileapps.chefmate.text.asTextData
+import dev.zacsweers.metro.Inject
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@Inject
+class ManageProfileViewModel(
+    @Main mainContext: CoroutineContext,
+    private val authenticationRepository: AuthenticationRepository,
+) : ViewModel(mainContext) {
+
+    private val _state = MutableStateFlow(initialState())
+    val state: StateFlow<Model> = _state.asStateFlow()
+
+    private val _outputs = Channel<Output>(Channel.BUFFERED)
+    val outputs: Flow<Output> = _outputs.receiveAsFlow()
+
+    private fun initialState(): Model {
+        val user = (authenticationRepository.state.value as? AuthState.Authenticated)?.user
+        return Model(
+            displayName = user?.userName.orEmpty(),
+            email = user?.userEmail.orEmpty(),
+        )
+    }
+
+    fun setDisplayName(displayName: String) {
+        _state.update { it.copy(displayName = displayName, saveError = null) }
+    }
+
+    fun save() {
+        val current = _state.value
+        if (!current.canSave) return
+        _state.update { it.copy(isSaving = true, saveError = null) }
+        scope.launch {
+            authenticationRepository
+                .updateProfile(displayName = current.displayName.trim())
+                .onSuccess { _outputs.send(Output.Saved) }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            isSaving = false,
+                            saveError = Res.string.manage_profile_save_error.asTextData(),
+                        )
+                    }
+                }
+        }
+    }
+
+    sealed interface Output {
+        data object Saved : Output
+    }
+}

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfilePreviews.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfilePreviews.kt
@@ -1,0 +1,39 @@
+package com.plusmobileapps.chefmate.profile.impl.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Model
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+
+private fun manageProfileBloc(model: Model): ManageProfileBloc =
+    object : ManageProfileBloc {
+        override val state = MutableStateFlow(model)
+
+        override fun onBack() = Unit
+
+        override fun onDisplayNameChanged(displayName: String) = Unit
+
+        override fun onSaveClicked() = Unit
+
+        @Composable
+        override fun Content(modifier: Modifier) {
+            ManageProfileScreen(bloc = this, modifier = modifier)
+        }
+    }
+
+val previewManageProfileBloc: ManageProfileBloc =
+    manageProfileBloc(Model(displayName = "Julia Child", email = "julia@example.com"))
+
+val previewManageProfileSavingBloc: ManageProfileBloc =
+    manageProfileBloc(
+        Model(displayName = "Julia Child", email = "julia@example.com", isSaving = true)
+    )
+
+@Preview
+@Composable
+internal fun ManageProfilePreview() {
+    ChefMateTheme { previewManageProfileBloc.Content(Modifier) }
+}

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfileScreen.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfileScreen.kt
@@ -1,0 +1,83 @@
+package com.plusmobileapps.chefmate.profile.impl.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import chefmate.client.profile.public.generated.resources.Res
+import chefmate.client.profile.public.generated.resources.manage_profile_display_name_hint
+import chefmate.client.profile.public.generated.resources.manage_profile_display_name_label
+import chefmate.client.profile.public.generated.resources.manage_profile_email_label
+import chefmate.client.profile.public.generated.resources.manage_profile_save
+import chefmate.client.profile.public.generated.resources.manage_profile_title
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
+import com.plusmobileapps.chefmate.profile.ManageProfileTestTags
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusButton
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusTextField
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@Composable
+fun ManageProfileScreen(bloc: ManageProfileBloc, modifier: Modifier = Modifier) {
+    val state by bloc.state.collectAsState()
+
+    PlusHeaderContainer(
+        modifier = modifier.testTag(ManageProfileTestTags.SCREEN),
+        data =
+            PlusHeaderData.Child(
+                title = Res.string.manage_profile_title.asTextData(),
+                onBackClick = bloc::onBack,
+            ),
+        content = {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingNormal),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal),
+            ) {
+                PlusTextField(
+                    value = state.displayName,
+                    onValueChange = bloc::onDisplayNameChanged,
+                    modifier = Modifier.fillMaxWidth().testTag(ManageProfileTestTags.DISPLAY_NAME),
+                    label = {
+                        Text(Res.string.manage_profile_display_name_label.asTextData().localized())
+                    },
+                    placeholder = {
+                        Text(Res.string.manage_profile_display_name_hint.asTextData().localized())
+                    },
+                    singleLine = true,
+                    enabled = !state.isSaving,
+                    error = state.saveError,
+                )
+
+                PlusTextField(
+                    value = state.email,
+                    onValueChange = {},
+                    modifier = Modifier.fillMaxWidth(),
+                    label = {
+                        Text(Res.string.manage_profile_email_label.asTextData().localized())
+                    },
+                    singleLine = true,
+                    enabled = false,
+                    readOnly = true,
+                )
+
+                PlusButton(
+                    text = Res.string.manage_profile_save.asTextData(),
+                    modifier = Modifier.fillMaxWidth().testTag(ManageProfileTestTags.SAVE),
+                    enabled = state.canSave,
+                    isLoading = state.isSaving,
+                    onClick = bloc::onSaveClicked,
+                )
+            }
+        },
+    )
+}

--- a/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
+++ b/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
@@ -1,0 +1,76 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.profile.impl
+
+import app.cash.turbine.test
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.ChefMateUser
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
+import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.plusmobileapps.chefmate.testing.TestConsumer
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class ManageProfileBlocImplTest {
+
+    private val context = TestBlocContext.create()
+    private val output = TestConsumer<ManageProfileBloc.Output>()
+    private val authRepository =
+        FakeAuthenticationRepository().apply {
+            setState(
+                AuthState.Authenticated(
+                    ChefMateUser(
+                        userId = "id-1",
+                        userName = "Original Name",
+                        userEmail = "chef@example.com",
+                        userProfileImageUrl = null,
+                    )
+                )
+            )
+        }
+    private val bloc by lazy {
+        ManageProfileBlocImpl(
+            context = context,
+            output = output,
+            viewModelFactory = {
+                ManageProfileViewModel(
+                    mainContext = context.mainContext,
+                    authenticationRepository = authRepository,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun When_opened_Then_state_is_seeded_from_signed_in_user() {
+        bloc.state.value.displayName shouldBe "Original Name"
+        bloc.state.value.email shouldBe "chef@example.com"
+    }
+
+    @Test
+    fun When_name_changed_and_saved_Then_profile_is_updated_and_back_emitted() = runTest {
+        bloc.onDisplayNameChanged("New Name")
+        bloc.onSaveClicked()
+
+        authRepository.lastUpdatedDisplayName shouldBe "New Name"
+        output.lastValue shouldBe ManageProfileBloc.Output.Back
+    }
+
+    @Test
+    fun When_save_fails_Then_save_error_is_surfaced() = runTest {
+        authRepository.updateProfileResult = Result.failure(RuntimeException("boom"))
+
+        bloc.state.test {
+            awaitItem() // seeded
+            bloc.onSaveClicked()
+
+            var item = awaitItem()
+            while (item.saveError == null) item = awaitItem()
+            item.isSaving shouldBe false
+            cancelAndIgnoreRemainingEvents()
+        }
+        output.values.isEmpty() shouldBe true
+    }
+}

--- a/client/profile/public/build.gradle.kts
+++ b/client/profile/public/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.arkivanov.decompose.core)
+            implementation(projects.client.shared)
+            api(projects.client.text.public)
+            api(projects.client.util.public)
+            implementation(projects.client.ui.public)
+            implementation(compose.components.resources)
+        }
+    }
+}
+
+compose { resources { publicResClass = true } }
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.profile" }

--- a/client/profile/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/profile/public/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,8 @@
+<resources>
+    <string name="manage_profile_title">Manage Profile</string>
+    <string name="manage_profile_display_name_label">Display name</string>
+    <string name="manage_profile_display_name_hint">Enter your name</string>
+    <string name="manage_profile_email_label">Email</string>
+    <string name="manage_profile_save">Save</string>
+    <string name="manage_profile_save_error">Couldn’t save your profile. Please try again.</string>
+</resources>

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileBloc.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileBloc.kt
@@ -1,0 +1,35 @@
+package com.plusmobileapps.chefmate.profile
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.ui.BlocScreen
+import kotlinx.coroutines.flow.StateFlow
+
+interface ManageProfileBloc : BlocScreen {
+    val state: StateFlow<Model>
+
+    fun onBack()
+
+    fun onDisplayNameChanged(displayName: String)
+
+    fun onSaveClicked()
+
+    data class Model(
+        val displayName: String = "",
+        val email: String = "",
+        val isSaving: Boolean = false,
+        val saveError: TextData? = null,
+    ) {
+        val canSave: Boolean
+            get() = displayName.isNotBlank() && !isSaving
+    }
+
+    sealed class Output {
+        data object Back : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): ManageProfileBloc
+    }
+}

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileTestTags.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileTestTags.kt
@@ -1,0 +1,7 @@
+package com.plusmobileapps.chefmate.profile
+
+object ManageProfileTestTags {
+    const val SCREEN = "manage_profile_screen"
+    const val DISPLAY_NAME = "manage_profile_display_name"
+    const val SAVE = "manage_profile_save"
+}

--- a/client/root/impl/build.gradle.kts
+++ b/client/root/impl/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             implementation(projects.client.cook.public)
             implementation(projects.client.featureflag.public)
             implementation(projects.client.grocery.core.public)
+            implementation(projects.client.profile.public)
             implementation(projects.client.recipe.core.public)
             implementation(projects.client.recipe.exporter.public)
             implementation(projects.client.recipebook.edit.public)

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -20,6 +20,7 @@ import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.featureflag.FeatureFlags
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
@@ -47,6 +48,7 @@ class RootBlocImpl(
     private val authentication: AuthenticationBloc.Factory,
     private val otpBloc: OtpBloc.Factory,
     private val settingsRoot: SettingsRootBloc.Factory,
+    private val manageProfile: ManageProfileBloc.Factory,
     private val developerSettings: DeveloperSettingsBloc.Factory,
     private val cookMode: CookModeBloc.Factory,
     private val featureFlags: FeatureFlags,
@@ -183,6 +185,15 @@ class RootBlocImpl(
                         settingsRoot.create(context = context, output = ::handleSettingsRootOutput)
                 )
 
+            Configuration.ManageProfile ->
+                RootBloc.Child.ManageProfile(
+                    bloc =
+                        manageProfile.create(
+                            context = context,
+                            output = ::handleManageProfileOutput,
+                        )
+                )
+
             Configuration.DeveloperSettings ->
                 RootBloc.Child.DeveloperSettings(
                     bloc =
@@ -282,6 +293,10 @@ class RootBlocImpl(
                 navigation.bringToFront(Configuration.MealPlanner(output.props))
             }
 
+            BottomNavBloc.Output.OpenManageProfile -> {
+                navigation.bringToFront(Configuration.ManageProfile)
+            }
+
             BottomNavBloc.Output.OpenAppSettings -> {
                 navigation.bringToFront(Configuration.SettingsRoot)
             }
@@ -333,6 +348,12 @@ class RootBlocImpl(
     private fun handleSettingsRootOutput(output: SettingsRootBloc.Output) {
         when (output) {
             SettingsRootBloc.Output.Back -> navigation.pop()
+        }
+    }
+
+    private fun handleManageProfileOutput(output: ManageProfileBloc.Output) {
+        when (output) {
+            ManageProfileBloc.Output.Back -> navigation.pop()
         }
     }
 
@@ -451,6 +472,8 @@ class RootBlocImpl(
         @Serializable data class MealPlanner(val props: MealPlannerRootBloc.Props) : Configuration()
 
         @Serializable data object SettingsRoot : Configuration()
+
+        @Serializable data object ManageProfile : Configuration()
 
         @Serializable data object DeveloperSettings : Configuration()
 

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -31,6 +31,9 @@ class RootBlocTest {
     var recipeOutput: Consumer<RecipeRootBloc.Output> = Consumer {}
     var recipeProps: RecipeRootBloc.Props? = null
     var settingsRootOutput: Consumer<SettingsRootBloc.Output> = Consumer {}
+    var manageProfileOutput:
+        Consumer<com.plusmobileapps.chefmate.profile.ManageProfileBloc.Output> =
+        Consumer {}
     var developerSettingsOutput:
         Consumer<com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc.Output> =
         Consumer {}
@@ -83,6 +86,10 @@ class RootBlocTest {
             },
             settingsRoot = { _, output ->
                 settingsRootOutput = output
+                mock()
+            },
+            manageProfile = { _, output ->
+                manageProfileOutput = output
                 mock()
             },
             developerSettings = { _, output ->

--- a/client/root/public/build.gradle.kts
+++ b/client/root/public/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             api(projects.client.developerSettings.public)
             api(projects.client.featureflag.public)
             api(projects.client.grocery.core.public)
+            api(projects.client.profile.public)
             api(projects.client.recipe.core.public)
             api(projects.client.recipe.exporter.public)
             api(projects.client.recipebook.edit.public)

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -12,6 +12,7 @@ import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
+import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
@@ -39,6 +40,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class MealPlanner(val bloc: MealPlannerRootBloc) : Child(), BlocScreen by bloc
 
         data class SettingsRoot(val bloc: SettingsRootBloc) : Child(), BlocScreen by bloc
+
+        data class ManageProfile(val bloc: ManageProfileBloc) : Child(), BlocScreen by bloc
 
         data class DeveloperSettings(val bloc: DeveloperSettingsBloc) : Child(), BlocScreen by bloc
 

--- a/client/settings/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/robots/MoreRobot.kt
+++ b/client/settings/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/robots/MoreRobot.kt
@@ -28,6 +28,8 @@ class MoreRobot(private val test: ComposeUiTest) {
 
     fun clickAppSettingsRow(): MoreRobot = clickRow("Settings")
 
+    fun clickManageProfileRow(): MoreRobot = clickRow("Manage Profile")
+
     private fun clickRow(label: String): MoreRobot = apply {
         test.waitUntilExactlyOneExists(hasText(label) and onScreen)
         test.onNode(hasText(label) and onScreen).performClick()

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -67,6 +67,10 @@ class SettingsBlocImpl(
         viewModel.dismissSignOutConfirmationDialog()
     }
 
+    override fun onManageProfileClicked() {
+        output.onNext(Output.OpenManageProfile)
+    }
+
     override fun onUrlClicked(url: String) {
         output.onNext(Output.OpenUrl(url))
     }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/ui/SettingsScreen.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/ui/SettingsScreen.kt
@@ -33,6 +33,7 @@ import chefmate.client.settings.public.generated.resources.Res
 import chefmate.client.settings.public.generated.resources.about
 import chefmate.client.settings.public.generated.resources.developer_settings
 import chefmate.client.settings.public.generated.resources.greeting_authenticated
+import chefmate.client.settings.public.generated.resources.manage_profile
 import chefmate.client.settings.public.generated.resources.more
 import chefmate.client.settings.public.generated.resources.privacy_policy
 import chefmate.client.settings.public.generated.resources.settings
@@ -100,6 +101,11 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
                         GreetingSection(greeting = greeting)
                         HorizontalDivider()
                     }
+                    SettingsRow(
+                        name = Res.string.manage_profile.asTextData(),
+                        onClick = bloc::onManageProfileClicked,
+                    )
+                    HorizontalDivider()
                     SettingsRow(
                         name = Res.string.sign_out.asTextData(),
                         onClick = bloc::onSignOutClicked,
@@ -276,6 +282,8 @@ private val previewBlocUnauthenticated =
 
         override fun onSignOutDismissed() = Unit
 
+        override fun onManageProfileClicked() = Unit
+
         override fun onUrlClicked(url: String) = Unit
 
         override fun onAppSettingsClicked() = Unit
@@ -312,6 +320,8 @@ private val previewBlocAuthenticated =
 
         override fun onSignOutDismissed() = Unit
 
+        override fun onManageProfileClicked() = Unit
+
         override fun onUrlClicked(url: String) = Unit
 
         override fun onAppSettingsClicked() = Unit
@@ -343,6 +353,8 @@ private val previewBlocAnonymous =
         override fun onSignOutConfirmed() = Unit
 
         override fun onSignOutDismissed() = Unit
+
+        override fun onManageProfileClicked() = Unit
 
         override fun onUrlClicked(url: String) = Unit
 

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="sign_in">Sign In</string>
     <string name="sign_out">Sign Out</string>
     <string name="sign_up">Sign Up</string>
+    <string name="manage_profile">Manage Profile</string>
     <string name="greeting_authenticated">Hello {name}!</string>
     <string name="email_verification_required">Please check your email ({email}) to verify your account before signing in.</string>
     <string name="settings_guest_banner">You’re using ChefMate as a guest. Sign up to back up your recipes across devices.</string>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -19,6 +19,8 @@ interface SettingsBloc : BlocScreen {
 
     fun onSignOutDismissed()
 
+    fun onManageProfileClicked()
+
     fun onUrlClicked(url: String)
 
     fun onAppSettingsClicked()
@@ -48,6 +50,8 @@ interface SettingsBloc : BlocScreen {
         data object OpenSignUp : Output()
 
         data object OpenSignIn : Output()
+
+        data object OpenManageProfile : Output()
 
         data object OpenAppSettings : Output()
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -110,6 +110,12 @@ include(":client:recipe:categories:impl-robots")
 
 include(":client:recipe:categories:public")
 
+include(":client:profile:impl")
+
+include(":client:profile:impl-robots")
+
+include(":client:profile:public")
+
 include(":client:recipe:core:impl")
 
 include(":client:recipe:core:impl-robots")


### PR DESCRIPTION
## Summary
- add Manage Profile navigation from More
- show signed-in user name and email
- allow updating display name

## Tests
- ./gradlew :client:profile:impl:allTests :client:root:impl:allTests :client:composeApp:allTests