### PR TITLE
refactor: express nav Child/Sheet bloc via abstract val (+docs)

### DIFF
--- a/.agents/seed.md
+++ b/.agents/seed.md
@@ -70,7 +70,7 @@ Every screen is a BLoC. The pattern is:
 2. **Impl** (`GroceryListBlocImpl`) — annotated with `@Inject` + `@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = ...)`. Delegates `BlocContext by context`. Gets a ViewModel via `instanceKeeper.getViewModel { ... }`.
 3. **ViewModel** — annotated `@Inject`. Extends `ViewModel(@Main mainContext)`. Uses `scope` (coroutine scope on main thread) for async work. Holds `MutableStateFlow<State>`.
 
-Navigation BLoCs expose `routerState: Value<ChildStack<*, Child>>`, use `StackNavigation<Configuration>` with `childStack()`, and use serializable `Configuration` sealed classes.
+Navigation BLoCs expose `routerState: Value<ChildStack<*, Child>>`, use `StackNavigation<Configuration>` with `childStack()`, and use serializable `Configuration` sealed classes. The `Child` sealed class exposes an `abstract val bloc: BlocScreen`, and each variant overrides it with its concrete bloc (`data class Detail(override val bloc: RecipeDetailBloc) : Child()`). This lets the navigation screen render any child uniformly with `child.instance.bloc.Content()` — no `when` over child types.
 
 See `docs/architecture.md` for full annotated examples of both patterns.
 

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatRootScreen.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatRootScreen.kt
@@ -15,6 +15,6 @@ fun AiChatRootScreen(bloc: AiChatRootBloc, modifier: Modifier = Modifier) {
         stack = bloc.routerState,
         animation = backAnimation(backHandler = bloc.backHandler, onBack = bloc::onBackClicked),
     ) { child ->
-        child.instance.Content()
+        child.instance.bloc.Content()
     }
 }

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatRootBloc.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatRootBloc.kt
@@ -12,10 +12,13 @@ import com.plusmobileapps.chefmate.ui.BlocScreen
 interface AiChatRootBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
     val routerState: Value<ChildStack<*, Child>>
 
-    sealed class Child : BlocScreen {
-        data class Chat(val bloc: AiChatBloc) : Child(), BlocScreen by bloc
+    sealed class Child {
 
-        data class History(val bloc: AiChatHistoryBloc) : Child(), BlocScreen by bloc
+        abstract val bloc: BlocScreen
+
+        data class Chat(override val bloc: AiChatBloc) : Child()
+
+        data class History(override val bloc: AiChatHistoryBloc) : Child()
     }
 
     sealed class Output {

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/ui/BottomNavScreen.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/ui/BottomNavScreen.kt
@@ -149,7 +149,7 @@ private fun BottomNavContentContainer(bloc: BottomNavBloc, modifier: Modifier = 
                 },
             ),
     ) { created ->
-        created.instance.Content()
+        created.instance.bloc.Content()
     }
 }
 

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -46,16 +46,19 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
         SETTINGS,
     }
 
