### PR TITLE
feat(profile): add account deletion

### DIFF
--- a/client/auth/data/impl/build.gradle.kts
+++ b/client/auth/data/impl/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
             implementation(libs.supabase.auth)
             implementation(libs.supabase.postgrest)
             implementation(libs.supabase.storage)
+            implementation(libs.supabase.functions)
         }
         jvmMain.dependencies { implementation(libs.ktor.client.cio) }
         androidMain.dependencies { implementation(libs.ktor.client.cio) }

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
@@ -18,6 +18,7 @@ import io.github.jan.supabase.auth.providers.builtin.Email
 import io.github.jan.supabase.auth.providers.builtin.OTP
 import io.github.jan.supabase.auth.status.SessionStatus
 import io.github.jan.supabase.auth.user.UserInfo
+import io.github.jan.supabase.functions.functions
 import kotlin.coroutines.CoroutineContext
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -215,6 +216,17 @@ class SupabaseAuthenticationRepository(
             Result.success(Unit)
         } catch (e: Exception) {
             Logger.w(throwable = e, tag = TAG) { "Failed to update profile" }
+            Result.failure(e)
+        }
+
+    override suspend fun deleteAccount(): Result<Unit> =
+        try {
+            // The client SDK can't delete auth users, so the actual deletion happens in a
+            // service-role Edge Function. It reads the caller's JWT and admin-deletes that user.
+            supabaseClient.functions.invoke("delete-account")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) { "Failed to delete account" }
             Result.failure(e)
         }
 

--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseModule.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseModule.kt
@@ -10,6 +10,7 @@ import dev.zacsweers.metro.SingleIn
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.functions.Functions
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.storage.Storage
 
@@ -35,6 +36,7 @@ interface SupabaseModule {
             install(Auth)
             install(Postgrest)
             install(Storage)
+            install(Functions)
         }
     }
 }

--- a/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
+++ b/client/auth/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/AuthenticationRepository.kt
@@ -31,6 +31,14 @@ interface AuthenticationRepository {
      */
     suspend fun updateProfile(displayName: String, avatarUrl: String?): Result<Unit>
 
+    /**
+     * Permanently deletes the signed-in user's remote account. The actual deletion runs in a
+     * service-role Supabase Edge Function (`delete-account`) because the client SDK can't delete
+     * auth users. Callers are responsible for the subsequent sign-out + local-data wipe (see
+     * `DeleteAccountUseCase`).
+     */
+    suspend fun deleteAccount(): Result<Unit>
+
     suspend fun sendPasswordResetEmail(email: String): Result<Unit>
 
     suspend fun sendSignInOtp(email: String): Result<Unit>

--- a/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
+++ b/client/auth/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/testing/FakeAuthenticationRepository.kt
@@ -20,11 +20,15 @@ class FakeAuthenticationRepository : AuthenticationRepository {
     var resendOtpResult: Result<Unit> = Result.success(Unit)
     var ensureSessionResult: Result<Unit> = Result.success(Unit)
     var updateProfileResult: Result<Unit> = Result.success(Unit)
+    var deleteAccountResult: Result<Unit> = Result.success(Unit)
 
     var lastUpdatedDisplayName: String? = null
         private set
 
     var lastUpdatedAvatarUrl: String? = null
+        private set
+
+    var deleteAccountCallCount: Int = 0
         private set
 
     var ensureSessionCallCount: Int = 0
@@ -93,6 +97,11 @@ class FakeAuthenticationRepository : AuthenticationRepository {
                 }
             }
         }
+    }
+
+    override suspend fun deleteAccount(): Result<Unit> {
+        deleteAccountCallCount += 1
+        return deleteAccountResult
     }
 
     override suspend fun sendPasswordResetEmail(email: String): Result<Unit> =

