### PR TITLE
Add account deletion from manage profile

### DIFF
--- a/client/auth/data/impl/build.gradle.kts
+++ b/client/auth/data/impl/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
             implementation(projects.client.shared)
             implementation(libs.supabase.client)
             implementation(libs.supabase.auth)
+            implementation(libs.supabase.functions)
             implementation(libs.supabase.postgrest)
             implementation(libs.supabase.storage)
         }

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
@@ -18,6 +18,7 @@ import io.github.jan.supabase.auth.providers.builtin.Email
 import io.github.jan.supabase.auth.providers.builtin.OTP
 import io.github.jan.supabase.auth.status.SessionStatus
 import io.github.jan.supabase.auth.user.UserInfo
+import io.github.jan.supabase.functions.functions
 import kotlin.coroutines.CoroutineContext
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -214,6 +215,15 @@ class SupabaseAuthenticationRepository(
             Result.success(Unit)
         } catch (e: Exception) {
             Logger.w(throwable = e, tag = TAG) { "Failed to update profile" }
+            Result.failure(e)
+        }
+
+    override suspend fun deleteAccount(): Result<Unit> =
+        try {
+            supabaseClient.functions.invoke("delete-account")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) { "Failed to delete account" }
             Result.failure(e)
         }
 

--- a/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
+++ b/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
@@ -26,6 +26,8 @@ interface AuthenticationRepository {
 
     suspend fun updateProfile(displayName: String): Result<Unit>
 
+    suspend fun deleteAccount(): Result<Unit>
+
     suspend fun sendPasswordResetEmail(email: String): Result<Unit>
 
     suspend fun sendSignInOtp(email: String): Result<Unit>

--- a/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
+++ b/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
@@ -20,10 +20,14 @@ class FakeAuthenticationRepository : AuthenticationRepository {
     var resendOtpResult: Result<Unit> = Result.success(Unit)
     var ensureSessionResult: Result<Unit> = Result.success(Unit)
     var updateProfileResult: Result<Unit> = Result.success(Unit)
+    var deleteAccountResult: Result<Unit> = Result.success(Unit)
     var lastUpdatedDisplayName: String? = null
         private set
 
     var ensureSessionCallCount: Int = 0
+        private set
+
+    var deleteAccountCallCount: Int = 0
         private set
 
     var lastVerifyOtpFlow: OtpFlow? = null
@@ -82,6 +86,11 @@ class FakeAuthenticationRepository : AuthenticationRepository {
                 }
             }
         }
+    }
+
+    override suspend fun deleteAccount(): Result<Unit> {
+        deleteAccountCallCount += 1
+        return deleteAccountResult
     }
 
     override suspend fun sendPasswordResetEmail(email: String): Result<Unit> =

--- a/client/auth/usecase/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImpl.kt
+++ b/client/auth/usecase/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImpl.kt
@@ -1,0 +1,26 @@
+package com.plusmobileapps.chefmate.auth.usecase.impl
+
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.DeleteAccountUseCase
+import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
+import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DeleteAccountUseCaseImpl(
+    private val authenticationRepository: AuthenticationRepository,
+    private val signOutUseCase: SignOutUseCase,
+) : DeleteAccountUseCase {
+    override suspend fun invoke(): Result<Unit> {
+        // Delete the remote account first. Only if that succeeds do we tear down the local session
+        // and data — otherwise we'd leave the user signed out with their cloud account intact.
+        val result = authenticationRepository.deleteAccount()
+        if (result.isFailure) return result
+        signOutUseCase()
+        return Result.success(Unit)
+    }
+}

