### PR TITLE
fix(profile): delete old avatar after profile photo update

### DIFF
--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
@@ -62,6 +62,10 @@ class ManageProfileViewModel(
         val current = _state.value
         if (!current.canSave) return
         _state.update { it.copy(isSaving = true, saveError = null) }
+        // Capture the avatar that's currently persisted so we can clean it up once a new one is
+        // uploaded and saved. Uploads use a fresh randomized path, so without this the old object
+        // is orphaned in Supabase storage.
+        val previousPhotoUrl = current.photoUrl
         scope.launch {
             val avatarUrl =
                 pickedImage.value?.let { picked ->
@@ -80,7 +84,18 @@ class ManageProfileViewModel(
                 }
             authenticationRepository
                 .updateProfile(displayName = current.displayName.trim(), avatarUrl = avatarUrl)
-                .onSuccess { _outputs.send(Output.Saved) }
+                .onSuccess {
+                    // Only after the profile points at the new avatar do we delete the old one,
+                    // best-effort, so a delete failure can't strand the user without an avatar.
+                    if (
+                        avatarUrl != null &&
+                            !previousPhotoUrl.isNullOrBlank() &&
+                            previousPhotoUrl != avatarUrl
+                    ) {
+                        profilePhotoStorage.deletePhoto(previousPhotoUrl)
+                    }
+                    _outputs.send(Output.Saved)
+                }
                 .onFailure {
                     _state.update {
                         it.copy(

--- a/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
+++ b/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
@@ -81,6 +81,52 @@ class ManageProfileBlocImplTest {
     }
 
     @Test
+    fun When_existing_photo_replaced_and_saved_Then_old_photo_deleted() = runTest {
+        authRepository.setState(
+            AuthState.Authenticated(
+                ChefMateUser(
+                    userId = "id-1",
+                    userName = "Original Name",
+                    userEmail = "chef@example.com",
+                    userProfileImageUrl = "https://example.com/avatars/id-1/old.png",
+                )
+            )
+        )
+        photoStorage.uploadResult = "https://example.com/avatars/id-1/new.png"
+        bloc.onPhotoPicked(PickedImage(bytes = byteArrayOf(1, 2, 3), fileExtension = "png"))
+        bloc.onSaveClicked()
+
+        photoStorage.deletedUrls shouldBe listOf("https://example.com/avatars/id-1/old.png")
+    }
+
+    @Test
+    fun When_first_photo_added_and_saved_Then_nothing_deleted() = runTest {
+        photoStorage.uploadResult = "https://example.com/avatars/id-1/new.png"
+        bloc.onPhotoPicked(PickedImage(bytes = byteArrayOf(1, 2, 3), fileExtension = "png"))
+        bloc.onSaveClicked()
+
+        photoStorage.deletedUrls.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun When_only_name_changed_and_saved_Then_existing_photo_kept() = runTest {
+        authRepository.setState(
+            AuthState.Authenticated(
+                ChefMateUser(
+                    userId = "id-1",
+                    userName = "Original Name",
+                    userEmail = "chef@example.com",
+                    userProfileImageUrl = "https://example.com/avatars/id-1/old.png",
+                )
+            )
+        )
+        bloc.onDisplayNameChanged("New Name")
+        bloc.onSaveClicked()
+
+        photoStorage.deletedUrls.isEmpty() shouldBe true
+    }
+
+    @Test
     fun When_save_fails_Then_save_error_is_surfaced() = runTest {
         authRepository.updateProfileResult = Result.failure(RuntimeException("boom"))
 

--- a/supabase/functions/cleanup-avatars/index.ts
+++ b/supabase/functions/cleanup-avatars/index.ts
@@ -1,0 +1,136 @@
+// Supabase Edge Function: cleanup-avatars
+//
+// Sweeps the `avatars` bucket for orphaned objects — files no longer referenced by any user's
+// `avatar_url` metadata. The app deletes the previous avatar best-effort when a photo is replaced
+// (see ManageProfileViewModel.save), and delete-account removes a user's folder on deletion, but
+// neither is a hard guarantee: a failed client-side delete still leaks, and avatars orphaned before
+// those safeguards shipped remain. This function is the backstop — run it once to clear the backlog
+// and/or on a schedule (pg_cron + pg_net, or any external cron) to keep storage tidy.
+//
+// Direct DELETE on storage.objects is blocked by storage.protect_delete(), so deletion goes through
+// the Storage API with the service-role client.
+//
+// Auth: callers must present `Authorization: Bearer <CLEANUP_SECRET>`. This is an admin sweep over
+// every user's storage, so it must NOT be reachable with an ordinary user JWT. Set CLEANUP_SECRET to
+// a long random value.
+//
+// Dry run: pass `{ "dryRun": true }` (or `?dryRun=true`) to list orphans without deleting — do this
+// on the first run to eyeball the result before letting it delete anything.
+//
+// Deploy:  supabase functions deploy cleanup-avatars
+// Secret:  supabase secrets set CLEANUP_SECRET=<random>   (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY
+//          are injected automatically by Supabase.)
+//
+// Example:
+//   curl -X POST "$SUPABASE_URL/functions/v1/cleanup-avatars" \
+//     -H "Authorization: Bearer $CLEANUP_SECRET" \
+//     -H "Content-Type: application/json" \
+//     -d '{"dryRun": true}'
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const BUCKET = "avatars";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const cleanupSecret = Deno.env.get("CLEANUP_SECRET");
+    if (!cleanupSecret) {
+      return json({ error: "CLEANUP_SECRET is not configured" }, 500);
+    }
+    const authHeader = req.headers.get("Authorization");
+    if (authHeader !== `Bearer ${cleanupSecret}`) {
+      return json({ error: "Unauthorized" }, 401);
+    }
+
+    const dryRun = await wantsDryRun(req);
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const admin = createClient(supabaseUrl, serviceRoleKey);
+
+    // 1. Collect every avatar path still referenced by a user's metadata.
+    const referenced = new Set<string>();
+    for (let page = 1; ; page++) {
+      const { data, error } = await admin.auth.admin.listUsers({ page, perPage: 1000 });
+      if (error) return json({ error: `listUsers failed: ${error.message}` }, 500);
+      if (data.users.length === 0) break;
+      for (const user of data.users) {
+        const url = user.user_metadata?.avatar_url;
+        if (typeof url === "string" && url.includes(`/${BUCKET}/`)) {
+          // Public URL: <...>/storage/v1/object/public/avatars/<userId>/<uuid>.<ext>[?query]
+          referenced.add(url.split(`/${BUCKET}/`)[1].split("?")[0]);
+        }
+      }
+    }
+
+    // 2. Walk the bucket (<userId>/ prefixes -> files) and flag anything unreferenced.
+    const orphans: string[] = [];
+    let scanned = 0;
+    const { data: folders, error: foldersError } = await admin.storage
+      .from(BUCKET)
+      .list("", { limit: 100000 });
+    if (foldersError) return json({ error: `list root failed: ${foldersError.message}` }, 500);
+
+    // A null `id` marks a prefix (folder); real objects have an id.
+    for (const folder of (folders ?? []).filter((entry) => entry.id === null)) {
+      const { data: files, error: filesError } = await admin.storage
+        .from(BUCKET)
+        .list(folder.name, { limit: 100000 });
+      if (filesError) return json({ error: `list ${folder.name} failed: ${filesError.message}` }, 500);
+      for (const file of files ?? []) {
+        scanned++;
+        const path = `${folder.name}/${file.name}`;
+        if (!referenced.has(path)) orphans.push(path);
+      }
+    }
+
+    // 3. Delete the orphans (unless this is a dry run), in batches to stay within request limits.
+    let deleted = 0;
+    if (!dryRun && orphans.length > 0) {
+      for (let i = 0; i < orphans.length; i += 100) {
+        const batch = orphans.slice(i, i + 100);
+        const { error } = await admin.storage.from(BUCKET).remove(batch);
+        if (error) return json({ error: `remove failed: ${error.message}`, deleted }, 500);
+        deleted += batch.length;
+      }
+    }
+
+    return json({
+      dryRun,
+      scanned,
+      referenced: referenced.size,
+      orphans: orphans.length,
+      deleted,
+      orphanPaths: orphans,
+    }, 200);
+  } catch (e) {
+    return json({ error: String(e) }, 500);
+  }
+});
+
+async function wantsDryRun(req: Request): Promise<boolean> {
+  if (new URL(req.url).searchParams.get("dryRun") === "true") return true;
+  try {
+    const body = await req.clone().json();
+    return body?.dryRun === true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
## Problem

Closes #277 — updating a profile photo leaves the previous avatar orphaned in Supabase storage.

`SupabaseProfilePhotoStorage.uploadPhoto` intentionally writes each avatar to a **fresh randomized path** (`<userId>/<uuid>.<ext>`) so the Supabase CDN and Coil don't serve a stale image after an update. A `deletePhoto` helper already existed for cleaning up the old object, but `ManageProfileViewModel.save()` never called it — so every photo change left the old file behind.

## Fix (app side)

In `ManageProfileViewModel.save()`:
- Capture the currently-persisted avatar URL (`state.photoUrl`) before uploading.
- After `updateProfile` succeeds with a newly uploaded URL, delete the previous object **best-effort** (only when an old URL exists and differs from the new one). Deletion happens *after* the profile is repointed, so a delete failure can never strand the user without an avatar. `deletePhoto` already swallows failures and ignores non-avatar URLs.

Name-only edits and the first-ever photo upload delete nothing.

## Backstop (server side) — `cleanup-avatars` edge function

The client delete is best-effort, and it doesn't retroactively clean avatars orphaned before this fix. New `supabase/functions/cleanup-avatars/index.ts` sweeps the bucket: it builds the set of avatar paths still referenced by any user's `avatar_url` metadata, walks the `avatars` bucket, and removes the unreferenced objects via the Storage API (direct `DELETE` on `storage.objects` is blocked by `storage.protect_delete()`).

- Gated behind an `Authorization: Bearer <CLEANUP_SECRET>` check — it sweeps **all** users' storage, so it must not be reachable with an ordinary user JWT.
- Supports `{"dryRun": true}` to preview orphans before deleting.
- Run once to clear the backlog and/or schedule it (pg_cron + pg_net, or any external cron).

Account-deletion cleanup was already handled — `delete-account/index.ts` removes the user's `avatars` folder on deletion.

## Tests

Added to `ManageProfileBlocImplTest`:
- replacing an existing photo deletes the old URL
- adding a first photo deletes nothing
- a name-only save keeps the existing photo

`./gradlew :client:profile:impl:jvmTest` passes. (Edge function not type-checked locally — Deno isn't installed; it mirrors the existing `delete-account` function's patterns.)

## Deploy notes for the backstop

```
supabase secrets set CLEANUP_SECRET=<random>
supabase functions deploy cleanup-avatars
# dry run first:
curl -X POST "$SUPABASE_URL/functions/v1/cleanup-avatars" \
  -H "Authorization: Bearer $CLEANUP_SECRET" -H "Content-Type: application/json" \
  -d '{"dryRun": true}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)