### PR TITLE
fix(grocery): autocomplete item entry

### DIFF
--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/GroceryListAutocompleteUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/GroceryListAutocompleteUiTest.kt
@@ -1,0 +1,22 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package com.plusmobileapps.chefmate.tests
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.plusmobileapps.chefmate.grocery.core.robots.groceryList
+import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.recipe.bottomnav.robots.bottomNav
+import kotlin.test.Test
+
+class GroceryListAutocompleteUiTest {
+
+    @Test
+    fun selecting_autocomplete_suggestion_fills_item_input() = runRootBlocTest {
+        bottomNav().clickGroceriesTab()
+
+        groceryList()
+            .enterItemNamePrefix("stra")
+            .clickItemSuggestion("Strawberries")
+            .assertItemInputText("Strawberries")
+    }
+}

--- a/client/grocery/core/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/robots/GroceryListRobot.kt
+++ b/client/grocery/core/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/robots/GroceryListRobot.kt
@@ -5,12 +5,14 @@ package com.plusmobileapps.chefmate.grocery.core.robots
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailTestTags
@@ -42,6 +44,24 @@ class GroceryListRobot(private val test: ComposeUiTest) {
 
     fun assertAisleSelected(label: String): GroceryListRobot = apply {
         test.onNode(hasText(label) and inDetailSheet).assertIsDisplayed()
+    }
+
+    fun enterItemNamePrefix(prefix: String): GroceryListRobot = apply {
+        test
+            .onNode(hasTestTag(GroceryListTestTags.ITEM_INPUT) and onScreen)
+            .assertIsDisplayed()
+            .performClick()
+            .performTextInput(prefix)
+    }
+
+    fun clickItemSuggestion(suggestion: String): GroceryListRobot = apply {
+        val matcher = hasTestTag(GroceryListTestTags.ITEM_SUGGESTION) and hasText(suggestion)
+        test.waitUntilExactlyOneExists(matcher)
+        test.onNode(matcher).assertIsDisplayed().performClick()
+    }
+
+    fun assertItemInputText(text: String): GroceryListRobot = apply {
+        test.onNode(hasTestTag(GroceryListTestTags.ITEM_INPUT) and onScreen).assertTextEquals(text)
     }
 
     /** Opens the list selector (bottom sheet on phones, dropdown on tablets). */

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
@@ -71,6 +71,7 @@ class GroceryListBlocImpl(
                 filter = it.filter,
                 recipeFilter = it.recipeFilter,
                 availableRecipes = it.availableRecipes.toImmutableList(),
+                autocompleteSuggestions = it.autocompleteSuggestions.toImmutableList(),
                 hasNoRecipeItems = it.hasNoRecipeItems,
                 isSyncing = it.isSyncing,
                 lists = it.lists.toImmutableList(),

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
@@ -12,6 +12,7 @@ import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.GroceryListInvite
 import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
 import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
+import com.plusmobileapps.chefmate.grocery.data.IngredientParser
 import com.plusmobileapps.chefmate.grocery.data.ListRole
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.string
@@ -86,9 +87,12 @@ class GroceryListViewModel(
                     _filter,
                     _sort,
                     _recipeFilter,
-                ) { items, filter, sort, recipeFilter ->
+                    _newGroceryItemName,
+                ) { items, filter, sort, recipeFilter, newGroceryItemName ->
                     val availableRecipes = items.mapNotNull { it.recipeName }.distinct().sorted()
                     val hasNoRecipeItems = items.any { it.recipeName == null }
+                    val autocompleteSuggestions =
+                        buildAutocompleteSuggestions(query = newGroceryItemName, items = items)
                     val filtered =
                         when (filter) {
                             GroceryFilter.ALL -> items
@@ -131,14 +135,20 @@ class GroceryListViewModel(
                                     )
                                     .filter { it.items.isNotEmpty() }
                         }
-                    Triple(grouped, availableRecipes, hasNoRecipeItems)
+                    GroceryListContent(
+                        groupedItems = grouped,
+                        availableRecipes = availableRecipes,
+                        autocompleteSuggestions = autocompleteSuggestions,
+                        hasNoRecipeItems = hasNoRecipeItems,
+                    )
                 }
-                .collect { (grouped, availableRecipes, hasNoRecipeItems) ->
+                .collect { content ->
                     _state.update {
                         it.copy(
-                            groupedItems = grouped,
-                            availableRecipes = availableRecipes,
-                            hasNoRecipeItems = hasNoRecipeItems,
+                            groupedItems = content.groupedItems,
+                            availableRecipes = content.availableRecipes,
+                            autocompleteSuggestions = content.autocompleteSuggestions,
+                            hasNoRecipeItems = content.hasNoRecipeItems,
                         )
                     }
                 }
@@ -305,6 +315,7 @@ class GroceryListViewModel(
         val filter: GroceryFilter = GroceryFilter.ALL,
         val recipeFilter: String? = null,
         val availableRecipes: List<String> = emptyList(),
+        val autocompleteSuggestions: List<String> = emptyList(),
         val hasNoRecipeItems: Boolean = false,
         val isSyncing: Boolean = false,
         val lists: List<GroceryListModel> = emptyList(),
@@ -316,8 +327,39 @@ class GroceryListViewModel(
         val currentUserRole: ListRole = ListRole.OWNER,
     )
 
+    private data class GroceryListContent(
+        val groupedItems: List<GroceryGroup>,
+        val availableRecipes: List<String>,
+        val autocompleteSuggestions: List<String>,
+        val hasNoRecipeItems: Boolean,
+    )
+
     companion object {
         private const val KEY_SORT = "grocery_list_sort"
         private const val KEY_FILTER = "grocery_list_filter"
+        private const val MAX_AUTOCOMPLETE_SUGGESTIONS = 6
+
+        private fun buildAutocompleteSuggestions(
+            query: String,
+            items: List<GroceryItem>,
+        ): List<String> {
+            val normalizedQuery = IngredientParser.parse(query).name.trim().lowercase()
+            if (normalizedQuery.isBlank()) return emptyList()
+
+            val existingItemSuggestions =
+                items
+                    .asSequence()
+                    .map { it.displayName.trim() }
+                    .filter { it.isNotBlank() }
+                    .distinctBy { it.lowercase() }
+                    .filter { it.lowercase().startsWith(normalizedQuery) }
+
+            return (existingItemSuggestions +
+                    IngredientParser.suggestedNamesFor(query).asSequence())
+                .distinctBy { it.lowercase() }
+                .filter { it.lowercase() != normalizedQuery }
+                .take(MAX_AUTOCOMPLETE_SUGGESTIONS)
+                .toList()
+        }
     }
 }

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListPreviews.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListPreviews.kt
@@ -161,6 +161,20 @@ val previewGroceryListBlocFilteredEmpty: GroceryListBloc =
         )
     )
 
+/** Grocery list with autocomplete suggestions visible for screenshot coverage. */
+val previewGroceryListBlocAutocomplete: GroceryListBloc =
+    groceryListBloc(
+        model =
+            GroceryListBloc.Model(
+                groupedItems = sampleGroups,
+                autocompleteSuggestions =
+                    persistentListOf("Strawberries", "Strawberry jam", "Strawberry yogurt"),
+                lists = persistentListOf(sampleList),
+                selectedList = sampleList,
+            ),
+        pendingInput = "stra",
+    )
+
 @Preview(showBackground = true, heightDp = 1100)
 @Composable
 internal fun GroceryListPreview() {
@@ -177,4 +191,15 @@ internal fun GroceryListEmptyPreview() {
 @Composable
 internal fun GroceryListFilteredEmptyPreview() {
     ChefMateTheme { GroceryListScreen(bloc = previewGroceryListBlocFilteredEmpty) }
+}
+
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+internal fun GroceryListAutocompletePreview() {
+    ChefMateTheme {
+        GroceryListScreen(
+            bloc = previewGroceryListBlocAutocomplete,
+            forceShowAutocompleteSuggestions = true,
+        )
+    }
 }

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
@@ -46,7 +46,10 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -330,6 +333,7 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
                 if (state.currentUserRole != ListRole.VIEWER) {
                     GroceryListInput(
                         name = bloc.newGroceryItemName,
+                        suggestions = state.autocompleteSuggestions,
                         onNameChange = bloc::onNewGroceryItemNameChange,
                         onAddClick = bloc::saveGroceryItem,
                     )
@@ -766,9 +770,11 @@ private fun DeleteItemsDialog(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun GroceryListInput(
     name: StateFlow<String>,
+    suggestions: List<String>,
     onNameChange: (String) -> Unit,
     onAddClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -778,35 +784,55 @@ private fun GroceryListInput(
     val focusManager = LocalFocusManager.current
     val isIos = isIosPlatform()
     var isFocused by remember { mutableStateOf(false) }
+    val expanded = isFocused && suggestions.isNotEmpty()
 
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
-        OutlinedTextField(
-            value = state.value,
-            onValueChange = onNameChange,
-            modifier = Modifier.weight(1f).onFocusChanged { isFocused = it.isFocused },
-            singleLine = true,
-            placeholder = { Text(stringResource(Res.string.grocery_add_item_hint)) },
-            keyboardOptions =
-                KeyboardOptions(
-                    capitalization = KeyboardCapitalization.Sentences,
-                    imeAction = ImeAction.Done,
-                ),
-            keyboardActions =
-                KeyboardActions(
-                    onDone = {
-                        if (state.value.isNotBlank()) onAddClick()
-                        keyboardController?.hide()
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = {},
+            modifier = Modifier.weight(1f),
+        ) {
+            OutlinedTextField(
+                value = state.value,
+                onValueChange = onNameChange,
+                modifier =
+                    Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
+                        .fillMaxWidth()
+                        .onFocusChanged { isFocused = it.isFocused }
+                        .testTag(GroceryListTestTags.ITEM_INPUT),
+                singleLine = true,
+                placeholder = { Text(stringResource(Res.string.grocery_add_item_hint)) },
+                keyboardOptions =
+                    KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Sentences,
+                        imeAction = ImeAction.Done,
+                    ),
+                keyboardActions =
+                    KeyboardActions(
+                        onDone = {
+                            if (state.value.isNotBlank()) onAddClick()
+                            keyboardController?.hide()
+                        }
+                    ),
+                trailingIcon = {
+                    IconButton(onClick = onAddClick, enabled = state.value.isNotBlank()) {
+                        Icon(
+                            Icons.Default.Add,
+                            contentDescription = stringResource(Res.string.grocery_add_item),
+                        )
                     }
-                ),
-            trailingIcon = {
-                IconButton(onClick = onAddClick, enabled = state.value.isNotBlank()) {
-                    Icon(
-                        Icons.Default.Add,
-                        contentDescription = stringResource(Res.string.grocery_add_item),
+                },
+            )
+            ExposedDropdownMenu(expanded = expanded, onDismissRequest = {}) {
+                suggestions.forEach { suggestion ->
+                    DropdownMenuItem(
+                        text = { Text(suggestion) },
+                        onClick = { onNameChange(suggestion) },
+                        modifier = Modifier.testTag(GroceryListTestTags.ITEM_SUGGESTION),
                     )
                 }
-            },
-        )
+            }
+        }
         AnimatedVisibility(
             visible = isIos && isFocused,
             enter = fadeIn() + expandHorizontally(),

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -161,7 +162,11 @@ import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
+fun GroceryListScreen(
+    bloc: GroceryListBloc,
+    modifier: Modifier = Modifier,
+    forceShowAutocompleteSuggestions: Boolean = false,
+) {
     val state by bloc.state.collectAsState()
     var showSortFilterSheet by remember { mutableStateOf(false) }
     val hasActiveFilter = state.filter != GroceryListBloc.GroceryFilter.ALL
@@ -336,6 +341,7 @@ fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
                         suggestions = state.autocompleteSuggestions,
                         onNameChange = bloc::onNewGroceryItemNameChange,
                         onAddClick = bloc::saveGroceryItem,
+                        forceShowSuggestions = forceShowAutocompleteSuggestions,
                     )
                 }
             },
@@ -778,58 +784,49 @@ private fun GroceryListInput(
     onNameChange: (String) -> Unit,
     onAddClick: () -> Unit,
     modifier: Modifier = Modifier,
+    forceShowSuggestions: Boolean = false,
 ) {
     val state = name.collectAsState()
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
     val isIos = isIosPlatform()
     var isFocused by remember { mutableStateOf(false) }
-    val expanded = isFocused && suggestions.isNotEmpty()
+    val expanded = (isFocused || forceShowSuggestions) && suggestions.isNotEmpty()
 
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
-        ExposedDropdownMenuBox(
-            expanded = expanded,
-            onExpandedChange = {},
-            modifier = Modifier.weight(1f),
-        ) {
-            OutlinedTextField(
-                value = state.value,
-                onValueChange = onNameChange,
-                modifier =
-                    Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
-                        .fillMaxWidth()
-                        .onFocusChanged { isFocused = it.isFocused }
-                        .testTag(GroceryListTestTags.ITEM_INPUT),
-                singleLine = true,
-                placeholder = { Text(stringResource(Res.string.grocery_add_item_hint)) },
-                keyboardOptions =
-                    KeyboardOptions(
-                        capitalization = KeyboardCapitalization.Sentences,
-                        imeAction = ImeAction.Done,
-                    ),
-                keyboardActions =
-                    KeyboardActions(
-                        onDone = {
-                            if (state.value.isNotBlank()) onAddClick()
-                            keyboardController?.hide()
-                        }
-                    ),
-                trailingIcon = {
-                    IconButton(onClick = onAddClick, enabled = state.value.isNotBlank()) {
-                        Icon(
-                            Icons.Default.Add,
-                            contentDescription = stringResource(Res.string.grocery_add_item),
+        if (forceShowSuggestions && suggestions.isNotEmpty()) {
+            Column(modifier = Modifier.weight(1f)) {
+                AutocompleteSuggestionRows(suggestions = suggestions, onNameChange = onNameChange)
+                GroceryItemNameTextField(
+                    value = state.value,
+                    onValueChange = onNameChange,
+                    onFocusChanged = { isFocused = it },
+                    onAddClick = onAddClick,
+                    keyboardController = keyboardController,
+                )
+            }
+        } else {
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = {},
+                modifier = Modifier.weight(1f),
+            ) {
+                GroceryItemNameTextField(
+                    value = state.value,
+                    onValueChange = onNameChange,
+                    onFocusChanged = { isFocused = it },
+                    onAddClick = onAddClick,
+                    keyboardController = keyboardController,
+                    modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable),
+                )
+                ExposedDropdownMenu(expanded = expanded, onDismissRequest = {}) {
+                    suggestions.forEach { suggestion ->
+                        DropdownMenuItem(
+                            text = { Text(suggestion) },
+                            onClick = { onNameChange(suggestion) },
+                            modifier = Modifier.testTag(GroceryListTestTags.ITEM_SUGGESTION),
                         )
                     }
-                },
-            )
-            ExposedDropdownMenu(expanded = expanded, onDismissRequest = {}) {
-                suggestions.forEach { suggestion ->
-                    DropdownMenuItem(
-                        text = { Text(suggestion) },
-                        onClick = { onNameChange(suggestion) },
-                        modifier = Modifier.testTag(GroceryListTestTags.ITEM_SUGGESTION),
-                    )
                 }
             }
         }
@@ -848,6 +845,69 @@ private fun GroceryListInput(
             }
         }
     }
+}
+
+@Composable
+private fun AutocompleteSuggestionRows(suggestions: List<String>, onNameChange: (String) -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraSmall,
+        shadowElevation = ChefMateTheme.dimens.paddingExtraSmall,
+        tonalElevation = ChefMateTheme.dimens.paddingExtraSmall,
+    ) {
+        Column {
+            suggestions.forEach { suggestion ->
+                ListItem(
+                    headlineContent = { Text(suggestion) },
+                    modifier =
+                        Modifier.clickable { onNameChange(suggestion) }
+                            .testTag(GroceryListTestTags.ITEM_SUGGESTION),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroceryItemNameTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onFocusChanged: (Boolean) -> Unit,
+    onAddClick: () -> Unit,
+    keyboardController: androidx.compose.ui.platform.SoftwareKeyboardController?,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .onFocusChanged { onFocusChanged(it.isFocused) }
+                .testTag(GroceryListTestTags.ITEM_INPUT),
+        singleLine = true,
+        placeholder = { Text(stringResource(Res.string.grocery_add_item_hint)) },
+        keyboardOptions =
+            KeyboardOptions(
+                capitalization = KeyboardCapitalization.Sentences,
+                imeAction = ImeAction.Done,
+            ),
+        keyboardActions =
+            KeyboardActions(
+                onDone = {
+                    if (value.isNotBlank()) onAddClick()
+                    keyboardController?.hide()
+                }
+            ),
+        trailingIcon = {
+            IconButton(onClick = onAddClick, enabled = value.isNotBlank()) {
+                Icon(
+                    Icons.Default.Add,
+                    contentDescription = stringResource(Res.string.grocery_add_item),
+                )
+            }
+        },
+    )
 }
 
 @Composable

--- a/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
+++ b/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
@@ -312,6 +312,61 @@ class GroceryListBlocTest {
     }
 
     @Test
+    fun When_item_name_entered_Then_autocomplete_suggestions_include_matching_items() = runTest {
+        bloc.state.test {
+            awaitItem() shouldBe GroceryListBloc.Model()
+            groceries.emit(
+                listOf(
+                    GroceryItem(
+                        id = 1,
+                        name = "Milk chocolate",
+                        displayName = "Milk chocolate",
+                        category = GroceryCategory.BAKING,
+                    ),
+                    GroceryItem(
+                        id = 2,
+                        name = "Spinach",
+                        displayName = "Spinach",
+                        category = GroceryCategory.PRODUCE,
+                    ),
+                )
+            )
+            awaitItem().autocompleteSuggestions shouldBe emptyList()
+
+            bloc.onNewGroceryItemNameChange("mi")
+
+            val result = awaitItem()
+            result.autocompleteSuggestions.take(2) shouldBe listOf("Milk chocolate", "Microgreen")
+        }
+    }
+
+    @Test
+    fun When_item_name_matches_suggestion_exactly_Then_exact_suggestion_is_hidden() = runTest {
+        bloc.state.test {
+            awaitItem() shouldBe GroceryListBloc.Model()
+            groceries.emit(
+                listOf(
+                    GroceryItem(
+                        id = 1,
+                        name = "Eggs",
+                        displayName = "Eggs",
+                        category = GroceryCategory.DAIRY,
+                    )
+                )
+            )
+            awaitItem()
+
+            bloc.onNewGroceryItemNameChange("sal")
+            awaitItem().autocompleteSuggestions shouldBe
+                listOf("Salami", "Salmon", "Salad", "Salsa", "Salt")
+
+            bloc.onNewGroceryItemNameChange("salt")
+
+            awaitItem().autocompleteSuggestions shouldBe emptyList()
+        }
+    }
+
+    @Test
     fun When_clear_filters_applied_Then_recipe_filter_is_also_cleared() = runTest {
         val items =
             listOf(

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
@@ -89,6 +89,7 @@ interface GroceryListBloc : BlocScreen {
         val filter: GroceryFilter = GroceryFilter.ALL,
         val recipeFilter: String? = null,
         val availableRecipes: ImmutableList<String> = persistentListOf(),
+        val autocompleteSuggestions: ImmutableList<String> = persistentListOf(),
         val hasNoRecipeItems: Boolean = false,
         val isSyncing: Boolean = false,
         val lists: ImmutableList<GroceryListModel> = persistentListOf(),

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListTestTags.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListTestTags.kt
@@ -7,4 +7,6 @@ object GroceryListTestTags {
     const val CLEAR_FILTERS_BUTTON = "grocery_list_clear_filters_button"
     const val BROWSE_RECIPES_BUTTON = "grocery_list_browse_recipes_button"
     const val LIST_SELECTOR = "grocery_list_selector_title"
+    const val ITEM_INPUT = "grocery_list_item_input"
+    const val ITEM_SUGGESTION = "grocery_list_item_suggestion"
 }

--- a/client/grocery/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/IngredientParser.kt
+++ b/client/grocery/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/IngredientParser.kt
@@ -35,7 +35,27 @@ object IngredientParser {
         return ParsedIngredient(name = name, quantity = quantity, category = category)
     }
 
+    fun suggestedNamesFor(
+        query: String,
+        maxSuggestions: Int = DEFAULT_MAX_SUGGESTIONS,
+    ): List<String> {
+        val normalizedQuery = parse(query).name.trim().lowercase()
+        if (normalizedQuery.isBlank()) return emptyList()
+
+        return CATEGORY_MAP.asSequence()
+            .map { it.first }
+            .distinct()
+            .filter { it.lowercase().startsWith(normalizedQuery) }
+            .take(maxSuggestions)
+            .map { it.toSuggestionDisplayName() }
+            .toList()
+    }
+
     private val PARENTHETICAL_PATTERN = Regex("""\s*\([^)]*\)""")
+
+    private fun String.toSuggestionDisplayName(): String =
+        SUGGESTION_DISPLAY_NAMES[this]
+            ?: replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
 
     private fun categorize(name: String): GroceryCategory {
         val lower = name.lowercase().replace(PARENTHETICAL_PATTERN, "").trim()
@@ -587,4 +607,16 @@ object IngredientParser {
                 "zaatar" to GroceryCategory.SPICES,
             )
             .sortedByDescending { it.first.length }
+
+    private const val DEFAULT_MAX_SUGGESTIONS = 6
+
+    private val SUGGESTION_DISPLAY_NAMES =
+        mapOf(
+            "strawberr" to "Strawberries",
+            "blueberr" to "Blueberries",
+            "raspberr" to "Raspberries",
+            "blackberr" to "Blackberries",
+            "cranberr" to "Cranberries",
+            "cherr" to "Cherries",
+        )
 }

--- a/client/grocery/data/public/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/data/IngredientParserTest.kt
+++ b/client/grocery/data/public/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/data/IngredientParserTest.kt
@@ -33,6 +33,20 @@ class IngredientParserTest {
     }
 
     @Test
+    fun suggestions_return_ingredient_names_that_start_with_query() {
+        val suggestions = IngredientParser.suggestedNamesFor("stra")
+
+        assertEquals(listOf("Strawberries"), suggestions)
+    }
+
+    @Test
+    fun suggestions_use_ingredient_name_when_query_includes_quantity() {
+        val suggestions = IngredientParser.suggestedNamesFor("2 lb ground")
+
+        assertEquals(listOf("Ground turkey", "Ground beef"), suggestions)
+    }
+
+    @Test
     fun parse_large_quantity_modifier() {
         val result = IngredientParser.parse("3 large eggs")
         assertEquals("eggs", result.name)

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTest.kt
@@ -8,7 +8,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.GroceryListScreen
 import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBloc
+import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBlocAutocomplete
 import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBlocEmpty
 import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBlocFilteredEmpty
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
@@ -22,6 +24,18 @@ private fun GroceryListScreenshot(bloc: GroceryListBloc, darkTheme: Boolean = fa
     ChefMateTheme(darkTheme = darkTheme) {
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
             bloc.Content()
+        }
+    }
+}
+
+@Composable
+private fun GroceryListAutocompleteScreenshot(darkTheme: Boolean = false) {
+    ChefMateTheme(darkTheme = darkTheme) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            GroceryListScreen(
+                bloc = previewGroceryListBlocAutocomplete,
+                forceShowAutocompleteSuggestions = true,
+            )
         }
     }
 }
@@ -40,6 +54,13 @@ fun GroceryListPhonePortraitLightScreenshot() {
 @Composable
 fun GroceryListPhonePortraitDarkScreenshot() {
     GroceryListScreenshot(bloc = previewGroceryListBloc, darkTheme = true)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun GroceryListAutocompletePhonePortraitLightScreenshot() {
+    GroceryListAutocompleteScreenshot()
 }
 
 // ── Empty state — regression coverage for the "Browse my recipes" CTA ──────

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListAutocompletePhonePortraitLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListAutocompletePhonePortraitLightScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fe269026ce51ca7855231f0ec6ad78c044c7503f6c4faa72ab62dd11bfce712
+size 70910


### PR DESCRIPTION
## Summary
- Add grocery item autocomplete suggestions while typing in the list input
- Reuse the ingredient parser vocabulary and existing list item names for matches
- Add focused coverage for parser suggestions, grocery list BLoC suggestion state, and the user-level autocomplete selection flow

Closes #288

## Test plan
- ./gradlew :client:grocery:data:public:ktfmtFormat :client:grocery:core:public:ktfmtFormat :client:grocery:core:impl:ktfmtFormat :client:grocery:data:public:jvmTest :client:grocery:core:impl:jvmTest
- ./gradlew :client:ui:screenshot-test:validateDebugScreenshotTest
- ./gradlew :client:grocery:core:impl-robots:ktfmtFormat :client:composeApp:ktfmtFormat
- ./gradlew :client:composeApp:jvmTest