--- a/client/auth/usecase/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImplTest.kt
+++ b/client/auth/usecase/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImplTest.kt
@@ -1,0 +1,41 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.auth.usecase.impl
+
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class DeleteAccountUseCaseImplTest {
+
+    private val authenticationRepository = FakeAuthenticationRepository()
+    private var signedOut = false
+    private val signOutUseCase = SignOutUseCase { signedOut = true }
+
+    private val useCase =
+        DeleteAccountUseCaseImpl(
+            authenticationRepository = authenticationRepository,
+            signOutUseCase = signOutUseCase,
+        )
+
+    @Test
+    fun When_remote_deletion_succeeds_Then_user_is_signed_out() = runTest {
+        val result = useCase()
+
+        result.isSuccess shouldBe true
+        authenticationRepository.deleteAccountCallCount shouldBe 1
+        signedOut shouldBe true
+    }
+
+    @Test
+    fun When_remote_deletion_fails_Then_user_is_not_signed_out() = runTest {
+        authenticationRepository.deleteAccountResult = Result.failure(RuntimeException("boom"))
+
+        val result = useCase()
+
+        result.isFailure shouldBe true
+        signedOut shouldBe false
+    }
+}

--- a/client/auth/usecase/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/DeleteAccountUseCase.kt
+++ b/client/auth/usecase/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/DeleteAccountUseCase.kt
@@ -1,0 +1,10 @@
+package com.plusmobileapps.chefmate.auth.usecase
+
+/**
+ * Deletes the signed-in user's remote account, then signs out and wipes all local data. Returns a
+ * failure if the remote deletion fails so callers can surface an error and leave the user signed
+ * in.
+ */
+fun interface DeleteAccountUseCase {
+    suspend operator fun invoke(): Result<Unit>
+}

--- a/client/profile/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/robots/ManageProfileRobot.kt
+++ b/client/profile/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/robots/ManageProfileRobot.kt
@@ -42,6 +42,10 @@ class ManageProfileRobot(private val test: ComposeUiTest) {
         test.onNode(hasTestTag(ManageProfileTestTags.SAVE) and onScreen).performClick()
     }
 
+    fun tapDeleteAccount(): ManageProfileRobot = apply {
+        test.onNode(hasTestTag(ManageProfileTestTags.DELETE_ACCOUNT) and onScreen).performClick()
+    }
+
     fun assertDisplayed(): ManageProfileRobot = apply {
         test.onNode(hasTestTag(ManageProfileTestTags.SCREEN)).assertIsDisplayed()
     }

--- a/client/profile/impl/build.gradle.kts
+++ b/client/profile/impl/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             implementation(libs.arkivanov.decompose.compose.extensions)
             implementation(projects.client.shared)
             implementation(projects.client.auth.data.public)
+            implementation(projects.client.auth.usecase.public)
             implementation(compose.components.resources)
         }
         commonTest.dependencies { implementation(projects.client.auth.data.testing) }

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImpl.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImpl.kt
@@ -39,6 +39,7 @@ class ManageProfileBlocImpl(
             viewModel.outputs.collect {
                 when (it) {
                     ManageProfileViewModel.Output.Saved -> output.onNext(Output.Back)
+                    ManageProfileViewModel.Output.Deleted -> output.onNext(Output.AccountDeleted)
                 }
             }
         }
@@ -54,6 +55,18 @@ class ManageProfileBlocImpl(
 
     override fun onSaveClicked() {
         viewModel.save()
+    }
+
+    override fun onDeleteAccountClicked() {
+        viewModel.showDeleteDialog()
+    }
+
+    override fun onDeleteConfirmed() {
+        viewModel.deleteAccount()
+    }
+
+    override fun onDeleteDismissed() {
+        viewModel.dismissDeleteDialog()
     }
 
     @Composable

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
@@ -1,10 +1,12 @@
 package com.plusmobileapps.chefmate.profile.impl
 
 import chefmate.client.profile.public.generated.resources.Res
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_error
 import chefmate.client.profile.public.generated.resources.manage_profile_save_error
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.DeleteAccountUseCase
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Model
 import com.plusmobileapps.chefmate.text.asTextData
@@ -23,6 +25,7 @@ import kotlinx.coroutines.launch
 class ManageProfileViewModel(
     @Main mainContext: CoroutineContext,
     private val authenticationRepository: AuthenticationRepository,
+    private val deleteAccountUseCase: DeleteAccountUseCase,
 ) : ViewModel(mainContext) {
 
     private val _state = MutableStateFlow(initialState())
@@ -62,7 +65,33 @@ class ManageProfileViewModel(
         }
     }
 
+    fun showDeleteDialog() {
+        _state.update { it.copy(showDeleteDialog = true, deleteError = null) }
+    }
+
+    fun dismissDeleteDialog() {
+        _state.update { it.copy(showDeleteDialog = false) }
+    }
+
+    fun deleteAccount() {
+        _state.update { it.copy(showDeleteDialog = false, isDeleting = true, deleteError = null) }
+        scope.launch {
+            deleteAccountUseCase()
+                .onSuccess { _outputs.send(Output.Deleted) }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            isDeleting = false,
+                            deleteError = Res.string.manage_profile_delete_error.asTextData(),
+                        )
+                    }
+                }
+        }
+    }
+
     sealed interface Output {
         data object Saved : Output
+
+        data object Deleted : Output
     }
 }

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfilePreviews.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfilePreviews.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Model
+import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -17,6 +18,12 @@ private fun manageProfileBloc(model: Model): ManageProfileBloc =
         override fun onDisplayNameChanged(displayName: String) = Unit
 
         override fun onSaveClicked() = Unit
