### PR TITLE
Clean up AGP 9 Kotlin warning in screenshot tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,12 +2,12 @@ plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
     alias(libs.plugins.androidApplication) apply false
+    alias(libs.plugins.androidBuiltInKotlin) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.buildkonfig) apply false
     alias(libs.plugins.composeHotReload) apply false
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
-    alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.kotlinSerialization) apply false

--- a/client/ui/screenshot-test/build.gradle.kts
+++ b/client/ui/screenshot-test/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.kotlinAndroid)
+    alias(libs.plugins.androidBuiltInKotlin)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.screenshot)
     alias(libs.plugins.plusKtfmt)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -133,6 +133,7 @@ turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
+androidBuiltInKotlin = { id = "com.android.built-in-kotlin", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }
@@ -141,7 +142,6 @@ composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMul
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
-kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary
- migrate the screenshot-test Android library module from the deprecated Kotlin Android plugin to AGP's built-in Kotlin plugin
- remove the unused kotlinAndroid plugin alias from the root plugin catalog

## Findings
- Latest origin/main no longer reproduces the issue #158 KMP library-module warning; shared KMP library modules are already using com.android.kotlin.multiplatform.library.
- Removing android.builtInKotlin=false and android.newDsl=false globally currently fails because :client:composeApp combines org.jetbrains.kotlin.multiplatform with com.android.application. AGP/Kotlin now require that application plugin usage to move into a separate Android app subproject that depends on the KMP module.
- The remaining composeApp warning is therefore a larger module split rather than a small warning cleanup.

## Verification
- ./gradlew :client:composeApp:assembleDebug --warning-mode all
- ./gradlew :client:composeApp:assembleDebug

Closes #158