### PR TITLE
feat(recipebook): group collaborators by role with section headers

### DIFF
--- a/client/recipebook/edit/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipebook/edit/public/src/commonMain/composeResources/values/strings.xml
@@ -15,5 +15,8 @@
     <string name="edit_recipe_book_role_editor">Editor</string>
     <string name="edit_recipe_book_role_viewer">Viewer</string>
     <string name="edit_recipe_book_member_pending">Pending</string>
+    <string name="edit_recipe_book_group_owner">Owner</string>
+    <string name="edit_recipe_book_group_editors">Editors</string>
+    <string name="edit_recipe_book_group_viewers">Viewers</string>
     <string name="edit_recipe_book_remove_member">Remove %1$s</string>
 </resources>

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
@@ -33,6 +33,9 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import chefmate.client.recipebook.edit.public.generated.resources.Res
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_collaborators
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_group_editors
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_group_owner
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_group_viewers
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_invite_button
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_invite_email_label
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_member_pending
@@ -52,6 +55,7 @@ import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusTextField
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -110,13 +114,26 @@ private fun CollaboratorsSection(bloc: EditRecipeBookBloc, model: EditRecipeBook
             modifier = Modifier.padding(top = ChefMateTheme.dimens.paddingSmall),
         )
 
-        model.members.forEach { member ->
-            MemberRow(
-                member = member,
-                canManage = model.canManageCollaborators,
-                onRemove = bloc::onRemoveMember,
-            )
-        }
+        // Grouped by role so the owner is separated from editors and viewers. Pending invites keep
+        // their invited role, so they land in the matching group (dimmed).
+        MemberGroup(
+            title = Res.string.edit_recipe_book_group_owner,
+            members = model.members.filter { it.isOwner || it.role == RecipeBookRole.OWNER },
+            canManage = model.canManageCollaborators,
+            onRemove = bloc::onRemoveMember,
+        )
+        MemberGroup(
+            title = Res.string.edit_recipe_book_group_editors,
+            members = model.members.filter { !it.isOwner && it.role == RecipeBookRole.EDITOR },
+            canManage = model.canManageCollaborators,
+            onRemove = bloc::onRemoveMember,
+        )
+        MemberGroup(
+            title = Res.string.edit_recipe_book_group_viewers,
+            members = model.members.filter { !it.isOwner && it.role == RecipeBookRole.VIEWER },
+            canManage = model.canManageCollaborators,
+            onRemove = bloc::onRemoveMember,
+        )
 
         // Invite controls are owner-only; collaborators just see the list above.
         if (model.canManageCollaborators) {
@@ -167,14 +184,38 @@ private fun CollaboratorsSection(bloc: EditRecipeBookBloc, model: EditRecipeBook
 }
 
 @Composable
+private fun MemberGroup(
+    title: StringResource,
+    members: List<RecipeBookMember>,
+    canManage: Boolean,
+    onRemove: (String) -> Unit,
+) {
+    if (members.isEmpty()) return
+    Text(
+        text = stringResource(title),
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = ChefMateTheme.dimens.paddingSmall),
+    )
+    members.forEach { member ->
+        MemberRow(member = member, canManage = canManage, onRemove = onRemove)
+    }
+}
+
+@Composable
 private fun MemberRow(member: RecipeBookMember, canManage: Boolean, onRemove: (String) -> Unit) {
-    // name → email → role. Pending invites are dimmed and have no account, so they fall back to the
-    // email as the primary line. The role is always shown so collaborators can see who does what.
+    // name → email, with pending invites dimmed and tagged. Role is conveyed by the group header
+    // above, so it isn't repeated per row. Pending invites have no account, so they fall back to
+    // the email as the primary line.
     val name = member.name?.takeIf { it.isNotBlank() }
-    val roleLabel = member.role.label()
-    val roleLine =
-        if (member.accepted) roleLabel
-        else "$roleLabel · ${stringResource(Res.string.edit_recipe_book_member_pending)}"
+    val secondary =
+        listOfNotNull(
+                member.email.takeIf { name != null },
+                stringResource(Res.string.edit_recipe_book_member_pending).takeIf {
+                    !member.accepted
+                },
+            )
+            .joinToString(" · ")
     Row(
         modifier = Modifier.fillMaxWidth().alpha(if (member.accepted) 1f else 0.5f),
         verticalAlignment = Alignment.CenterVertically,
@@ -187,18 +228,13 @@ private fun MemberRow(member: RecipeBookMember, canManage: Boolean, onRemove: (S
         )
         Column(modifier = Modifier.weight(1f)) {
             Text(text = name ?: member.email, style = MaterialTheme.typography.bodyMedium)
-            if (name != null) {
+            if (secondary.isNotEmpty()) {
                 Text(
-                    text = member.email,
+                    text = secondary,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            Text(
-                text = roleLine,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
         }
         if (canManage && !member.isOwner && member.id != null) {
             IconButton(onClick = { onRemove(member.id!!) }) {

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookCollaboratorsScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookCollaboratorsScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23e76699cbac0282fa61ddc5b2d65b1170cb9a43a21a922ddec75d08630a86f8
-size 82885
+oid sha256:94fcb97ace7e682d09b9a6cf60afa65047db71b8b2f43feb4ecfdc8b2fc2847a
+size 85866

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookMemberViewScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookMemberViewScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4074b44d2b6875cc5bb50aec0f688165e96804dd1dfac79c3656337ef921addd
-size 71291
+oid sha256:57dbc5f9dff22c3baf0d3ef5e711cc1793a9d1b18b36e6c83d43207a7410757f
+size 74182


### PR DESCRIPTION
Follow-up to #283. The recipe-book edit screen's Collaborators list is now split into **Owner / Editors / Viewers** groups, each under its own header, so it's clear who has which role at a glance.

## What changed

- Collaborators are grouped by role, with a header above each non-empty group.
- The role now lives in the **group header** instead of being repeated on every row — each row is just name → email.
- Pending invites keep their invited role (so they sort into the matching group) and stay **dimmed** with a `Pending` tag.

Note: these are section headers, not pinned/sticky — the edit modal is a single `verticalScroll` column (not a `LazyColumn`), and the form is short, so true pin-on-scroll would mean converting the whole screen to a lazy list for no real benefit.

## Snapshots

Refreshed both `EditRecipeBookCollaboratorsScreenshot` (owner view, with invite controls) and `EditRecipeBookMemberViewScreenshot` (member read-only view).

No backend change — purely a UI regrouping of data the `recipe_book_collaborators` RPC already returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)