--- a/client/auth/usecase/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImpl.kt
+++ b/client/auth/usecase/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImpl.kt
@@ -1,0 +1,26 @@
+package com.plusmobileapps.chefmate.auth.usecase.impl
+
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.DeleteAccountUseCase
+import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
+import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DeleteAccountUseCaseImpl(
+    private val authenticationRepository: AuthenticationRepository,
+    private val signOutUseCase: SignOutUseCase,
+) : DeleteAccountUseCase {
+    override suspend fun invoke(): Result<Unit> {
+        // Delete the remote account first. Only if that succeeds do we tear down the local session
+        // and data — otherwise we'd leave the user signed out with their cloud account intact.
+        val result = authenticationRepository.deleteAccount()
+        if (result.isFailure) return result
+        signOutUseCase()
+        return Result.success(Unit)
+    }
+}

--- a/client/auth/usecase/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImplTest.kt
+++ b/client/auth/usecase/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/auth/usecase/impl/DeleteAccountUseCaseImplTest.kt
@@ -1,0 +1,41 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.auth.usecase.impl
+
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class DeleteAccountUseCaseImplTest {
+
+    private val authenticationRepository = FakeAuthenticationRepository()
+    private var signedOut = false
+    private val signOutUseCase = SignOutUseCase { signedOut = true }
+
+    private val useCase =
+        DeleteAccountUseCaseImpl(
+            authenticationRepository = authenticationRepository,
+            signOutUseCase = signOutUseCase,
+        )
+
+    @Test
+    fun When_remote_deletion_succeeds_Then_user_is_signed_out() = runTest {
+        val result = useCase()
+
+        result.isSuccess shouldBe true
+        authenticationRepository.deleteAccountCallCount shouldBe 1
+        signedOut shouldBe true
+    }
+
+    @Test
+    fun When_remote_deletion_fails_Then_user_is_not_signed_out() = runTest {
+        authenticationRepository.deleteAccountResult = Result.failure(RuntimeException("boom"))
+
+        val result = useCase()
+
+        result.isFailure shouldBe true
+        signedOut shouldBe false
+    }
+}

--- a/client/auth/usecase/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/DeleteAccountUseCase.kt
+++ b/client/auth/usecase/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/usecase/DeleteAccountUseCase.kt
@@ -1,0 +1,10 @@
+package com.plusmobileapps.chefmate.auth.usecase
+
+/**
+ * Deletes the signed-in user's remote account, then signs out and wipes all local data. Returns a
+ * failure if the remote deletion fails so callers can surface an error and leave the user signed
+ * in.
+ */
+fun interface DeleteAccountUseCase {
+    suspend operator fun invoke(): Result<Unit>
+}

--- a/client/profile/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/robots/ManageProfileRobot.kt
+++ b/client/profile/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/robots/ManageProfileRobot.kt
@@ -42,6 +42,10 @@ class ManageProfileRobot(private val test: ComposeUiTest) {
         test.onNode(hasTestTag(ManageProfileTestTags.SAVE) and onScreen).performClick()
     }
 
+    fun tapDeleteAccount(): ManageProfileRobot = apply {
+        test.onNode(hasTestTag(ManageProfileTestTags.DELETE_ACCOUNT) and onScreen).performClick()
+    }
+
     fun assertDisplayed(): ManageProfileRobot = apply {
         test.onNode(hasTestTag(ManageProfileTestTags.SCREEN)).assertIsDisplayed()
     }

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImpl.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImpl.kt
@@ -40,6 +40,7 @@ class ManageProfileBlocImpl(
             viewModel.outputs.collect {
                 when (it) {
                     ManageProfileViewModel.Output.Saved -> output.onNext(Output.Back)
+                    ManageProfileViewModel.Output.Deleted -> output.onNext(Output.AccountDeleted)
                 }
             }
         }
