### PR TITLE
fix(profile): stop user metadata leaking JSON quotes

### DIFF
--- a/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
+++ b/client/auth/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/data/impl/SupabaseAuthenticationRepository.kt
@@ -28,8 +28,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -242,16 +245,23 @@ class SupabaseAuthenticationRepository(
         ChefMateUser(
             userId = id,
             userName =
-                userMetadata?.get("name")?.toString()
-                    ?: userMetadata?.get("username")?.toString()
+                userMetadata.stringValue("name")
+                    ?: userMetadata.stringValue("username")
                     ?: email?.substringBefore("@")
                     ?: "User",
             userEmail = email ?: "",
             userProfileImageUrl =
-                userMetadata?.get("avatar_url")?.toString()
-                    ?: userMetadata?.get("picture")?.toString(),
+                userMetadata.stringValue("avatar_url") ?: userMetadata.stringValue("picture"),
             isAnonymous = isAnonymous,
         )
+
+    /**
+     * Reads a string metadata value as its raw content. [JsonElement.toString] would wrap string
+     * primitives in literal quotes (e.g. `"Chef"`), which previously leaked into the display name
+     * and corrupted the `avatar_url` into an unloadable quoted URL.
+     */
+    private fun JsonObject?.stringValue(key: String): String? =
+        (this?.get(key) as? JsonPrimitive)?.contentOrNull
 
     /**
      * Reads the `is_anonymous` claim from the JWT payload directly. supabase-kt 3.2.6's UserInfo


### PR DESCRIPTION
## Summary

Fixes two related profile-management bugs that share a single root cause.

`SupabaseAuthenticationRepository.toChefMateUser` read the `name`, `username`, and `avatar_url` user-metadata fields via `JsonElement.toString()`. For string primitives that returns the JSON representation **including the surrounding quotes** (e.g. `"Chef"` rather than `Chef`), which leaked into the app:

- **#273 — display name adds quotes when saving.** The name came back wrapped in quotes; on the next save those quotes got persisted back into the metadata, compounding the corruption.
- **#274 — profile image doesn't persist after saving.** The `avatar_url` became a quoted string (`"https://…"`) that isn't a valid URL, so the saved avatar failed to load on reload.

The fix extracts a `JsonObject?.stringValue(key)` helper that reads the primitive's raw content via `contentOrNull`, so both fields round-trip cleanly.

## Testing

- `./gradlew :client:auth:data:impl:compileKotlinJvm :client:auth:data:impl:ktfmtCheck` ✅

The affected method is private and wraps live Supabase `UserInfo`/`JsonObject` types, so it isn't covered by the existing fake-backed unit tests. The change is a localized parsing fix.

Closes #273
Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)