### PR TITLE
refactor: address PR #235 review feedback (#295)

### DIFF
--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/detail/GroceryDetailBlocImpl.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/detail/GroceryDetailBlocImpl.kt
@@ -10,7 +10,6 @@ import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc.Output
 import com.plusmobileapps.chefmate.grocery.core.impl.detail.ui.GroceryDetailSheetContent
 import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
-import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
@@ -27,14 +26,12 @@ class GroceryDetailBlocImpl(
     @Assisted context: BlocContext,
     @Assisted id: Long,
     @Assisted private val output: Consumer<Output>,
-    repository: GroceryRepository,
+    viewModelFactory: GroceryDetailViewModel.Factory,
 ) : GroceryDetailBloc, BlocContext by context {
 
     private val scope = createScope()
 
-    private val viewModel = instanceKeeper.getViewModel {
-        GroceryDetailViewModel(id = id, mainContext = mainContext, repository = repository)
-    }
+    private val viewModel = instanceKeeper.getViewModel { viewModelFactory.create(id) }
 
     override val models: StateFlow<GroceryDetailBloc.Model> =
         viewModel.state.mapState {

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/detail/GroceryDetailViewModel.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/detail/GroceryDetailViewModel.kt
@@ -1,9 +1,13 @@
 package com.plusmobileapps.chefmate.grocery.core.impl.detail
 
 import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
 import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -13,9 +17,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
+@AssistedInject
 class GroceryDetailViewModel(
-    id: Long,
-    mainContext: CoroutineContext,
+    @Assisted id: Long,
+    @Main mainContext: CoroutineContext,
     private val repository: GroceryRepository,
 ) : ViewModel(mainContext) {
     private val _state = MutableStateFlow(State())
@@ -86,5 +91,10 @@ class GroceryDetailViewModel(
 
     sealed class Output {
         data object Finished : Output()
+    }
+
+    @AssistedFactory
+    fun interface Factory {
+        fun create(id: Long): GroceryDetailViewModel
     }
 }

--- a/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/detail/GroceryDetailBlocTest.kt
+++ b/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/detail/GroceryDetailBlocTest.kt
@@ -20,16 +20,23 @@ import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
 class GroceryDetailBlocTest {
+    val context = TestBlocContext.create()
     val groceryItem = GroceryItem(id = 1L, name = "Milk", isChecked = false)
     val repository: GroceryRepository = mock { everySuspend { getGrocery(1L) } returns groceryItem }
     val testConsumer = TestConsumer<GroceryDetailBloc.Output>()
 
     val bloc =
         GroceryDetailBlocImpl(
-            context = TestBlocContext.create(),
+            context = context,
             id = 1L,
             output = testConsumer,
-            repository = repository,
+            viewModelFactory = { id ->
+                GroceryDetailViewModel(
+                    id = id,
+                    mainContext = context.mainContext,
+                    repository = repository,
+                )
+            },
         )
 
     @Test

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/ui/RecipeDetailScreen.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/ui/RecipeDetailScreen.kt
@@ -153,6 +153,7 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
+import com.plusmobileapps.chefmate.letIfTrue
 import com.plusmobileapps.chefmate.recipe.categories.pickerLabelRes
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailTestTags
@@ -407,7 +408,7 @@ private fun RecipeDetailBody(
                 scrollEnabled = false,
                 maxContentWidth = if (isCompact) 600.dp else Dp.Unspecified,
                 floatingToolbar =
-                    if (showToolbar) {
+                    letIfTrue(showToolbar) {
                         {
                             HorizontalFloatingToolbar(
                                 expanded = true,
@@ -462,8 +463,6 @@ private fun RecipeDetailBody(
                                 }
                             }
                         }
-                    } else {
-                        null
                     },
             ) {
                 if (state.isLoading) {

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListScreen.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListScreen.kt
@@ -174,6 +174,7 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_list_view_l
 import chefmate.client.recipe.list.public.generated.resources.recipe_sync_not_synced
 import chefmate.client.recipe.list.public.generated.resources.recipe_sync_synced
 import chefmate.client.recipe.list.public.generated.resources.recipe_sync_syncing
+import com.plusmobileapps.chefmate.letIfTrue
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.SyncStatus
 import com.plusmobileapps.chefmate.recipe.list.RecipeFilterOption
@@ -281,7 +282,7 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                         if (showBookSelector) FixedString("")
                         else Res.string.recipe_list_title.asTextData(),
                     leading =
-                        if (showBookSelector) {
+                        letIfTrue(showBookSelector) {
                             {
                                 BookSelector(
                                     activeBookName = bookSelectorLabel,
@@ -305,8 +306,6 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                                     }
                                 }
                             }
-                        } else {
-                            null
                         },
                     trailingAccessory =
                         PlusHeaderData.TrailingAccessory.Custom {

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/LetIfTrue.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/LetIfTrue.kt
@@ -1,0 +1,14 @@
+package com.plusmobileapps.chefmate
+
+/**
+ * Returns the result of [block] when [condition] is `true`, or `null` otherwise.
+ *
+ * Handy for conditionally supplying an optional value — such as a nullable trailing-content
+ * composable — without the noisy `if (condition) { … } else null` idiom:
+ * ```kotlin
+ * trailingContent = letIfTrue(canRemove) {
+ *     { IconButton(onClick = onRemove) { /* … */ } }
+ * }
+ * ```
+ */
+inline fun <T> letIfTrue(condition: Boolean, block: () -> T): T? = if (condition) block() else null


### PR DESCRIPTION
Addresses the review follow-ups tracked in #295. The grocery `edit` screen was renamed to `detail` before #235 merged, so each item is mapped onto the merged code.

### 1. Shared `letIfTrue` helper
Added `letIfTrue(condition) { … }` in `client/shared` to replace the noisy `if (cond) { { … } } else null` trailing-content idiom. The original call site was rewritten away during the merge, but the same idiom was live in three screens, all now converted:
- `GroceryListScreen` — `trailingContent`
- `RecipeDetailScreen` — `floatingToolbar`
- `RecipeListScreen` — `leading`

### 2. Inject the Detail ViewModel factory
`GroceryDetailViewModel` is now `@AssistedInject` with an `@AssistedFactory` taking the assisted item id. `GroceryDetailBlocImpl` injects that factory instead of constructing the ViewModel by hand with `GroceryRepository` — matching the `AddRecipeToGroceryListBlocImpl` pattern. The bloc unit test supplies the factory.

### 3. Use the imported `flowOf`
Already resolved on `main` — `GroceryListBlocTest` no longer has any fully-qualified `kotlinx.coroutines.flow.flowOf` call. No change needed.

## Testing
- `:client:grocery:core:impl:jvmTest` passes
- `:client:composeApp:compileKotlinJvm` compiles (validates the Metro assisted-factory DI wiring)
- Recipe modules compile; changed files are ktfmt-clean

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)