### PR TITLE
feat(recipe): search modal with cross-book scope (#282)

### DIFF
--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/FakeDatabase.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/FakeDatabase.kt
@@ -51,6 +51,20 @@ class FakeDatabase(private val delegate: Database = provideTestDatabase()) : Dat
         recipeQueries.deleteAll()
     }
 
+    /** Creates a non-default recipe book and returns its local id. */
+    fun createBook(name: String): Long {
+        recipeBookQueries.create(
+            name = name,
+            isDefault = false,
+            createdAt = DEFAULT_TIMESTAMP,
+            updatedAt = DEFAULT_TIMESTAMP,
+            clientId = null,
+            ownerId = null,
+        )
+        return recipeBookQueries.lastInsertId().executeAsOne().MAX
+            ?: error("Failed to get last insert id")
+    }
+
     private fun ensureDefaultBookId(): Long {
         recipeBookQueries.getDefault().executeAsOneOrNull()?.let {
             return it.id

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/RecipeSearchUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/RecipeSearchUiTest.kt
@@ -1,0 +1,42 @@
+package com.plusmobileapps.chefmate.tests
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.plusmobileapps.chefmate.fixtures.TestRecipes
+import com.plusmobileapps.chefmate.harness.TestUserState
+import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.recipe.list.robots.recipeList
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class RecipeSearchUiTest {
+
+    /**
+     * A recipe filed under a non-active book is hidden in the default (active-book-scoped) list,
+     * but switching the search modal to "All recipe books" surfaces it across every book.
+     */
+    @Test
+    fun searching_all_books_surfaces_recipes_from_other_books() =
+        runRootBlocTest(
+            userState = TestUserState.Authenticated(recipes = listOf(TestRecipes.fullyPopulated))
+        ) { app ->
+            val dessertsBookId = app.fakeDatabase.createBook("Desserts")
+            app.fakeDatabase.addRecipe(
+                TestRecipes.fullyPopulated.copy(
+                    id = 99L,
+                    title = "Tiramisu",
+                    isFavorite = false,
+                    recipeBookIds = setOf(dessertsBookId),
+                )
+            )
+
+            recipeList()
+                // Active book only shows its own recipe.
+                .assertRecipeIsDisplayed(TestRecipes.fullyPopulated.title)
+                .assertRecipeNotDisplayed("Tiramisu")
+                // Search across every book surfaces the recipe from the other book.
+                .openSearch()
+                .selectAllBooks()
+                .closeSearch()
+                .awaitRecipeDisplayed("Tiramisu")
+        }
+}

--- a/client/recipe/list/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/robots/RecipeListRobot.kt
+++ b/client/recipe/list/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/robots/RecipeListRobot.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import com.plusmobileapps.chefmate.recipe.list.RecipeListTestTags
 
@@ -29,6 +30,15 @@ class RecipeListRobot(private val test: ComposeUiTest) {
 
     fun assertRecipeIsDisplayed(title: String): RecipeListRobot = apply {
         test.onNode(hasText(title) and onScreen).assertIsDisplayed()
+    }
+
+    /** Waits for a recipe with [title] to appear in the list (e.g. after an async scope change). */
+    fun awaitRecipeDisplayed(title: String): RecipeListRobot = apply {
+        test.waitUntilExactlyOneExists(hasText(title) and onScreen)
+    }
+
+    fun assertRecipeNotDisplayed(title: String): RecipeListRobot = apply {
+        test.onNode(hasText(title) and onScreen).assertDoesNotExist()
     }
 
     fun clickRecipe(title: String): RecipeListRobot = apply {
@@ -67,6 +77,28 @@ class RecipeListRobot(private val test: ComposeUiTest) {
 
     fun openBookPicker(): RecipeListRobot = apply {
         test.onNodeWithTag(RecipeListTestTags.BOOK_SELECTOR).performClick()
+    }
+
+    /** Opens the search modal from the app-bar Search action. */
+    fun openSearch(): RecipeListRobot = apply {
+        test.onNode(hasTestTag(RecipeListTestTags.SEARCH_BUTTON) and onScreen).performClick()
+        // The sheet renders in a popup outside SCREEN; wait for it before interacting.
+        test.waitUntilExactlyOneExists(hasTestTag(RecipeListTestTags.SEARCH_SHEET))
+    }
+
+    /** Types into the search field of the open modal. */
+    fun typeSearch(query: String): RecipeListRobot = apply {
+        test.onNode(hasTestTag(RecipeListTestTags.SEARCH_FIELD)).performTextInput(query)
+    }
+
+    /** Selects the "All recipe books" scope in the open search modal. */
+    fun selectAllBooks(): RecipeListRobot = apply {
+        test.onNode(hasTestTag(RecipeListTestTags.SEARCH_SCOPE_ALL)).performClick()
+    }
+
+    /** Dismisses the search modal via its Done button. */
+    fun closeSearch(): RecipeListRobot = apply {
+        test.onNode(hasTestTag(RecipeListTestTags.SEARCH_DONE)).performClick()
     }
 }
 

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
@@ -13,6 +13,7 @@ import com.plusmobileapps.chefmate.recipe.list.RecipeFilterOption
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc.Output
 import com.plusmobileapps.chefmate.recipe.list.RecipeListItem
+import com.plusmobileapps.chefmate.recipe.list.RecipeSearchScope
 import com.plusmobileapps.chefmate.recipe.list.RecipeSortOption
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.RecipeListScreen
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
@@ -46,32 +47,43 @@ class RecipeListBlocImpl(
     }
 
     override val state: StateFlow<RecipeListBloc.Model> =
-        viewModel.state.mapState {
+        viewModel.state.mapState { state ->
+            val bookNameById = state.recipeBooks.associate { book -> book.id to book.name }
             RecipeListBloc.Model(
-                isLoading = it.isLoading,
-                isSyncing = it.isSyncing,
+                isLoading = state.isLoading,
+                isSyncing = state.isSyncing,
                 recipes =
-                    it.displayRecipes.map { recipe -> recipe.toRecipeListItem() }.toImmutableList(),
-                totalRecipeCount = it.recipes.size,
-                currentSort = it.currentSort,
-                activeFilters = it.activeFilters,
-                activeCategories = it.activeCategories,
-                activeUserCategoryIds = it.activeUserCategoryIds,
-                availableUserCategories = it.availableUserCategories.toImmutableList(),
-                isGridView = it.isGridView,
-                searchQuery = it.searchQuery,
-                isSearchActive = it.isSearchActive,
-                cookingRecipeCount = it.cookingRecipeIds.size,
-                showDoneCookingDialog = it.showDoneCookingDialog,
-                isSelectionMode = it.isSelectionMode,
-                selectedRecipeIds = it.selectedRecipeIds,
-                isScanning = it.isScanning,
-                scanError = it.scanError,
-                isScanFromPhotoEnabled = it.isScanFromPhotoEnabled,
-                recipeBooks = it.recipeBooks,
-                activeBook = it.activeBook,
-                isBookPickerOpen = it.isBookPickerOpen,
-                pendingInvites = it.pendingInvites,
+                    state.displayRecipes
+                        .map { recipe ->
+                            recipe.toRecipeListItem(
+                                bookName =
+                                    if (state.isCrossBookSearch) recipe.bookLabel(bookNameById)
+                                    else null
+                            )
+                        }
+                        .toImmutableList(),
+                totalRecipeCount = state.recipes.size,
+                currentSort = state.currentSort,
+                activeFilters = state.activeFilters,
+                activeCategories = state.activeCategories,
+                activeUserCategoryIds = state.activeUserCategoryIds,
+                availableUserCategories = state.availableUserCategories.toImmutableList(),
+                isGridView = state.isGridView,
+                searchQuery = state.searchQuery,
+                isSearchActive = state.isSearchActive,
+                isSearchOpen = state.isSearchOpen,
+                searchScope = state.resolvedSearchScope,
+                cookingRecipeCount = state.cookingRecipeIds.size,
+                showDoneCookingDialog = state.showDoneCookingDialog,
+                isSelectionMode = state.isSelectionMode,
+                selectedRecipeIds = state.selectedRecipeIds,
+                isScanning = state.isScanning,
+                scanError = state.scanError,
+                isScanFromPhotoEnabled = state.isScanFromPhotoEnabled,
+                recipeBooks = state.recipeBooks,
+                activeBook = state.activeBook,
+                isBookPickerOpen = state.isBookPickerOpen,
+                pendingInvites = state.pendingInvites,
             )
         }
 
@@ -117,6 +129,22 @@ class RecipeListBlocImpl(
 
     override fun onSearchQueryChanged(query: String) {
         viewModel.updateSearchQuery(query)
+    }
+
+    override fun onOpenSearch() {
+        viewModel.openSearch()
+    }
+
+    override fun onCloseSearch() {
+        viewModel.closeSearch()
+    }
+
+    override fun onSearchScopeSelected(scope: RecipeSearchScope) {
+        viewModel.selectSearchScope(scope)
+    }
+
+    override fun onClearSearch() {
+        viewModel.clearSearch()
     }
 
     override fun onClearFilters() {
@@ -227,7 +255,7 @@ class RecipeListBlocImpl(
         RecipeListScreen(bloc = this, modifier = modifier)
     }
 
-    private fun Recipe.toRecipeListItem(): RecipeListItem =
+    private fun Recipe.toRecipeListItem(bookName: String? = null): RecipeListItem =
         RecipeListItem(
             id = id,
             title = title,
@@ -240,5 +268,10 @@ class RecipeListBlocImpl(
             calories = calories,
             isFavorite = isFavorite,
             syncStatus = syncStatus,
+            bookName = bookName,
         )
+
+    /** Joined names of the books this recipe belongs to, or null if none resolve. */
+    private fun Recipe.bookLabel(namesById: Map<Long, String>): String? =
+        recipeBookIds.mapNotNull { namesById[it] }.takeIf { it.isNotEmpty() }?.joinToString(", ")
 }

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
@@ -20,6 +20,7 @@ import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import com.plusmobileapps.chefmate.recipe.data.RecipeImageExtractor
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import com.plusmobileapps.chefmate.recipe.list.RecipeFilterOption
+import com.plusmobileapps.chefmate.recipe.list.RecipeSearchScope
 import com.plusmobileapps.chefmate.recipe.list.RecipeSortOption
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookCollaborationRepository
@@ -42,9 +43,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -152,9 +155,25 @@ class RecipeListViewModel(
         }
     }
 
+    /**
+     * Streams the recipes to display. The source book is the *effective search scope*: a
+     * [RecipeSearchScope] override when the user is searching, otherwise the active book. The
+     * override never touches the persisted active book — it is reset by [clearSearch] /
+     * [selectBook]. `null` book id means "all books".
+     */
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun observeRecipes() {
-        recipeBookRepository.activeBookId
+        combine(
+                recipeBookRepository.activeBookId,
+                _state.map { it.searchScope }.distinctUntilChanged(),
+            ) { activeBookId, scope ->
+                when (scope) {
+                    RecipeSearchScope.AllBooks -> null
+                    is RecipeSearchScope.Book -> scope.bookId
+                    null -> activeBookId
+                }
+            }
+            .distinctUntilChanged()
             .flatMapLatest { bookId ->
                 if (bookId == null) repository.getRecipes() else repository.getRecipes(bookId)
             }
@@ -286,6 +305,26 @@ class RecipeListViewModel(
         _state.update { it.copy(searchQuery = query) }
     }
 
+    fun openSearch() {
+        _state.update { it.copy(isSearchOpen = true) }
+    }
+
+    fun closeSearch() {
+        _state.update { it.copy(isSearchOpen = false) }
+    }
+
+    /**
+     * Overrides which book(s) the search reads from. Leaves the persisted active book untouched.
+     */
+    fun selectSearchScope(scope: RecipeSearchScope) {
+        _state.update { it.copy(searchScope = scope) }
+    }
+
+    /** Ends the search session: clears the query and reverts the scope to the active book. */
+    fun clearSearch() {
+        _state.update { it.copy(searchQuery = "", searchScope = null) }
+    }
+
     fun onSyncClicked() {
         scope.launch {
             _state.update { it.copy(isSyncing = true) }
@@ -349,7 +388,9 @@ class RecipeListViewModel(
     }
 
     fun selectBook(bookId: Long) {
-        _state.update { it.copy(isBookPickerOpen = false) }
+        // Switching the active book ends any in-flight search session so the list isn't left
+        // showing a stale cross-book result set against the newly-selected book.
+        _state.update { it.copy(isBookPickerOpen = false, searchQuery = "", searchScope = null) }
         scope.launch { recipeBookRepository.setActiveBook(bookId) }
     }
 
@@ -396,6 +437,12 @@ class RecipeListViewModel(
         val availableUserCategories: List<Category> = emptyList(),
         val isGridView: Boolean = false,
         val searchQuery: String = "",
+        val isSearchOpen: Boolean = false,
+        /**
+         * Active search-scope override. `null` follows the active book (the normal, non-search
+         * view).
+         */
+        val searchScope: RecipeSearchScope? = null,
         val cookingRecipeIds: List<Long> = emptyList(),
         val showDoneCookingDialog: Boolean = false,
         val isSelectionMode: Boolean = false,
@@ -410,6 +457,17 @@ class RecipeListViewModel(
     ) {
         val isSearchActive: Boolean
             get() = searchQuery.isNotBlank()
+
+        /** The scope override resolved against the active book, for display in the search modal. */
+        val resolvedSearchScope: RecipeSearchScope
+            get() =
+                searchScope
+                    ?: activeBook?.let { RecipeSearchScope.Book(it.id) }
+                    ?: RecipeSearchScope.AllBooks
+
+        /** True when results span every book, so each item should be labelled with its book. */
+        val isCrossBookSearch: Boolean
+            get() = resolvedSearchScope == RecipeSearchScope.AllBooks
 
         val displayRecipes: List<Recipe>
             get() =

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
@@ -169,6 +169,28 @@ val previewRecipeListBlocCooking: RecipeListBloc =
         )
     )
 
+private val crossBookRecipes =
+    persistentListOf(
+        sampleRecipes[0].copy(bookName = "Weeknight Dinners"),
+        sampleRecipes[1].copy(bookName = "Salads"),
+        sampleRecipes[2].copy(bookName = "Breakfast"),
+    )
+
+/**
+ * Cross-book search results — scope is [RecipeSearchScope.AllBooks], so each recipe row is labelled
+ * with the recipe book it lives in.
+ */
+val previewRecipeListBlocCrossBookSearch: RecipeListBloc =
+    recipeListBloc(
+        RecipeListBloc.Model(
+            recipes = crossBookRecipes,
+            totalRecipeCount = crossBookRecipes.size,
+            recipeBooks = RecipeBook.Samples,
+            activeBook = RecipeBook.Sample,
+            searchScope = RecipeSearchScope.AllBooks,
+        )
+    )
+
 /** Recipe list with one active category filter — exercises the filter-icon badge indicator. */
 val previewRecipeListBlocCategoryFiltered: RecipeListBloc =
     recipeListBloc(
@@ -266,4 +288,10 @@ internal fun RecipeListCookingTabletPreview() {
 @Composable
 internal fun RecipeListSelectionPreview() {
     ChefMateTheme { RecipeListScreen(bloc = previewRecipeListBlocSelectionMode) }
+}
+
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+internal fun RecipeListCrossBookSearchPreview() {
+    ChefMateTheme { RecipeListScreen(bloc = previewRecipeListBlocCrossBookSearch) }
 }

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
@@ -8,6 +8,7 @@ import com.plusmobileapps.chefmate.recipe.data.SyncStatus
 import com.plusmobileapps.chefmate.recipe.list.RecipeFilterOption
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc
 import com.plusmobileapps.chefmate.recipe.list.RecipeListItem
+import com.plusmobileapps.chefmate.recipe.list.RecipeSearchScope
 import com.plusmobileapps.chefmate.recipe.list.RecipeSortOption
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookInvite
@@ -83,6 +84,14 @@ private fun recipeListBloc(model: RecipeListBloc.Model): RecipeListBloc =
         override fun onToggleViewMode() = Unit
 
         override fun onSearchQueryChanged(query: String) = Unit
+
+        override fun onOpenSearch() = Unit
+
+        override fun onCloseSearch() = Unit
+
+        override fun onSearchScopeSelected(scope: RecipeSearchScope) = Unit
+
+        override fun onClearSearch() = Unit
 
         override fun onClearFilters() = Unit
 

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListScreen.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListScreen.kt
@@ -1,8 +1,5 @@
 package com.plusmobileapps.chefmate.recipe.list.impl.ui
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -76,6 +73,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -150,9 +148,14 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_list_scan_f
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scanning_message
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scanning_title
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_all_books
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_clear
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_done
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_empty
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_in_book
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_placeholder
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_scope
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_title
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_count
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_deselect_all
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_exit
@@ -177,6 +180,7 @@ import com.plusmobileapps.chefmate.recipe.list.RecipeFilterOption
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc
 import com.plusmobileapps.chefmate.recipe.list.RecipeListItem
 import com.plusmobileapps.chefmate.recipe.list.RecipeListTestTags
+import com.plusmobileapps.chefmate.recipe.list.RecipeSearchScope
 import com.plusmobileapps.chefmate.recipe.list.RecipeSortOption
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
@@ -201,7 +205,6 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
-    var showSearchBar by remember { mutableStateOf(state.isSearchActive) }
     var showSortFilterSheet by remember { mutableStateOf(false) }
     val listState = rememberLazyListState()
     val gridState = rememberLazyGridState()
@@ -300,15 +303,23 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                     trailingAccessory =
                         PlusHeaderData.TrailingAccessory.Custom {
                             IconButton(
-                                onClick = {
-                                    showSearchBar = !showSearchBar
-                                    if (!showSearchBar) bloc.onSearchQueryChanged("")
-                                }
+                                onClick = bloc::onOpenSearch,
+                                modifier = Modifier.testTag(RecipeListTestTags.SEARCH_BUTTON),
                             ) {
+                                val searchTint =
+                                    if (
+                                        state.isSearchActive ||
+                                            state.searchScope == RecipeSearchScope.AllBooks
+                                    ) {
+                                        MaterialTheme.colorScheme.primary
+                                    } else {
+                                        androidx.compose.ui.graphics.Color.Unspecified
+                                    }
                                 Icon(
                                     imageVector = Icons.Default.Search,
                                     contentDescription =
                                         stringResource(Res.string.recipe_list_search),
+                                    tint = searchTint,
                                 )
                             }
                             IconButton(onClick = bloc::onToggleViewMode) {
@@ -366,20 +377,6 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                 data = headerData,
                 scrollEnabled = false,
                 content = {
-                    AnimatedVisibility(
-                        visible = showSearchBar,
-                        enter = expandVertically(),
-                        exit = shrinkVertically(),
-                    ) {
-                        SearchBar(
-                            query = state.searchQuery,
-                            onQueryChanged = bloc::onSearchQueryChanged,
-                            onClear = {
-                                bloc.onSearchQueryChanged("")
-                                showSearchBar = false
-                            },
-                        )
-                    }
                     state.pendingInvites.forEach { invite ->
                         InviteBanner(
                             invite = invite,
@@ -439,6 +436,18 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                     }
                 },
             )
+
+            if (state.isSearchOpen) {
+                SearchBottomSheet(
+                    query = state.searchQuery,
+                    scope = state.searchScope,
+                    books = state.recipeBooks,
+                    onQueryChanged = bloc::onSearchQueryChanged,
+                    onScopeSelected = bloc::onSearchScopeSelected,
+                    onClear = bloc::onClearSearch,
+                    onDismiss = bloc::onCloseSearch,
+                )
+            }
 
             if (showSortFilterSheet) {
                 SortFilterBottomSheet(
@@ -1082,36 +1091,134 @@ private fun BuiltinCategory.labelRes(): StringResource =
 
 // region Search
 
+/**
+ * Full search modal launched from the app-bar Search action. Owns the query field plus a book-scope
+ * picker so the user can search within the active book, a specific book, or across every book. The
+ * scope is a temporary view — it never changes the persisted active book.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SearchBar(
+private fun SearchBottomSheet(
     query: String,
+    scope: RecipeSearchScope,
+    books: List<com.plusmobileapps.chefmate.recipebook.data.RecipeBook>,
     onQueryChanged: (String) -> Unit,
+    onScopeSelected: (RecipeSearchScope) -> Unit,
     onClear: () -> Unit,
-    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit,
 ) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
-    OutlinedTextField(
-        value = query,
-        onValueChange = onQueryChanged,
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = Modifier.testTag(RecipeListTestTags.SEARCH_SHEET),
+    ) {
+        Column(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(horizontal = ChefMateTheme.dimens.paddingNormal)
+                    .navigationBarsPadding()
+        ) {
+            Text(
+                text = stringResource(Res.string.recipe_list_search_title),
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Spacer(Modifier.height(ChefMateTheme.dimens.paddingNormal))
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChanged,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .focusRequester(focusRequester)
+                        .testTag(RecipeListTestTags.SEARCH_FIELD),
+                placeholder = { Text(stringResource(Res.string.recipe_list_search_placeholder)) },
+                leadingIcon = {
+                    Icon(imageVector = Icons.Default.Search, contentDescription = null)
+                },
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { onQueryChanged("") }) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription =
+                                    stringResource(Res.string.recipe_list_search_clear),
+                            )
+                        }
+                    }
+                },
+                singleLine = true,
+            )
+
+            if (books.isNotEmpty()) {
+                Spacer(Modifier.height(ChefMateTheme.dimens.paddingNormal))
+                Text(
+                    text = stringResource(Res.string.recipe_list_search_scope),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(ChefMateTheme.dimens.paddingSmall))
+                SearchScopeRow(
+                    label = stringResource(Res.string.recipe_list_search_all_books),
+                    selected = scope == RecipeSearchScope.AllBooks,
+                    onClick = { onScopeSelected(RecipeSearchScope.AllBooks) },
+                    modifier = Modifier.testTag(RecipeListTestTags.SEARCH_SCOPE_ALL),
+                )
+                books.forEach { book ->
+                    SearchScopeRow(
+                        label = book.name,
+                        selected = scope == RecipeSearchScope.Book(book.id),
+                        onClick = { onScopeSelected(RecipeSearchScope.Book(book.id)) },
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(ChefMateTheme.dimens.paddingNormal))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall),
+            ) {
+                OutlinedButton(
+                    onClick = onClear,
+                    modifier = Modifier.weight(1f).testTag(RecipeListTestTags.SEARCH_CLEAR),
+                ) {
+                    Text(stringResource(Res.string.recipe_list_search_clear))
+                }
+                Button(onClick = onDismiss, modifier = Modifier.weight(1f)) {
+                    Text(stringResource(Res.string.recipe_list_search_done))
+                }
+            }
+            Spacer(Modifier.height(ChefMateTheme.dimens.paddingNormal))
+        }
+    }
+}
+
+@Composable
+private fun SearchScopeRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp)
-                .focusRequester(focusRequester),
-        placeholder = { Text(stringResource(Res.string.recipe_list_search_placeholder)) },
-        leadingIcon = { Icon(imageVector = Icons.Default.Search, contentDescription = null) },
-        trailingIcon = {
-            IconButton(onClick = onClear) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(Res.string.recipe_list_search_clear),
-                )
-            }
-        },
-        singleLine = true,
-    )
+                .clickable(onClick = onClick)
+                .padding(vertical = ChefMateTheme.dimens.paddingExtraSmall),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Spacer(Modifier.width(ChefMateTheme.dimens.paddingSmall))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
 }
 
 @Composable
@@ -1316,6 +1423,7 @@ private fun RecipeGridItem(
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
+            recipe.bookName?.let { bookName -> RecipeBookLabel(bookName) }
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -1446,6 +1554,7 @@ private fun RecipeListItemContent(
                     )
                 }
             }
+            recipe.bookName?.let { bookName -> RecipeBookLabel(bookName) }
             recipe.description?.let { description ->
                 Text(
                     text = description,
@@ -1551,6 +1660,21 @@ private fun StarRating(
             )
         }
     }
+}
+
+/** "in <book>" caption shown on a recipe row when results span more than one recipe book. */
+@Composable
+private fun RecipeBookLabel(bookName: String, modifier: Modifier = Modifier) {
+    Text(
+        text =
+            PhraseModel(Res.string.recipe_list_search_in_book, "book" to FixedString(bookName))
+                .localized(),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+    )
 }
 
 @Composable

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListScreen.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListScreen.kt
@@ -1186,7 +1186,10 @@ private fun SearchBottomSheet(
                 ) {
                     Text(stringResource(Res.string.recipe_list_search_clear))
                 }
-                Button(onClick = onDismiss, modifier = Modifier.weight(1f)) {
+                Button(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f).testTag(RecipeListTestTags.SEARCH_DONE),
+                ) {
                     Text(stringResource(Res.string.recipe_list_search_done))
                 }
             }

--- a/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
+++ b/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
@@ -19,7 +19,9 @@ import com.plusmobileapps.chefmate.recipe.data.testing.FakePendingRecipePhotoSto
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeImageExtractor
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.plusmobileapps.chefmate.recipe.list.RecipeFilterOption
+import com.plusmobileapps.chefmate.recipe.list.RecipeSearchScope
 import com.plusmobileapps.chefmate.recipe.list.RecipeSortOption
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookCollaborationRepository
 import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookRepository
 import com.russhwolf.settings.Settings
@@ -212,6 +214,7 @@ class RecipeListViewModelTest {
         starRating: Int? = null,
         totalTime: Int? = null,
         category: BuiltinCategory? = null,
+        recipeBookIds: Set<Long> = emptySet(),
         createdAt: Instant = Instant.fromEpochSeconds(id * 1000),
     ) =
         Recipe(
@@ -233,10 +236,128 @@ class RecipeListViewModelTest {
                 category?.let {
                     setOf(Category(id = it.ordinal + 1L, name = it.id, builtinId = it.id))
                 } ?: emptySet(),
+            recipeBookIds = recipeBookIds,
             syncStatus = SyncStatus.NOT_SYNCED,
             createdAt = createdAt,
             updatedAt = createdAt,
         )
+
+    private fun book(id: Long, name: String) =
+        RecipeBook(
+            id = id,
+            name = name,
+            isDefault = id == 1L,
+            createdAt = Instant.DISTANT_PAST,
+            updatedAt = Instant.DISTANT_PAST,
+        )
+
+    private fun viewModelWith(repo: FakeRecipeRepository, bookRepo: FakeRecipeBookRepository) =
+        RecipeListViewModel(
+            mainContext = UnconfinedTestDispatcher(),
+            repository = repo,
+            recipeBookRepository = bookRepo,
+            collaborationRepository = FakeRecipeBookCollaborationRepository(),
+            categoryRepository = categoryRepository,
+            cookingSessionRepository = cookingSessionRepository,
+            imageExtractor = imageExtractor,
+            pendingPhotoStore = pendingPhotoStore,
+            featureFlags = featureFlags,
+            settings = settings,
+        )
+
+    @Test
+    fun When_open_search_Then_modal_open_and_scope_follows_active_book() {
+        val vm =
+            viewModelWith(
+                FakeRecipeRepository(MutableStateFlow(emptyList())),
+                FakeRecipeBookRepository(
+                    MutableStateFlow(listOf(book(1, "Book A"), book(2, "Book B")))
+                ),
+            )
+        vm.openSearch()
+        vm.state.value.isSearchOpen shouldBe true
+        vm.state.value.resolvedSearchScope shouldBe RecipeSearchScope.Book(1L)
+    }
+
+    @Test
+    fun When_search_scope_all_books_Then_recipes_from_every_book_shown() {
+        val recipeFlow =
+            MutableStateFlow(
+                listOf(recipe(1, recipeBookIds = setOf(1)), recipe(2, recipeBookIds = setOf(2)))
+            )
+        val bookRepo =
+            FakeRecipeBookRepository(MutableStateFlow(listOf(book(1, "Book A"), book(2, "Book B"))))
+        val vm = viewModelWith(FakeRecipeRepository(recipeFlow), bookRepo)
+
+        // Default scope follows the active book (Book A), so only its recipe shows.
+        vm.state.value.displayRecipes.map { it.id } shouldBe listOf(1L)
+
+        vm.selectSearchScope(RecipeSearchScope.AllBooks)
+
+        vm.state.value.displayRecipes.map { it.id }.sorted() shouldBe listOf(1L, 2L)
+        // Temporary scope must not change the persisted active book.
+        bookRepo.activeBookId.value shouldBe 1L
+    }
+
+    @Test
+    fun When_search_query_with_all_books_Then_filters_across_books() {
+        val recipeFlow =
+            MutableStateFlow(
+                listOf(
+                    recipe(1, title = "Apple Pie", recipeBookIds = setOf(1)),
+                    recipe(2, title = "Banana Bread", recipeBookIds = setOf(2)),
+                )
+            )
+        val vm =
+            viewModelWith(
+                FakeRecipeRepository(recipeFlow),
+                FakeRecipeBookRepository(
+                    MutableStateFlow(listOf(book(1, "Book A"), book(2, "Book B")))
+                ),
+            )
+
+        vm.selectSearchScope(RecipeSearchScope.AllBooks)
+        vm.updateSearchQuery("banana")
+
+        vm.state.value.displayRecipes.map { it.id } shouldBe listOf(2L)
+    }
+
+    @Test
+    fun When_clear_search_Then_query_cleared_and_scope_back_to_active_book() {
+        val recipeFlow =
+            MutableStateFlow(
+                listOf(recipe(1, recipeBookIds = setOf(1)), recipe(2, recipeBookIds = setOf(2)))
+            )
+        val vm =
+            viewModelWith(
+                FakeRecipeRepository(recipeFlow),
+                FakeRecipeBookRepository(
+                    MutableStateFlow(listOf(book(1, "Book A"), book(2, "Book B")))
+                ),
+            )
+
+        vm.selectSearchScope(RecipeSearchScope.AllBooks)
+        vm.updateSearchQuery("recipe")
+        vm.state.value.displayRecipes.map { it.id }.sorted() shouldBe listOf(1L, 2L)
+
+        vm.clearSearch()
+
+        vm.state.value.searchQuery shouldBe ""
+        vm.state.value.resolvedSearchScope shouldBe RecipeSearchScope.Book(1L)
+        vm.state.value.displayRecipes.map { it.id } shouldBe listOf(1L)
+    }
+
+    @Test
+    fun When_search_scope_specific_book_Then_active_book_unchanged() {
+        val bookRepo =
+            FakeRecipeBookRepository(MutableStateFlow(listOf(book(1, "Book A"), book(2, "Book B"))))
+        val vm = viewModelWith(FakeRecipeRepository(MutableStateFlow(emptyList())), bookRepo)
+
+        vm.selectSearchScope(RecipeSearchScope.Book(2L))
+
+        vm.state.value.resolvedSearchScope shouldBe RecipeSearchScope.Book(2L)
+        bookRepo.activeBookId.value shouldBe 1L
+    }
 
     @Test
     fun initial_state_has_empty_recipes_and_default_sort() {

--- a/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
@@ -15,6 +15,11 @@
     <string name="recipe_list_search_placeholder">Search recipes…</string>
     <string name="recipe_list_search_clear">Clear search</string>
     <string name="recipe_list_search_empty">No recipes match your search</string>
+    <string name="recipe_list_search_title">Search recipes</string>
+    <string name="recipe_list_search_scope">Search in</string>
+    <string name="recipe_list_search_all_books">All recipe books</string>
+    <string name="recipe_list_search_done">Done</string>
+    <string name="recipe_list_search_in_book">in {book}</string>
 
     <!-- Sort -->
     <string name="recipe_list_sort">Sort</string>

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
@@ -43,6 +43,18 @@ interface RecipeListBloc : BlocScreen {
 
     fun onSearchQueryChanged(query: String)
 
+    /** Opens the search modal. */
+    fun onOpenSearch()
+
+    /** Closes the search modal, leaving the active search query and scope in place. */
+    fun onCloseSearch()
+
+    /** Picks which recipe book(s) the search reads from. Does not change the active book. */
+    fun onSearchScopeSelected(scope: RecipeSearchScope)
+
+    /** Clears the search query and resets the scope back to the active book. */
+    fun onClearSearch()
+
     fun onClearFilters()
 
     fun onApplySortAndFilters(
@@ -116,6 +128,10 @@ interface RecipeListBloc : BlocScreen {
         val isGridView: Boolean = false,
         val searchQuery: String = "",
         val isSearchActive: Boolean = false,
+        /** True while the search modal is shown. */
+        val isSearchOpen: Boolean = false,
+        /** Which book(s) the current search reads from. Resolves to the active book by default. */
+        val searchScope: RecipeSearchScope = RecipeSearchScope.AllBooks,
         val cookingRecipeCount: Int = 0,
         val showDoneCookingDialog: Boolean = false,
         val isSelectionMode: Boolean = false,

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListItem.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListItem.kt
@@ -15,4 +15,9 @@ data class RecipeListItem(
     val calories: Int?,
     val isFavorite: Boolean,
     val syncStatus: SyncStatus = SyncStatus.NOT_SYNCED,
+    /**
+     * Name of the recipe book(s) this recipe lives in, shown only for cross-book search results.
+     * Null when the result set is scoped to a single book, which hides the label.
+     */
+    val bookName: String? = null,
 )

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListTestTags.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListTestTags.kt
@@ -13,4 +13,9 @@ object RecipeListTestTags {
     const val SCANNING_DIALOG: String = "recipe_list_scanning_dialog"
     const val SCAN_ERROR_DIALOG: String = "recipe_list_scan_error_dialog"
     const val BOOK_SELECTOR: String = "recipe_list_book_selector"
+    const val SEARCH_BUTTON: String = "recipe_list_search_button"
+    const val SEARCH_SHEET: String = "recipe_list_search_sheet"
+    const val SEARCH_FIELD: String = "recipe_list_search_field"
+    const val SEARCH_SCOPE_ALL: String = "recipe_list_search_scope_all"
+    const val SEARCH_CLEAR: String = "recipe_list_search_clear"
 }

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListTestTags.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListTestTags.kt
@@ -18,4 +18,5 @@ object RecipeListTestTags {
     const val SEARCH_FIELD: String = "recipe_list_search_field"
     const val SEARCH_SCOPE_ALL: String = "recipe_list_search_scope_all"
     const val SEARCH_CLEAR: String = "recipe_list_search_clear"
+    const val SEARCH_DONE: String = "recipe_list_search_done"
 }

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeSearchScope.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeSearchScope.kt
@@ -1,0 +1,14 @@
+package com.plusmobileapps.chefmate.recipe.list
+
+/**
+ * Which recipe books a search session reads from. A scope is a *temporary* view that never changes
+ * the persisted active book — it is reset when the search is cleared or the active book is
+ * switched.
+ */
+sealed interface RecipeSearchScope {
+    /** Search across every recipe book the user can see. */
+    data object AllBooks : RecipeSearchScope
+
+    /** Search within a single recipe book (by local id). */
+    data class Book(val bookId: Long) : RecipeSearchScope
+}

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTest.kt
@@ -11,6 +11,7 @@ import com.android.tools.screenshot.PreviewTest
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBloc
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocCooking
+import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocCrossBookSearch
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocPendingInvite
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocScanError
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocScanning
@@ -114,6 +115,22 @@ fun RecipeListScanningDarkScreenshot() {
 @Composable
 fun RecipeListScanErrorLightScreenshot() {
     RecipeListScreenshot(bloc = previewRecipeListBlocScanError)
+}
+
+// ── Cross-book search results — each row labelled with its recipe book ─────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun RecipeListCrossBookSearchLightScreenshot() {
+    RecipeListScreenshot(bloc = previewRecipeListBlocCrossBookSearch)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun RecipeListCrossBookSearchDarkScreenshot() {
+    RecipeListScreenshot(bloc = previewRecipeListBlocCrossBookSearch, darkTheme = true)
 }
 
 // ── Pending recipe-book invite banner (accept / decline) ───────────────────

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListCrossBookSearchDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListCrossBookSearchDarkScreenshot_805fa67c_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6ef214e40da721c85036969f134969b1eaa1ca4f9dcd878fca8a0793d056d7b
+size 119826

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListCrossBookSearchLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListCrossBookSearchLightScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8c4af3764d6b511b6ff7e1790711c1972e99c6a39c43499f79a60506c207c36
+size 119133


### PR DESCRIPTION
Closes #282.

## Why

With recipe books, the list is scoped to one **active book** and the old inline search only searched within it — awkward when you don't remember which book a recipe is in. This replaces the inline search bar with a **search modal** that can scope across books.

## What

- App-bar Search opens a **modal** (bottom sheet) with the query field plus a **book-scope picker**: the active book, a specific book, or **All recipe books**.
- Cross-book results label each row with the book it lives in (e.g. *"in Weeknight Dinners"*).
- **Temporary scope** — searching across books never changes the persisted active book; it resets on Clear or when the active book is switched.
- The existing sort/filter sheet and app-bar book selector are unchanged (per scoping decision).
- No data-layer changes — `RecipeRepository` already exposed `getRecipes()` (all) and `getRecipes(bookId)`; the ViewModel switches the effective source via a new `RecipeSearchScope`.

## Commits

1. **feat(recipe): search modal with cross-book scope** — public API (`RecipeSearchScope`, model/handlers, `RecipeListItem.bookName`, test tags, strings), ViewModel source-switching, BlocImpl, screen — bundled with the new `RecipeListViewModel` unit tests.
2. **test(recipe): snapshot cross-book search labels** — preview fixture + light/dark `@PreviewTest` wrappers + recorded references.
3. **test(recipe): robot flow for cross-book search** — `RecipeListRobot` verbs + a `runRootBlocTest` flow proving a recipe in a second book surfaces only after switching to "All recipe books".

## Verification

- `:client:recipe:list:impl:jvmTest` — VM search-scope tests pass.
- `:client:composeApp:jvmTest --tests *RecipeSearchUiTest` — robot flow passes.
- `:client:ui:screenshot-test:validateDebugScreenshotTest` — snapshots validate; inspected the recorded PNG (book labels + scope-tinted search icon render correctly).

Note: the modal is a `ModalBottomSheet`, whose content doesn't render in Compose preview screenshots, so the snapshot covers the new **on-screen** surface (cross-book labels); the sheet interaction itself is covered by the robot test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)