### PR TITLE
feat(onboarding): add onboarding flow skeleton

### DIFF
--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -243,6 +243,7 @@ class BottomNavBlocImpl(
             SettingsBloc.Output.OpenAppSettings -> OpenAppSettings
             SettingsBloc.Output.OpenAiChat -> BottomNavBloc.Output.OpenAiChat
             SettingsBloc.Output.OpenDeveloperSettings -> BottomNavBloc.Output.OpenDeveloperSettings
+            SettingsBloc.Output.OpenOnboarding -> BottomNavBloc.Output.OpenOnboarding
             is SettingsBloc.Output.OpenUrl -> BottomNavBloc.Output.OpenUrl(output.url)
         }.let { this.output.onNext(it) }
     }

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -81,6 +81,9 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
 
         data object OpenDeveloperSettings : Output()
 
+        /** Replay the onboarding flow, launched from the More tab. */
+        data object OpenOnboarding : Output()
+
         data class OpenUrl(val url: String) : Output()
 
         data class OpenMealPlanner(val props: MealPlannerRootBloc.Props) : Output()

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -90,6 +90,8 @@ kotlin {
             api(projects.client.grocery.core.public)
             api(projects.client.meal.data.impl)
             api(projects.client.meal.core.impl)
+            api(projects.client.onboarding.impl)
+            api(projects.client.onboarding.public)
             implementation(libs.kotlinx.serialization.json)
             api(projects.client.database.core)
             api(projects.client.root.public)

--- a/client/composeApp/src/commonMain/kotlin/com/plusmobileapps/chefmate/ApplicationComponent.kt
+++ b/client/composeApp/src/commonMain/kotlin/com/plusmobileapps/chefmate/ApplicationComponent.kt
@@ -1,11 +1,13 @@
 package com.plusmobileapps.chefmate
 
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.di.OnboardingRepository
 import com.plusmobileapps.chefmate.root.RootBloc
 import com.russhwolf.settings.Settings
 
 interface ApplicationComponent {
     val rootBlocFactory: RootBloc.Factory
     val authenticationRepository: AuthenticationRepository
+    val onboardingRepository: OnboardingRepository
     val settings: Settings
 }

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
@@ -54,6 +54,9 @@ fun runRootBlocTest(
 ): TestResult = runComposeUiTest {
     val app = createTestApplicationComponent()
     app.applyUserState(userState)
+    // Default to a returning user so tests boot straight into the main app. Onboarding-specific
+    // tests can assert the first-run flow before flipping this in their own setup.
+    app.onboardingRepository.setOnboardingCompleted()
     beforeContent(app)
     setContent { App(rootBloc = app.createRootBloc()) }
     block(app)

--- a/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlag.kt
+++ b/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlag.kt
@@ -50,5 +50,15 @@ object FeatureFlagRegistry {
                     "option. When off, the add button opens the blank editor directly.",
         )
 
-    val all: List<FeatureFlag<*>> = listOf(CookModeV2, HomeBannerText, AiChat, ScanRecipeFromPhoto)
+    object Onboarding :
+        BooleanFlag(
+            key = "onboarding",
+            defaultValue = false,
+            description =
+                "Show the first-run onboarding flow (and the \"View Onboarding Again\" row in the " +
+                    "More tab). When off, onboarding is never shown.",
+        )
+
+    val all: List<FeatureFlag<*>> =
+        listOf(CookModeV2, HomeBannerText, AiChat, ScanRecipeFromPhoto, Onboarding)
 }

--- a/client/onboarding/impl/build.gradle.kts
+++ b/client/onboarding/impl/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+    alias(libs.plugins.kotlinSerialization)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.onboarding.public)
+            implementation(projects.client.text.public)
+            implementation(projects.client.ui.public)
+            implementation(projects.client.shared)
+            implementation(libs.arkivanov.decompose.core)
+            implementation(libs.arkivanov.decompose.compose.extensions)
+            implementation(compose.components.resources)
+        }
+        commonTest.dependencies { implementation(libs.multiplatform.settings.test) }
+    }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.onboarding.impl"
+    enableDi = true
+    enableTesting = true
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/OnboardingRootBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/OnboardingRootBlocImpl.kt
@@ -1,0 +1,102 @@
+@file:OptIn(DelicateDecomposeApi::class)
+
+package com.plusmobileapps.chefmate.onboarding.impl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.arkivanov.decompose.DelicateDecomposeApi
+import com.arkivanov.decompose.router.stack.ChildStack
+import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.bringToFront
+import com.arkivanov.decompose.router.stack.childStack
+import com.arkivanov.decompose.router.stack.pop
+import com.arkivanov.decompose.value.Value
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.di.OnboardingRepository
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc.Output
+import com.plusmobileapps.chefmate.onboarding.StartCookingBloc
+import com.plusmobileapps.chefmate.onboarding.WelcomeBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.OnboardingRootScreen
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+import kotlinx.serialization.Serializable
+
+@AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = OnboardingRootBloc.Factory::class,
+)
+class OnboardingRootBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<Output>,
+    private val onboardingRepository: OnboardingRepository,
+    private val welcome: WelcomeBloc.Factory,
+    private val startCooking: StartCookingBloc.Factory,
+) : OnboardingRootBloc, BlocContext by context {
+
+    private val navigation = StackNavigation<Configuration>()
+
+    private val stack =
+        childStack(
+            source = navigation,
+            serializer = Configuration.serializer(),
+            initialStack = { listOf(Configuration.Welcome) },
+            handleBackButton = true,
+            key = "OnboardingRootRouter",
+            childFactory = ::createChild,
+        )
+
+    override val routerState: Value<ChildStack<*, OnboardingRootBloc.Child>> = stack
+
+    override fun onBackClicked() {
+        navigation.pop()
+    }
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        OnboardingRootScreen(bloc = this, modifier = modifier)
+    }
+
+    private fun createChild(config: Configuration, context: BlocContext): OnboardingRootBloc.Child =
+        when (config) {
+            Configuration.Welcome ->
+                OnboardingRootBloc.Child.Welcome(
+                    bloc = welcome.create(context = context, output = ::handleWelcomeOutput)
+                )
+
+            Configuration.StartCooking ->
+                OnboardingRootBloc.Child.StartCooking(
+                    bloc =
+                        startCooking.create(context = context, output = ::handleStartCookingOutput)
+                )
+        }
+
+    private fun handleWelcomeOutput(output: WelcomeBloc.Output) {
+        when (output) {
+            WelcomeBloc.Output.GetStarted -> navigation.bringToFront(Configuration.StartCooking)
+        }
+    }
+
+    private fun handleStartCookingOutput(output: StartCookingBloc.Output) {
+        when (output) {
+            StartCookingBloc.Output.StartCooking -> {
+                // Persist completion so the flow is never shown again, then hand control back to
+                // the
+                // root to load the rest of the app.
+                onboardingRepository.setOnboardingCompleted()
+                this.output.onNext(Output.Finished)
+            }
+        }
+    }
+
+    @Serializable
+    private sealed class Configuration {
+        @Serializable data object Welcome : Configuration()
+
+        @Serializable data object StartCooking : Configuration()
+    }
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/StartCookingBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/StartCookingBlocImpl.kt
@@ -1,0 +1,32 @@
+package com.plusmobileapps.chefmate.onboarding.impl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.onboarding.StartCookingBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.StartCookingScreen
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+
+@AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = StartCookingBloc.Factory::class,
+)
+class StartCookingBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<StartCookingBloc.Output>,
+) : StartCookingBloc, BlocContext by context {
+
+    override fun onStartCookingClicked() {
+        output.onNext(StartCookingBloc.Output.StartCooking)
+    }
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        StartCookingScreen(bloc = this, modifier = modifier)
+    }
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/WelcomeBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/WelcomeBlocImpl.kt
@@ -1,0 +1,29 @@
+package com.plusmobileapps.chefmate.onboarding.impl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.onboarding.WelcomeBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.WelcomeScreen
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+
+@AssistedInject
+@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = WelcomeBloc.Factory::class)
+class WelcomeBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<WelcomeBloc.Output>,
+) : WelcomeBloc, BlocContext by context {
+
+    override fun onGetStartedClicked() {
+        output.onNext(WelcomeBloc.Output.GetStarted)
+    }
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        WelcomeScreen(bloc = this, modifier = modifier)
+    }
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/OnboardingRootScreen.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/OnboardingRootScreen.kt
@@ -1,0 +1,20 @@
+package com.plusmobileapps.chefmate.onboarding.impl.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.arkivanov.decompose.extensions.compose.stack.Children
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
+import com.plusmobileapps.chefmate.ui.Content
+import com.plusmobileapps.chefmate.ui.backAnimation
+
+@Composable
+fun OnboardingRootScreen(bloc: OnboardingRootBloc, modifier: Modifier = Modifier) {
+    Children(
+        modifier = modifier.fillMaxSize(),
+        stack = bloc.routerState,
+        animation = backAnimation(backHandler = bloc.backHandler, onBack = bloc::onBackClicked),
+    ) { child ->
+        child.instance.Content()
+    }
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/OnboardingRootScreen.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/OnboardingRootScreen.kt
@@ -15,6 +15,6 @@ fun OnboardingRootScreen(bloc: OnboardingRootBloc, modifier: Modifier = Modifier
         stack = bloc.routerState,
         animation = backAnimation(backHandler = bloc.backHandler, onBack = bloc::onBackClicked),
     ) { child ->
-        child.instance.Content()
+        child.instance.bloc.Content()
     }
 }

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/StartCookingScreen.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/StartCookingScreen.kt
@@ -1,0 +1,63 @@
+package com.plusmobileapps.chefmate.onboarding.impl.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import chefmate.client.onboarding.public.generated.resources.Res
+import chefmate.client.onboarding.public.generated.resources.onboarding_start_cooking_button
+import chefmate.client.onboarding.public.generated.resources.onboarding_start_cooking_message
+import chefmate.client.onboarding.public.generated.resources.onboarding_start_cooking_title
+import com.plusmobileapps.chefmate.onboarding.OnboardingTestTags
+import com.plusmobileapps.chefmate.onboarding.StartCookingBloc
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusButton
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun StartCookingScreen(bloc: StartCookingBloc, modifier: Modifier = Modifier) {
+    val dimens = ChefMateTheme.dimens
+
+    PlusHeaderContainer(
+        modifier = modifier.testTag(OnboardingTestTags.START_COOKING_SCREEN).fillMaxWidth(),
+        data = PlusHeaderData.None,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(dimens.paddingLarge),
+            verticalArrangement = Arrangement.spacedBy(dimens.paddingNormal),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(Res.string.onboarding_start_cooking_title),
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(Res.string.onboarding_start_cooking_message),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            PlusButton(
+                text = Res.string.onboarding_start_cooking_button.asTextData(),
+                onClick = bloc::onStartCookingClicked,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(top = dimens.paddingNormal)
+                        .testTag(OnboardingTestTags.START_COOKING_BUTTON),
+            )
+        }
+    }
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/WelcomeScreen.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/WelcomeScreen.kt
@@ -1,0 +1,63 @@
+package com.plusmobileapps.chefmate.onboarding.impl.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import chefmate.client.onboarding.public.generated.resources.Res
+import chefmate.client.onboarding.public.generated.resources.onboarding_welcome_get_started
+import chefmate.client.onboarding.public.generated.resources.onboarding_welcome_message
+import chefmate.client.onboarding.public.generated.resources.onboarding_welcome_title
+import com.plusmobileapps.chefmate.onboarding.OnboardingTestTags
+import com.plusmobileapps.chefmate.onboarding.WelcomeBloc
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusButton
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun WelcomeScreen(bloc: WelcomeBloc, modifier: Modifier = Modifier) {
+    val dimens = ChefMateTheme.dimens
+
+    PlusHeaderContainer(
+        modifier = modifier.testTag(OnboardingTestTags.WELCOME_SCREEN).fillMaxWidth(),
+        data = PlusHeaderData.None,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(dimens.paddingLarge),
+            verticalArrangement = Arrangement.spacedBy(dimens.paddingNormal),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(Res.string.onboarding_welcome_title),
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(Res.string.onboarding_welcome_message),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            PlusButton(
+                text = Res.string.onboarding_welcome_get_started.asTextData(),
+                onClick = bloc::onGetStartedClicked,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(top = dimens.paddingNormal)
+                        .testTag(OnboardingTestTags.WELCOME_GET_STARTED_BUTTON),
+            )
+        }
+    }
+}