+
+        override fun onDeleteAccountClicked() = Unit
+
+        override fun onDeleteConfirmed() = Unit
+
+        override fun onDeleteDismissed() = Unit
 
         @Composable
         override fun Content(modifier: Modifier) {
@@ -32,8 +39,28 @@ val previewManageProfileSavingBloc: ManageProfileBloc =
         Model(displayName = "Julia Child", email = "julia@example.com", isSaving = true)
     )
 
+val previewManageProfileDeleteDialogBloc: ManageProfileBloc =
+    manageProfileBloc(
+        Model(displayName = "Julia Child", email = "julia@example.com", showDeleteDialog = true)
+    )
+
+val previewManageProfileDeleteErrorBloc: ManageProfileBloc =
+    manageProfileBloc(
+        Model(
+            displayName = "Julia Child",
+            email = "julia@example.com",
+            deleteError = FixedString("Couldn’t delete your account. Please try again."),
+        )
+    )
+
 @Preview
 @Composable
 internal fun ManageProfilePreview() {
     ChefMateTheme { previewManageProfileBloc.Content(Modifier) }
+}
+
+@Preview
+@Composable
+internal fun ManageProfileDeleteDialogPreview() {
+    ChefMateTheme { previewManageProfileDeleteDialogBloc.Content(Modifier) }
 }

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfileScreen.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfileScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -11,7 +12,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import chefmate.client.profile.public.generated.resources.Res
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_account
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_cancel
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_confirm
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_message
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_title
 import chefmate.client.profile.public.generated.resources.manage_profile_display_name_hint
 import chefmate.client.profile.public.generated.resources.manage_profile_display_name_label
 import chefmate.client.profile.public.generated.resources.manage_profile_email_label
@@ -21,6 +28,8 @@ import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.profile.ManageProfileTestTags
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusButton
+import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
+import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusTextField
@@ -29,6 +38,17 @@ import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 @Composable
 fun ManageProfileScreen(bloc: ManageProfileBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
+
+    if (state.showDeleteDialog) {
+        PlusDialog(
+            title = Res.string.manage_profile_delete_dialog_title.asTextData(),
+            message = Res.string.manage_profile_delete_dialog_message.asTextData(),
+            confirmButtonText = Res.string.manage_profile_delete_dialog_confirm.asTextData(),
+            dismissButtonText = Res.string.manage_profile_delete_dialog_cancel.asTextData(),
+            onConfirmClick = bloc::onDeleteConfirmed,
+            onDismissRequest = bloc::onDeleteDismissed,
+        )
+    }
 
     PlusHeaderContainer(
         modifier = modifier.testTag(ManageProfileTestTags.SCREEN),
@@ -54,7 +74,7 @@ fun ManageProfileScreen(bloc: ManageProfileBloc, modifier: Modifier = Modifier) 
                         Text(Res.string.manage_profile_display_name_hint.asTextData().localized())
                     },
                     singleLine = true,
-                    enabled = !state.isSaving,
+                    enabled = !state.isSaving && !state.isDeleting,
                     error = state.saveError,
                 )
 
