### PR TITLE
feat(recipe): show recipe book on meal planner picker results

### DIFF
--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/RecipePickerViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/RecipePickerViewModel.kt
@@ -4,11 +4,14 @@ import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRepository
 import dev.zacsweers.metro.Inject
 import kotlin.coroutines.CoroutineContext
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -16,6 +19,7 @@ import kotlinx.coroutines.launch
 class RecipePickerViewModel(
     @Main mainContext: CoroutineContext,
     private val recipeRepository: RecipeRepository,
+    private val recipeBookRepository: RecipeBookRepository,
 ) : ViewModel(mainContext) {
 
     private val _state = MutableStateFlow(State())
@@ -28,35 +32,49 @@ class RecipePickerViewModel(
     }
 
     fun updateSearchQuery(query: String) {
-        _state.update { it.copy(searchQuery = query) }
-        applySearch()
+        _state.update { it.copy(searchQuery = query, displayRecipes = filter(allRecipes, query)) }
     }
 
     private fun loadRecipes() {
         scope.launch {
-            recipeRepository.getRecipes().collect { recipes ->
-                allRecipes = recipes.map { recipe ->
-                    RecipePickerBloc.RecipePickerItem(
-                        id = recipe.id,
-                        title = recipe.title,
-                        imageUrl = recipe.imageUrl,
-                    )
+            combine(recipeRepository.getRecipes(), recipeBookRepository.getRecipeBooks()) {
+                    recipes,
+                    books ->
+                    val bookNamesById = books.associate { it.id to it.name }
+                    recipes.map { recipe ->
+                        RecipePickerBloc.RecipePickerItem(
+                            id = recipe.id,
+                            title = recipe.title,
+                            imageUrl = recipe.imageUrl,
+                            // Surface which book(s) each result lives in so cross-book matches
+                            // (e.g. same title in different books) are distinguishable.
+                            bookNames =
+                                recipe.recipeBookIds
+                                    .mapNotNull { bookNamesById[it] }
+                                    .sorted()
+                                    .toImmutableList(),
+                        )
+                    }
                 }
-                _state.update { it.copy(isLoading = false) }
-                applySearch()
-            }
+                .collect { items ->
+                    allRecipes = items
+                    _state.update {
+                        it.copy(isLoading = false, displayRecipes = filter(items, it.searchQuery))
+                    }
+                }
         }
     }
 
-    private fun applySearch() {
-        val query = _state.value.searchQuery.trim()
-        val filtered =
-            if (query.isEmpty()) {
-                allRecipes
-            } else {
-                allRecipes.filter { it.title.contains(query, ignoreCase = true) }
-            }
-        _state.update { it.copy(displayRecipes = filtered) }
+    private fun filter(
+        recipes: List<RecipePickerBloc.RecipePickerItem>,
+        query: String,
+    ): List<RecipePickerBloc.RecipePickerItem> {
+        val trimmed = query.trim()
+        return if (trimmed.isEmpty()) {
+            recipes
+        } else {
+            recipes.filter { it.title.contains(trimmed, ignoreCase = true) }
+        }
     }
 
     data class State(

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/ui/RecipePickerPreviews.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/ui/RecipePickerPreviews.kt
@@ -1,0 +1,58 @@
+package com.plusmobileapps.chefmate.recipe.core.impl.addmeal.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.MutableStateFlow
+
+private fun recipePickerBloc(model: RecipePickerBloc.Model): RecipePickerBloc =
+    object : RecipePickerBloc {
+        override val state = MutableStateFlow(model)
+
+        override fun onSearchQueryChanged(query: String) = Unit
+
+        override fun onRecipeSelected(item: RecipePickerBloc.RecipePickerItem) = Unit
+
+        @Composable
+        override fun Content(modifier: Modifier) =
+            RecipePickerScreen(bloc = this, modifier = modifier)
+    }
+
+private val sampleRecipes =
+    persistentListOf(
+        RecipePickerBloc.RecipePickerItem(
+            id = 1L,
+            title = "Sourdough Pancakes",
+            imageUrl = null,
+            bookNames = persistentListOf("Breakfast Favorites"),
+        ),
+        RecipePickerBloc.RecipePickerItem(
+            id = 2L,
+            title = "Caesar Salad",
+            imageUrl = null,
+            bookNames = persistentListOf("Weeknight Dinners", "Salads"),
+        ),
+        // A recipe filed under no named book — should render just its title.
+        RecipePickerBloc.RecipePickerItem(id = 3L, title = "Pasta Carbonara", imageUrl = null),
+    )
+
+val previewRecipePickerBloc: RecipePickerBloc =
+    recipePickerBloc(RecipePickerBloc.Model(recipes = sampleRecipes, isLoading = false))
+
+val previewRecipePickerBlocLoading: RecipePickerBloc =
+    recipePickerBloc(RecipePickerBloc.Model(isLoading = true))
+
+@Preview
+@Composable
+internal fun RecipePickerScreenPreview() {
+    ChefMateTheme { previewRecipePickerBloc.Content(Modifier) }
+}
+
+@Preview
+@Composable
+internal fun RecipePickerScreenLoadingPreview() {
+    ChefMateTheme { previewRecipePickerBlocLoading.Content(Modifier) }
+}

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/ui/RecipePickerScreen.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/ui/RecipePickerScreen.kt
@@ -2,6 +2,7 @@ package com.plusmobileapps.chefmate.recipe.core.impl.addmeal.ui
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -101,10 +102,15 @@ private fun RecipePickerItem(
             contentDescription = recipe.title,
             modifier = Modifier.size(48.dp),
         )
-        Text(
-            text = recipe.title,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.weight(1f),
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = recipe.title, style = MaterialTheme.typography.bodyLarge)
+            if (recipe.bookNames.isNotEmpty()) {
+                Text(
+                    text = recipe.bookNames.joinToString(", "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/RecipePickerBlocTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addmeal/RecipePickerBlocTest.kt
@@ -1,0 +1,95 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+
+package com.plusmobileapps.chefmate.recipe.core.impl.addmeal
+
+import app.cash.turbine.test
+import com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
+import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookRepository
+import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.plusmobileapps.chefmate.testing.TestConsumer
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+
+class RecipePickerBlocTest {
+    private val context = TestBlocContext.create()
+    private val output = TestConsumer<RecipePickerBloc.Output>()
+
+    private val books =
+        listOf(
+            RecipeBook.Sample.copy(id = 1L, name = "Weeknight Dinners"),
+            RecipeBook.Sample.copy(id = 2L, name = "Holiday Baking"),
+        )
+    private val recipes =
+        listOf(
+            recipe(id = 10L, title = "Pasta Carbonara", bookIds = setOf(1L)),
+            recipe(id = 20L, title = "Gingerbread", bookIds = setOf(2L, 1L)),
+            recipe(id = 30L, title = "Mystery Stew", bookIds = setOf(99L)),
+        )
+
+    private val recipeRepository = FakeRecipeRepository(MutableStateFlow(recipes))
+    private val recipeBookRepository = FakeRecipeBookRepository(MutableStateFlow(books))
+
+    private fun createBloc(): RecipePickerBlocImpl =
+        RecipePickerBlocImpl(
+            context = context,
+            output = output,
+            viewModelFactory = {
+                RecipePickerViewModel(
+                    mainContext = context.mainContext,
+                    recipeRepository = recipeRepository,
+                    recipeBookRepository = recipeBookRepository,
+                )
+            },
+        )
+
+    @Test
+    fun WHEN_loaded_THEN_each_result_lists_its_recipe_book_names() = runTest {
+        createBloc().state.test {
+            val state = awaitItem()
+            state.isLoading shouldBe false
+            state.recipes.first { it.id == 10L }.bookNames shouldBe listOf("Weeknight Dinners")
+            // Multiple books are sorted alphabetically.
+            state.recipes.first { it.id == 20L }.bookNames shouldBe
+                listOf("Holiday Baking", "Weeknight Dinners")
+        }
+    }
+
+    @Test
+    fun WHEN_recipe_book_is_unknown_THEN_no_book_name_is_shown() = runTest {
+        createBloc().state.test {
+            // Recipe 30 references a book id that has no matching book — it should drop silently
+            // rather than crash or show a blank label.
+            awaitItem().recipes.first { it.id == 30L }.bookNames shouldBe emptyList()
+        }
+    }
+
+    @Test
+    fun WHEN_search_query_set_THEN_results_filter_by_title_across_all_books() = runTest {
+        val bloc = createBloc()
+        bloc.state.test {
+            awaitItem().recipes.map { it.id } shouldBe listOf(10L, 20L, 30L)
+
+            bloc.onSearchQueryChanged("ginger")
+
+            awaitItem().recipes.map { it.id } shouldBe listOf(20L)
+        }
+    }
+
+    private fun recipe(id: Long, title: String, bookIds: Set<Long>): Recipe =
+        Recipe.Empty.copy(
+            id = id,
+            title = title,
+            createdAt = Instant.DISTANT_PAST,
+            updatedAt = Instant.DISTANT_PAST,
+            recipeBookIds = bookIds,
+        )
+}

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addmeal/RecipePickerBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addmeal/RecipePickerBloc.kt
@@ -14,7 +14,13 @@ interface RecipePickerBloc : BlocScreen {
 
     fun onRecipeSelected(item: RecipePickerItem)
 
-    data class RecipePickerItem(val id: Long, val title: String, val imageUrl: String?)
+    data class RecipePickerItem(
+        val id: Long,
+        val title: String,
+        val imageUrl: String?,
+        /** Names of the recipe book(s) this recipe belongs to, sorted alphabetically. */
+        val bookNames: ImmutableList<String> = persistentListOf(),
+    )
 
     data class Model(
         val recipes: ImmutableList<RecipePickerItem> = persistentListOf(),

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipePickerScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipePickerScreenshotTest.kt
@@ -1,0 +1,48 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc
+import com.plusmobileapps.chefmate.recipe.core.impl.addmeal.ui.previewRecipePickerBloc
+import com.plusmobileapps.chefmate.recipe.core.impl.addmeal.ui.previewRecipePickerBlocLoading
+import com.plusmobileapps.chefmate.ui.Content
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+// RecipePickerScreen uses PlusHeaderContainer, which paints no top-level Surface — wrap each test
+// in
+// one so dark snapshots render dark instead of inheriting the white screenshot canvas.
+@Composable
+private fun RecipePickerScreenshot(bloc: RecipePickerBloc, darkTheme: Boolean = false) {
+    ChefMateTheme(darkTheme = darkTheme) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            bloc.Content()
+        }
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun RecipePickerLightScreenshot() {
+    RecipePickerScreenshot(bloc = previewRecipePickerBloc)
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun RecipePickerDarkScreenshot() {
+    RecipePickerScreenshot(bloc = previewRecipePickerBloc, darkTheme = true)
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun RecipePickerLoadingScreenshot() {
+    RecipePickerScreenshot(bloc = previewRecipePickerBlocLoading)
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipePickerScreenshotTestKt/RecipePickerDarkScreenshot_4d30ee2f_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipePickerScreenshotTestKt/RecipePickerDarkScreenshot_4d30ee2f_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea7442aae67f2cdb68d719b165a82639c16983e3728301c1e6d05619a14628bf
+size 58940

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipePickerScreenshotTestKt/RecipePickerLightScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipePickerScreenshotTestKt/RecipePickerLightScreenshot_748aa731_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e3dc0e3730ac398b94047b0fba47a4e00abfd469530a3ae3bf967f1a1e3160a
+size 58524

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipePickerScreenshotTestKt/RecipePickerLoadingScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipePickerScreenshotTestKt/RecipePickerLoadingScreenshot_748aa731_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:030583f77eb3cc7543a8658b3c3f04fb4f77e8b51d593ce61ca55e665685c4f1
+size 45302


### PR DESCRIPTION
## What & why

Closes #293 — "update meal planner search to search across recipe books."

The meal planner recipe picker **already** searches across every recipe book: its `RecipePickerViewModel` reads `RecipeRepository.getRecipes()` (all recipes), not the active-book-scoped `getRecipes(bookId)` the main recipe list uses. The real gap was that a search result gave no hint **which** book it came from, so two recipes sharing a title in different books were indistinguishable.

This surfaces the owning recipe book name(s) on each picker result.

## Changes

- **`RecipePickerBloc.RecipePickerItem`** gains a `bookNames: ImmutableList<String>` field.
- **`RecipePickerViewModel`** now `combine`s `getRecipes()` with `getRecipeBooks()`, resolves each recipe's `recipeBookIds` to names, and exposes them sorted. Search/filter was also folded into a single state update so query changes emit one state, not an intermediate.
- **`RecipePickerScreen`** renders the comma-joined book name(s) as a `bodySmall` / `onSurfaceVariant` subtitle beneath the title. Recipes with no named book show just the title.

## Behavior

| Result | Subtitle |
|---|---|
| Recipe in one book | `Breakfast Favorites` |
| Recipe in multiple books | `Weeknight Dinners, Salads` |
| Recipe with no named book | _(none)_ |

## Tests

- `RecipePickerBlocTest` — verifies book names are resolved (incl. multi-book sorting), unknown book ids drop silently, and search filters by title across all books.
- New light/dark/loading snapshot coverage (`RecipePickerPreviews` + `RecipePickerScreenshotTest`) exercising single-book, multi-book, and no-book results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)