--- a/client/onboarding/public/build.gradle.kts
+++ b/client/onboarding/public/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(projects.client.text.public)
+            api(libs.arkivanov.decompose.core)
+            api(libs.kotlin.coroutines.core)
+            api(projects.client.shared)
+            api(projects.client.ui.public)
+            implementation(compose.components.resources)
+        }
+    }
+}
+
+compose { resources { publicResClass = true } }
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.onboarding" }

--- a/client/onboarding/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/onboarding/public/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,9 @@
+<resources>
+    <string name="onboarding_welcome_title">Welcome to ChefMate</string>
+    <string name="onboarding_welcome_message">Your kitchen companion for saving recipes, planning meals, and building grocery lists.</string>
+    <string name="onboarding_welcome_get_started">Get started</string>
+
+    <string name="onboarding_start_cooking_title">You’re all set</string>
+    <string name="onboarding_start_cooking_message">Everything’s ready to go. Let’s start cooking!</string>
+    <string name="onboarding_start_cooking_button">Start cooking</string>
+</resources>

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingRootBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingRootBloc.kt
@@ -1,0 +1,37 @@
+package com.plusmobileapps.chefmate.onboarding
+
+import com.arkivanov.decompose.router.stack.ChildStack
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.essenty.backhandler.BackHandlerOwner
+import com.plusmobileapps.chefmate.BackClickBloc
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.ui.BlocScreen
+
+/**
+ * Navigation BLoC that drives the first-run onboarding flow. It owns a Decompose router that walks
+ * the user from the [WelcomeBloc] through to the final [StartCookingBloc]. When the user finishes,
+ * it marks onboarding as completed and emits [Output.Finished] so the root can load the rest of the
+ * app.
+ *
+ * This is currently a skeleton with only the welcome and start-cooking screens; additional steps
+ * will be inserted between them in follow-up work.
+ */
+interface OnboardingRootBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
+    val routerState: Value<ChildStack<*, Child>>
+
+    sealed class Child : BlocScreen {
+        data class Welcome(val bloc: WelcomeBloc) : Child(), BlocScreen by bloc
+
+        data class StartCooking(val bloc: StartCookingBloc) : Child(), BlocScreen by bloc
+    }
+
+    sealed class Output {
+        /** The user reached the end of onboarding; the root should load the main app. */
+        data object Finished : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): OnboardingRootBloc
+    }
+}

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingRootBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingRootBloc.kt
@@ -20,10 +20,13 @@ import com.plusmobileapps.chefmate.ui.BlocScreen
 interface OnboardingRootBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
     val routerState: Value<ChildStack<*, Child>>
 
