### PR TITLE
feat(importer): choose which recipe books to import recipes into

### DIFF
--- a/client/recipe/importer/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/robots/ImportRecipesRobot.kt
+++ b/client/recipe/importer/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/robots/ImportRecipesRobot.kt
@@ -36,6 +36,10 @@ class ImportRecipesRobot(private val test: ComposeUiTest) {
         test.onNode(hasText(title) and onScreen).assertIsDisplayed().performClick()
     }
 
+    fun toggleBook(name: String): ImportRecipesRobot = apply {
+        test.onNode(hasText(name) and onScreen).assertIsDisplayed().performClick()
+    }
+
     fun clickImport(): ImportRecipesRobot = apply {
         test.onNodeWithTag(ImportRecipesTestTags.IMPORT_BUTTON).assertIsDisplayed().performClick()
     }

--- a/client/recipe/importer/impl/build.gradle.kts
+++ b/client/recipe/importer/impl/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.client.recipe.importer.public)
             implementation(projects.client.recipe.data.public)
+            implementation(projects.client.recipebook.data.public)
             implementation(projects.client.text.public)
             implementation(projects.client.shared)
             implementation(libs.arkivanov.decompose.core)
@@ -16,6 +17,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(projects.client.recipe.data.testing)
+            implementation(projects.client.recipebook.data.testing)
             implementation(projects.client.recipe.importer.implRobots)
         }
     }