@@ -59,6 +60,18 @@ class ManageProfileBlocImpl(
 
     override fun onSaveClicked() {
         viewModel.save()
+    }
+
+    override fun onDeleteAccountClicked() {
+        viewModel.showDeleteDialog()
+    }
+
+    override fun onDeleteConfirmed() {
+        viewModel.deleteAccount()
+    }
+
+    override fun onDeleteDismissed() {
+        viewModel.dismissDeleteDialog()
     }
 
     @Composable

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
@@ -1,11 +1,13 @@
 package com.plusmobileapps.chefmate.profile.impl
 
 import chefmate.client.profile.public.generated.resources.Res
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_error
 import chefmate.client.profile.public.generated.resources.manage_profile_save_error
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
 import com.plusmobileapps.chefmate.auth.data.ProfilePhotoStorage
+import com.plusmobileapps.chefmate.auth.usecase.DeleteAccountUseCase
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Model
 import com.plusmobileapps.chefmate.text.asTextData
@@ -26,12 +28,13 @@ class ManageProfileViewModel(
     @Main mainContext: CoroutineContext,
     private val authenticationRepository: AuthenticationRepository,
     private val profilePhotoStorage: ProfilePhotoStorage,
+    private val deleteAccountUseCase: DeleteAccountUseCase,
 ) : ViewModel(mainContext) {
 
     private val _state = MutableStateFlow(initialState())
     val state: StateFlow<Model> = _state.asStateFlow()
 
-    /** Emitted when the screen should pop: after a successful save. */
+    /** Emitted when the screen should pop: after a successful save or account deletion. */
     private val _outputs = Channel<Output>(Channel.BUFFERED)
     val outputs: Flow<Output> = _outputs.receiveAsFlow()
 
@@ -89,7 +92,33 @@ class ManageProfileViewModel(
         }
     }
 
+    fun showDeleteDialog() {
+        _state.update { it.copy(showDeleteDialog = true, deleteError = null) }
+    }
+
+    fun dismissDeleteDialog() {
+        _state.update { it.copy(showDeleteDialog = false) }
+    }
+
+    fun deleteAccount() {
+        _state.update { it.copy(showDeleteDialog = false, isDeleting = true, deleteError = null) }
+        scope.launch {
+            deleteAccountUseCase()
+                .onSuccess { _outputs.send(Output.Deleted) }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            isDeleting = false,
+                            deleteError = Res.string.manage_profile_delete_error.asTextData(),
+                        )
+                    }
+                }
+        }
+    }
+
     sealed interface Output {
         data object Saved : Output
+
+        data object Deleted : Output
     }
 }

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfilePreviews.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfilePreviews.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc.Model
+import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import com.plusmobileapps.chefmate.util.PickedImage
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,6 +21,12 @@ private fun manageProfileBloc(model: Model): ManageProfileBloc =
         override fun onPhotoPicked(image: PickedImage) = Unit
 
         override fun onSaveClicked() = Unit
+
+        override fun onDeleteAccountClicked() = Unit
+
+        override fun onDeleteConfirmed() = Unit
+
+        override fun onDeleteDismissed() = Unit
 
         @Composable
         override fun Content(modifier: Modifier) {
@@ -37,8 +44,28 @@ val previewManageProfileSavingBloc: ManageProfileBloc =
         Model(displayName = "Julia Child", email = "julia@example.com", isSaving = true)
     )
 
+val previewManageProfileDeleteDialogBloc: ManageProfileBloc =
+    manageProfileBloc(
+        Model(displayName = "Julia Child", email = "julia@example.com", showDeleteDialog = true)
+    )
+
+val previewManageProfileErrorBloc: ManageProfileBloc =
+    manageProfileBloc(
+        Model(
+            displayName = "Julia Child",
+            email = "julia@example.com",
+            deleteError = FixedString("Couldn’t delete your account. Please try again."),
+        )
+    )
+
 @Preview
 @Composable
 internal fun ManageProfilePreview() {
     ChefMateTheme { previewManageProfileBloc.Content(Modifier) }
+}
+
+@Preview
+@Composable
+internal fun ManageProfileDeleteDialogPreview() {
+    ChefMateTheme { previewManageProfileDeleteDialogBloc.Content(Modifier) }
 }

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfileScreen.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfileScreen.kt
@@ -22,10 +22,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import chefmate.client.profile.public.generated.resources.Res
 import chefmate.client.profile.public.generated.resources.manage_profile_avatar_content_description
 import chefmate.client.profile.public.generated.resources.manage_profile_change_photo
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_account
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_cancel
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_confirm
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_message
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_title
 import chefmate.client.profile.public.generated.resources.manage_profile_display_name_hint
 import chefmate.client.profile.public.generated.resources.manage_profile_display_name_label
 import chefmate.client.profile.public.generated.resources.manage_profile_email_label
