### PR TITLE
feat(recipebook): add "All recipes" cross-book view and search

### DIFF
--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
@@ -70,6 +70,7 @@ class RecipeListBlocImpl(
                 isScanFromPhotoEnabled = it.isScanFromPhotoEnabled,
                 recipeBooks = it.recipeBooks,
                 activeBook = it.activeBook,
+                isAllRecipesSelected = it.isAllRecipesSelected,
                 isBookPickerOpen = it.isBookPickerOpen,
                 pendingInvites = it.pendingInvites,
             )
@@ -197,6 +198,10 @@ class RecipeListBlocImpl(
 
     override fun onBookSelected(bookId: Long) {
         viewModel.selectBook(bookId)
+    }
+
+    override fun onAllRecipesSelected() {
+        viewModel.selectAllRecipes()
     }
 
     override fun onCreateBookClicked() {

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
@@ -171,7 +171,10 @@ class RecipeListViewModel(
                 _state.update { state ->
                     state.copy(
                         recipeBooks = books,
-                        activeBook = books.firstOrNull { it.id == activeId } ?: books.firstOrNull(),
+                        // A null active id is the explicit "All recipes" selection — span every
+                        // book rather than falling back to the first one.
+                        activeBook = books.firstOrNull { it.id == activeId },
+                        isAllRecipesSelected = activeId == null,
                     )
                 }
             }
@@ -353,6 +356,11 @@ class RecipeListViewModel(
         scope.launch { recipeBookRepository.setActiveBook(bookId) }
     }
 
+    fun selectAllRecipes() {
+        _state.update { it.copy(isBookPickerOpen = false) }
+        scope.launch { recipeBookRepository.selectAllRecipes() }
+    }
+
     fun enterSelectionMode() {
         _state.update { it.copy(isSelectionMode = true, selectedRecipeIds = emptySet()) }
     }
@@ -405,6 +413,8 @@ class RecipeListViewModel(
         val isScanFromPhotoEnabled: Boolean = false,
         val recipeBooks: List<RecipeBook> = emptyList(),
         val activeBook: RecipeBook? = null,
+        /** True when the cross-book "All recipes" view is active (no single book selected). */
+        val isAllRecipesSelected: Boolean = false,
         val isBookPickerOpen: Boolean = false,
         val pendingInvites: List<RecipeBookInvite> = emptyList(),
     ) {

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
@@ -123,6 +123,8 @@ private fun recipeListBloc(model: RecipeListBloc.Model): RecipeListBloc =
 
         override fun onBookSelected(bookId: Long) = Unit
 
+        override fun onAllRecipesSelected() = Unit
+
         override fun onCreateBookClicked() = Unit
 
         override fun onEditBookClicked(bookId: Long) = Unit
@@ -143,6 +145,34 @@ val previewRecipeListBloc: RecipeListBloc =
             totalRecipeCount = sampleRecipes.size,
             recipeBooks = RecipeBook.Samples,
             activeBook = RecipeBook.Sample,
+        )
+    )
+
+/** "All recipes" cross-book view active — the selector reads "All recipes" with no single book. */
+val previewRecipeListBlocAllRecipes: RecipeListBloc =
+    recipeListBloc(
+        RecipeListBloc.Model(
+            recipes = sampleRecipes,
+            totalRecipeCount = sampleRecipes.size,
+            recipeBooks = RecipeBook.Samples,
+            activeBook = null,
+            isAllRecipesSelected = true,
+        )
+    )
+
+/**
+ * Search inside a single book returned nothing — exercises the empty state's "Search all recipes"
+ * broaden action (offered only when a single book is active).
+ */
+val previewRecipeListBlocSearchEmpty: RecipeListBloc =
+    recipeListBloc(
+        RecipeListBloc.Model(
+            recipes = persistentListOf(),
+            totalRecipeCount = sampleRecipes.size,
+            recipeBooks = RecipeBook.Samples,
+            activeBook = RecipeBook.Sample,
+            searchQuery = "tonkotsu",
+            isSearchActive = true,
         )
     )
 

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListScreen.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListScreen.kt
@@ -101,6 +101,7 @@ import androidx.compose.ui.unit.dp
 import chefmate.client.recipe.list.public.generated.resources.Res
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_add_recipe
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_apply
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_all_recipes
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_create
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_edit
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_picker_title
@@ -150,8 +151,10 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_list_scan_f
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scanning_message
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scanning_title
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_all_recipes
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_clear
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_empty
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_empty_book_hint
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_placeholder
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_count
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_deselect_all
@@ -218,6 +221,11 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
     }
 
     PlusResponsiveContainer { windowSizeClass ->
+        // The selector stands in for the title once any book exists — it names the active book, or
+        // "All recipes" when the cross-book view is active.
+        val showBookSelector = state.recipeBooks.isNotEmpty()
+        val bookSelectorLabel =
+            state.activeBook?.name ?: stringResource(Res.string.recipe_list_book_all_recipes)
         val headerData =
             if (state.isSelectionMode) {
                 PlusHeaderData.Parent(
@@ -267,17 +275,16 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                 )
             } else {
                 PlusHeaderData.Parent(
-                    // The book selector stands in for the title when a book is active, so the
-                    // static
+                    // The book selector stands in for the title when any book exists, so the static
                     // "Recipes" title is suppressed to avoid a cramped double-title in the app bar.
                     title =
-                        if (state.activeBook != null) FixedString("")
+                        if (showBookSelector) FixedString("")
                         else Res.string.recipe_list_title.asTextData(),
                     leading =
-                        state.activeBook?.let { activeBook ->
+                        if (showBookSelector) {
                             {
                                 BookSelector(
-                                    activeBookName = activeBook.name,
+                                    activeBookName = bookSelectorLabel,
                                     isPickerOpen = state.isBookPickerOpen,
                                     onClick = bloc::onBookSelectorClicked,
                                 ) {
@@ -288,14 +295,18 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                                             expanded = state.isBookPickerOpen,
                                             books = state.recipeBooks,
                                             activeBookId = state.activeBook?.id,
+                                            isAllRecipesSelected = state.isAllRecipesSelected,
                                             onDismiss = bloc::onBookPickerDismissed,
                                             onBookSelected = bloc::onBookSelected,
+                                            onAllRecipesSelected = bloc::onAllRecipesSelected,
                                             onEditBook = bloc::onEditBookClicked,
                                             onCreateBook = bloc::onCreateBookClicked,
                                         )
                                     }
                                 }
                             }
+                        } else {
+                            null
                         },
                     trailingAccessory =
                         PlusHeaderData.TrailingAccessory.Custom {
@@ -401,7 +412,11 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                                 )
                             }
                             state.recipes.isEmpty() && state.isSearchActive -> {
-                                SearchEmptyState(modifier = Modifier.fillMaxSize())
+                                SearchEmptyState(
+                                    canSearchAllRecipes = !state.isAllRecipesSelected,
+                                    onSearchAllRecipes = bloc::onAllRecipesSelected,
+                                    modifier = Modifier.fillMaxSize(),
+                                )
                             }
                             state.recipes.isEmpty() && state.totalActiveFilterCount > 0 -> {
                                 FilterEmptyState(
@@ -488,8 +503,10 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                 BookPickerSheet(
                     books = state.recipeBooks,
                     activeBookId = state.activeBook?.id,
+                    isAllRecipesSelected = state.isAllRecipesSelected,
                     onDismiss = bloc::onBookPickerDismissed,
                     onBookSelected = bloc::onBookSelected,
+                    onAllRecipesSelected = bloc::onAllRecipesSelected,
                     onEditBook = bloc::onEditBookClicked,
                     onCreateBook = bloc::onCreateBookClicked,
                 )
@@ -770,12 +787,25 @@ private fun BookPickerDropdown(
     expanded: Boolean,
     books: List<com.plusmobileapps.chefmate.recipebook.data.RecipeBook>,
     activeBookId: Long?,
+    isAllRecipesSelected: Boolean,
     onDismiss: () -> Unit,
     onBookSelected: (Long) -> Unit,
+    onAllRecipesSelected: () -> Unit,
     onEditBook: (Long) -> Unit,
     onCreateBook: () -> Unit,
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        DropdownMenuItem(
+            text = { Text(stringResource(Res.string.recipe_list_book_all_recipes)) },
+            onClick = onAllRecipesSelected,
+            leadingIcon = {
+                if (isAllRecipesSelected) {
+                    Icon(Icons.Default.Check, contentDescription = null)
+                } else {
+                    Spacer(modifier = Modifier.size(24.dp))
+                }
+            },
+        )
         books.forEach { book ->
             DropdownMenuItem(
                 text = { Text(book.name) },
@@ -810,8 +840,10 @@ private fun BookPickerDropdown(
 private fun BookPickerSheet(
     books: List<com.plusmobileapps.chefmate.recipebook.data.RecipeBook>,
     activeBookId: Long?,
+    isAllRecipesSelected: Boolean,
     onDismiss: () -> Unit,
     onBookSelected: (Long) -> Unit,
+    onAllRecipesSelected: () -> Unit,
     onEditBook: (Long) -> Unit,
     onCreateBook: () -> Unit,
 ) {
@@ -823,6 +855,27 @@ private fun BookPickerSheet(
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(ChefMateTheme.dimens.paddingNormal),
             )
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .clickable { onAllRecipesSelected() }
+                        .padding(
+                            horizontal = ChefMateTheme.dimens.paddingNormal,
+                            vertical = ChefMateTheme.dimens.paddingSmall,
+                        ),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector =
+                        if (isAllRecipesSelected) Icons.Default.Check else Icons.Outlined.Circle,
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.width(ChefMateTheme.dimens.paddingNormal))
+                Text(
+                    text = stringResource(Res.string.recipe_list_book_all_recipes),
+                    modifier = Modifier.weight(1f),
+                )
+            }
             books.forEach { book ->
                 Row(
                     modifier =
@@ -1115,9 +1168,13 @@ private fun SearchBar(
 }
 
 @Composable
-private fun SearchEmptyState(modifier: Modifier = Modifier) {
+private fun SearchEmptyState(
+    canSearchAllRecipes: Boolean,
+    onSearchAllRecipes: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().padding(horizontal = 32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -1133,6 +1190,26 @@ private fun SearchEmptyState(modifier: Modifier = Modifier) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(top = 16.dp),
         )
+        // When the search was scoped to a single book, offer to broaden it across every book in
+        // case the match lives elsewhere.
+        if (canSearchAllRecipes) {
+            Text(
+                text = stringResource(Res.string.recipe_list_search_empty_book_hint),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+            Button(onClick = onSearchAllRecipes, modifier = Modifier.padding(top = 16.dp)) {
+                Icon(
+                    Icons.Default.Search,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.size(8.dp))
+                Text(stringResource(Res.string.recipe_list_search_all_recipes))
+            }
+        }
     }
 }
 

--- a/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
+++ b/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
@@ -20,6 +20,7 @@ import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeImageExtractor
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.plusmobileapps.chefmate.recipe.list.RecipeFilterOption
 import com.plusmobileapps.chefmate.recipe.list.RecipeSortOption
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookCollaborationRepository
 import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookRepository
 import com.russhwolf.settings.Settings
@@ -212,6 +213,7 @@ class RecipeListViewModelTest {
         starRating: Int? = null,
         totalTime: Int? = null,
         category: BuiltinCategory? = null,
+        recipeBookIds: Set<Long> = emptySet(),
         createdAt: Instant = Instant.fromEpochSeconds(id * 1000),
     ) =
         Recipe(
@@ -229,6 +231,7 @@ class RecipeListViewModelTest {
             calories = null,
             starRating = starRating,
             isFavorite = isFavorite,
+            recipeBookIds = recipeBookIds,
             categories =
                 category?.let {
                     setOf(Category(id = it.ordinal + 1L, name = it.id, builtinId = it.id))
@@ -431,6 +434,64 @@ class RecipeListViewModelTest {
         viewModel.state.value.displayRecipes shouldBe emptyList()
         viewModel.state.value.isSearchActive shouldBe true
     }
+
+    // region Recipe-book scope / "All recipes"
+
+    /** Books id 1 & 3 from the sample set, with one recipe filed under each. */
+    private fun twoBookViewModel(): RecipeListViewModel {
+        recipes.value =
+            listOf(
+                recipe(1, title = "Carbonara", recipeBookIds = setOf(1L)),
+                recipe(2, title = "Stollen", recipeBookIds = setOf(3L)),
+            )
+        return RecipeListViewModel(
+            mainContext = UnconfinedTestDispatcher(),
+            repository = repository,
+            recipeBookRepository = FakeRecipeBookRepository(MutableStateFlow(RecipeBook.Samples)),
+            collaborationRepository = FakeRecipeBookCollaborationRepository(),
+            categoryRepository = categoryRepository,
+            cookingSessionRepository = cookingSessionRepository,
+            imageExtractor = imageExtractor,
+            pendingPhotoStore = pendingPhotoStore,
+            featureFlags = featureFlags,
+            settings = settings,
+        )
+    }
+
+    @Test
+    fun When_a_book_is_active_Then_only_its_recipes_are_shown() {
+        val vm = twoBookViewModel()
+        // Active book defaults to the first sample book (id 1).
+        vm.state.value.isAllRecipesSelected shouldBe false
+        vm.state.value.activeBook?.id shouldBe 1L
+        vm.state.value.displayRecipes.map { it.id } shouldBe listOf(1L)
+    }
+
+    @Test
+    fun When_select_all_recipes_Then_every_book_is_spanned_and_flag_set() {
+        val vm = twoBookViewModel()
+
+        vm.selectAllRecipes()
+
+        vm.state.value.isAllRecipesSelected shouldBe true
+        vm.state.value.activeBook shouldBe null
+        vm.state.value.displayRecipes.map { it.id }.toSet() shouldBe setOf(1L, 2L)
+    }
+
+    @Test
+    fun When_all_recipes_selected_Then_search_spans_every_book() {
+        val vm = twoBookViewModel()
+        // Scoped to book 1, a search for the book-3 recipe finds nothing.
+        vm.updateSearchQuery("stollen")
+        vm.state.value.displayRecipes shouldBe emptyList()
+
+        vm.selectAllRecipes()
+
+        // The query is retained and now matches across all books.
+        vm.state.value.displayRecipes.map { it.id } shouldBe listOf(2L)
+    }
+
+    // endregion
 
     @Test
     fun When_search_is_case_insensitive_Then_matches_regardless_of_case() {

--- a/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
@@ -15,6 +15,8 @@
     <string name="recipe_list_search_placeholder">Search recipes…</string>
     <string name="recipe_list_search_clear">Clear search</string>
     <string name="recipe_list_search_empty">No recipes match your search</string>
+    <string name="recipe_list_search_empty_book_hint">This search only covers the current book.</string>
+    <string name="recipe_list_search_all_recipes">Search all recipes</string>
 
     <!-- Sort -->
     <string name="recipe_list_sort">Sort</string>
@@ -80,6 +82,7 @@
 
     <!-- Recipe book selector -->
     <string name="recipe_list_book_selector">Switch recipe book</string>
+    <string name="recipe_list_book_all_recipes">All recipes</string>
     <string name="recipe_list_book_create">Create new book</string>
     <string name="recipe_list_book_edit">Edit recipe book</string>
     <string name="recipe_list_book_picker_title">Recipe books</string>

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
@@ -88,6 +88,12 @@ interface RecipeListBloc : BlocScreen {
 
     fun onBookSelected(bookId: Long)
 
+    /**
+     * Selects the cross-book "All recipes" view so the list and search span every recipe book. Also
+     * used by the search-empty state's broaden action.
+     */
+    fun onAllRecipesSelected()
+
     fun onCreateBookClicked()
 
     fun onEditBookClicked(bookId: Long)
@@ -131,6 +137,8 @@ interface RecipeListBloc : BlocScreen {
         val isScanFromPhotoEnabled: Boolean = false,
         val recipeBooks: List<RecipeBook> = emptyList(),
         val activeBook: RecipeBook? = null,
+        /** True when the cross-book "All recipes" view is active (no single book selected). */
+        val isAllRecipesSelected: Boolean = false,
         val isBookPickerOpen: Boolean = false,
         /** Pending recipe-book invites addressed to the current user (the list banner). */
         val pendingInvites: List<RecipeBookInvite> = emptyList(),

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImpl.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImpl.kt
@@ -59,7 +59,12 @@ class RecipeBookRepositoryImpl(
             val defaultId = ensureDefaultBookId()
             val stored = settings.getLong(KEY_ACTIVE_BOOK, NO_ACTIVE_BOOK)
             _activeBookId.value =
-                if (stored != NO_ACTIVE_BOOK && bookExists(stored)) stored else defaultId
+                when {
+                    // The user explicitly picked the cross-book "All recipes" view.
+                    stored == ALL_RECIPES_SELECTED -> null
+                    stored != NO_ACTIVE_BOOK && bookExists(stored) -> stored
+                    else -> defaultId
+                }
         }
         scope.launch {
             authRepository.state.collect { state ->
@@ -84,6 +89,11 @@ class RecipeBookRepositoryImpl(
     override suspend fun setActiveBook(id: Long) {
         settings.putLong(KEY_ACTIVE_BOOK, id)
         _activeBookId.value = id
+    }
+
+    override suspend fun selectAllRecipes() {
+        settings.putLong(KEY_ACTIVE_BOOK, ALL_RECIPES_SELECTED)
+        _activeBookId.value = null
     }
 
     override suspend fun createBook(name: String): RecipeBook {
@@ -363,6 +373,8 @@ class RecipeBookRepositoryImpl(
         const val TAG = "RecipeBookRepositoryImpl"
         const val KEY_ACTIVE_BOOK = "recipe_active_book"
         const val NO_ACTIVE_BOOK = -1L
+        // Sentinel persisted when the user picks the cross-book "All recipes" view.
+        const val ALL_RECIPES_SELECTED = -2L
         const val DEFAULT_BOOK_NAME = "My Recipes"
     }
 }

--- a/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImplTest.kt
+++ b/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImplTest.kt
@@ -147,6 +147,22 @@ class RecipeBookRepositoryImplTest {
         }
 
     @Test
+    fun selectAllRecipes_clears_active_book_and_persists_across_reload() =
+        runTest(testDispatcher) {
+            val repo = repository()
+            val created = repo.createBook("Holiday Baking")
+            repo.setActiveBook(created.id)
+
+            repo.selectAllRecipes()
+
+            // "All recipes" is modelled as a null active id spanning every book.
+            repo.activeBookId.value shouldBe null
+            // A fresh repository reading the same settings restores the "All recipes" selection
+            // rather than falling back to the default book.
+            repository().activeBookId.value shouldBe null
+        }
+
+    @Test
     fun pull_skips_books_with_only_a_pending_invite() =
         runTest(testDispatcher) {
             fakeAuth.setAuthenticated()

--- a/client/recipebook/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/RecipeBookRepository.kt
+++ b/client/recipebook/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/RecipeBookRepository.kt
@@ -11,7 +11,12 @@ interface RecipeBookRepository {
     /**
      * The local id of the currently active book — the one whose recipes the list shows and that new
      * recipes are filed under. Backed by persisted settings; resolves to the default book when the
-     * user hasn't picked one yet. Null only before the default book has been created.
+     * user hasn't picked one yet.
+     *
+     * Null carries two meanings that callers disambiguate by lifecycle: it is the transient value
+     * before the default book has been created, and — once [selectAllRecipes] has been chosen — the
+     * persisted "All recipes" selection that spans every book. New recipes still file under the
+     * default book while "All recipes" is active.
      */
     val activeBookId: StateFlow<Long?>
 
@@ -19,6 +24,12 @@ interface RecipeBookRepository {
     suspend fun getDefaultBookId(): Long
 
     suspend fun setActiveBook(id: Long)
+
+    /**
+     * Selects the cross-book "All recipes" view: clears the active book so the list shows recipes
+     * from every book and search spans all of them. Persisted like [setActiveBook].
+     */
+    suspend fun selectAllRecipes()
 
     suspend fun createBook(name: String): RecipeBook
 

--- a/client/recipebook/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/testing/FakeRecipeBookRepository.kt
+++ b/client/recipebook/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/testing/FakeRecipeBookRepository.kt
@@ -35,6 +35,10 @@ class FakeRecipeBookRepository(
         _activeBookId.value = id
     }
 
+    override suspend fun selectAllRecipes() {
+        _activeBookId.value = null
+    }
+
     override suspend fun createBook(name: String): RecipeBook {
         val book =
             RecipeBook(

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTest.kt
@@ -10,10 +10,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.android.tools.screenshot.PreviewTest
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBloc
+import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocAllRecipes
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocCooking
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocPendingInvite
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocScanError
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocScanning
+import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocSearchEmpty
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocSelectionMode
 import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBlocSelectionModeEmpty
 import com.plusmobileapps.chefmate.ui.Content
@@ -45,6 +47,29 @@ fun RecipeListPhonePortraitLightScreenshot() {
 @Composable
 fun RecipeListPhonePortraitDarkScreenshot() {
     RecipeListScreenshot(bloc = previewRecipeListBloc, darkTheme = true)
+}
+
+// ── "All recipes" cross-book selector + search-empty broaden action ────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun RecipeListAllRecipesLightScreenshot() {
+    RecipeListScreenshot(bloc = previewRecipeListBlocAllRecipes)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun RecipeListSearchEmptyLightScreenshot() {
+    RecipeListScreenshot(bloc = previewRecipeListBlocSearchEmpty)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun RecipeListSearchEmptyDarkScreenshot() {
+    RecipeListScreenshot(bloc = previewRecipeListBlocSearchEmpty, darkTheme = true)
 }
 
 // ── Cooking-session FAB stack — regression coverage for #150 ───────────────

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListAllRecipesLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListAllRecipesLightScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:336055f033c402836a3dff6431b3534f5ebfb996f91b8e964b43293984eb34df
+size 110220

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSearchEmptyDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSearchEmptyDarkScreenshot_805fa67c_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3632115ccefbc0db9f2dbde687c8c3180cbef948279165c664191f6440d7633
+size 54565

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSearchEmptyLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSearchEmptyLightScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd41cf863a15fc8a684d669bf1789cbd87e7041f907d0ceb1b7604cfeb8a3f18
+size 54171


### PR DESCRIPTION
## Overview

Adds an **"All recipes"** option to the recipe-book selector so the list and search span every recipe book instead of being scoped to one. When a search inside a single book returns nothing, the empty state now offers a **"Search all recipes"** action to retry the same query across all books.

## How it works

"All recipes" is modelled as a **null active book** in `RecipeBookRepository` — the list's `observeRecipes` already queried across all books when the active id was null; that path is now intentional and persisted. A dedicated `ALL_RECIPES_SELECTED` settings sentinel is restored on reload rather than falling back to the default book. New recipes still file under the default book while the cross-book view is active.

## What changed

**Data layer**
- `RecipeBookRepository.selectAllRecipes()` (interface + impl + fake).
- Impl persists/restores the "All recipes" selection via a sentinel.

**BLoC / ViewModel**
- New `isAllRecipesSelected` state (true when no single book is active) and an `onAllRecipesSelected()` handler.

**UI (`RecipeListScreen`)**
- Selector now renders whenever books exist, labeled **"All recipes"** for the cross-book view.
- Both the anchored dropdown (tablet/desktop) and the bottom sheet (phone) get an "All recipes" row at the top, checked when active.
- The single-book search-empty state shows a hint + **"Search all recipes"** button that switches to the cross-book view while preserving the query.

## Tests & snapshots

- Repository test: `selectAllRecipes` clears the active book and persists across reload.
- ViewModel tests: single-book scoping, cross-book spanning, and search spanning every book after switching.
- New screenshot references (visually inspected): cross-book "All recipes" view, and search-empty light/dark with the broaden button.

## Reviewer notes

- The dual meaning of a null `activeBookId` (transient pre-init vs. explicit "All recipes") is documented on the interface. Existing ViewModel tests use empty book lists, so they continue to exercise the all-books query path unchanged.