@@ -76,6 +96,25 @@ fun ManageProfileScreen(bloc: ManageProfileBloc, modifier: Modifier = Modifier) 
                     enabled = state.canSave,
                     isLoading = state.isSaving,
                     onClick = bloc::onSaveClicked,
+                )
+
+                state.deleteError?.let { error ->
+                    Text(
+                        error.localized(),
+                        style = ChefMateTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+
+                PlusButton(
+                    text = Res.string.manage_profile_delete_account.asTextData(),
+                    variant = PlusButtonVariant.DESTRUCTIVE,
+                    modifier =
+                        Modifier.fillMaxWidth().testTag(ManageProfileTestTags.DELETE_ACCOUNT),
+                    enabled = !state.isSaving && !state.isDeleting,
+                    isLoading = state.isDeleting,
+                    onClick = bloc::onDeleteAccountClicked,
                 )
             }
         },

--- a/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
+++ b/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.ChefMateUser
 import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.DeleteAccountUseCase
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
@@ -30,6 +31,11 @@ class ManageProfileBlocImplTest {
                 )
             )
         }
+    private var deleteCalled = false
+    private val deleteAccountUseCase = DeleteAccountUseCase {
+        deleteCalled = true
+        Result.success(Unit)
+    }
     private val bloc by lazy {
         ManageProfileBlocImpl(
             context = context,
@@ -38,6 +44,7 @@ class ManageProfileBlocImplTest {
                 ManageProfileViewModel(
                     mainContext = context.mainContext,
                     authenticationRepository = authRepository,
+                    deleteAccountUseCase = deleteAccountUseCase,
                 )
             },
         )
@@ -72,5 +79,36 @@ class ManageProfileBlocImplTest {
             cancelAndIgnoreRemainingEvents()
         }
         output.values.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun When_delete_clicked_Then_dialog_is_shown() = runTest {
+        bloc.state.test {
+            awaitItem()
+            bloc.onDeleteAccountClicked()
+            awaitItem().showDeleteDialog shouldBe true
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun When_delete_dismissed_Then_dialog_is_hidden() = runTest {
+        bloc.state.test {
+            awaitItem()
+            bloc.onDeleteAccountClicked()
+            awaitItem().showDeleteDialog shouldBe true
+            bloc.onDeleteDismissed()
+            awaitItem().showDeleteDialog shouldBe false
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun When_delete_confirmed_Then_account_deleted_and_output_emitted() = runTest {
+        bloc.onDeleteAccountClicked()
+        bloc.onDeleteConfirmed()
+
+        deleteCalled shouldBe true
+        output.lastValue shouldBe ManageProfileBloc.Output.AccountDeleted
     }
 }

--- a/client/profile/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/profile/public/src/commonMain/composeResources/values/strings.xml
@@ -5,4 +5,10 @@
     <string name="manage_profile_email_label">Email</string>
     <string name="manage_profile_save">Save</string>
     <string name="manage_profile_save_error">Couldn’t save your profile. Please try again.</string>
+    <string name="manage_profile_delete_account">Delete Account</string>
+    <string name="manage_profile_delete_dialog_title">Delete account?</string>
+    <string name="manage_profile_delete_dialog_message">This permanently deletes your account and all of your recipes, groceries, and meal plans. This can’t be undone.</string>
+    <string name="manage_profile_delete_dialog_confirm">Delete</string>
+    <string name="manage_profile_delete_dialog_cancel">Cancel</string>
+    <string name="manage_profile_delete_error">Couldn’t delete your account. Please try again.</string>
 </resources>

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileBloc.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileBloc.kt
@@ -15,18 +15,29 @@ interface ManageProfileBloc : BlocScreen {
 
     fun onSaveClicked()
 
+    fun onDeleteAccountClicked()
+
+    fun onDeleteConfirmed()
+
+    fun onDeleteDismissed()
+
     data class Model(
         val displayName: String = "",
         val email: String = "",
         val isSaving: Boolean = false,
         val saveError: TextData? = null,
+        val showDeleteDialog: Boolean = false,
+        val isDeleting: Boolean = false,
+        val deleteError: TextData? = null,
     ) {
         val canSave: Boolean
-            get() = displayName.isNotBlank() && !isSaving
+            get() = displayName.isNotBlank() && !isSaving && !isDeleting
     }
 
     sealed class Output {
         data object Back : Output()
+
+        data object AccountDeleted : Output()
     }
 
     fun interface Factory {

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileTestTags.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileTestTags.kt
@@ -4,4 +4,5 @@ object ManageProfileTestTags {
     const val SCREEN = "manage_profile_screen"
     const val DISPLAY_NAME = "manage_profile_display_name"
     const val SAVE = "manage_profile_save"
+    const val DELETE_ACCOUNT = "manage_profile_delete_account"
 }

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -353,7 +353,8 @@ class RootBlocImpl(
 
     private fun handleManageProfileOutput(output: ManageProfileBloc.Output) {
         when (output) {
-            ManageProfileBloc.Output.Back -> navigation.pop()
+            ManageProfileBloc.Output.Back,
+            ManageProfileBloc.Output.AccountDeleted -> navigation.pop()
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -129,6 +129,7 @@ supabase-client = { module = "io.github.jan-tennert.supabase:supabase-kt", versi
 supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
 supabase-postgrest = { module = "io.github.jan-tennert.supabase:postgrest-kt", version.ref = "supabase" }
 supabase-storage = { module = "io.github.jan-tennert.supabase:storage-kt", version.ref = "supabase" }
+supabase-functions = { module = "io.github.jan-tennert.supabase:functions-kt", version.ref = "supabase" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 [plugins]

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,87 @@
+// Supabase Edge Function: delete-account
+//
+// Permanently deletes the *calling* user's account. The client SDK can't delete auth users, so the
+// app invokes this function (see SupabaseAuthenticationRepository.deleteAccount). It:
+//   1. Reads the caller's JWT from the Authorization header.
+//   2. Resolves the user with an anon-key client (RLS-scoped to that user).
+//   3. Deletes the user with a service-role client (admin.deleteUser).
+//
+// App tables (recipes, groceries, meals, categories, …) must declare their owner FK to
+// auth.users(id) with ON DELETE CASCADE so the user's rows are removed alongside the auth row.
+// Storage objects under the user's folder in the `recipe-photos` / `avatars` buckets are best-effort
+// removed here too.
+//
+// Deploy:  supabase functions deploy delete-account
+// Secrets: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are injected automatically by Supabase.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return json({ error: "Missing Authorization header" }, 401);
+    }
+
+    // Resolve the caller from their JWT.
+    const userClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+    const {
+      data: { user },
+      error: userError,
+    } = await userClient.auth.getUser();
+
+    if (userError || !user) {
+      return json({ error: "Invalid or expired session" }, 401);
+    }
+
+    const admin = createClient(supabaseUrl, serviceRoleKey);
+
+    // Best-effort: remove the user's storage objects before deleting the auth row. Failures here
+    // don't block account deletion — orphaned objects can be swept later.
+    for (const bucket of ["recipe-photos", "avatars"]) {
+      try {
+        const { data: files } = await admin.storage.from(bucket).list(user.id);
+        if (files && files.length > 0) {
+          await admin.storage
+            .from(bucket)
+            .remove(files.map((f) => `${user.id}/${f.name}`));
+        }
+      } catch (_) {
+        // ignore storage cleanup failures
+      }
+    }
+
+    // Delete the auth user. App-table rows cascade via ON DELETE CASCADE FKs to auth.users.
+    const { error: deleteError } = await admin.auth.admin.deleteUser(user.id);
+    if (deleteError) {
+      return json({ error: deleteError.message }, 500);
+    }
+
+    return new Response(null, { status: 204, headers: corsHeaders });
+  } catch (e) {
+    return json({ error: String(e) }, 500);
+  }
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
## Summary
- add account deletion confirmation and error state to Manage Profile
- call the Supabase delete-account function through a use case
- add the delete-account Edge Function

## Tests
- ./gradlew :client:auth:usecase:impl:allTests :client:profile:impl:allTests :client:root:impl:allTests :client:composeApp:allTests