### PR TITLE
feat(recipebook): confirm before removing a collaborator

### DIFF
--- a/client/recipebook/edit/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookBlocImpl.kt
+++ b/client/recipebook/edit/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookBlocImpl.kt
@@ -50,7 +50,11 @@ class EditRecipeBookBlocImpl(
 
     override fun onInviteClicked() = viewModel.onInviteClicked()
 
-    override fun onRemoveMember(memberId: String) = viewModel.onRemoveMember(memberId)
+    override fun onRemoveMemberClicked(memberId: String) = viewModel.onRemoveMemberClicked(memberId)
+
+    override fun onConfirmRemoveMember() = viewModel.onConfirmRemoveMember()
+
+    override fun onDismissRemoveMember() = viewModel.onDismissRemoveMember()
 
     @Composable
     override fun Content(modifier: Modifier) {
@@ -70,5 +74,6 @@ class EditRecipeBookBlocImpl(
             inviteRole = inviteRole,
             isInviting = isInviting,
             inviteError = inviteError,
+            removingMember = removingMember,
         )
 }

--- a/client/recipebook/edit/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModel.kt
+++ b/client/recipebook/edit/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModel.kt
@@ -118,8 +118,19 @@ class EditRecipeBookViewModel(
         }
     }
 
-    fun onRemoveMember(memberId: String) {
+    fun onRemoveMemberClicked(memberId: String) {
+        val member = _state.value.members.firstOrNull { it.id == memberId } ?: return
+        _state.update { it.copy(removingMember = member) }
+    }
+
+    fun onDismissRemoveMember() {
+        _state.update { it.copy(removingMember = null) }
+    }
+
+    fun onConfirmRemoveMember() {
         val bookId = (props as? EditRecipeBookBloc.Props.Edit)?.bookId ?: return
+        val memberId = _state.value.removingMember?.id ?: return
+        _state.update { it.copy(removingMember = null) }
         scope.launch {
             withContext(ioContext) { collaborationRepository.removeMember(memberId) }
             loadMembers(bookId)
@@ -163,6 +174,7 @@ class EditRecipeBookViewModel(
         val inviteRole: RecipeBookRole = RecipeBookRole.EDITOR,
         val isInviting: Boolean = false,
         val inviteError: TextData? = null,
+        val removingMember: RecipeBookMember? = null,
     )
 
     @AssistedFactory

--- a/client/recipebook/edit/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookScreenUiTest.kt
+++ b/client/recipebook/edit/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookScreenUiTest.kt
@@ -55,7 +55,11 @@ class EditRecipeBookScreenUiTest {
 
         override fun onInviteClicked() = Unit
 
-        override fun onRemoveMember(memberId: String) = Unit
+        override fun onRemoveMemberClicked(memberId: String) = Unit
+
+        override fun onConfirmRemoveMember() = Unit
+
+        override fun onDismissRemoveMember() = Unit
 
         @Composable
         override fun Content(modifier: Modifier) {

--- a/client/recipebook/edit/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModelTest.kt
+++ b/client/recipebook/edit/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModelTest.kt
@@ -70,6 +70,60 @@ class EditRecipeBookViewModelTest {
         }
 
     @Test
+    fun removing_a_member_confirms_first_then_calls_repository() =
+        runTest(testDispatcher) {
+            val collab = FakeRecipeBookCollaborationRepository(owner = true)
+            collab.members.add(
+                com.plusmobileapps.chefmate.recipebook.data.RecipeBookMember(
+                    id = "m1",
+                    email = "alex@example.com",
+                    role = com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole.EDITOR,
+                    accepted = true,
+                )
+            )
+            val vm =
+                viewModel(
+                    EditRecipeBookBloc.Props.Edit(bookId = 3),
+                    collaborationRepository = collab,
+                )
+
+            vm.onRemoveMemberClicked("m1")
+            // Clicking only opens the confirmation — nothing removed yet.
+            vm.state.value.removingMember?.id shouldBe "m1"
+            collab.removed.isEmpty() shouldBe true
+
+            vm.onConfirmRemoveMember()
+
+            collab.removed shouldBe listOf("m1")
+            vm.state.value.removingMember shouldBe null
+        }
+
+    @Test
+    fun dismissing_remove_confirmation_does_not_remove() =
+        runTest(testDispatcher) {
+            val collab = FakeRecipeBookCollaborationRepository(owner = true)
+            collab.members.add(
+                com.plusmobileapps.chefmate.recipebook.data.RecipeBookMember(
+                    id = "m1",
+                    email = "alex@example.com",
+                    role = com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole.EDITOR,
+                    accepted = true,
+                )
+            )
+            val vm =
+                viewModel(
+                    EditRecipeBookBloc.Props.Edit(bookId = 3),
+                    collaborationRepository = collab,
+                )
+
+            vm.onRemoveMemberClicked("m1")
+            vm.onDismissRemoveMember()
+
+            vm.state.value.removingMember shouldBe null
+            collab.removed.isEmpty() shouldBe true
+        }
+
+    @Test
     fun invalid_invite_email_sets_an_error_and_does_not_invite() =
         runTest(testDispatcher) {
             val collab = FakeRecipeBookCollaborationRepository(owner = true)

--- a/client/recipebook/edit/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipebook/edit/public/src/commonMain/composeResources/values/strings.xml
@@ -19,4 +19,8 @@
     <string name="edit_recipe_book_group_editors">Editors</string>
     <string name="edit_recipe_book_group_viewers">Viewers</string>
     <string name="edit_recipe_book_remove_member">Remove %1$s</string>
+    <string name="edit_recipe_book_remove_title">Remove collaborator</string>
+    <string name="edit_recipe_book_remove_message">Remove “{name}” from this book? They’ll lose access.</string>
+    <string name="edit_recipe_book_remove_confirm">Remove</string>
+    <string name="edit_recipe_book_remove_cancel">Cancel</string>
 </resources>

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookBloc.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookBloc.kt
@@ -24,7 +24,14 @@ interface EditRecipeBookBloc : BlocScreen {
 
     fun onInviteClicked()
 
-    fun onRemoveMember(memberId: String)
+    /** Owner tapped remove on a collaborator — asks for confirmation first. */
+    fun onRemoveMemberClicked(memberId: String)
+
+    /** Confirms the pending removal. */
+    fun onConfirmRemoveMember()
+
+    /** Dismisses the remove-confirmation dialog without removing. */
+    fun onDismissRemoveMember()
 
     data class Model(
         val title: TextData,
@@ -39,6 +46,8 @@ interface EditRecipeBookBloc : BlocScreen {
         val inviteRole: RecipeBookRole = RecipeBookRole.EDITOR,
         val isInviting: Boolean = false,
         val inviteError: TextData? = null,
+        /** The collaborator awaiting remove confirmation; non-null shows the confirm dialog. */
+        val removingMember: RecipeBookMember? = null,
     ) {
         val canSave: Boolean
             get() = name.isNotBlank() && !isSaving

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookPreviews.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookPreviews.kt
@@ -30,7 +30,11 @@ private fun editRecipeBookBloc(model: Model): EditRecipeBookBloc =
 
         override fun onInviteClicked() = Unit
 
-        override fun onRemoveMember(memberId: String) = Unit
+        override fun onRemoveMemberClicked(memberId: String) = Unit
+
+        override fun onConfirmRemoveMember() = Unit
+
+        override fun onDismissRemoveMember() = Unit
 
         @Composable
         override fun Content(modifier: Modifier) {
@@ -135,6 +139,43 @@ val previewEditRecipeBookMemberViewBloc: EditRecipeBookBloc =
                         role = RecipeBookRole.VIEWER,
                         accepted = false,
                     ),
+                ),
+        )
+    )
+
+/** Owner view with the remove-collaborator confirmation dialog showing. */
+val previewEditRecipeBookRemoveConfirmBloc: EditRecipeBookBloc =
+    editRecipeBookBloc(
+        Model(
+            title = Res.string.edit_recipe_book_edit_title.asTextData(),
+            name = "Weeknight Dinners",
+            isCreate = false,
+            canManageCollaborators = true,
+            members =
+                listOf(
+                    RecipeBookMember(
+                        id = null,
+                        email = "you@example.com",
+                        role = RecipeBookRole.OWNER,
+                        accepted = true,
+                        name = "Jordan Lee",
+                        isOwner = true,
+                    ),
+                    RecipeBookMember(
+                        id = "1",
+                        email = "alex@example.com",
+                        role = RecipeBookRole.EDITOR,
+                        accepted = true,
+                        name = "Alex Rivera",
+                    ),
+                ),
+            removingMember =
+                RecipeBookMember(
+                    id = "1",
+                    email = "alex@example.com",
+                    role = RecipeBookRole.EDITOR,
+                    accepted = true,
+                    name = "Alex Rivera",
                 ),
         )
     )

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
@@ -40,17 +40,24 @@ import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_bo
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_invite_email_label
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_member_pending
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_name_label
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_remove_cancel
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_remove_confirm
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_remove_member
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_remove_message
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_remove_title
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_role_editor
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_role_owner
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_role_viewer
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_save
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMember
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusAvatar
 import com.plusmobileapps.chefmate.ui.components.PlusButton
 import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
+import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusTextField
@@ -95,6 +102,21 @@ fun EditRecipeBookScreen(bloc: EditRecipeBookBloc, modifier: Modifier = Modifier
             CollaboratorsSection(bloc = bloc, model = model)
         }
     }
+
+    model.removingMember?.let { member ->
+        PlusDialog(
+            title = Res.string.edit_recipe_book_remove_title.asTextData(),
+            message =
+                PhraseModel(
+                    Res.string.edit_recipe_book_remove_message,
+                    "name" to FixedString(member.name?.takeIf { it.isNotBlank() } ?: member.email),
+                ),
+            confirmButtonText = Res.string.edit_recipe_book_remove_confirm.asTextData(),
+            dismissButtonText = Res.string.edit_recipe_book_remove_cancel.asTextData(),
+            onConfirmClick = bloc::onConfirmRemoveMember,
+            onDismissRequest = bloc::onDismissRemoveMember,
+        )
+    }
 }
 
 @Composable
@@ -120,19 +142,19 @@ private fun CollaboratorsSection(bloc: EditRecipeBookBloc, model: EditRecipeBook
             title = Res.string.edit_recipe_book_group_owner,
             members = model.members.filter { it.isOwner || it.role == RecipeBookRole.OWNER },
             canManage = model.canManageCollaborators,
-            onRemove = bloc::onRemoveMember,
+            onRemove = bloc::onRemoveMemberClicked,
         )
         MemberGroup(
             title = Res.string.edit_recipe_book_group_editors,
             members = model.members.filter { !it.isOwner && it.role == RecipeBookRole.EDITOR },
             canManage = model.canManageCollaborators,
-            onRemove = bloc::onRemoveMember,
+            onRemove = bloc::onRemoveMemberClicked,
         )
         MemberGroup(
             title = Res.string.edit_recipe_book_group_viewers,
             members = model.members.filter { !it.isOwner && it.role == RecipeBookRole.VIEWER },
             canManage = model.canManageCollaborators,
-            onRemove = bloc::onRemoveMember,
+            onRemove = bloc::onRemoveMemberClicked,
         )
 
         // Invite controls are owner-only; collaborators just see the list above.

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTest.kt
@@ -10,6 +10,7 @@ import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookCreateBl
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookEditBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookErrorBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookMemberViewBloc
+import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookRemoveConfirmBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookSavingBloc
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
@@ -60,4 +61,11 @@ fun EditRecipeBookCollaboratorsScreenshot() {
 @Composable
 fun EditRecipeBookMemberViewScreenshot() {
     ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookMemberViewBloc) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun EditRecipeBookRemoveConfirmScreenshot() {
+    ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookRemoveConfirmBloc) }
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookRemoveConfirmScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookRemoveConfirmScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05ab052cf0933471cbb998f38d6070ea3cfe7f208945b6a1cebb396ce5fc41a1
+size 104118


### PR DESCRIPTION
**Stacked on #285** (role-grouped headers) — base it against that branch; retarget to `main` once #285 merges.

Removing a collaborator was already owner-only (the ✕ on editor/viewer rows, gated on `canManageCollaborators` and enforced by the RLS `DELETE` policy), but it deleted on the first tap. This adds a **confirmation dialog** so a destructive action isn't a single misfire.

## What changed

- The ✕ now opens a `PlusDialog`: **"Remove collaborator" → "Remove '<name>' from this book? They'll lose access." → Cancel / Remove**.
- Bloc: `onRemoveMember(id)` → `onRemoveMemberClicked(id)` (opens the dialog) + `onConfirmRemoveMember()` / `onDismissRemoveMember()`; model gains `removingMember`.
- Still owner-only and unchanged server-side — no migration.

## Tests & snapshot

- VM unit tests: clicking only opens the dialog (nothing removed); confirm calls the repository and clears the dialog; dismiss removes nothing.
- New `EditRecipeBookRemoveConfirmScreenshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)