### PR TITLE
Edit recipe polish

### DIFF
--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/ui/EditRecipeScreen.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/ui/EditRecipeScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -100,6 +102,8 @@ import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
+import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
+import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import com.plusmobileapps.chefmate.util.cropImageToSquare
 import com.plusmobileapps.chefmate.util.decodeImageBitmap
@@ -127,20 +131,29 @@ fun EditRecipeScreen(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
         UploadErrorDialog(message = error.localized(), onDismiss = bloc::onUploadErrorDismissed)
     }
 
-    PlusHeaderContainer(
-        modifier = modifier.fillMaxSize().imePadding().testTag(EditRecipeTestTags.SCREEN),
-        data = PlusHeaderData.Child(title = state.title, onBackClick = bloc::onBackClicked),
-        verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal),
-        floatingActionButton = {
-            SaveRecipeFab(isSaving = state.isSaving, onSaveClicked = bloc::onSaveClicked)
-        },
-    ) {
-        if (state.isLoading) {
-            Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
-                LoadingIndicator()
+    PlusResponsiveContainer(modifier = modifier.fillMaxSize()) { windowSizeClass ->
+        // The form lays out in two regions on a wide window (expanded); narrower windows keep the
+        // single capped column. Opting out of the content-width cap lets the wide layout spread.
+        val isExpanded = windowSizeClass == WindowSizeClass.EXPANDED
+
+        PlusHeaderContainer(
+            modifier = Modifier.fillMaxSize().imePadding().testTag(EditRecipeTestTags.SCREEN),
+            data = PlusHeaderData.Child(title = state.title, onBackClick = bloc::onBackClicked),
+            verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal),
+            maxContentWidth = if (isExpanded) Dp.Unspecified else 600.dp,
+            floatingActionButton = {
+                SaveRecipeFab(isSaving = state.isSaving, onSaveClicked = bloc::onSaveClicked)
+            },
+        ) {
+            if (state.isLoading) {
+                Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                    LoadingIndicator()
+                }
+            } else if (isExpanded) {
+                WideEditRecipeContent(bloc = bloc)
+            } else {
+                EditRecipeContent(bloc = bloc)
             }
-        } else {
-            EditRecipeContent(bloc = bloc)
         }
     }
 }
@@ -189,6 +202,62 @@ private fun EditRecipeContent(bloc: EditRecipeBloc, modifier: Modifier = Modifie
         RecipeCaloriesField(bloc = bloc)
         RecipeIngredientsField(bloc = bloc)
         RecipeDirectionsField(bloc = bloc)
+        // Clearance so the floating Save button never covers the last field.
+        Spacer(modifier = Modifier.height(ChefMateTheme.dimens.fabClearance))
+    }
+}
+
+/**
+ * Wide-window layout: the photo + metadata fields share a top row, and the long-form fields split
+ * into two panes below — ingredients on the left, description and directions on the right — so the
+ * form fills the available width instead of a single centered column. Reuses the same field
+ * composables as [EditRecipeContent]; only the arrangement differs.
+ */
+@Composable
+private fun WideEditRecipeContent(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
+    val spacing = ChefMateTheme.dimens.paddingNormal
+    Column(
+        modifier = modifier.fillMaxWidth().padding(spacing),
+        verticalArrangement = Arrangement.spacedBy(spacing),
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+            Box(modifier = Modifier.width(220.dp)) { RecipePhotoUploader(bloc = bloc) }
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(spacing),
+            ) {
+                RecipeTitleField(bloc = bloc)
+                RecipeStarRatingField(bloc = bloc)
+                Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+                    RecipeServingsField(bloc = bloc, modifier = Modifier.weight(1f))
+                    RecipeCaloriesField(bloc = bloc, modifier = Modifier.weight(1f))
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+                    RecipePrepTimeField(bloc = bloc, modifier = Modifier.weight(1f))
+                    RecipeCookTimeField(bloc = bloc, modifier = Modifier.weight(1f))
+                    RecipeTotalTimeField(bloc = bloc, modifier = Modifier.weight(1f))
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+                    RecipeImageUrlField(bloc = bloc, modifier = Modifier.weight(1f))
+                    RecipeSourceUrlField(bloc = bloc, modifier = Modifier.weight(1f))
+                }
+                RecipeCategoryField(bloc = bloc)
+                RecipeBooksField(bloc = bloc)
+            }
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+            Column(modifier = Modifier.weight(1f)) { RecipeIngredientsField(bloc = bloc) }
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(spacing),
+            ) {
+                RecipeDescriptionField(bloc = bloc)
+                RecipeDirectionsField(bloc = bloc)
+            }
+        }
+        // Clearance so the floating Save button never covers the last field.
+        Spacer(modifier = Modifier.height(ChefMateTheme.dimens.fabClearance))
     }
 }
 

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/ui/EditRecipeScreen.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/ui/EditRecipeScreen.kt
@@ -678,7 +678,11 @@ private fun DiscardChangesDialog(
     )
 }
 