-    sealed class Child : BlocScreen {
-        data class Welcome(val bloc: WelcomeBloc) : Child(), BlocScreen by bloc
+    sealed class Child {
 
-        data class StartCooking(val bloc: StartCookingBloc) : Child(), BlocScreen by bloc
+        abstract val bloc: BlocScreen
+
+        data class Welcome(override val bloc: WelcomeBloc) : Child()
+
+        data class StartCooking(override val bloc: StartCookingBloc) : Child()
     }
 
     sealed class Output {

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingTestTags.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingTestTags.kt
@@ -1,0 +1,10 @@
+package com.plusmobileapps.chefmate.onboarding
+
+/** Stable test tags for the onboarding screens, used by snapshot and robot UI tests. */
+object OnboardingTestTags {
+    const val WELCOME_SCREEN = "onboarding_welcome_screen"
+    const val WELCOME_GET_STARTED_BUTTON = "onboarding_welcome_get_started_button"
+
+    const val START_COOKING_SCREEN = "onboarding_start_cooking_screen"
+    const val START_COOKING_BUTTON = "onboarding_start_cooking_button"
+}

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/StartCookingBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/StartCookingBloc.kt
@@ -1,0 +1,19 @@
+package com.plusmobileapps.chefmate.onboarding
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.ui.BlocScreen
+
+/** Final screen of the onboarding flow — confirms setup and launches the rest of the app. */
+interface StartCookingBloc : BlocScreen {
+    fun onStartCookingClicked()
+
+    sealed class Output {
+        /** The user is done with onboarding and wants to start using the app. */
+        data object StartCooking : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): StartCookingBloc
+    }
+}

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/WelcomeBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/WelcomeBloc.kt
@@ -1,0 +1,19 @@
+package com.plusmobileapps.chefmate.onboarding
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.ui.BlocScreen
+
+/** First screen of the onboarding flow — greets the user and kicks off the flow. */
+interface WelcomeBloc : BlocScreen {
+    fun onGetStartedClicked()
+
+    sealed class Output {
+        /** Advance to the next onboarding step. */
+        data object GetStarted : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): WelcomeBloc
+    }
+}

