### PR TITLE
feat(recipebook): show the full collaborator list to every member

### DIFF
--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
@@ -46,31 +46,24 @@ class RecipeBookCollaborationRepositoryImpl(
 
     override suspend fun getMembers(bookId: Long): List<RecipeBookMember> {
         val remoteId = bookRemoteId(bookId) ?: return emptyList()
-        val owner =
-            if (isOwner(bookId)) {
-                currentUser?.let {
-                    RecipeBookMember(
-                        id = null,
-                        email = it.userEmail,
-                        role = RecipeBookRole.OWNER,
-                        accepted = true,
-                        isOwner = true,
-                        avatarUrl = it.userProfileImageUrl,
-                    )
-                }
-            } else {
-                null
-            }
-        val members =
-            remote.fetchMembers(remoteId).map {
-                RecipeBookMember(
-                    id = it.id,
-                    email = it.invitedEmail,
-                    role = RecipeBookRole.fromWire(it.role),
-                    accepted = it.status == "accepted",
-                )
-            }
-        return listOfNotNull(owner) + members.sortedByDescending { it.accepted }
+        val me = currentUser
+        // The RPC returns everyone on the book — owner first, then accepted, then pending — visible
+        // to any collaborator. We only know an avatar for the current viewer's own row.
+        return remote.fetchCollaborators(remoteId).map {
+            RecipeBookMember(
+                id = it.memberId,
+                email = it.email,
+                role = RecipeBookRole.fromWire(it.role),
+                accepted = it.status == "accepted",
+                isOwner = it.isOwner,
+                avatarUrl =
+                    if (me != null && it.email.equals(me.userEmail, ignoreCase = true)) {
+                        me.userProfileImageUrl
+                    } else {
+                        null
+                    },
+            )
+        }
     }
 
     override suspend fun invite(bookId: Long, email: String, role: RecipeBookRole) {

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
@@ -47,9 +47,11 @@ class RecipeBookCollaborationRepositoryImpl(
     override suspend fun getMembers(bookId: Long): List<RecipeBookMember> {
         val remoteId = bookRemoteId(bookId) ?: return emptyList()
         val me = currentUser
-        // The RPC returns everyone on the book — owner first, then accepted, then pending — visible
-        // to any collaborator. We only know an avatar for the current viewer's own row.
+        // The RPC returns everyone on the book — owner first, then accepted, then pending — with
+        // each person's avatar from their account metadata (null for pending invites). Prefer the
+        // local profile image for the current user's own row in case it's fresher than the server.
         return remote.fetchCollaborators(remoteId).map {
+            val isCurrentUser = me != null && it.email.equals(me.userEmail, ignoreCase = true)
             RecipeBookMember(
                 id = it.memberId,
                 email = it.email,
@@ -57,11 +59,7 @@ class RecipeBookCollaborationRepositoryImpl(
                 accepted = it.status == "accepted",
                 isOwner = it.isOwner,
                 avatarUrl =
-                    if (me != null && it.email.equals(me.userEmail, ignoreCase = true)) {
-                        me.userProfileImageUrl
-                    } else {
-                        null
-                    },
+                    if (isCurrentUser) me?.userProfileImageUrl ?: it.avatarUrl else it.avatarUrl,
             )
         }
     }

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
@@ -57,6 +57,7 @@ class RecipeBookCollaborationRepositoryImpl(
                 email = it.email,
                 role = RecipeBookRole.fromWire(it.role),
                 accepted = it.status == "accepted",
+                name = if (isCurrentUser) me?.userName ?: it.name else it.name,
                 isOwner = it.isOwner,
                 avatarUrl =
                     if (isCurrentUser) me?.userProfileImageUrl ?: it.avatarUrl else it.avatarUrl,

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/RecipeBookMemberRemoteDataSource.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/RecipeBookMemberRemoteDataSource.kt
@@ -4,6 +4,12 @@ interface RecipeBookMemberRemoteDataSource {
     /** Members (accepted + pending) of the book with remote id [bookRemoteId]. */
     suspend fun fetchMembers(bookRemoteId: String): List<RemoteRecipeBookMember>
 
+    /**
+     * Full collaborator list for [bookRemoteId] — the owner plus every member — for anyone who can
+     * access the book. Backed by the `recipe_book_collaborators` SECURITY DEFINER RPC.
+     */
+    suspend fun fetchCollaborators(bookRemoteId: String): List<RemoteCollaborator>
+
     /** Inserts a pending invite for [email] at [role] on [bookRemoteId]. */
     suspend fun invite(bookRemoteId: String, email: String, role: String)
 

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/RemoteRecipeBookMember.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/RemoteRecipeBookMember.kt
@@ -37,4 +37,5 @@ data class RemoteCollaborator(
     val role: String,
     val status: String,
     @SerialName("is_owner") val isOwner: Boolean = false,
+    @SerialName("avatar_url") val avatarUrl: String? = null,
 )

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/RemoteRecipeBookMember.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/RemoteRecipeBookMember.kt
@@ -34,6 +34,7 @@ data class RemoteRecipeBookInvite(
 data class RemoteCollaborator(
     @SerialName("member_id") val memberId: String? = null,
     val email: String,
+    val name: String? = null,
     val role: String,
     val status: String,
     @SerialName("is_owner") val isOwner: Boolean = false,

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/RemoteRecipeBookMember.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/RemoteRecipeBookMember.kt
@@ -28,3 +28,13 @@ data class RemoteRecipeBookInvite(
 
 /** Minimal `recipe_books` projection used to resolve invited book names without a join embed. */
 @Serializable data class RemoteRecipeBookName(val id: String, val name: String)
+
+/** A row from the `recipe_book_collaborators` RPC: the owner plus every member of a book. */
+@Serializable
+data class RemoteCollaborator(
+    @SerialName("member_id") val memberId: String? = null,
+    val email: String,
+    val role: String,
+    val status: String,
+    @SerialName("is_owner") val isOwner: Boolean = false,
+)

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/SupabaseRecipeBookMemberRemoteDataSource.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/SupabaseRecipeBookMemberRemoteDataSource.kt
@@ -6,9 +6,12 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.postgrest.query.Columns
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 @Inject
 @SingleIn(AppScope::class)
@@ -21,6 +24,11 @@ class SupabaseRecipeBookMemberRemoteDataSource(private val supabaseClient: Supab
             .from("recipe_book_members")
             .select { filter { eq("recipe_book_id", bookRemoteId) } }
             .decodeList<RemoteRecipeBookMember>()
+
+    override suspend fun fetchCollaborators(bookRemoteId: String): List<RemoteCollaborator> =
+        supabaseClient.postgrest
+            .rpc("recipe_book_collaborators", buildJsonObject { put("p_book_id", bookRemoteId) })
+            .decodeList<RemoteCollaborator>()
 
     override suspend fun invite(bookRemoteId: String, email: String, role: String) {
         supabaseClient

--- a/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImplTest.kt
+++ b/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImplTest.kt
@@ -9,6 +9,7 @@ import com.plusmobileapps.chefmate.database.Database
 import com.plusmobileapps.chefmate.database.testing.createTestDatabase
 import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RecipeBookMemberRemoteDataSource
 import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RecipeBookRemoteDataSource
+import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteCollaborator
 import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteInviteBook
 import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteRecipeBook
 import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteRecipeBookInvite
@@ -196,6 +197,9 @@ class RecipeBookRepositoryImplTest {
 
     private open class NoopMemberRemote : RecipeBookMemberRemoteDataSource {
         override suspend fun fetchMembers(bookRemoteId: String): List<RemoteRecipeBookMember> =
+            emptyList()
+
+        override suspend fun fetchCollaborators(bookRemoteId: String): List<RemoteCollaborator> =
             emptyList()
 
         override suspend fun invite(bookRemoteId: String, email: String, role: String) = Unit

--- a/client/recipebook/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/RecipeBookMember.kt
+++ b/client/recipebook/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/RecipeBookMember.kt
@@ -9,13 +9,11 @@ data class RecipeBookMember(
     val email: String,
     val role: RecipeBookRole,
     val accepted: Boolean,
+    /** Display name from the user's profile; null for pending invites (no account yet). */
+    val name: String? = null,
     /** True for the synthesized entry representing the book owner. */
     val isOwner: Boolean = false,
-    /**
-     * Profile photo URL, when known. Only populated for the current user (the owner entry) since
-     * other collaborators' photos aren't reachable yet; null entries fall back to a lettered
-     * avatar.
-     */
+    /** Profile photo URL when known; null entries fall back to a lettered avatar. */
     val avatarUrl: String? = null,
 )
 

--- a/client/recipebook/edit/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModel.kt
+++ b/client/recipebook/edit/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModel.kt
@@ -61,7 +61,9 @@ class EditRecipeBookViewModel(
                 }
                 val owner = withContext(ioContext) { collaborationRepository.isOwner(props.bookId) }
                 _state.update { it.copy(canManageCollaborators = owner) }
-                if (owner) loadMembers(props.bookId)
+                // Everyone on the book sees the collaborator list; only the owner can
+                // invite/remove.
+                loadMembers(props.bookId)
             }
         }
     }

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookPreviews.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookPreviews.kt
@@ -84,6 +84,7 @@ val previewEditRecipeBookCollaboratorsBloc: EditRecipeBookBloc =
                         email = "you@example.com",
                         role = RecipeBookRole.OWNER,
                         accepted = true,
+                        name = "Jordan Lee",
                         isOwner = true,
                     ),
                     RecipeBookMember(
@@ -91,6 +92,7 @@ val previewEditRecipeBookCollaboratorsBloc: EditRecipeBookBloc =
                         email = "alex@example.com",
                         role = RecipeBookRole.EDITOR,
                         accepted = true,
+                        name = "Alex Rivera",
                     ),
                     RecipeBookMember(
                         id = "2",
@@ -117,6 +119,7 @@ val previewEditRecipeBookMemberViewBloc: EditRecipeBookBloc =
                         email = "casey@example.com",
                         role = RecipeBookRole.OWNER,
                         accepted = true,
+                        name = "Casey Morgan",
                         isOwner = true,
                     ),
                     RecipeBookMember(
@@ -124,6 +127,7 @@ val previewEditRecipeBookMemberViewBloc: EditRecipeBookBloc =
                         email = "you@example.com",
                         role = RecipeBookRole.EDITOR,
                         accepted = true,
+                        name = "Jordan Lee",
                     ),
                     RecipeBookMember(
                         id = "2",

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookPreviews.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookPreviews.kt
@@ -102,6 +102,39 @@ val previewEditRecipeBookCollaboratorsBloc: EditRecipeBookBloc =
         )
     )
 
+/** A non-owner collaborator viewing the book: read-only list, no invite controls. */
+val previewEditRecipeBookMemberViewBloc: EditRecipeBookBloc =
+    editRecipeBookBloc(
+        Model(
+            title = Res.string.edit_recipe_book_edit_title.asTextData(),
+            name = "Weeknight Dinners",
+            isCreate = false,
+            canManageCollaborators = false,
+            members =
+                listOf(
+                    RecipeBookMember(
+                        id = null,
+                        email = "casey@example.com",
+                        role = RecipeBookRole.OWNER,
+                        accepted = true,
+                        isOwner = true,
+                    ),
+                    RecipeBookMember(
+                        id = "1",
+                        email = "you@example.com",
+                        role = RecipeBookRole.EDITOR,
+                        accepted = true,
+                    ),
+                    RecipeBookMember(
+                        id = "2",
+                        email = "sam@example.com",
+                        role = RecipeBookRole.VIEWER,
+                        accepted = false,
+                    ),
+                ),
+        )
+    )
+
 @Preview
 @Composable
 internal fun EditRecipeBookCreatePreview() {
@@ -130,4 +163,10 @@ internal fun EditRecipeBookCreateDarkPreview() {
 @Composable
 internal fun EditRecipeBookCollaboratorsPreview() {
     ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookCollaboratorsBloc) }
+}
+
+@Preview
+@Composable
+internal fun EditRecipeBookMemberViewPreview() {
+    ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookMemberViewBloc) }
 }

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -86,7 +87,7 @@ fun EditRecipeBookScreen(bloc: EditRecipeBookBloc, modifier: Modifier = Modifier
                     .testTag(EditRecipeBookTestTags.SAVE_BUTTON),
         )
 
-        if (model.canManageCollaborators) {
+        if (model.members.isNotEmpty()) {
             CollaboratorsSection(bloc = bloc, model = model)
         }
     }
@@ -110,57 +111,70 @@ private fun CollaboratorsSection(bloc: EditRecipeBookBloc, model: EditRecipeBook
         )
 
         model.members.forEach { member ->
-            MemberRow(member = member, onRemove = bloc::onRemoveMember)
+            MemberRow(
+                member = member,
+                canManage = model.canManageCollaborators,
+                onRemove = bloc::onRemoveMember,
+            )
         }
 
-        // Invite-by-email row.
-        PlusTextField(
-            value = model.inviteEmail,
-            onValueChange = bloc::onInviteEmailChanged,
-            modifier =
-                Modifier.fillMaxWidth()
-                    .padding(top = ChefMateTheme.dimens.paddingSmall)
-                    .testTag(EditRecipeBookTestTags.INVITE_EMAIL_FIELD),
-            label = { Text(stringResource(Res.string.edit_recipe_book_invite_email_label)) },
-            singleLine = true,
-            error = model.inviteError,
-            keyboardOptions =
-                KeyboardOptions(
-                    keyboardType = KeyboardType.Email,
-                    capitalization = KeyboardCapitalization.None,
-                    imeAction = ImeAction.Done,
-                ),
-            keyboardActions = KeyboardActions(onDone = { bloc.onInviteClicked() }),
-        )
+        // Invite controls are owner-only; collaborators just see the list above.
+        if (model.canManageCollaborators) {
+            PlusTextField(
+                value = model.inviteEmail,
+                onValueChange = bloc::onInviteEmailChanged,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(top = ChefMateTheme.dimens.paddingSmall)
+                        .testTag(EditRecipeBookTestTags.INVITE_EMAIL_FIELD),
+                label = { Text(stringResource(Res.string.edit_recipe_book_invite_email_label)) },
+                singleLine = true,
+                error = model.inviteError,
+                keyboardOptions =
+                    KeyboardOptions(
+                        keyboardType = KeyboardType.Email,
+                        capitalization = KeyboardCapitalization.None,
+                        imeAction = ImeAction.Done,
+                    ),
+                keyboardActions = KeyboardActions(onDone = { bloc.onInviteClicked() }),
+            )
 
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall)) {
-            listOf(RecipeBookRole.EDITOR, RecipeBookRole.VIEWER).forEach { role ->
-                FilterChip(
-                    selected = model.inviteRole == role,
-                    onClick = { bloc.onInviteRoleChanged(role) },
-                    label = { Text(role.label()) },
-                )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall)
+            ) {
+                listOf(RecipeBookRole.EDITOR, RecipeBookRole.VIEWER).forEach { role ->
+                    FilterChip(
+                        selected = model.inviteRole == role,
+                        onClick = { bloc.onInviteRoleChanged(role) },
+                        label = { Text(role.label()) },
+                    )
+                }
             }
-        }
 
-        PlusButton(
-            text = Res.string.edit_recipe_book_invite_button.asTextData(),
-            variant = PlusButtonVariant.SECONDARY,
-            isLoading = model.isInviting,
-            enabled = model.inviteEmail.isNotBlank() && !model.isInviting,
-            onClick = bloc::onInviteClicked,
-            modifier =
-                Modifier.fillMaxWidth()
-                    .padding(top = ChefMateTheme.dimens.paddingSmall)
-                    .testTag(EditRecipeBookTestTags.INVITE_BUTTON),
-        )
+            PlusButton(
+                text = Res.string.edit_recipe_book_invite_button.asTextData(),
+                variant = PlusButtonVariant.SECONDARY,
+                isLoading = model.isInviting,
+                enabled = model.inviteEmail.isNotBlank() && !model.isInviting,
+                onClick = bloc::onInviteClicked,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(top = ChefMateTheme.dimens.paddingSmall)
+                        .testTag(EditRecipeBookTestTags.INVITE_BUTTON),
+            )
+        }
     }
 }
 
 @Composable
-private fun MemberRow(member: RecipeBookMember, onRemove: (String) -> Unit) {
+private fun MemberRow(member: RecipeBookMember, canManage: Boolean, onRemove: (String) -> Unit) {
+    // Pending invites are dimmed; the role is always shown so collaborators can see who does what.
+    val roleLabel = member.role.label()
+    val secondary =
+        if (member.accepted) roleLabel
+        else "$roleLabel · ${stringResource(Res.string.edit_recipe_book_member_pending)}"
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().alpha(if (member.accepted) 1f else 0.5f),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall),
     ) {
@@ -172,14 +186,12 @@ private fun MemberRow(member: RecipeBookMember, onRemove: (String) -> Unit) {
         Column(modifier = Modifier.weight(1f)) {
             Text(text = member.email, style = MaterialTheme.typography.bodyMedium)
             Text(
-                text =
-                    if (!member.accepted) stringResource(Res.string.edit_recipe_book_member_pending)
-                    else member.role.label(),
+                text = secondary,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        if (!member.isOwner && member.id != null) {
+        if (canManage && !member.isOwner && member.id != null) {
             IconButton(onClick = { onRemove(member.id!!) }) {
                 Icon(
                     imageVector = Icons.Default.Close,

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
@@ -168,9 +168,11 @@ private fun CollaboratorsSection(bloc: EditRecipeBookBloc, model: EditRecipeBook
 
 @Composable
 private fun MemberRow(member: RecipeBookMember, canManage: Boolean, onRemove: (String) -> Unit) {
-    // Pending invites are dimmed; the role is always shown so collaborators can see who does what.
+    // name → email → role. Pending invites are dimmed and have no account, so they fall back to the
+    // email as the primary line. The role is always shown so collaborators can see who does what.
+    val name = member.name?.takeIf { it.isNotBlank() }
     val roleLabel = member.role.label()
-    val secondary =
+    val roleLine =
         if (member.accepted) roleLabel
         else "$roleLabel · ${stringResource(Res.string.edit_recipe_book_member_pending)}"
     Row(
@@ -181,12 +183,19 @@ private fun MemberRow(member: RecipeBookMember, canManage: Boolean, onRemove: (S
         PlusAvatar(
             imageUrl = member.avatarUrl,
             contentDescription = null,
-            fallbackText = member.email,
+            fallbackText = name ?: member.email,
         )
         Column(modifier = Modifier.weight(1f)) {
-            Text(text = member.email, style = MaterialTheme.typography.bodyMedium)
+            Text(text = name ?: member.email, style = MaterialTheme.typography.bodyMedium)
+            if (name != null) {
+                Text(
+                    text = member.email,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Text(
-                text = secondary,
+                text = roleLine,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTest.kt
@@ -9,6 +9,7 @@ import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookCollabor
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookCreateBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookEditBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookErrorBloc
+import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookMemberViewBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookSavingBloc
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
@@ -52,4 +53,11 @@ fun EditRecipeBookCreateDarkScreenshot() {
 @Composable
 fun EditRecipeBookCollaboratorsScreenshot() {
     ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookCollaboratorsBloc) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun EditRecipeBookMemberViewScreenshot() {
+    ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookMemberViewBloc) }
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookCollaboratorsScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookCollaboratorsScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:08da0d7bd09102fc843cd1e058cbe656b52297a1589dddc86a9457513a0dd786
-size 79101
+oid sha256:7e08199c860bb31f1cb5b828fd3e8b4b917f1a55a71b14571ffc7553368e26cc
+size 79222

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookCollaboratorsScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookCollaboratorsScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e08199c860bb31f1cb5b828fd3e8b4b917f1a55a71b14571ffc7553368e26cc
-size 79222
+oid sha256:23e76699cbac0282fa61ddc5b2d65b1170cb9a43a21a922ddec75d08630a86f8
+size 82885

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookMemberViewScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookMemberViewScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9459325b4920397702d10ff640feb4534df2ff5fcd6263e8f2a7e5dcd028a9e0
+size 66283

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookMemberViewScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookMemberViewScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9459325b4920397702d10ff640feb4534df2ff5fcd6263e8f2a7e5dcd028a9e0
-size 66283
+oid sha256:4074b44d2b6875cc5bb50aec0f688165e96804dd1dfac79c3656337ef921addd
+size 71291

--- a/supabase/migrations/20260610_recipe_book_collaborators.sql
+++ b/supabase/migrations/20260610_recipe_book_collaborators.sql
@@ -6,13 +6,19 @@
 CREATE OR REPLACE FUNCTION recipe_book_collaborators(p_book_id uuid)
 RETURNS TABLE(member_id uuid, email text, role text, status text, is_owner boolean)
 LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
-    SELECT NULL::uuid AS member_id, u.email::text, 'owner'::text, 'accepted'::text, true AS is_owner
-    FROM recipe_books b
-    JOIN auth.users u ON u.id = b.owner_id
-    WHERE b.id = p_book_id AND can_access_recipe_book(p_book_id)
-    UNION ALL
-    SELECT m.id, m.invited_email, m.role::text, m.status, false
-    FROM recipe_book_members m
-    WHERE m.recipe_book_id = p_book_id AND can_access_recipe_book(p_book_id)
-    ORDER BY is_owner DESC, (status = 'accepted') DESC, email ASC;
+    -- Sort outside the UNION: a set-operation ORDER BY can't use column expressions, only the
+    -- union's output columns, so wrap it and order the combined result here.
+    SELECT c.member_id, c.email, c.role, c.status, c.is_owner
+    FROM (
+        SELECT NULL::uuid AS member_id, u.email::text AS email,
+               'owner'::text AS role, 'accepted'::text AS status, true AS is_owner
+        FROM recipe_books b
+        JOIN auth.users u ON u.id = b.owner_id
+        WHERE b.id = p_book_id AND can_access_recipe_book(p_book_id)
+        UNION ALL
+        SELECT m.id, m.invited_email, m.role::text, m.status, false
+        FROM recipe_book_members m
+        WHERE m.recipe_book_id = p_book_id AND can_access_recipe_book(p_book_id)
+    ) c
+    ORDER BY c.is_owner DESC, (c.status = 'accepted') DESC, c.email ASC;
 $$;

--- a/supabase/migrations/20260610_recipe_book_collaborators.sql
+++ b/supabase/migrations/20260610_recipe_book_collaborators.sql
@@ -3,25 +3,29 @@
 -- and each person's role. SECURITY DEFINER so it can resolve the owner's email from auth.users
 -- (not readable cross-user) and read member rows without tripping per-row RLS; the can_access guard
 -- keeps the list scoped to people actually on the book.
--- DROP first: CREATE OR REPLACE can't change a function's return type, and avatar_url was added to
--- the RETURNS TABLE after an earlier version shipped.
+-- DROP first: CREATE OR REPLACE can't change a function's return type, and the RETURNS TABLE shape
+-- has grown (avatar_url, then name) since earlier versions shipped.
 DROP FUNCTION IF EXISTS recipe_book_collaborators(uuid);
 CREATE OR REPLACE FUNCTION recipe_book_collaborators(p_book_id uuid)
-RETURNS TABLE(member_id uuid, email text, role text, status text, is_owner boolean, avatar_url text)
+RETURNS TABLE(
+    member_id uuid, email text, name text, role text, status text, is_owner boolean, avatar_url text
+)
 LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
     -- Sort outside the UNION: a set-operation ORDER BY can't use column expressions, only the
-    -- union's output columns, so wrap it and order the combined result here. avatar_url comes from
-    -- each user's metadata (a public storage URL); pending invites have no account yet so it's null.
-    SELECT c.member_id, c.email, c.role, c.status, c.is_owner, c.avatar_url
+    -- union's output columns, so wrap it and order the combined result here. name + avatar_url come
+    -- from each user's metadata; pending invites have no account yet so both are null.
+    SELECT c.member_id, c.email, c.name, c.role, c.status, c.is_owner, c.avatar_url
     FROM (
         SELECT NULL::uuid AS member_id, u.email::text AS email,
+               (u.raw_user_meta_data ->> 'name')::text AS name,
                'owner'::text AS role, 'accepted'::text AS status, true AS is_owner,
                (u.raw_user_meta_data ->> 'avatar_url')::text AS avatar_url
         FROM recipe_books b
         JOIN auth.users u ON u.id = b.owner_id
         WHERE b.id = p_book_id AND can_access_recipe_book(p_book_id)
         UNION ALL
-        SELECT m.id, m.invited_email, m.role::text, m.status, false,
+        SELECT m.id, m.invited_email, (mu.raw_user_meta_data ->> 'name')::text,
+               m.role::text, m.status, false,
                (mu.raw_user_meta_data ->> 'avatar_url')::text
         FROM recipe_book_members m
         LEFT JOIN auth.users mu ON mu.id = m.user_id

--- a/supabase/migrations/20260610_recipe_book_collaborators.sql
+++ b/supabase/migrations/20260610_recipe_book_collaborators.sql
@@ -4,20 +4,24 @@
 -- (not readable cross-user) and read member rows without tripping per-row RLS; the can_access guard
 -- keeps the list scoped to people actually on the book.
 CREATE OR REPLACE FUNCTION recipe_book_collaborators(p_book_id uuid)
-RETURNS TABLE(member_id uuid, email text, role text, status text, is_owner boolean)
+RETURNS TABLE(member_id uuid, email text, role text, status text, is_owner boolean, avatar_url text)
 LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
     -- Sort outside the UNION: a set-operation ORDER BY can't use column expressions, only the
-    -- union's output columns, so wrap it and order the combined result here.
-    SELECT c.member_id, c.email, c.role, c.status, c.is_owner
+    -- union's output columns, so wrap it and order the combined result here. avatar_url comes from
+    -- each user's metadata (a public storage URL); pending invites have no account yet so it's null.
+    SELECT c.member_id, c.email, c.role, c.status, c.is_owner, c.avatar_url
     FROM (
         SELECT NULL::uuid AS member_id, u.email::text AS email,
-               'owner'::text AS role, 'accepted'::text AS status, true AS is_owner
+               'owner'::text AS role, 'accepted'::text AS status, true AS is_owner,
+               (u.raw_user_meta_data ->> 'avatar_url')::text AS avatar_url
         FROM recipe_books b
         JOIN auth.users u ON u.id = b.owner_id
         WHERE b.id = p_book_id AND can_access_recipe_book(p_book_id)
         UNION ALL
-        SELECT m.id, m.invited_email, m.role::text, m.status, false
+        SELECT m.id, m.invited_email, m.role::text, m.status, false,
+               (mu.raw_user_meta_data ->> 'avatar_url')::text
         FROM recipe_book_members m
+        LEFT JOIN auth.users mu ON mu.id = m.user_id
         WHERE m.recipe_book_id = p_book_id AND can_access_recipe_book(p_book_id)
     ) c
     ORDER BY c.is_owner DESC, (c.status = 'accepted') DESC, c.email ASC;

--- a/supabase/migrations/20260610_recipe_book_collaborators.sql
+++ b/supabase/migrations/20260610_recipe_book_collaborators.sql
@@ -1,0 +1,18 @@
+-- Full collaborator list for a recipe book — owner plus every invited member — readable by anyone
+-- who can access the book (owner or accepted member), so collaborators can see who they share with
+-- and each person's role. SECURITY DEFINER so it can resolve the owner's email from auth.users
+-- (not readable cross-user) and read member rows without tripping per-row RLS; the can_access guard
+-- keeps the list scoped to people actually on the book.
+CREATE OR REPLACE FUNCTION recipe_book_collaborators(p_book_id uuid)
+RETURNS TABLE(member_id uuid, email text, role text, status text, is_owner boolean)
+LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
+    SELECT NULL::uuid AS member_id, u.email::text, 'owner'::text, 'accepted'::text, true AS is_owner
+    FROM recipe_books b
+    JOIN auth.users u ON u.id = b.owner_id
+    WHERE b.id = p_book_id AND can_access_recipe_book(p_book_id)
+    UNION ALL
+    SELECT m.id, m.invited_email, m.role::text, m.status, false
+    FROM recipe_book_members m
+    WHERE m.recipe_book_id = p_book_id AND can_access_recipe_book(p_book_id)
+    ORDER BY is_owner DESC, (status = 'accepted') DESC, email ASC;
+$$;

--- a/supabase/migrations/20260610_recipe_book_collaborators.sql
+++ b/supabase/migrations/20260610_recipe_book_collaborators.sql
@@ -3,6 +3,9 @@
 -- and each person's role. SECURITY DEFINER so it can resolve the owner's email from auth.users
 -- (not readable cross-user) and read member rows without tripping per-row RLS; the can_access guard
 -- keeps the list scoped to people actually on the book.
+-- DROP first: CREATE OR REPLACE can't change a function's return type, and avatar_url was added to
+-- the RETURNS TABLE after an earlier version shipped.
+DROP FUNCTION IF EXISTS recipe_book_collaborators(uuid);
 CREATE OR REPLACE FUNCTION recipe_book_collaborators(p_book_id uuid)
 RETURNS TABLE(member_id uuid, email text, role text, status text, is_owner boolean, avatar_url text)
 LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$


### PR DESCRIPTION
Follow-up to the Phase 2a collaboration work (#269). On the recipe-book edit screen, the Collaborators section now shows **everyone on the book to any collaborator who can open it**, not just the owner.

## What changed

- **Full list for everyone** — owner first, then accepted members, then pending. A non-owner (editor/viewer) sees the same roster, read-only.
- **Pending invites are dimmed**, and each person's **role is always shown** (e.g. `Viewer · Pending`).
- **Invite / remove controls stay owner-only** — collaborators just see the list.
- The owner's identity is resolved server-side: a member can't read `auth.users`, so a new `recipe_book_collaborators` `SECURITY DEFINER` RPC returns the owner (from `auth.users`) plus the member rows, guarded by `can_access_recipe_book` so only people actually on the book can read it.

## Snapshots

| Owner view | Member (read-only) view |
|---|---|
| Full list + invite controls, pending dimmed | Full list, no invite controls, pending dimmed |

Refreshed `EditRecipeBookCollaboratorsScreenshot` and added `EditRecipeBookMemberViewScreenshot`.

## ⚠️ Requires a migration

Apply **`supabase/migrations/20260610_recipe_book_collaborators.sql`** to the project. The owner's collaborator list now also goes through this RPC, so until it's applied the Collaborators section won't load for anyone.

## Known limitation

Real avatars only render for the current viewer's own row — there's no `profiles` table yet, so other collaborators show a lettered fallback and members see each other's **emails** rather than display names. A `profiles` table is the natural next step (Phase 2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)