@@ -36,6 +42,8 @@ import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.profile.ManageProfileTestTags
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusButton
+import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
+import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusTextField
@@ -47,6 +55,17 @@ fun ManageProfileScreen(bloc: ManageProfileBloc, modifier: Modifier = Modifier) 
     val state by bloc.state.collectAsState()
 
     val pickPhoto = rememberImagePickerLauncher { picked -> picked?.let(bloc::onPhotoPicked) }
+
+    if (state.showDeleteDialog) {
+        PlusDialog(
+            title = Res.string.manage_profile_delete_dialog_title.asTextData(),
+            message = Res.string.manage_profile_delete_dialog_message.asTextData(),
+            confirmButtonText = Res.string.manage_profile_delete_dialog_confirm.asTextData(),
+            dismissButtonText = Res.string.manage_profile_delete_dialog_cancel.asTextData(),
+            onConfirmClick = bloc::onDeleteConfirmed,
+            onDismissRequest = bloc::onDeleteDismissed,
+        )
+    }
 
     PlusHeaderContainer(
         modifier = modifier.testTag(ManageProfileTestTags.SCREEN),
@@ -84,7 +103,7 @@ fun ManageProfileScreen(bloc: ManageProfileBloc, modifier: Modifier = Modifier) 
                         Text(Res.string.manage_profile_display_name_hint.asTextData().localized())
                     },
                     singleLine = true,
-                    enabled = !state.isSaving,
+                    enabled = !state.isSaving && !state.isDeleting,
                     error = state.saveError,
                 )
 
@@ -106,6 +125,25 @@ fun ManageProfileScreen(bloc: ManageProfileBloc, modifier: Modifier = Modifier) 
                     enabled = state.canSave,
                     isLoading = state.isSaving,
                     onClick = bloc::onSaveClicked,
+                )
+
+                state.deleteError?.let { error ->
+                    Text(
+                        error.localized(),
+                        style = ChefMateTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+
+                PlusButton(
+                    text = Res.string.manage_profile_delete_account.asTextData(),
+                    variant = PlusButtonVariant.DESTRUCTIVE,
+                    modifier =
+                        Modifier.fillMaxWidth().testTag(ManageProfileTestTags.DELETE_ACCOUNT),
+                    enabled = !state.isSaving && !state.isDeleting,
+                    isLoading = state.isDeleting,
+                    onClick = bloc::onDeleteAccountClicked,
                 )
             }
         },

--- a/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
+++ b/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
@@ -7,6 +7,7 @@ import com.plusmobileapps.chefmate.auth.data.AuthState
 import com.plusmobileapps.chefmate.auth.data.ChefMateUser
 import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
 import com.plusmobileapps.chefmate.auth.data.testing.FakeProfilePhotoStorage
+import com.plusmobileapps.chefmate.auth.usecase.DeleteAccountUseCase
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
@@ -33,6 +34,11 @@ class ManageProfileBlocImplTest {
             )
         }
     private val photoStorage = FakeProfilePhotoStorage()