--- a/client/recipe/importer/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesBlocImpl.kt
+++ b/client/recipe/importer/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesBlocImpl.kt
@@ -30,12 +30,18 @@ class ImportRecipesBlocImpl(
 
     override val state: StateFlow<ImportRecipesBloc.Model> = viewModel.state
 
+    override val recipeBooks = viewModel.recipeBooks
+
+    override val selectedBookIds = viewModel.selectedBookIds
+
     override fun onArchiveSelected(bytes: ByteArray, fileName: String) =
         viewModel.onArchiveSelected(bytes, fileName)
 
     override fun onRecipeToggled(id: String) = viewModel.onRecipeToggled(id)
 
     override fun onToggleSelectAll() = viewModel.onToggleSelectAll()
+
+    override fun onToggleBook(bookId: Long) = viewModel.onToggleBook(bookId)
 
     override fun onImportClicked() = viewModel.onImportClicked()
 

--- a/client/recipe/importer/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesViewModel.kt
+++ b/client/recipe/importer/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesViewModel.kt
@@ -127,7 +127,9 @@ class ImportRecipesViewModel(
         val selected = review.recipes.filter { it.selected }
         if (selected.isEmpty()) return
 
+        // A book is required: imported recipes must have an explicit home.
         val bookIds = _selectedBookIds.value
+        if (bookIds.isEmpty()) return
         _state.value = Model(review.copy(isImporting = true))
         scope.launch {
             try {

--- a/client/recipe/importer/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesViewModel.kt
+++ b/client/recipe/importer/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesViewModel.kt
@@ -16,6 +16,8 @@ import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc.ImportItem
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc.Model
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc.Phase
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRepository
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.asTextData
@@ -25,8 +27,10 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -36,14 +40,33 @@ class ImportRecipesViewModel(
     @Main mainContext: CoroutineContext,
     @IO private val ioContext: CoroutineContext,
     private val repository: RecipeRepository,
+    private val recipeBookRepository: RecipeBookRepository,
     private val photoStorage: RecipePhotoStorage,
 ) : ViewModel(mainContext) {
 
     private val _state = MutableStateFlow(Model())
     val state: StateFlow<Model> = _state.asStateFlow()
 
+    val recipeBooks: StateFlow<List<RecipeBook>> =
+        recipeBookRepository
+            .getRecipeBooks()
+            .stateIn(scope = scope, started = SharingStarted.Eagerly, initialValue = emptyList())
+
+    private val _selectedBookIds = MutableStateFlow<Set<Long>>(emptySet())
+    val selectedBookIds: StateFlow<Set<Long>> = _selectedBookIds.asStateFlow()
+
     // Parsed recipes indexed by [ImportItem.id] (the item's position in the parsed list).
     private var parsed: List<ParsedArchiveRecipe> = emptyList()
+
+    init {
+        // Default the import target to the active book (falling back to the default book), matching
+        // where a manually created recipe would land.
+        scope.launch {
+            val activeBook =
+                recipeBookRepository.activeBookId.value ?: recipeBookRepository.getDefaultBookId()
+            _selectedBookIds.update { it.ifEmpty { setOf(activeBook) } }
+        }
+    }
 
     fun onArchiveSelected(bytes: ByteArray, fileName: String) {
         _state.value = Model(Phase.Parsing)
@@ -92,19 +115,26 @@ class ImportRecipesViewModel(
         }
     }
 
+    fun onToggleBook(bookId: Long) {
+        _selectedBookIds.update { current ->
+            if (bookId in current) current - bookId else current + bookId
+        }
+    }
+
     fun onImportClicked() {
         val review = _state.value.phase as? Phase.Review ?: return
         if (review.isImporting) return
         val selected = review.recipes.filter { it.selected }
         if (selected.isEmpty()) return
 
+        val bookIds = _selectedBookIds.value
         _state.value = Model(review.copy(isImporting = true))
         scope.launch {
             try {
                 var imported = 0
                 for (item in selected) {
                     val recipe = parsed.getOrNull(item.id.toIntOrNull() ?: -1) ?: continue
-                    repository.createRecipe(recipe.toRecipe())
+                    repository.createRecipe(recipe.toRecipe().copy(recipeBookIds = bookIds))
                     imported++
                 }
                 _state.value = Model(Phase.Done(importedCount = imported))

--- a/client/recipe/importer/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesScreenTest.kt
+++ b/client/recipe/importer/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesScreenTest.kt
@@ -14,6 +14,7 @@ import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc.Model
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc.Phase
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesScreen
 import com.plusmobileapps.chefmate.recipe.importer.robots.importRecipes
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlin.test.Test
@@ -47,6 +48,8 @@ class ImportRecipesScreenTest {
                     )
                 )
             )
+        override val recipeBooks = MutableStateFlow(RecipeBook.Samples)
+        override val selectedBookIds = MutableStateFlow(setOf(1L))
 
         override fun onArchiveSelected(bytes: ByteArray, fileName: String) = Unit
 
@@ -64,6 +67,8 @@ class ImportRecipesScreenTest {
         }
 
         override fun onToggleSelectAll() = Unit
+
+        override fun onToggleBook(bookId: Long) = Unit
 
         override fun onImportClicked() {
             val review = state.value.phase as? Phase.Review ?: return

--- a/client/recipe/importer/impl/src/jvmTest/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesViewModelTest.kt
+++ b/client/recipe/importer/impl/src/jvmTest/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesViewModelTest.kt
@@ -7,6 +7,9 @@ import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipePhotoStorage
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc.Phase
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
+import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookRepository
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.io.ByteArrayOutputStream
@@ -21,6 +24,14 @@ class ImportRecipesViewModelTest {
 
     private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
     private val repository = FakeRecipeRepository(recipes)
+    private val books =
+        MutableStateFlow(
+            listOf(
+                RecipeBook.Sample.copy(id = 1L, name = "My Recipes", isDefault = true),
+                RecipeBook.Sample.copy(id = 2L, name = "Weeknight Dinners", isDefault = false),
+            )
+        )
+    private val recipeBookRepository = FakeRecipeBookRepository(books)
     private val photoStorage = FakeRecipePhotoStorage()
     private val dispatcher = UnconfinedTestDispatcher()
 
@@ -29,6 +40,7 @@ class ImportRecipesViewModelTest {
             mainContext = dispatcher,
             ioContext = dispatcher,
             repository = repository,
+            recipeBookRepository = recipeBookRepository,
             photoStorage = photoStorage,
         )
 
@@ -79,6 +91,40 @@ class ImportRecipesViewModelTest {
 
         vm.state.value.phase.shouldBeInstanceOf<Phase.Done>().importedCount shouldBe 2
         recipes.value.size shouldBe 2
+    }
+
+    @Test
+    fun Initially_the_active_book_is_selected_as_the_import_target() {
+        val vm = createViewModel()
+
+        vm.selectedBookIds.value shouldBe setOf(1L)
+        vm.recipeBooks.value.map { it.id } shouldBe listOf(1L, 2L)
+    }
+
+    @Test
+    fun When_imported_Then_recipes_are_filed_under_the_selected_books() {
+        val vm = createViewModel()
+        vm.onArchiveSelected(twoRecipeArchive(), "export.zip")
+
+        // Also file under the second book in addition to the default active one.
+        vm.onToggleBook(2L)
+        vm.onImportClicked()
+
+        vm.state.value.phase.shouldBeInstanceOf<Phase.Done>()
+        recipes.value.forEach { it.recipeBookIds shouldBe setOf(1L, 2L) }
+    }
+
+    @Test
+    fun When_active_book_deselected_Then_recipes_file_under_remaining_book() {
+        val vm = createViewModel()
+        vm.onArchiveSelected(twoRecipeArchive(), "export.zip")
+
+        vm.onToggleBook(2L)
+        vm.onToggleBook(1L)
+        vm.selectedBookIds.value.shouldContainExactlyInAnyOrder(2L)
+        vm.onImportClicked()
+
+        recipes.value.forEach { it.recipeBookIds shouldBe setOf(2L) }
     }
 
     @Test

--- a/client/recipe/importer/impl/src/jvmTest/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesViewModelTest.kt
+++ b/client/recipe/importer/impl/src/jvmTest/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ImportRecipesViewModelTest.kt
@@ -128,6 +128,20 @@ class ImportRecipesViewModelTest {
     }
 
     @Test
+    fun When_no_book_selected_Then_import_is_blocked() {
+        val vm = createViewModel()
+        vm.onArchiveSelected(twoRecipeArchive(), "export.zip")
+
+        // Deselect the pre-selected active book, leaving no import target.
+        vm.onToggleBook(1L)
+        vm.selectedBookIds.value shouldBe emptySet()
+        vm.onImportClicked()
+
+        vm.state.value.phase.shouldBeInstanceOf<Phase.Review>()
+        recipes.value shouldBe emptyList()
+    }
+
+    @Test
     fun When_start_over_clicked_Then_state_resets_to_empty() {
         val vm = createViewModel()
         vm.onArchiveSelected(twoRecipeArchive(), "export.zip")

--- a/client/recipe/importer/public/build.gradle.kts
+++ b/client/recipe/importer/public/build.gradle.kts
@@ -7,6 +7,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.arkivanov.decompose.core)
+            api(projects.client.recipebook.data.public)
             api(projects.client.text.public)
             implementation(projects.client.shared)
             api(projects.client.ui.public)

--- a/client/recipe/importer/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/importer/public/src/commonMain/composeResources/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="import_recipes_parsing">Reading archive…</string>
     <string name="import_recipes_review_headline">Select recipes to import</string>
     <string name="import_recipes_books_label">Save to</string>
+    <string name="import_recipes_books_required">Select at least one book to save these recipes to.</string>
     <string name="import_recipes_select_all">Select all</string>
     <string name="import_recipes_deselect_all">Deselect all</string>
     <string name="import_recipes_import_button">Import {count}</string>

--- a/client/recipe/importer/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/importer/public/src/commonMain/composeResources/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="import_recipes_choose_file">Choose ZIP file</string>
     <string name="import_recipes_parsing">Reading archive…</string>
     <string name="import_recipes_review_headline">Select recipes to import</string>
+    <string name="import_recipes_books_label">Save to</string>
     <string name="import_recipes_select_all">Select all</string>
     <string name="import_recipes_deselect_all">Deselect all</string>
     <string name="import_recipes_import_button">Import {count}</string>

--- a/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesBloc.kt
+++ b/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesBloc.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.recipe.importer
 import com.arkivanov.essenty.backhandler.BackHandlerOwner
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.ui.BlocScreen
 import kotlinx.collections.immutable.ImmutableList
@@ -11,12 +12,21 @@ import kotlinx.coroutines.flow.StateFlow
 interface ImportRecipesBloc : BackHandlerOwner, BlocScreen {
     val state: StateFlow<Model>
 
+    /** All of the user's recipe books, offered as a multi-select target for the import. */
+    val recipeBooks: StateFlow<List<RecipeBook>>
+
+    /** Local ids of the books the imported recipes will be filed under. */
+    val selectedBookIds: StateFlow<Set<Long>>
+
     /** Called by the screen once the platform picker returns the chosen archive. */
     fun onArchiveSelected(bytes: ByteArray, fileName: String)
 
     fun onRecipeToggled(id: String)
 
     fun onToggleSelectAll()
+
+    /** Toggles whether the imported recipes are filed under the book with local id [bookId]. */
+    fun onToggleBook(bookId: Long)
 
     fun onImportClicked()
 

--- a/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesPreviews.kt
+++ b/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesPreviews.kt
@@ -8,6 +8,7 @@ import com.arkivanov.essenty.backhandler.BackHandler
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc.ImportItem
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc.Model
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc.Phase
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.collections.immutable.persistentListOf
@@ -17,12 +18,16 @@ private fun importRecipesBloc(model: Model): ImportRecipesBloc =
     object : ImportRecipesBloc {
         override val backHandler: BackHandler = BackDispatcher()
         override val state = MutableStateFlow(model)
+        override val recipeBooks = MutableStateFlow(RecipeBook.Samples)
+        override val selectedBookIds = MutableStateFlow(setOf(1L))
 
         override fun onArchiveSelected(bytes: ByteArray, fileName: String) = Unit
 
         override fun onRecipeToggled(id: String) = Unit
 
         override fun onToggleSelectAll() = Unit
+
+        override fun onToggleBook(bookId: Long) = Unit
 
         override fun onImportClicked() = Unit
 

--- a/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesPreviews.kt
+++ b/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesPreviews.kt
@@ -14,12 +14,15 @@ import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 
-private fun importRecipesBloc(model: Model): ImportRecipesBloc =
+private fun importRecipesBloc(
+    model: Model,
+    selectedBookIds: Set<Long> = setOf(1L),
+): ImportRecipesBloc =
     object : ImportRecipesBloc {
         override val backHandler: BackHandler = BackDispatcher()
         override val state = MutableStateFlow(model)
         override val recipeBooks = MutableStateFlow(RecipeBook.Samples)
-        override val selectedBookIds = MutableStateFlow(setOf(1L))
+        override val selectedBookIds = MutableStateFlow(selectedBookIds)
 
         override fun onArchiveSelected(bytes: ByteArray, fileName: String) = Unit
 
@@ -76,6 +79,10 @@ val previewImportRecipesReviewBloc: ImportRecipesBloc =
 val previewImportRecipesImportingBloc: ImportRecipesBloc =
     importRecipesBloc(Model(Phase.Review(recipes = sampleItems, isImporting = true)))
 
+/** Review with no book selected — the required-book hint shows and import is disabled. */
+val previewImportRecipesNoBookBloc: ImportRecipesBloc =
+    importRecipesBloc(Model(Phase.Review(recipes = sampleItems)), selectedBookIds = emptySet())
+
 val previewImportRecipesDoneBloc: ImportRecipesBloc =
     importRecipesBloc(Model(Phase.Done(importedCount = 2)))
 
@@ -92,6 +99,12 @@ internal fun ImportRecipesEmptyPreview() {
 @Composable
 internal fun ImportRecipesReviewPreview() {
     ChefMateTheme { ImportRecipesScreen(bloc = previewImportRecipesReviewBloc) }
+}
+
+@Preview
+@Composable
+internal fun ImportRecipesNoBookPreview() {
+    ChefMateTheme { ImportRecipesScreen(bloc = previewImportRecipesNoBookBloc) }
 }
 
 @Preview

--- a/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesScreen.kt
+++ b/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesScreen.kt
@@ -3,6 +3,8 @@ package com.plusmobileapps.chefmate.recipe.importer
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +17,7 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
@@ -30,6 +33,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import chefmate.client.recipe.importer.`public`.generated.resources.Res
+import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_books_label
 import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_choose_file
 import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_deselect_all
 import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_done_button
@@ -44,6 +48,7 @@ import chefmate.client.recipe.importer.`public`.generated.resources.import_recip
 import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_start_over
 import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_title
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc.Phase
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.asTextData
@@ -74,13 +79,19 @@ fun ImportRecipesScreen(bloc: ImportRecipesBloc, modifier: Modifier = Modifier) 
                     StatusContent(
                         message = Res.string.import_recipes_parsing.asTextData().localized()
                     )
-                is Phase.Review ->
+                is Phase.Review -> {
+                    val books by bloc.recipeBooks.collectAsState()
+                    val selectedBookIds by bloc.selectedBookIds.collectAsState()
                     ReviewContent(
                         phase = phase,
+                        books = books,
+                        selectedBookIds = selectedBookIds,
                         onToggle = bloc::onRecipeToggled,
                         onToggleSelectAll = bloc::onToggleSelectAll,
+                        onToggleBook = bloc::onToggleBook,
                         onImport = bloc::onImportClicked,
                     )
+                }
                 is Phase.Done ->
                     DoneContent(
                         importedCount = phase.importedCount,
@@ -144,8 +155,11 @@ private fun StatusContent(message: String) {
 @Composable
 private fun ReviewContent(
     phase: Phase.Review,
+    books: List<RecipeBook>,
+    selectedBookIds: Set<Long>,
     onToggle: (String) -> Unit,
     onToggleSelectAll: () -> Unit,
+    onToggleBook: (Long) -> Unit,
     onImport: () -> Unit,
 ) {
     val selectedCount = phase.recipes.count { it.selected }
@@ -184,6 +198,15 @@ private fun ReviewContent(
     }
     HorizontalDivider()
 
+    if (books.isNotEmpty()) {
+        BookSelector(
+            books = books,
+            selectedBookIds = selectedBookIds,
+            enabled = !phase.isImporting,
+            onToggleBook = onToggleBook,
+        )
+    }
+
     Spacer(Modifier.height(ChefMateTheme.dimens.paddingNormal))
     Button(
         onClick = onImport,
@@ -206,6 +229,41 @@ private fun ReviewContent(
         }
     }
     Spacer(Modifier.height(ChefMateTheme.dimens.paddingNormal))
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun BookSelector(
+    books: List<RecipeBook>,
+    selectedBookIds: Set<Long>,
+    enabled: Boolean,
+    onToggleBook: (Long) -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier.fillMaxWidth()
+                .padding(horizontal = ChefMateTheme.dimens.paddingNormal)
+                .padding(top = ChefMateTheme.dimens.paddingNormal),
+        verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall),
+    ) {
+        Text(
+            Res.string.import_recipes_books_label.asTextData().localized(),
+            style = ChefMateTheme.typography.titleMedium,
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall),
+            verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall),
+        ) {
+            books.forEach { book ->
+                FilterChip(
+                    selected = book.id in selectedBookIds,
+                    onClick = { onToggleBook(book.id) },
+                    enabled = enabled,
+                    label = { Text(book.name) },
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesScreen.kt
+++ b/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import chefmate.client.recipe.importer.`public`.generated.resources.Res
 import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_books_label
+import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_books_required
 import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_choose_file
 import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_deselect_all
 import chefmate.client.recipe.importer.`public`.generated.resources.import_recipes_done_button
@@ -207,10 +208,14 @@ private fun ReviewContent(
         )
     }
 
+    // A book is required so imported recipes always have an explicit home; the default book is
+    // pre-selected, but the user can swap it out as long as one remains chosen.
+    val bookRequired = books.isNotEmpty() && selectedBookIds.isEmpty()
+
     Spacer(Modifier.height(ChefMateTheme.dimens.paddingNormal))
     Button(
         onClick = onImport,
-        enabled = selectedCount > 0 && !phase.isImporting,
+        enabled = selectedCount > 0 && !phase.isImporting && !bookRequired,
         modifier =
             Modifier.fillMaxWidth()
                 .padding(horizontal = ChefMateTheme.dimens.paddingNormal)
@@ -262,6 +267,13 @@ private fun BookSelector(
                     label = { Text(book.name) },
                 )
             }
+        }
+        if (selectedBookIds.isEmpty()) {
+            Text(
+                Res.string.import_recipes_books_required.asTextData().localized(),
+                style = ChefMateTheme.typography.bodySmall,
+                color = ChefMateTheme.colorScheme.error,
+            )
         }
     }
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/ImportRecipesScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/ImportRecipesScreenshotTest.kt
@@ -8,6 +8,7 @@ import com.plusmobileapps.chefmate.recipe.importer.previewImportRecipesDoneBloc
 import com.plusmobileapps.chefmate.recipe.importer.previewImportRecipesEmptyBloc
 import com.plusmobileapps.chefmate.recipe.importer.previewImportRecipesErrorBloc
 import com.plusmobileapps.chefmate.recipe.importer.previewImportRecipesImportingBloc
+import com.plusmobileapps.chefmate.recipe.importer.previewImportRecipesNoBookBloc
 import com.plusmobileapps.chefmate.recipe.importer.previewImportRecipesReviewBloc
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -31,6 +32,13 @@ fun ImportRecipesReviewScreenshot() {
 @Composable
 fun ImportRecipesReviewDarkScreenshot() {
     ChefMateTheme(darkTheme = true) { previewImportRecipesReviewBloc.Content() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun ImportRecipesNoBookScreenshot() {
+    ChefMateTheme { previewImportRecipesNoBookBloc.Content() }
 }
 
 @PreviewTest

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ImportRecipesScreenshotTestKt/ImportRecipesImportingScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ImportRecipesScreenshotTestKt/ImportRecipesImportingScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2432c9018dec936ff0a7d23d65c04bdfd07321ea03ca9778fbd0642ebdae037d
-size 65449
+oid sha256:548f37fe91feb10bff00bc05ff3b1583b4d7268b7e736d44b4d1ab3a8c9460f0
+size 81266

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ImportRecipesScreenshotTestKt/ImportRecipesNoBookScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ImportRecipesScreenshotTestKt/ImportRecipesNoBookScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3486485d851c9c81f6ae4546625daf56f80ab56a069848c4bd1d17bebb7df238
+size 89427

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ImportRecipesScreenshotTestKt/ImportRecipesReviewDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ImportRecipesScreenshotTestKt/ImportRecipesReviewDarkScreenshot_658f3c84_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82948e66b3324fc58ba97a47d6e4e3548388a89b262ec688399516dda5d6f2fb
-size 68038
+oid sha256:b5849fa7fd557c46351c47bc7ca461eed7ccaaea66a76ed7942a743f77bfd066
+size 85545

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ImportRecipesScreenshotTestKt/ImportRecipesReviewScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ImportRecipesScreenshotTestKt/ImportRecipesReviewScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b934378642a6f5da024ce2219e364f8ba5d45841cf35793281db876227b66286
-size 67772
+oid sha256:3d97ef44bb68dbcb43e58586dc2cd72bb809be090b9e24602b67500aedc639dc
+size 85266


### PR DESCRIPTION
Closes #280.

## What

When importing a recipe archive, the review screen now lets you choose which recipe book(s) the imported recipes are saved to.

- Adds a **"Save to"** multi-select (FilterChips) on the import review screen listing all of the user's recipe books.
- Defaults the selection to the **active book** (falling back to the default book) — the same destination a manually created recipe would land in.
- The selected book ids are filed onto each imported recipe via `Recipe.recipeBookIds`; the data layer already supports filing a recipe under multiple books, so no schema/data-layer changes were needed.

## How it works

`ImportRecipesBloc` now exposes `recipeBooks` and `selectedBookIds` plus an `onToggleBook(bookId)` handler, mirroring the existing pattern in `EditRecipeBloc`. The view model loads books from `RecipeBookRepository`, seeds the default selection, and passes the chosen ids to `createRecipe` on import.

## Screenshot

The review screen with the new "Save to" book chips (active book pre-selected):

The recorded reference matches the previews — "My Recipes" is selected by default, with "Weeknight Dinners" / "Holiday Baking" selectable.

## Tests

- View model unit tests: default selection is the active book, toggling files recipes under the selected books, and deselecting the active book files under the remaining one.
- Refreshed Review / Review (dark) / Importing reference snapshots.
- Added a `toggleBook` robot helper and updated the screen-test bloc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)