-    sealed class Child : BlocScreen {
-        data class RecipeList(val bloc: RecipeListBloc) : Child(), BlocScreen by bloc
+    sealed class Child {
 
-        data class GroceryList(val bloc: GroceryListBloc) : Child(), BlocScreen by bloc
+        abstract val bloc: BlocScreen
 
-        data class Meals(val bloc: MealPlanBloc) : Child(), BlocScreen by bloc
+        data class RecipeList(override val bloc: RecipeListBloc) : Child()
 
-        data class Browser(val bloc: BrowserRootBloc) : Child(), BlocScreen by bloc
+        data class GroceryList(override val bloc: GroceryListBloc) : Child()
 
-        data class Settings(val bloc: SettingsBloc) : Child(), BlocScreen by bloc
+        data class Meals(override val bloc: MealPlanBloc) : Child()
+
+        data class Browser(override val bloc: BrowserRootBloc) : Child()
+
+        data class Settings(override val bloc: SettingsBloc) : Child()
     }
 
     sealed class Output {

--- a/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserRootBloc.kt
+++ b/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserRootBloc.kt
@@ -12,12 +12,15 @@ interface BrowserRootBloc : BlocScreen {
 
     fun navigateToUrl(url: String)
 
-    sealed class Child : BlocScreen {
-        data class Landing(val bloc: BrowserLandingBloc) : Child(), BlocScreen by bloc
+    sealed class Child {
 
-        data class EditQuery(val bloc: BrowserEditQueryBloc) : Child(), BlocScreen by bloc
+        abstract val bloc: BlocScreen
 
-        data class Browser(val bloc: BrowserBloc) : Child(), BlocScreen by bloc
+        data class Landing(override val bloc: BrowserLandingBloc) : Child()
+
+        data class EditQuery(override val bloc: BrowserEditQueryBloc) : Child()
+
+        data class Browser(override val bloc: BrowserBloc) : Child()
     }
 
     sealed class Output {

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
@@ -136,7 +136,6 @@ import chefmate.client.grocery.core.public.generated.resources.grocery_sync_sync
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_syncing
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.plusmobileapps.chefmate.grocery.core.displayName
-import com.plusmobileapps.chefmate.grocery.core.impl.detail.ui.GroceryDetailSheetContent
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryDisplayGroup
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryDisplayItem
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryGroupedList
@@ -150,6 +149,7 @@ import com.plusmobileapps.chefmate.grocery.data.SyncStatus
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
@@ -453,10 +453,7 @@ private fun GroceryDetailSheet(bloc: GroceryListBloc) {
             title = Res.string.grocery_detail.asTextData(),
             onCloseClick = bloc::onDismissSheet,
         ) {
-            when (active) {
-                is GroceryListBloc.Sheet.GroceryDetail ->
-                    GroceryDetailSheetContent(bloc = active.bloc)
-            }
+            active.bloc.Content()
         }
     }
 }

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
@@ -108,7 +108,10 @@ interface GroceryListBloc : BlocScreen {
     }
 
     sealed class Sheet {
-        data class GroceryDetail(val bloc: GroceryDetailBloc) : Sheet()
+
+        abstract val bloc: BlocScreen
+
+        data class GroceryDetail(override val bloc: GroceryDetailBloc) : Sheet()
     }
 
     fun interface Factory {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/ui/RecipeDetailScreen.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/ui/RecipeDetailScreen.kt
@@ -157,7 +157,6 @@ import com.plusmobileapps.chefmate.letIfTrue
 import com.plusmobileapps.chefmate.recipe.categories.pickerLabelRes
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailTestTags
-import com.plusmobileapps.chefmate.recipe.core.impl.addgrocery.ui.AddRecipeToGroceryListScreen
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.Category
 import com.plusmobileapps.chefmate.recipe.data.IngredientSection
@@ -166,6 +165,7 @@ import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.LocalAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.LocalSecondaryAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
@@ -567,11 +567,7 @@ private fun RecipeDetailSheet(
                 }
             },
         ) {
-            when (val current = sheetChild) {
-                is RecipeDetailBloc.Sheet.AddToGroceryList ->
-                    AddRecipeToGroceryListScreen(current.bloc)
-                null -> {}
-            }
+            sheetChild?.bloc?.Content()
         }
     }
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/ui/RecipeRootScreen.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/ui/RecipeRootScreen.kt
@@ -19,6 +19,6 @@ fun RecipeRootScreen(recipeRootBloc: RecipeRootBloc, modifier: Modifier = Modifi
                 onBack = recipeRootBloc::onBackClicked,
             ),
     ) { child ->
-        child.instance.Content()
+        child.instance.bloc.Content()
     }
 }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addmeal/MealPlannerRootBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addmeal/MealPlannerRootBloc.kt
@@ -12,12 +12,15 @@ import kotlinx.serialization.Serializable
 interface MealPlannerRootBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
     val routerState: Value<ChildStack<*, Child>>
 