+    private var deleteCalled = false
+    private val deleteAccountUseCase = DeleteAccountUseCase {
+        deleteCalled = true
+        Result.success(Unit)
+    }
 
     private val bloc by lazy {
         ManageProfileBlocImpl(
@@ -43,6 +49,7 @@ class ManageProfileBlocImplTest {
                     mainContext = context.mainContext,
                     authenticationRepository = authRepository,
                     profilePhotoStorage = photoStorage,
+                    deleteAccountUseCase = deleteAccountUseCase,
                 )
             },
         )
@@ -87,5 +94,36 @@ class ManageProfileBlocImplTest {
             cancelAndIgnoreRemainingEvents()
         }
         output.values.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun When_delete_clicked_Then_dialog_is_shown() = runTest {
+        bloc.state.test {
+            awaitItem()
+            bloc.onDeleteAccountClicked()
+            awaitItem().showDeleteDialog shouldBe true
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun When_delete_dismissed_Then_dialog_is_hidden() = runTest {
+        bloc.state.test {
+            awaitItem()
+            bloc.onDeleteAccountClicked()
+            awaitItem().showDeleteDialog shouldBe true
+            bloc.onDeleteDismissed()
+            awaitItem().showDeleteDialog shouldBe false
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun When_delete_confirmed_Then_account_deleted_and_output_emitted() = runTest {
+        bloc.onDeleteAccountClicked()
+        bloc.onDeleteConfirmed()
+
+        deleteCalled shouldBe true
+        output.lastValue shouldBe ManageProfileBloc.Output.AccountDeleted
     }
 }

--- a/client/profile/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/profile/public/src/commonMain/composeResources/values/strings.xml
@@ -7,4 +7,10 @@
     <string name="manage_profile_avatar_content_description">Profile photo</string>
     <string name="manage_profile_save">Save</string>
     <string name="manage_profile_save_error">Couldn’t save your profile. Please try again.</string>
+    <string name="manage_profile_delete_account">Delete Account</string>
+    <string name="manage_profile_delete_dialog_title">Delete account?</string>
+    <string name="manage_profile_delete_dialog_message">This permanently deletes your account and all of your recipes, groceries, and meal plans. This can’t be undone.</string>
+    <string name="manage_profile_delete_dialog_confirm">Delete</string>
+    <string name="manage_profile_delete_dialog_cancel">Cancel</string>
+    <string name="manage_profile_delete_error">Couldn’t delete your account. Please try again.</string>
 </resources>

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileBloc.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileBloc.kt
@@ -18,6 +18,12 @@ interface ManageProfileBloc : BlocScreen {
 
     fun onSaveClicked()
 
+    fun onDeleteAccountClicked()
+
+    fun onDeleteConfirmed()
+
+    fun onDeleteDismissed()
+
     data class Model(
         val displayName: String = "",
         val email: String = "",
@@ -27,10 +33,13 @@ interface ManageProfileBloc : BlocScreen {
         val pickedPhoto: ByteArray? = null,
         val isSaving: Boolean = false,
         val saveError: TextData? = null,
+        val showDeleteDialog: Boolean = false,
+        val isDeleting: Boolean = false,
+        val deleteError: TextData? = null,
     ) {
-        /** Save is enabled once a non-blank name exists and no save is in flight. */
+        /** Save is enabled once a non-blank name exists and no save/delete is in flight. */
         val canSave: Boolean
-            get() = displayName.isNotBlank() && !isSaving
+            get() = displayName.isNotBlank() && !isSaving && !isDeleting
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -41,6 +50,9 @@ interface ManageProfileBloc : BlocScreen {
             if (!pickedPhoto.contentEqualsNullable(other.pickedPhoto)) return false
             if (isSaving != other.isSaving) return false
             if (saveError != other.saveError) return false
+            if (showDeleteDialog != other.showDeleteDialog) return false
+            if (isDeleting != other.isDeleting) return false
+            if (deleteError != other.deleteError) return false
             return true
         }
 
@@ -51,6 +63,9 @@ interface ManageProfileBloc : BlocScreen {
             result = 31 * result + (pickedPhoto?.contentHashCode() ?: 0)
             result = 31 * result + isSaving.hashCode()
             result = 31 * result + (saveError?.hashCode() ?: 0)
+            result = 31 * result + showDeleteDialog.hashCode()
+            result = 31 * result + isDeleting.hashCode()
+            result = 31 * result + (deleteError?.hashCode() ?: 0)
             return result
         }
 
@@ -65,6 +80,9 @@ interface ManageProfileBloc : BlocScreen {
     sealed class Output {
         /** Pop back to the More tab (also emitted after a successful save). */
         data object Back : Output()
+
+        /** The account was deleted; the host pops and the More tab re-renders unauthenticated. */
+        data object AccountDeleted : Output()
     }
 
     fun interface Factory {

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileTestTags.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileTestTags.kt
@@ -5,4 +5,5 @@ object ManageProfileTestTags {
     const val AVATAR = "manage_profile_avatar"
     const val DISPLAY_NAME = "manage_profile_display_name"
     const val SAVE = "manage_profile_save"
+    const val DELETE_ACCOUNT = "manage_profile_delete_account"
 }

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -353,7 +353,10 @@ class RootBlocImpl(
 
     private fun handleManageProfileOutput(output: ManageProfileBloc.Output) {
         when (output) {
-            ManageProfileBloc.Output.Back -> navigation.pop()
+            // Both pop back to the More tab; on deletion the More tab re-renders unauthenticated
+            // on its own once the auth state flips.
+            ManageProfileBloc.Output.Back,
+            ManageProfileBloc.Output.AccountDeleted -> navigation.pop()
         }
     }
 

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.android.tools.screenshot.PreviewTest
 import com.plusmobileapps.chefmate.profile.impl.ui.previewManageProfileBloc
+import com.plusmobileapps.chefmate.profile.impl.ui.previewManageProfileDeleteDialogBloc
 import com.plusmobileapps.chefmate.profile.impl.ui.previewManageProfileSavingBloc
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -28,4 +29,11 @@ fun ManageProfileDarkScreenshot() {
 @Composable
 fun ManageProfileSavingScreenshot() {
     ChefMateTheme { previewManageProfileSavingBloc.Content() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun ManageProfileDeleteDialogScreenshot() {
+    ChefMateTheme { previewManageProfileDeleteDialogBloc.Content() }
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDarkScreenshot_907cdd58_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDarkScreenshot_907cdd58_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d20a37580ac1bb0f83e209750215df4100b2e780837635bc8b540d9a52b533bf
-size 50213
+oid sha256:b8dc5cd84b7e9a6e6c296a5a70b6927dc7862283325b7173dc6475dfacf6467a
+size 55224

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDeleteDialogScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDeleteDialogScreenshot_e0e29121_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:901a89720ccb77fadad986e1ea3ff4af669adecce3797f57a88af97fc4c0240d
+size 89102

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileLightScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileLightScreenshot_e0e29121_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93ea7473f0737254e043d736f5fe4157deac70ea0ad4e59d8cf6fa6715300308
-size 48711
+oid sha256:02722416ecf8838ca689e462e04dc0b57eb4b5bbaf7d4dc4f85cbf881f31abdf
+size 53646

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileSavingScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileSavingScreenshot_e0e29121_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e1426e7e63dfe27c380ee2097c7e84546dc491134fdc225ef16e5fd8385753f
-size 45395
+oid sha256:370444ae2dace00e7966e9350b7e0a5e533ee41de887745f4d8afb5a9ffc7575
+size 49915

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -129,6 +129,7 @@ supabase-client = { module = "io.github.jan-tennert.supabase:supabase-kt", versi
 supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
 supabase-postgrest = { module = "io.github.jan-tennert.supabase:postgrest-kt", version.ref = "supabase" }
 supabase-storage = { module = "io.github.jan-tennert.supabase:storage-kt", version.ref = "supabase" }
+supabase-functions = { module = "io.github.jan-tennert.supabase:functions-kt", version.ref = "supabase" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 [plugins]

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,87 @@
+// Supabase Edge Function: delete-account
+//
+// Permanently deletes the *calling* user's account. The client SDK can't delete auth users, so the
+// app invokes this function (see SupabaseAuthenticationRepository.deleteAccount). It:
+//   1. Reads the caller's JWT from the Authorization header.
+//   2. Resolves the user with an anon-key client (RLS-scoped to that user).
+//   3. Deletes the user with a service-role client (admin.deleteUser).
+//
+// App tables (recipes, groceries, meals, categories, …) must declare their owner FK to
+// auth.users(id) with ON DELETE CASCADE so the user's rows are removed alongside the auth row.
+// Storage objects under the user's folder in the `recipe-photos` / `avatars` buckets are best-effort
+// removed here too.
+//
+// Deploy:  supabase functions deploy delete-account
+// Secrets: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are injected automatically by Supabase.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return json({ error: "Missing Authorization header" }, 401);
+    }
+
+    // Resolve the caller from their JWT.
+    const userClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+    const {
+      data: { user },
+      error: userError,
+    } = await userClient.auth.getUser();
+
+    if (userError || !user) {
+      return json({ error: "Invalid or expired session" }, 401);
+    }
+
+    const admin = createClient(supabaseUrl, serviceRoleKey);
+
+    // Best-effort: remove the user's storage objects before deleting the auth row. Failures here
+    // don't block account deletion — orphaned objects can be swept later.
+    for (const bucket of ["recipe-photos", "avatars"]) {
+      try {
+        const { data: files } = await admin.storage.from(bucket).list(user.id);
+        if (files && files.length > 0) {
+          await admin.storage
+            .from(bucket)
+            .remove(files.map((f) => `${user.id}/${f.name}`));
+        }
+      } catch (_) {
+        // ignore storage cleanup failures
+      }
+    }
+
+    // Delete the auth user. App-table rows cascade via ON DELETE CASCADE FKs to auth.users.
+    const { error: deleteError } = await admin.auth.admin.deleteUser(user.id);
+    if (deleteError) {
+      return json({ error: deleteError.message }, 500);
+    }
+
+    return new Response(null, { status: 204, headers: corsHeaders });
+  } catch (e) {
+    return json({ error: String(e) }, 500);
+  }
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
Part 2 of 2 for #52 (split from #254). **Stacked on #270 — review/merge that first; base will retarget to `main` automatically once #270 merges.**

## What

Adds **Delete Account** to the Manage Profile screen (from #270). Behind a confirmation dialog; on confirm it permanently deletes the remote Supabase account, signs out, and wipes all local data (recipes, groceries, meals, AI chat, categories).

## How

- **Deletion backend**: a service-role `delete-account` Supabase **edge function** (the client SDK can't delete auth users), invoked via `functions-kt`. It resolves the caller from their JWT, best-effort removes their storage objects, then `admin.deleteUser`.
- **`DeleteAccountUseCase`**: deletes the remote account, then reuses the existing `SignOutUseCase` for the local wipe.
- **UI**: destructive Delete Account button + confirmation dialog; on success the screen pops and the More tab re-renders unauthenticated.

## ⚠️ Deploy steps (backend, not in CI)

1. Deploy the edge function: `supabase functions deploy delete-account`
2. Ensure app tables (recipes/groceries/meals/categories) have `ON DELETE CASCADE` FKs to `auth.users` so a deleted user's rows are removed.

## Testing

- `DeleteAccountUseCaseImplTest` + account-deletion cases in `ManageProfileBlocImplTest`
- Snapshot updated with the delete-dialog variant
- This branch's tree is identical to the previously CI-green combined PR (#254)

🤖 Generated with [Claude Code](https://claude.com/claude-code)