--- a/client/root/impl/build.gradle.kts
+++ b/client/root/impl/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             implementation(projects.client.cook.public)
             implementation(projects.client.featureflag.public)
             implementation(projects.client.grocery.core.public)
+            implementation(projects.client.onboarding.public)
             implementation(projects.client.profile.public)
             implementation(projects.client.recipe.core.public)
             implementation(projects.client.recipe.exporter.public)
@@ -23,7 +24,10 @@ kotlin {
             implementation(projects.client.auth.ui.public)
             implementation(libs.kotlinx.serialization.json)
         }
-        commonTest.dependencies { implementation(projects.client.featureflag.testing) }
+        commonTest.dependencies {
+            implementation(projects.client.featureflag.testing)
+            implementation(libs.multiplatform.settings.test)
+        }
     }
 }
 

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -8,6 +8,7 @@ import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
+import com.arkivanov.decompose.router.stack.replaceAll
 import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.aichat.AiChatRootBloc
@@ -18,9 +19,11 @@ import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.di.OnboardingRepository
 import com.plusmobileapps.chefmate.featureflag.FeatureFlags
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
 import com.plusmobileapps.chefmate.grocery.core.edit.EditGroceryListBloc
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
@@ -42,6 +45,8 @@ import kotlinx.serialization.Serializable
 class RootBlocImpl(
     @Assisted context: BlocContext,
     @Assisted deepLink: DeepLink,
+    private val onboardingRepository: OnboardingRepository,
+    private val onboardingRoot: OnboardingRootBloc.Factory,
     private val bottomNav: BottomNavBloc.Factory,
     private val browserRootBlocFactory: BrowserRootBloc.Factory,
     private val recipeRoot: RecipeRootBloc.Factory,
@@ -83,8 +88,13 @@ class RootBlocImpl(
             childFactory = ::createChild,
         )
 
-    private fun initialStackFor(deepLink: DeepLink): List<Configuration> =
-        when (deepLink) {
+    private fun initialStackFor(deepLink: DeepLink): List<Configuration> {
+        // First run: show onboarding before anything else. Deep links are honored once onboarding
+        // has been completed on a previous launch.
+        if (!onboardingRepository.hasCompletedOnboarding) {
+            return listOf(Configuration.Onboarding)
+        }
+        return when (deepLink) {
             DeepLink.None,
             DeepLink.Groceries,
             DeepLink.MealPlanner -> listOf(Configuration.BottomNavigation)
@@ -103,6 +113,7 @@ class RootBlocImpl(
                     Configuration.Authentication(AuthenticationBloc.Props.SignUp),
                 )
         }
+    }
 
     override val state: Value<ChildStack<*, RootBloc.Child>> = stack
 
@@ -119,6 +130,12 @@ class RootBlocImpl(
 
     private fun createChild(config: Configuration, context: BlocContext): RootBloc.Child =
         when (config) {
+            Configuration.Onboarding ->
+                RootBloc.Child.Onboarding(
+                    bloc =
+                        onboardingRoot.create(context = context, output = ::handleOnboardingOutput)
+                )
+
             Configuration.BottomNavigation ->
                 BottomNavigation(
                     bottomNav.create(
@@ -263,6 +280,16 @@ class RootBlocImpl(
                         )
                 )
         }
+
+    private fun handleOnboardingOutput(output: OnboardingRootBloc.Output) {
+        when (output) {
+            // Onboarding marks itself completed; swap the whole stack for the main app so back
+            // can't
+            // return to the flow.
+            OnboardingRootBloc.Output.Finished ->
+                navigation.replaceAll(Configuration.BottomNavigation)
+        }
+    }
 
     private fun handleBottomNavOutput(output: BottomNavBloc.Output) {
         when (output) {
@@ -490,6 +517,8 @@ class RootBlocImpl(
 
     @Serializable
     private sealed class Configuration {
+        @Serializable data object Onboarding : Configuration()
+
         @Serializable data object BottomNavigation : Configuration()
 
         @Serializable data class RecipeRoot(val props: RecipeRootBloc.Props) : Configuration()

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -20,8 +20,10 @@ import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.di.OnboardingRepository
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.featureflag.FeatureFlags
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
+import com.plusmobileapps.chefmate.featureflag.isEnabled
 import com.plusmobileapps.chefmate.grocery.core.edit.EditGroceryListBloc
 import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc
@@ -89,9 +91,11 @@ class RootBlocImpl(
         )
 
     private fun initialStackFor(deepLink: DeepLink): List<Configuration> {
-        // First run: show onboarding before anything else. Deep links are honored once onboarding
-        // has been completed on a previous launch.
-        if (!onboardingRepository.hasCompletedOnboarding) {
+        // First run: show onboarding before anything else, but only when the feature flag is on.
+        // Deep links are honored once onboarding has been completed on a previous launch (or when
+        // the flag is off).
+        val onboardingEnabled = featureFlags.isEnabled(FeatureFlagRegistry.Onboarding).value
+        if (onboardingEnabled && !onboardingRepository.hasCompletedOnboarding) {
             return listOf(Configuration.Onboarding)
         }
         return when (deepLink) {

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -348,6 +348,10 @@ class RootBlocImpl(
                 navigation.bringToFront(Configuration.DeveloperSettings)
             }
 
+            BottomNavBloc.Output.OpenOnboarding -> {
+                navigation.bringToFront(Configuration.Onboarding)
+            }
+
             is BottomNavBloc.Output.OpenCookMode -> {
                 navigation.bringToFront(Configuration.CookMode(output.recipeId))
             }

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -152,6 +152,13 @@ class RootBlocTest {
     }
 
     @Test
+    fun When_bottom_nav_outputs_open_onboarding_Then_onboarding_is_pushed() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenOnboarding)
+        rootBloc.instance() should instanceOf<RootBloc.Child.Onboarding>()
+        rootBloc.state.value.backStack.size shouldBe 1
+    }
+
+    @Test
     fun When_bottom_nav_outputs_create_recipe_Then_recipe_root_shown_with_create_props() {
         bottomNavOutput.onNext(BottomNavBloc.Output.AddNewRecipe)
         rootBloc.instance() should instanceOf<RootBloc.Child.RecipeRoot>()

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -10,7 +10,9 @@ import com.plusmobileapps.chefmate.auth.ui.AuthenticationBloc
 import com.plusmobileapps.chefmate.auth.ui.otp.OtpBloc
 import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
+import com.plusmobileapps.chefmate.di.OnboardingRepository
 import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
@@ -18,6 +20,7 @@ import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
 import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
 import com.plusmobileapps.chefmate.settings.root.SettingsRootBloc
 import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.russhwolf.settings.MapSettings
 import dev.mokkery.MockMode
 import dev.mokkery.mock
 import io.kotest.matchers.should
@@ -45,14 +48,24 @@ class RootBlocTest {
     var exportRecipesOutput: Consumer<ExportRecipesBloc.Output> = Consumer {}
     var exportRecipesProps: ExportRecipesBloc.Props? = null
     var bottomNavInitialTab: BottomNavBloc.Tab? = null
+    var onboardingOutput: Consumer<OnboardingRootBloc.Output> = Consumer {}
 
     fun createRoot(
         deepLink: DeepLink = DeepLink.None,
         context: BlocContext = TestBlocContext.create(),
+        onboardingCompleted: Boolean = true,
     ): RootBlocImpl =
         RootBlocImpl(
             context = context,
             deepLink = deepLink,
+            onboardingRepository =
+                OnboardingRepository(MapSettings()).apply {
+                    if (onboardingCompleted) setOnboardingCompleted()
+                },
+            onboardingRoot = { _, output ->
+                onboardingOutput = output
+                mock()
+            },
             bottomNav = { _, output, initialTab ->
                 bottomNavOutput = output
                 bottomNavInitialTab = initialTab
@@ -120,6 +133,22 @@ class RootBlocTest {
     fun When_initialized_Then_bottom_nav_is_shown() {
         rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
         rootBloc.state.value.backStack.size shouldBe 0
+    }
+
+    @Test
+    fun When_onboarding_not_completed_Then_onboarding_is_shown() {
+        val root = createRoot(onboardingCompleted = false)
+        root.instance() should instanceOf<RootBloc.Child.Onboarding>()
+        root.state.value.backStack.size shouldBe 0
+    }
+
+    @Test
+    fun When_onboarding_finishes_Then_bottom_nav_replaces_the_stack() {
+        val root = createRoot(onboardingCompleted = false)
+        onboardingOutput.onNext(OnboardingRootBloc.Output.Finished)
+        root.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+        // replaceAll wipes the onboarding flow so back can't return to it.
+        root.state.value.backStack.size shouldBe 0
     }
 
     @Test

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -11,6 +11,7 @@ import com.plusmobileapps.chefmate.auth.ui.otp.OtpBloc
 import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.di.OnboardingRepository
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
 import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
@@ -54,6 +55,7 @@ class RootBlocTest {
         deepLink: DeepLink = DeepLink.None,
         context: BlocContext = TestBlocContext.create(),
         onboardingCompleted: Boolean = true,
+        onboardingFlagEnabled: Boolean = true,
     ): RootBlocImpl =
         RootBlocImpl(
             context = context,
@@ -110,7 +112,8 @@ class RootBlocTest {
                 mock()
             },
             cookMode = CookModeBloc.Factory { _, _, _ -> mock() },
-            featureFlags = FakeFeatureFlags(),
+            featureFlags =
+                FakeFeatureFlags(mapOf(FeatureFlagRegistry.Onboarding to onboardingFlagEnabled)),
             featureFlagsBlocFactory = { _, _ -> mock() },
             aiChat = { _, output ->
                 aiChatOutput = output
@@ -139,6 +142,13 @@ class RootBlocTest {
     fun When_onboarding_not_completed_Then_onboarding_is_shown() {
         val root = createRoot(onboardingCompleted = false)
         root.instance() should instanceOf<RootBloc.Child.Onboarding>()
+        root.state.value.backStack.size shouldBe 0
+    }
+
+    @Test
+    fun When_onboarding_flag_disabled_Then_bottom_nav_is_shown_even_if_not_completed() {
+        val root = createRoot(onboardingCompleted = false, onboardingFlagEnabled = false)
+        root.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
         root.state.value.backStack.size shouldBe 0
     }
 

--- a/client/root/public/build.gradle.kts
+++ b/client/root/public/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             api(projects.client.developerSettings.public)
             api(projects.client.featureflag.public)
             api(projects.client.grocery.core.public)
+            api(projects.client.onboarding.public)
             api(projects.client.profile.public)
             api(projects.client.recipe.core.public)
             api(projects.client.recipe.exporter.public)

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -13,6 +13,7 @@ import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
 import com.plusmobileapps.chefmate.grocery.core.edit.EditGroceryListBloc
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
@@ -28,6 +29,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
     fun handleSharedUrl(url: String)
 
     sealed class Child : BlocScreen {
+        data class Onboarding(val bloc: OnboardingRootBloc) : Child(), BlocScreen by bloc
+
         data class BottomNavigation(val bloc: BottomNavBloc) : Child(), BlocScreen by bloc
 
         data class RecipeRoot(val bloc: RecipeRootBloc) : Child(), BlocScreen by bloc

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -87,6 +87,10 @@ class SettingsBlocImpl(
         output.onNext(Output.OpenDeveloperSettings)
     }
 
+    override fun onReplayOnboardingClicked() {
+        output.onNext(Output.OpenOnboarding)
+    }
+
     @Composable
     override fun Content(modifier: Modifier) {
         SettingsScreen(bloc = this, modifier = modifier)

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -43,6 +43,7 @@ class SettingsBlocImpl(
                 showSignOutConfirmationDialog = it.showSignOutConfirmationDialog,
                 isDebugBuild = isDebugBuild,
                 isAiChatEnabled = it.isAiChatEnabled,
+                isOnboardingEnabled = it.isOnboardingEnabled,
                 versionName = BuildConfig.VERSION_NAME,
             )
         }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
@@ -31,14 +31,24 @@ class SettingsViewModel(
     private val aiChatEnabled: StateFlow<Boolean> =
         featureFlags.isEnabled(FeatureFlagRegistry.AiChat)
 
+    private val onboardingEnabled: StateFlow<Boolean> =
+        featureFlags.isEnabled(FeatureFlagRegistry.Onboarding)
+
     init {
         observeAuthState()
         observeAiChatFlag()
+        observeOnboardingFlag()
     }
 
     private fun observeAiChatFlag() {
         aiChatEnabled
             .onEach { enabled -> _state.update { it.copy(isAiChatEnabled = enabled) } }
+            .launchIn(scope)
+    }
+
+    private fun observeOnboardingFlag() {
+        onboardingEnabled
+            .onEach { enabled -> _state.update { it.copy(isOnboardingEnabled = enabled) } }
             .launchIn(scope)
     }
 
@@ -110,5 +120,6 @@ class SettingsViewModel(
         val emailAwaitingVerification: String? = null,
         val showSignOutConfirmationDialog: Boolean = false,
         val isAiChatEnabled: Boolean = false,
+        val isOnboardingEnabled: Boolean = false,
     )
 }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/ui/SettingsScreen.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/ui/SettingsScreen.kt
@@ -159,11 +159,13 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
                 name = Res.string.about.asTextData(),
                 onClick = { bloc.onUrlClicked("https://chefmate.plusmobileapps.com/") },
             )
-            HorizontalDivider()
-            SettingsRow(
-                name = Res.string.settings_replay_onboarding.asTextData(),
-                onClick = bloc::onReplayOnboardingClicked,
-            )
+            if (viewState.isOnboardingEnabled) {
+                HorizontalDivider()
+                SettingsRow(
+                    name = Res.string.settings_replay_onboarding.asTextData(),
+                    onClick = bloc::onReplayOnboardingClicked,
+                )
+            }
             if (viewState.isDebugBuild) {
                 HorizontalDivider()
                 SettingsRow(

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/ui/SettingsScreen.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/ui/SettingsScreen.kt
@@ -39,6 +39,7 @@ import chefmate.client.settings.public.generated.resources.privacy_policy
 import chefmate.client.settings.public.generated.resources.settings
 import chefmate.client.settings.public.generated.resources.settings_ai_chat
 import chefmate.client.settings.public.generated.resources.settings_guest_banner
+import chefmate.client.settings.public.generated.resources.settings_replay_onboarding
 import chefmate.client.settings.public.generated.resources.sign_in
 import chefmate.client.settings.public.generated.resources.sign_out
 import chefmate.client.settings.public.generated.resources.sign_out_confirmation_cancel
@@ -157,6 +158,11 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
             SettingsRow(
                 name = Res.string.about.asTextData(),
                 onClick = { bloc.onUrlClicked("https://chefmate.plusmobileapps.com/") },
+            )
+            HorizontalDivider()
+            SettingsRow(
+                name = Res.string.settings_replay_onboarding.asTextData(),
+                onClick = bloc::onReplayOnboardingClicked,
             )
             if (viewState.isDebugBuild) {
                 HorizontalDivider()
@@ -292,6 +298,8 @@ private val previewBlocUnauthenticated =
 
         override fun onDeveloperSettingsClicked() = Unit
 
+        override fun onReplayOnboardingClicked() = Unit
+
         @Composable override fun Content(modifier: Modifier) = SettingsScreen(this, modifier)
     }
 
@@ -330,6 +338,8 @@ private val previewBlocAuthenticated =
 
         override fun onDeveloperSettingsClicked() = Unit
 
+        override fun onReplayOnboardingClicked() = Unit
+
         @Composable override fun Content(modifier: Modifier) = SettingsScreen(this, modifier)
     }
 
@@ -363,6 +373,8 @@ private val previewBlocAnonymous =
         override fun onAiChatClicked() = Unit
 
         override fun onDeveloperSettingsClicked() = Unit
+
+        override fun onReplayOnboardingClicked() = Unit
 
         @Composable override fun Content(modifier: Modifier) = SettingsScreen(this, modifier)
     }

--- a/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImplTest.kt
+++ b/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImplTest.kt
@@ -124,6 +124,31 @@ class SettingsBlocImplTest {
     }
 
     @Test
+    fun When_replay_onboarding_clicked_Then_OpenOnboarding_output_emitted() {
+        bloc.onReplayOnboardingClicked()
+        output.lastValue shouldBe SettingsBloc.Output.OpenOnboarding
+    }
+
+    @Test
+    fun When_onboarding_flag_off_Then_isOnboardingEnabled_is_false() = runTest {
+        // Flag defaults to off — the replay row should be hidden.
+        bloc.state.value.isOnboardingEnabled shouldBe false
+    }
+
+    @Test
+    fun When_onboarding_flag_on_Then_isOnboardingEnabled_is_true() = runTest {
+        featureFlags.set(FeatureFlagRegistry.Onboarding, true)
+
+        bloc.state.test {
+            val initial = awaitItem()
+            if (!initial.isOnboardingEnabled) {
+                awaitItem().isOnboardingEnabled shouldBe true
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun When_authenticated_Then_state_reflects_authenticated() = runTest {
         bloc.state.test {
             awaitItem().isAuthenticated shouldBe false

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="sign_out_confirmation_cancel">Cancel</string>
     <string name="settings">Settings</string>
     <string name="settings_ai_chat">AI Chat</string>
+    <string name="settings_replay_onboarding">View Onboarding Again</string>
     <string name="import_recipes">Import Recipes</string>
     <string name="export_recipes">Export Recipes</string>
     <string name="app_settings_title">Settings</string>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -29,6 +29,8 @@ interface SettingsBloc : BlocScreen {
 
     fun onDeveloperSettingsClicked()
 
+    fun onReplayOnboardingClicked()
+
     data class Model(
         val isAuthenticated: Boolean = false,
         /**
@@ -58,6 +60,9 @@ interface SettingsBloc : BlocScreen {
         data object OpenAiChat : Output()
 
         data object OpenDeveloperSettings : Output()
+
+        /** Replay the first-run onboarding flow from the More tab. */
+        data object OpenOnboarding : Output()
 
         data class OpenUrl(val url: String) : Output()
     }

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -45,6 +45,8 @@ interface SettingsBloc : BlocScreen {
         val showSignOutConfirmationDialog: Boolean = false,
         val isDebugBuild: Boolean = false,
         val isAiChatEnabled: Boolean = false,
+        /** Gates the "View Onboarding Again" row behind the onboarding feature flag. */
+        val isOnboardingEnabled: Boolean = false,
         val versionName: String = "",
     )
 

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/OnboardingRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/OnboardingRepository.kt
@@ -1,0 +1,29 @@
+package com.plusmobileapps.chefmate.di
+
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.boolean
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+/**
+ * Tracks whether the user has completed the first-run onboarding flow. Persisted via
+ * multiplatform-settings so the flow is only ever shown once per install. The root navigation reads
+ * [hasCompletedOnboarding] when deciding the initial screen, and the onboarding flow calls
+ * [setOnboardingCompleted] once the user reaches the end.
+ */
+@Inject
+@SingleIn(AppScope::class)
+class OnboardingRepository(settings: Settings) {
+    private var completed by settings.boolean(KEY, defaultValue = false)
+
+    val hasCompletedOnboarding: Boolean
+        get() = completed
+
+    fun setOnboardingCompleted() {
+        completed = true
+    }
+
+    companion object {
+        private const val KEY = "onboarding_completed"
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -98,6 +98,10 @@ include(":client:meal:core:impl")
 
 include(":client:meal:core:public")
 
+include(":client:onboarding:impl")
+
+include(":client:onboarding:public")
+
 include(":client:meal:data:impl")
 
 include(":client:meal:data:public")


### PR DESCRIPTION
## Overview

Adds the skeleton of a first-run onboarding flow driven by a Decompose router, plus the wiring needed to show it once per install. The screens themselves are deliberately minimal — a **Welcome** screen and a final **Start cooking** screen — and will be fleshed out in follow-up PRs.

## What changed

**New `onboarding` feature module** (`public` + `impl`, following the BlocScreen-delegation pattern):
- `OnboardingRootBloc` — navigation BLoC owning a `StackNavigation`/`childStack` that walks `Welcome → StartCooking`. On finish it persists completion and emits `Output.Finished`.
- `WelcomeBloc` / `StartCookingBloc` — simple leaf screens built from `PlusHeaderContainer` + `PlusButton` with localized strings.

**Persistence** — `OnboardingRepository` (in `client/shared`) backed by multiplatform-settings (`onboarding_completed`, default `false`), mirroring the existing `MarkdownEditorModeRepository` / `KeepScreenOnRepository`.

**Root wiring** — `RootBloc` gains an `Onboarding` child. `RootBlocImpl` makes onboarding the initial stack when it hasn't been completed (deep links are honored once it has), and `replaceAll`s the stack with the bottom nav when onboarding finishes so back can't return to the flow. `OnboardingRepository` is exposed on `ApplicationComponent`.

**Plumbing** — registered both modules in `settings.gradle.kts` and the DI graph (`composeApp/build.gradle.kts`).

## Testing

- `:client:composeApp:compileKotlinJvm` (desktop) builds, exercising the full Metro DI graph.
- `:client:root:impl:jvmTest` passes, including new cases for the first-run flow and the finish→bottom-nav handoff.
- The shared UI-test harness now defaults onboarding to completed so existing navigation tests keep booting straight into the app.

## Reviewer notes

- **Deferred to follow-ups** (per "just the skeleton"): the onboarding screens' snapshot tests (`<Feature>Previews.kt` + `screenshot-test`) and robot UI tests. Flagging since the repo convention normally wants those alongside new UI.
- **Formatting**: `./gradlew ktfmtFormat` pins ktfmt **0.26.0**, but the pre-commit hook uses standalone ktfmt **0.63** — the gradle task rewrites unrelated committed files to the older style. Files here were formatted with `ktfmt --kotlinlang-style` (0.63) to match the committed style. Might be worth aligning the two versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)