-    sealed class Child : BlocScreen {
-        data class RecipePicker(val bloc: RecipePickerBloc) : Child(), BlocScreen by bloc
+    sealed class Child {
 
-        data class ChooseDate(val bloc: ChooseDateBloc) : Child(), BlocScreen by bloc
+        abstract val bloc: BlocScreen
 
-        data class ChooseMealType(val bloc: ChooseMealTypeBloc) : Child(), BlocScreen by bloc
+        data class RecipePicker(override val bloc: RecipePickerBloc) : Child()
+
+        data class ChooseDate(override val bloc: ChooseDateBloc) : Child()
+
+        data class ChooseMealType(override val bloc: ChooseMealTypeBloc) : Child()
     }
 
     sealed class Output {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -74,7 +74,10 @@ interface RecipeDetailBloc : BackClickBloc, BlocScreen {
     }
 
     sealed class Sheet {
-        data class AddToGroceryList(val bloc: AddRecipeToGroceryListBloc) : Sheet()
+
+        abstract val bloc: BlocScreen
+
+        data class AddToGroceryList(override val bloc: AddRecipeToGroceryListBloc) : Sheet()
     }
 
     sealed class FullImage {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/root/RecipeRootBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/root/RecipeRootBloc.kt
@@ -16,10 +16,13 @@ import kotlinx.serialization.Serializable
 interface RecipeRootBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
     val routerState: Value<ChildStack<*, Child>>
 
-    sealed class Child : BlocScreen {
-        data class Detail(val bloc: RecipeDetailBloc) : Child(), BlocScreen by bloc
+    sealed class Child {
 
-        data class Edit(val bloc: EditRecipeBloc) : Child(), BlocScreen by bloc
+        abstract val bloc: BlocScreen
+
+        data class Detail(override val bloc: RecipeDetailBloc) : Child()
+
+        data class Edit(override val bloc: EditRecipeBloc) : Child()
     }
 
     sealed class Output {

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -28,38 +28,41 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
 
     fun handleSharedUrl(url: String)
 
-    sealed class Child : BlocScreen {
-        data class Onboarding(val bloc: OnboardingRootBloc) : Child(), BlocScreen by bloc
+    sealed class Child {
 
-        data class BottomNavigation(val bloc: BottomNavBloc) : Child(), BlocScreen by bloc
+        abstract val bloc: BlocScreen
 
-        data class RecipeRoot(val bloc: RecipeRootBloc) : Child(), BlocScreen by bloc
+        data class Onboarding(override val bloc: OnboardingRootBloc) : Child()
 
-        data class Authentication(val bloc: AuthenticationBloc) : Child(), BlocScreen by bloc
+        data class BottomNavigation(override val bloc: BottomNavBloc) : Child()
 
-        data class OtpVerification(val bloc: OtpBloc) : Child(), BlocScreen by bloc
+        data class RecipeRoot(override val bloc: RecipeRootBloc) : Child()
 
-        data class Browser(val bloc: BrowserRootBloc) : Child(), BlocScreen by bloc
+        data class Authentication(override val bloc: AuthenticationBloc) : Child()
 
-        data class MealPlanner(val bloc: MealPlannerRootBloc) : Child(), BlocScreen by bloc
+        data class OtpVerification(override val bloc: OtpBloc) : Child()
 
-        data class SettingsRoot(val bloc: SettingsRootBloc) : Child(), BlocScreen by bloc
+        data class Browser(override val bloc: BrowserRootBloc) : Child()
 
-        data class ManageProfile(val bloc: ManageProfileBloc) : Child(), BlocScreen by bloc
+        data class MealPlanner(override val bloc: MealPlannerRootBloc) : Child()
 
-        data class DeveloperSettings(val bloc: DeveloperSettingsBloc) : Child(), BlocScreen by bloc
+        data class SettingsRoot(override val bloc: SettingsRootBloc) : Child()
 
-        data class FeatureFlags(val bloc: FeatureFlagsBloc) : Child(), BlocScreen by bloc
+        data class ManageProfile(override val bloc: ManageProfileBloc) : Child()
 
-        data class CookMode(val bloc: CookModeBloc) : Child(), BlocScreen by bloc
+        data class DeveloperSettings(override val bloc: DeveloperSettingsBloc) : Child()
 
-        data class AiChat(val bloc: AiChatRootBloc) : Child(), BlocScreen by bloc
+        data class FeatureFlags(override val bloc: FeatureFlagsBloc) : Child()
 
-        data class ExportRecipes(val bloc: ExportRecipesBloc) : Child(), BlocScreen by bloc
+        data class CookMode(override val bloc: CookModeBloc) : Child()
 
-        data class EditRecipeBook(val bloc: EditRecipeBookBloc) : Child(), BlocScreen by bloc
+        data class AiChat(override val bloc: AiChatRootBloc) : Child()
 
-        data class EditGroceryList(val bloc: EditGroceryListBloc) : Child(), BlocScreen by bloc
+        data class ExportRecipes(override val bloc: ExportRecipesBloc) : Child()
+
+        data class EditRecipeBook(override val bloc: EditRecipeBookBloc) : Child()
+
+        data class EditGroceryList(override val bloc: EditGroceryListBloc) : Child()
     }
 
     fun interface Factory {

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -46,7 +46,7 @@ fun RootScreen(rootBloc: RootBloc, modifier: Modifier = Modifier) {
                         isModal = { it.isModal() },
                     ),
             ) { child ->
-                child.instance.Content()
+                child.instance.bloc.Content()
             }
         }
     }
@@ -58,7 +58,7 @@ private fun RootBloc.Child.isModal(): Boolean =
         this is RootBloc.Child.MealPlanner ||
         this is RootBloc.Child.CookMode ||
         this is RootBloc.Child.EditRecipeBook ||
-            this is RootBloc.Child.EditGroceryList
+        this is RootBloc.Child.EditGroceryList
 
 private fun verticalSlide(): StackAnimator = stackAnimator { factor, direction, content ->
     content(Modifier.offsetYFactor(if (direction.isFront) factor else 0f))

--- a/client/settings/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/SettingsRootBloc.kt
+++ b/client/settings/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/SettingsRootBloc.kt
@@ -16,16 +16,19 @@ import com.plusmobileapps.chefmate.ui.BlocScreen
 interface SettingsRootBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
     val routerState: Value<ChildStack<*, Child>>
 
-    sealed class Child : BlocScreen {
-        data class AppSettings(val bloc: AppSettingsBloc) : Child(), BlocScreen by bloc
+    sealed class Child {
 
-        data class BottomNavOrder(val bloc: BottomNavOrderBloc) : Child(), BlocScreen by bloc
+        abstract val bloc: BlocScreen
 
-        data class ExportRecipes(val bloc: ExportRecipesBloc) : Child(), BlocScreen by bloc
+        data class AppSettings(override val bloc: AppSettingsBloc) : Child()
 
-        data class ImportRecipes(val bloc: ImportRecipesBloc) : Child(), BlocScreen by bloc
+        data class BottomNavOrder(override val bloc: BottomNavOrderBloc) : Child()
 
-        data class RecipeCategories(val bloc: RecipeCategoriesBloc) : Child(), BlocScreen by bloc
+        data class ExportRecipes(override val bloc: ExportRecipesBloc) : Child()
+
+        data class ImportRecipes(override val bloc: ImportRecipesBloc) : Child()
+
+        data class RecipeCategories(override val bloc: RecipeCategoriesBloc) : Child()
     }
 
     sealed class Output {

--- a/client/settings/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/SettingsRootScreen.kt
+++ b/client/settings/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/SettingsRootScreen.kt
@@ -15,6 +15,6 @@ fun SettingsRootScreen(bloc: SettingsRootBloc, modifier: Modifier = Modifier) {
         stack = bloc.routerState,
         animation = backAnimation(backHandler = bloc.backHandler, onBack = bloc::onBackClicked),
     ) { child ->
-        child.instance.Content()
+        child.instance.bloc.Content()
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,20 +175,27 @@ import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc
+import com.plusmobileapps.chefmate.ui.BlocScreen
 import kotlinx.serialization.Serializable
 
 interface RecipeRootBloc :
     BackHandlerOwner,
-    BackClickBloc {
+    BackClickBloc,
+    BlocScreen {
     val routerState: Value<ChildStack<*, Child>>
 
+    // The Child sealed class exposes an `abstract val bloc: BlocScreen`, and each
+    // variant overrides it with its concrete bloc. This lets the screen render any
+    // child uniformly with `child.instance.bloc.Content()` — no `when`.
     sealed class Child {
+        abstract val bloc: BlocScreen
+
         data class Detail(
-            val bloc: RecipeDetailBloc,
+            override val bloc: RecipeDetailBloc,
         ) : Child()
 
         data class Edit(
-            val bloc: EditRecipeBloc,
+            override val bloc: EditRecipeBloc,
         ) : Child()
     }
 
@@ -350,6 +357,21 @@ class RecipeRootBlocImpl(
 All UI is written using Compose Multiplatform to share the same UI across all of the client targets. Every UI has the suffix `Screen` to the name of its file, i.e. `RecipeListScreen.kt`. These files live in the feature's `public` module so that it could be bound into which ever feature depends on it.
 
 All reusable components for the project exist in `client/ui/public` module typically prefixing every component with `Plus`. `PlusHeaderContainer` is the most common component used at the base of every screen's `@Composable`.
+
+Every screen implements `BlocScreen`, which exposes a single `@Composable fun Content(modifier: Modifier)`. Because each navigation `Child` exposes its wrapped bloc via `val bloc: BlocScreen` (see the BLoC pattern above), a navigation screen renders the whole stack without a `when` over child types:
+
+```kotlin
+@Composable
+fun RecipeRootScreen(bloc: RecipeRootBloc, modifier: Modifier = Modifier) {
+    Children(
+        modifier = modifier.fillMaxSize(),
+        stack = bloc.routerState,
+        animation = backAnimation(backHandler = bloc.backHandler, onBack = bloc::onBackClicked),
+    ) { child ->
+        child.instance.bloc.Content()
+    }
+}
+```
 
 ### Navigation Animations & Shared Elements
 


### PR DESCRIPTION
## Overview

Standardizes how navigation BLoCs expose their child screens, following the `abstract val bloc: BlocScreen` shape introduced for `OnboardingRootBloc` in #303 (see [that commit](https://github.com/Plus-Mobile-Apps/chef-mate/pull/303/changes/3cebd8ae96ee301f20a4e0d4f487a76161a6f8ca)). Rebased on the latest `main`.

## The pattern

A `Child` sealed class declares the bloc as an abstract property; each variant overrides it. No interface delegation, and the render site reads the bloc explicitly:

```kotlin
sealed class Child {
    abstract val bloc: BlocScreen
    data class Detail(override val bloc: RecipeDetailBloc) : Child()
    data class Edit(override val bloc: EditRecipeBloc)     : Child()
}

// render:
Children(stack = bloc.routerState, ...) { child -> child.instance.bloc.Content() }
```

## What changed

### Refactor
Converted every nav `Child` sealed class (root, recipe, meal-planner, settings, ai-chat, browser, bottom-nav) **and** the two `childSlot` `Sheet` wrappers (recipe-detail, grocery-list) from `Child : BlocScreen` + `BlocScreen by bloc` to the abstract-val shape, and updated all render sites to `child.instance.bloc.Content()`. Browser/meal-planner already accessed `instance.bloc`, so they were untouched. Behavior is unchanged.

### Docs
- `docs/architecture.md` — `RecipeRootBloc` example updated to the abstract-val shape; added a `RecipeRootScreen` snippet rendering via `child.instance.bloc.Content()`.
- `.agents/seed.md` — documents the abstract-val `Child` accessor and the `when`-free render.

## Notes for reviewers

- `RecipeDetailBloc.FullImage` is intentionally **not** converted — it carries plain data (`imageUrl`, `recipeId`, `title`), not a child bloc.
- Touched files were formatted by the pre-commit hook (ktfmt 0.63). `./gradlew ktfmtFormat` (0.26) was avoided in the final state — it reformats unrelated files, per the drift noted on #303.

## Testing

- `:client:composeApp:compileKotlinJvm` (desktop, full DI graph) — BUILD SUCCESSFUL.
- `:client:root:impl:jvmTest`, `:client:grocery:core:impl:jvmTest`, `:client:recipe:core:impl:jvmTest` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)