-private val previewBloc =
+/**
+ * Public so `client/ui/screenshot-test` can reuse it for snapshot coverage of [EditRecipeScreen],
+ * the same way the other feature previews expose their fake blocs.
+ */
+val previewEditRecipeBloc =
     object : EditRecipeBloc {
         override val state: StateFlow<EditRecipeBloc.Model> =
             MutableStateFlow(
@@ -804,11 +808,11 @@ Salt for pasta water"""
 @Preview
 @Composable
 private fun EditRecipeScreenLightPreview() {
-    ChefMateTheme(darkTheme = false) { EditRecipeScreen(bloc = previewBloc) }
+    ChefMateTheme(darkTheme = false) { EditRecipeScreen(bloc = previewEditRecipeBloc) }
 }
 
 @Preview
 @Composable
 private fun EditRecipeScreenDarkPreview() {
-    ChefMateTheme(darkTheme = true) { EditRecipeScreen(bloc = previewBloc) }
+    ChefMateTheme(darkTheme = true) { EditRecipeScreen(bloc = previewEditRecipeBloc) }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/ui/EditRecipeScreen.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/ui/EditRecipeScreen.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.recipe.core.impl.edit.ui
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,13 +11,16 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AddPhotoAlternate
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.AlertDialog
@@ -43,9 +47,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import chefmate.client.recipe.core.public.generated.resources.Res
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_discard_cancel
@@ -72,6 +79,7 @@ import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_ingredients_placeholder
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_prep_time
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_prep_time_placeholder
+import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_resize_handle_a11y
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_servings
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_servings_placeholder
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_source_url
@@ -505,6 +513,7 @@ private fun RecipeServingsField(bloc: EditRecipeBloc, modifier: Modifier = Modif
         label = { Text(stringResource(Res.string.edit_recipe_field_servings)) },
         placeholder = { Text(stringResource(Res.string.edit_recipe_field_servings_placeholder)) },
         modifier = modifier.fillMaxWidth(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         singleLine = true,
     )
 }
@@ -519,6 +528,7 @@ private fun RecipePrepTimeField(bloc: EditRecipeBloc, modifier: Modifier = Modif
         label = { Text(stringResource(Res.string.edit_recipe_field_prep_time)) },
         placeholder = { Text(stringResource(Res.string.edit_recipe_field_prep_time_placeholder)) },
         modifier = modifier.fillMaxWidth(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         singleLine = true,
     )
 }
@@ -533,6 +543,7 @@ private fun RecipeCookTimeField(bloc: EditRecipeBloc, modifier: Modifier = Modif
         label = { Text(stringResource(Res.string.edit_recipe_field_cook_time)) },
         placeholder = { Text(stringResource(Res.string.edit_recipe_field_cook_time_placeholder)) },
         modifier = modifier.fillMaxWidth(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         singleLine = true,
     )
 }
@@ -547,6 +558,7 @@ private fun RecipeTotalTimeField(bloc: EditRecipeBloc, modifier: Modifier = Modi
         label = { Text(stringResource(Res.string.edit_recipe_field_total_time)) },
         placeholder = { Text(stringResource(Res.string.edit_recipe_field_total_time_placeholder)) },
         modifier = modifier.fillMaxWidth(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         singleLine = true,
     )
 }
@@ -561,6 +573,7 @@ private fun RecipeCaloriesField(bloc: EditRecipeBloc, modifier: Modifier = Modif
         label = { Text(stringResource(Res.string.edit_recipe_field_calories)) },
         placeholder = { Text(stringResource(Res.string.edit_recipe_field_calories_placeholder)) },
         modifier = modifier.fillMaxWidth(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         singleLine = true,
     )
 }
@@ -569,16 +582,12 @@ private fun RecipeCaloriesField(bloc: EditRecipeBloc, modifier: Modifier = Modif
 private fun RecipeIngredientsField(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
     val ingredients by bloc.ingredients.collectAsState()
 
-    OutlinedTextField(
+    ResizableMultilineField(
         value = ingredients,
         onValueChange = bloc::onIngredientsChanged,
-        label = { Text(stringResource(Res.string.edit_recipe_field_ingredients)) },
-        placeholder = {
-            Text(stringResource(Res.string.edit_recipe_field_ingredients_placeholder))
-        },
-        modifier = modifier.fillMaxWidth(),
-        minLines = 5,
-        maxLines = 10,
+        label = stringResource(Res.string.edit_recipe_field_ingredients),
+        placeholder = stringResource(Res.string.edit_recipe_field_ingredients_placeholder),
+        modifier = modifier,
     )
 }
 
@@ -586,15 +595,63 @@ private fun RecipeIngredientsField(bloc: EditRecipeBloc, modifier: Modifier = Mo
 private fun RecipeDirectionsField(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
     val directions by bloc.directions.collectAsState()
 
-    OutlinedTextField(
+    ResizableMultilineField(
         value = directions,
         onValueChange = bloc::onDirectionsChanged,
-        label = { Text(stringResource(Res.string.edit_recipe_field_directions)) },
-        placeholder = { Text(stringResource(Res.string.edit_recipe_field_directions_placeholder)) },
-        modifier = modifier.fillMaxWidth(),
-        minLines = 5,
-        maxLines = 10,
+        label = stringResource(Res.string.edit_recipe_field_directions),
+        placeholder = stringResource(Res.string.edit_recipe_field_directions_placeholder),
+        modifier = modifier,
     )
+}
+
+/**
+ * A tall multiline text field with a drag handle in the bottom-end corner. Dragging the handle
+ * grows or shrinks the field between [minHeight] and [maxHeight]; text scrolls internally once it
+ * exceeds the current height. The chosen height survives configuration changes via
+ * [rememberSaveable].
+ */
+@Composable
+private fun ResizableMultilineField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+    minHeight: Dp = 160.dp,
+    maxHeight: Dp = 480.dp,
+    initialHeight: Dp = 200.dp,
+) {
+    var heightDp by rememberSaveable { mutableStateOf(initialHeight.value) }
+
+    Box(modifier = modifier.fillMaxWidth()) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(label) },
+            placeholder = { Text(placeholder) },
+            modifier = Modifier.fillMaxWidth().height(heightDp.dp),
+        )
+        Icon(
+            imageVector = Icons.Default.DragHandle,
+            contentDescription =
+                stringResource(Res.string.edit_recipe_field_resize_handle_a11y, label),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier =
+                Modifier.align(Alignment.BottomEnd)
+                    .padding(ChefMateTheme.dimens.paddingSmall)
+                    .size(20.dp)
+                    .pointerInput(Unit) {
+                        detectDragGestures { change, dragAmount ->
+                            change.consume()
+                            heightDp =
+                                (heightDp + dragAmount.y.toDp().value).coerceIn(
+                                    minHeight.value,
+                                    maxHeight.value,
+                                )
+                        }
+                    },
+        )
+    }
 }
 
 @Composable

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="edit_recipe_field_ingredients_placeholder">Enter ingredients (one per line)</string>
     <string name="edit_recipe_field_directions">Directions</string>
     <string name="edit_recipe_field_directions_placeholder">Enter cooking directions</string>
+    <string name="edit_recipe_field_resize_handle_a11y">Drag to resize %1$s field</string>
     <string name="edit_recipe_field_category">Categories</string>
     <string name="edit_recipe_field_category_none">No categories</string>
     <string name="edit_recipe_field_category_add">Add category</string>

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.displayCutout
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
@@ -221,17 +220,22 @@ private fun ScrollingContent(
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     content: @Composable (ColumnScope.() -> Unit),
 ) {
-    val baseModifier =
-        modifier.fillMaxHeight().widthIn(max = maxContentWidth).padding(top = topPadding)
-    val insetModifier =
-        if (applyHorizontalInsets) baseModifier.scaffoldContentInsetPadding() else baseModifier
-    Column(
-        modifier = if (scrollEnabled) insetModifier.verticalScroll(scrollState) else insetModifier,
-        horizontalAlignment = horizontalAlignment,
-    ) {
-        content()
-        if (scrollEnabled) {
-            Spacer(modifier = Modifier.padding(WindowInsets.systemGestures.asPaddingValues()))
+    // The scroll surface fills the full width so the wheel/drag is captured everywhere — including
+    // the gutters on wide windows (desktop), where the capped content column doesn't reach. The
+    // visible content stays capped at [maxContentWidth] and centered inside it.
+    val scrollModifier =
+        modifier.fillMaxSize().padding(top = topPadding).let {
+            if (scrollEnabled) it.verticalScroll(scrollState) else it
+        }
+    Column(modifier = scrollModifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        val baseModifier = Modifier.fillMaxWidth().widthIn(max = maxContentWidth)
+        val insetModifier =
+            if (applyHorizontalInsets) baseModifier.scaffoldContentInsetPadding() else baseModifier
+        Column(modifier = insetModifier, horizontalAlignment = horizontalAlignment) {
+            content()
+            if (scrollEnabled) {
+                Spacer(modifier = Modifier.padding(WindowInsets.systemGestures.asPaddingValues()))
+            }
         }
     }
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTest.kt
@@ -1,0 +1,39 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.recipe.core.impl.edit.ui.previewEditRecipeBloc
+import com.plusmobileapps.chefmate.ui.Content
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+// Snapshot coverage for the recipe edit form. The form is long, so we render on a tall canvas to
+// capture the lower fields (numeric inputs + the resizable ingredients/directions fields with their
+// drag handles) where the polish from this PR lives.
+@Composable
+private fun EditRecipeScreenshot(darkTheme: Boolean = false) {
+    ChefMateTheme(darkTheme = darkTheme) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            previewEditRecipeBloc.Content()
+        }
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 2400)
+@Composable
+fun EditRecipeLightScreenshot() {
+    EditRecipeScreenshot()
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 2400, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun EditRecipeDarkScreenshot() {
+    EditRecipeScreenshot(darkTheme = true)
+}

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTest.kt
@@ -37,3 +37,24 @@ fun EditRecipeLightScreenshot() {
 fun EditRecipeDarkScreenshot() {
     EditRecipeScreenshot(darkTheme = true)
 }
+
+// Wide (expanded) window: the form spreads into the photo + metadata top row and the
+// ingredients | description+directions two-pane split.
+@PreviewTest
+@Preview(showBackground = true, widthDp = 1280, heightDp = 1300)
+@Composable
+fun EditRecipeWideLightScreenshot() {
+    EditRecipeScreenshot()
+}
+
+@PreviewTest
+@Preview(
+    showBackground = true,
+    widthDp = 1280,
+    heightDp = 1300,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun EditRecipeWideDarkScreenshot() {
+    EditRecipeScreenshot(darkTheme = true)
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeDarkScreenshot_a850d601_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeDarkScreenshot_a850d601_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2bda138c618018ed68f230503d7887974db0790e28f5381e07815a590ffcab1
+size 284943

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeLightScreenshot_c017aa92_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeLightScreenshot_c017aa92_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50d7cf075936fcfca6687e7ed63de77896506f1f95f2edc39c2eb653a2e0ac02
+size 286996

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeWideDarkScreenshot_1e8b529f_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeWideDarkScreenshot_1e8b529f_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a9b8cffca05609681da34500633d0a5670459484b78093b1f33a9984e4ff7e0
+size 254368

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeWideLightScreenshot_25537161_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeWideLightScreenshot_25537161_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e289e1427e63412c55da191670007856ddf0f27168bee933d81e69cf4c9e4acb
+size 256831


### PR DESCRIPTION
Closes #266.

Polishes the edit recipe form: the issue's three items plus a wide/tablet layout and Save-button clearance.

## Changes

**Desktop scrolls from the gutters** (`PlusHeaderContainer`)
The scroll surface was capped at the content width (600dp) and centered, so on wide windows the mouse wheel only scrolled when hovering the center column — the gutters were dead. The scrollable column now fills the full width while the visible content stays capped and centered inside it. Shared scaffold, so the fix applies app-wide.

**Number keyboards**
Servings, prep time, cook time, total time, and calories now request a number keyboard (`KeyboardType.Number`). All five are parsed as integers.

**Larger, resizable ingredients & directions fields**
Both fields are taller by default with a drag handle in the bottom-end corner. Dragging grows/shrinks the field between 160–480dp; text scrolls internally and the chosen height survives configuration changes.

**Wide / tablet layout + Save-button clearance**
On an expanded window (≥840dp) the form now lays out in two regions — photo + metadata in a top row, then ingredients on the left with description and directions on the right — instead of a single centered 600dp column. Narrower windows (phones, portrait tablets) keep the single column. Reuses the existing field composables; only the arrangement differs, and only components that already exist are used. A bottom spacer (`fabClearance`) keeps the floating Save button from covering the last field in both layouts.

## Deferred
Rich-text support (bold/italics) is a much larger change — it touches the recipe data model and storage format — so it's being explored separately.

## Testing
- Snapshot tests for `EditRecipeScreen` (`EditRecipeScreenshotTest`): compact light/dark on a tall canvas, plus expanded-window (1280dp) light/dark for the wide layout. Recorded and `validateDebugScreenshotTest` passes.
- `:client:recipe:core:impl:compileKotlinJvm` / `:client:ui:public:compileKotlinJvm` compile clean
- `:client:recipe:core:impl:jvmTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)