### PR TITLE
feat: plusApplication convention + standalone onboarding demo app

### DIFF
--- a/.agents/seed.md
+++ b/.agents/seed.md
@@ -14,6 +14,11 @@ This file provides shared guidance to Claude Code and Codex when working with co
 # Desktop (JVM)
 ./gradlew :client:composeApp:run
 
+# Feature demo apps (standalone, isolated builds — see "Demo apps" below)
+./gradlew :client:onboarding:demo:installDebug   # run a feature demo on Android
+./gradlew :client:onboarding:demo:run            # run a feature demo on desktop (JVM)
+./gradlew :client:onboarding:demo:assembleDebug  # compile-check a demo without a device
+
 # Server
 ./gradlew :server:run
 
@@ -55,6 +60,8 @@ Every feature is split into three module types:
 - `public` — API contracts (interfaces, models, UI screens). May depend on other `public` modules only.
 - `impl` — Production implementation. Depends on `public` modules only. Every new `impl` module must be added to `client/composeApp/build.gradle.kts` under `commonMain` to register it in the DI graph.
 - `testing` — Fake/stub implementations for use in other modules' tests.
+
+A feature may also have an optional `demo` module (e.g. `:client:onboarding:demo`) — a standalone Compose Multiplatform **application** (Android + JVM desktop) that renders one feature in isolation so it can be built and run without the full `:client:composeApp`. It applies the `plusApplication` convention plugin and wires the feature's **real** BLoCs through a small per-demo Metro `@DependencyGraph(AppScope::class)` that `@Provides` **fakes** (from the `testing` modules) for any heavy leaf dependencies, keeping the build minimal and fast. (A self-contained feature like onboarding needs no `@Provides` at all — the graph just exposes the root BLoC factory.) See the `add-demo-app` skill. Demo modules are standalone — do **not** add them to `client/composeApp`.
 
 The `plusLibrary` extension in each module's `build.gradle.kts` controls convention plugin features:
 - `enableDi = true` — sets up Metro (kotlin-inject) dependency injection

--- a/.agents/skills/add-demo-app.md
+++ b/.agents/skills/add-demo-app.md
@@ -1,0 +1,142 @@
+# add-demo-app
+
+Stand up a standalone **demo app** for a single feature — e.g. `:client:onboarding:demo` — so the
+feature can be built and run on its own (Android + JVM desktop) without compiling the whole
+`:client:composeApp`. The demo renders the feature's **real** screens/BLoCs, driven by a tiny
+per-demo Metro graph; heavy data-layer dependencies are swapped for fakes. Goal: minimal
+dependencies, fast iteration, visual review.
+
+## Required input
+
+Ask the user (if not provided):
+
+1. **Which feature** — e.g. `onboarding`. The demo module path is `client/<feature>/demo`.
+2. **Which entry screen / BLoC** — the screen to showcase. Prefer a feature's **root** navigation
+   BLoC if it has one (e.g. `OnboardingRootBloc`, `SettingsRootBloc`) — it already drives the whole
+   flow, so the demo gets multi-screen navigation for free. Otherwise pick the single screen's BLoC.
+
+## Where the pieces live
+
+| File | Purpose |
+|---|---|
+| `client/<feature>/demo/build.gradle.kts` | Applies `plusApplication`; declares the minimal dep set + `compose.desktop` mainClass. |
+| `commonMain/.../<feature>/demo/<Feature>DemoComponent.kt` | Metro `@DependencyGraph(AppScope::class)` exposing the BLoC factory + any `@Provides` fakes. |
+| `commonMain/.../<feature>/demo/<Feature>DemoApp.kt` | `buildXxxDemoBloc(componentContext)` helper + `@Composable XxxDemoApp(bloc)` (wraps `bloc.Content()` in `ChefMateTheme`). |
+| `androidMain/.../<feature>/demo/MainActivity.kt` | `ComponentActivity` → `defaultComponentContext()` → `setContent { XxxDemoApp(bloc) }`. |
+| `androidMain/AndroidManifest.xml` | Single exported launcher activity (MAIN/LAUNCHER only). |
+| `jvmMain/.../<feature>/demo/main.kt` | `fun main()` with `LifecycleRegistry` + `BackDispatcher` + `DefaultComponentContext`, `application { Window { XxxDemoApp(bloc) } }`. |
+| `settings.gradle.kts` | `include(":client:<feature>:demo")`. |
+
+The `plusApplication` convention plugin (`build-logic/.../convention/PlusApplicationConventionPlugin.kt`)
+applies Kotlin Multiplatform + `com.android.application` + the shared `compose` convention + ktfmt,
+configures the `androidTarget()` + `jvm()` targets and the AGP application block, and (by default,
+`enableDi = true`) the `metro` convention. The reference implementation is `client/onboarding/demo`
+— copy it.
+
+## The pattern
+
+### 1. `build.gradle.kts`
+
+```kotlin
+plugins { alias(libs.plugins.plusApplication) }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.<feature>.impl)
+            implementation(projects.client.<feature>.public)
+            implementation(projects.client.shared)    // AppScope + @Main (CoroutinesComponent)
+            implementation(projects.client.ui.public)  // ChefMateTheme + ComposeScreen
+            // + one public/testing pair per leaf dependency the BLoC's ViewModel needs
+            implementation(libs.arkivanov.decompose.core)
+            implementation(libs.arkivanov.decompose.compose.extensions)
+        }
+    }
+}
+
+plusApplication { namespace = "com.plusmobileapps.chefmate.<feature>.demo" }
+
+compose.desktop {
+    application { mainClass = "com.plusmobileapps.chefmate.<feature>.demo.MainKt" }
+}
+```
+
+### 2. Map the BLoC's dependencies
+
+Read the BLoC impl + its ViewModel constructor. For each non-`@Assisted` parameter:
+
+- **`@Main`/`@IO`/`@CPU` `CoroutineContext`** — free; `client/shared`'s `CoroutinesComponent` is
+  `@ContributesTo(AppScope::class)` and is on the classpath via `projects.client.shared`.
+- **A simple `@Inject` class whose own deps are satisfiable** (e.g. `OnboardingRepository`, which
+  just needs the contributed `Settings`) — nothing to do; Metro constructs it.
+- **A repository/service interface with a `testing` fake** — depend on its `public` + `testing`
+  modules and `@Provides` the fake in the demo graph.
+- **A use case / binding whose `impl` drags in the data layer** (Supabase, SQLDelight, many
+  repositories) — do **not** depend on the `impl`. Provide a lightweight stub directly:
+  `@Provides fun signOut(): SignOutUseCase = SignOutUseCase {}` (works for `fun interface`s).
+
+Only the dependencies **reachable from the BLoC factory you expose** must be satisfied — Metro
+validates lazily, so other BLoCs contributed by the same `impl` module won't force their deps.
+
+### 3. `<Feature>DemoComponent.kt`
+
+A self-contained feature needs no `@Provides` (onboarding):
+
+```kotlin
+@DependencyGraph(AppScope::class)
+@SingleIn(AppScope::class)
+interface OnboardingDemoComponent {
+    val onboardingRootBlocFactory: OnboardingRootBloc.Factory   // auto-contributed via @ContributesAssistedFactory
+
+    @DependencyGraph.Factory
+    fun interface Factory { fun create(): OnboardingDemoComponent }
+}
+```
+
+When the BLoC has heavy leaf deps, add fakes:
+
+```kotlin
+@Provides @SingleIn(AppScope::class)
+fun authRepo(): AuthenticationRepository = FakeAuthenticationRepository().apply { setAuthenticated() }
+```
+
+### 4. Shared app + entrypoints
+
+`<Feature>DemoApp.kt` (commonMain):
+
+```kotlin
+fun buildOnboardingDemoBloc(componentContext: ComponentContext): OnboardingRootBloc {
+    val component = createGraphFactory<OnboardingDemoComponent.Factory>().create()
+    return component.onboardingRootBlocFactory.create(
+        context = DefaultBlocContext(componentContext = componentContext),
+        output = Consumer { output -> println("OnboardingDemo bloc output: $output") },
+    )
+}
+
+@Composable
+fun OnboardingDemoApp(bloc: OnboardingRootBloc, modifier: Modifier = Modifier) {
+    ChefMateTheme { bloc.Content(modifier) }
+}
+```
+
+`MainActivity.kt` (androidMain) builds the bloc with `defaultComponentContext()`; `main.kt`
+(jvmMain) mirrors `client/composeApp/src/jvmMain/.../main.kt` with a `LifecycleRegistry` +
+`BackDispatcher` + `DefaultComponentContext` inside the `application { Window { … } }` block. Copy
+both from `client/onboarding/demo`.
+
+### 5. Register + build loop
+
+1. Add `include(":client:<feature>:demo")` to `settings.gradle.kts`.
+2. `./gradlew :client:<feature>:demo:assembleDebug` (Android compile-check, no device) and
+   `./gradlew :client:<feature>:demo:compileKotlinJvm` (desktop).
+3. For each binding Metro reports missing, add the matching `public` + `testing` (fake) module or
+   a `@Provides` stub — keep additions to `public`/`testing`, never a heavy `impl`.
+4. `./gradlew :client:<feature>:demo:ktfmtFormat`.
+5. Run it: `:demo:run` (desktop) or `:demo:installDebug` (Android emulator/device).
+
+## Caveats
+
+- **Don't add the demo to `client/composeApp`.** It's standalone — that's the whole point.
+- **No iOS target.** Demos are Android + JVM only.
+- The demo's `androidMain` source set requires an Android SDK; a worktree needs its own
+  `local.properties` (`sdk.dir=…`) — it's gitignored.

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -18,6 +18,11 @@ gradlePlugin {
             id = "com.plusmobileapps.chefmate.compose"
             implementationClass = "com.plusmobileapps.chefmate.convention.ComposeConventionPlugin"
         }
+        create("plusApplication") {
+            id = "com.plusmobileapps.chefmate.application"
+            implementationClass =
+                "com.plusmobileapps.chefmate.convention.PlusApplicationConventionPlugin"
+        }
 
         create("ktfmt") {
             id = "com.plusmobileapps.chefmate.ktfmt"

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/MetroConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/MetroConventionPlugin.kt
@@ -16,8 +16,13 @@ fun Project.applyMetro() {
 
     dependencies.apply {
         add("commonMainImplementation", libs.metroExtensions.assistedFactory.runtime)
+        // Only wire the KSP configurations that actually exist for this module's targets.
+        // KMP libraries have all four; an Android + JVM-only demo app (plusApplication) has
+        // just kspAndroid/kspJvm, so guard against the missing iOS configurations.
         listOf("kspAndroid", "kspJvm", "kspIosArm64", "kspIosSimulatorArm64").forEach { config ->
-            add(config, libs.metroExtensions.assistedFactory.compiler)
+            if (configurations.findByName(config) != null) {
+                add(config, libs.metroExtensions.assistedFactory.compiler)
+            }
         }
     }
 }

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/PlusApplicationConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/PlusApplicationConventionPlugin.kt
@@ -1,0 +1,87 @@
+package com.plusmobileapps.chefmate.convention
+
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.plusmobileapps.chefmate.libs
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.create
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/**
+ * Convention plugin for standalone feature **demo** apps (`plusApplication`), e.g.
+ * `:client:settings:demo`. Produces a tiny Compose Multiplatform application targeting Android +
+ * JVM desktop that renders a single feature in isolation, so a feature can be built and run without
+ * the full `:client:composeApp`.
+ *
+ * Reuses the shared `compose` convention for Compose setup and, by default, the `metro` convention
+ * so demos can wire the real BLoCs through a small per-demo dependency graph.
+ */
+class PlusApplicationConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val extension = extensions.create<PlusApplicationExtension>("plusApplication")
+
+            afterEvaluate {
+                if (extension.enableDi) applyMetro()
+                if (extension.enableTesting) applyTesting()
+            }
+
+            with(pluginManager) {
+                apply("org.jetbrains.kotlin.multiplatform")
+                apply(libs.plugins.androidApplication.get().pluginId)
+                apply(libs.plugins.compose.get().pluginId)
+            }
+
+            applyKtfmt()
+
+            extensions.configure<KotlinMultiplatformExtension> {
+                androidTarget { compilerOptions.jvmTarget.set(JvmTarget.JVM_11) }
+                jvm()
+                compilerOptions.optIn.add("kotlin.time.ExperimentalTime")
+            }
+
+            extensions.configure<ApplicationExtension> {
+                compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+                defaultConfig {
+                    minSdk = libs.versions.android.minSdk.get().toInt()
+                    targetSdk = libs.versions.android.targetSdk.get().toInt()
+                    versionCode = 1
+                    versionName = "1.0"
+                }
+
+                packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
+
+                compileOptions {
+                    sourceCompatibility = JavaVersion.VERSION_11
+                    targetCompatibility = JavaVersion.VERSION_11
+                }
+            }
+
+            // namespace / applicationId come from the plusApplication extension, which isn't
+            // populated until the module's build.gradle.kts has been evaluated — defer reading
+            // them to finalizeDsl (same approach as KmpLibraryConventionPlugin).
+            extensions.getByType(ApplicationAndroidComponentsExtension::class.java).finalizeDsl {
+                app ->
+                val ns =
+                    extension.namespace
+                        ?: throw IllegalStateException(
+                            """
+                        Please set the namespace for the demo app $name in the plusApplication extension in the module's build.gradle.kts file.
+                        Example:
+                        plusApplication {
+                            namespace = "com.plusmobileapps.chefmate.$name.demo"
+                        }
+                    """
+                                .trimIndent()
+                        )
+                app.namespace = ns
+                app.defaultConfig.applicationId = extension.applicationId ?: ns
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/PlusApplicationExtension.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/PlusApplicationExtension.kt
@@ -1,0 +1,22 @@
+package com.plusmobileapps.chefmate.convention
+
+/**
+ * Configuration for the `com.plusmobileapps.chefmate.application` (plusApplication) convention
+ * plugin used by standalone feature demo apps, e.g. `:client:settings:demo`.
+ */
+open class PlusApplicationExtension {
+    /**
+     * Android namespace + `applicationId` default, e.g.
+     * `com.plusmobileapps.chefmate.settings.demo`.
+     */
+    var namespace: String? = null
+
+    /** Android `applicationId`. Defaults to [namespace] when unset. */
+    var applicationId: String? = null
+
+    /** Wire up Metro DI (KSP + metro-extensions). On by default — demos run the real BLoCs. */
+    var enableDi: Boolean = true
+
+    /** Add the shared testing dependencies (mokkery, turbine, kotest) to `commonTest`. */
+    var enableTesting: Boolean = false
+}

--- a/client/onboarding/demo/build.gradle.kts
+++ b/client/onboarding/demo/build.gradle.kts
@@ -1,4 +1,7 @@
-plugins { alias(libs.plugins.plusApplication) }
+plugins {
+    alias(libs.plugins.plusApplication)
+    alias(libs.plugins.kotlinSerialization)
+}
 
 kotlin {
     sourceSets {

--- a/client/onboarding/demo/build.gradle.kts
+++ b/client/onboarding/demo/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins { alias(libs.plugins.plusApplication) }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.onboarding.impl)
+            implementation(projects.client.onboarding.public)
+            // shared: AppScope, Settings, @Main dispatcher (CoroutinesComponent)
+            implementation(projects.client.shared)
+            implementation(projects.client.ui.public) // ChefMateTheme + ComposeScreen
+            implementation(libs.arkivanov.decompose.core)
+            implementation(libs.arkivanov.decompose.compose.extensions)
+        }
+    }
+}
+
+plusApplication { namespace = "com.plusmobileapps.chefmate.onboarding.demo" }
+
+compose.desktop { application { mainClass = "com.plusmobileapps.chefmate.onboarding.demo.MainKt" } }

--- a/client/onboarding/demo/src/androidMain/AndroidManifest.xml
+++ b/client/onboarding/demo/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+            android:allowBackup="true"
+            android:label="Onboarding Demo"
+            android:supportsRtl="true"
+            android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        <activity
+                android:exported="true"
+                android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/client/onboarding/demo/src/androidMain/AndroidManifest.xml
+++ b/client/onboarding/demo/src/androidMain/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+            android:name=".OnboardingDemoApplication"
             android:allowBackup="true"
             android:label="Onboarding Demo"
             android:supportsRtl="true"

--- a/client/onboarding/demo/src/androidMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/MainActivity.kt
+++ b/client/onboarding/demo/src/androidMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/MainActivity.kt
@@ -1,0 +1,19 @@
+package com.plusmobileapps.chefmate.onboarding.demo
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import com.arkivanov.decompose.defaultComponentContext
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
+
+class MainActivity : ComponentActivity() {
+    private lateinit var bloc: OnboardingRootBloc
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        bloc = buildOnboardingDemoBloc(componentContext = defaultComponentContext())
+        setContent { OnboardingDemoApp(bloc) }
+    }
+}

--- a/client/onboarding/demo/src/androidMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/MainActivity.kt
+++ b/client/onboarding/demo/src/androidMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/MainActivity.kt
@@ -12,7 +12,12 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        bloc = buildOnboardingDemoBloc(componentContext = defaultComponentContext())
+        val component = (application as OnboardingDemoApplication).component
+        bloc =
+            buildOnboardingDemoBloc(
+                componentContext = defaultComponentContext(),
+                component = component,
+            )
         setContent { OnboardingDemoApp(bloc) }
     }
 }

--- a/client/onboarding/demo/src/androidMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/MainActivity.kt
+++ b/client/onboarding/demo/src/androidMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/MainActivity.kt
@@ -5,10 +5,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.arkivanov.decompose.defaultComponentContext
-import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 
 class MainActivity : ComponentActivity() {
-    private lateinit var bloc: OnboardingRootBloc
+    private lateinit var bloc: OnboardingDemoBloc
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/client/onboarding/demo/src/androidMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoApplication.kt
+++ b/client/onboarding/demo/src/androidMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoApplication.kt
@@ -1,0 +1,19 @@
+package com.plusmobileapps.chefmate.onboarding.demo
+
+import android.app.Application
+import dev.zacsweers.metro.createGraphFactory
+
+/**
+ * Creates the demo Metro graph once for the whole process — mirrors the production `MyApplication`.
+ * Building it here (instead of in [MainActivity.onCreate]) means it survives configuration changes
+ * like rotation rather than being recreated each time the activity is.
+ */
+class OnboardingDemoApplication : Application() {
+    lateinit var component: OnboardingDemoComponent
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        component = createGraphFactory<OnboardingDemoComponent.Factory>().create()
+    }
+}

--- a/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoApp.kt
+++ b/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoApp.kt
@@ -5,20 +5,23 @@ import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.ComponentContext
 import com.plusmobileapps.chefmate.DefaultBlocContext
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
-import dev.zacsweers.metro.createGraphFactory
 
 /**
- * Builds the [OnboardingDemoBloc] for the given [componentContext]. It hosts the real
- * [com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc] (resolved from the demo Metro graph)
- * behind a debug landing screen.
+ * Builds the [OnboardingDemoBloc] for the given [componentContext], hosting the real
+ * [com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc] behind a debug landing screen.
+ *
+ * The [component] (the demo Metro graph) is passed in rather than created here, so it can be
+ * created once at app scope — the Android `Application` / the desktop `main()` — instead of being
+ * recreated every time the host is rebuilt (e.g. on an Android configuration change).
  */
-fun buildOnboardingDemoBloc(componentContext: ComponentContext): OnboardingDemoBloc {
-    val component = createGraphFactory<OnboardingDemoComponent.Factory>().create()
-    return OnboardingDemoBlocImpl(
+fun buildOnboardingDemoBloc(
+    componentContext: ComponentContext,
+    component: OnboardingDemoComponent,
+): OnboardingDemoBloc =
+    OnboardingDemoBlocImpl(
         context = DefaultBlocContext(componentContext = componentContext),
         onboardingRootFactory = component.onboardingRootBlocFactory,
     )
-}
 
 /** Renders the onboarding demo (landing screen + onboarding flow), wrapped in the app theme. */
 @Composable

--- a/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoApp.kt
+++ b/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoApp.kt
@@ -1,0 +1,29 @@
+package com.plusmobileapps.chefmate.onboarding.demo
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.arkivanov.decompose.ComponentContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.DefaultBlocContext
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import dev.zacsweers.metro.createGraphFactory
+
+/**
+ * Builds the real [OnboardingRootBloc] from the demo graph for the given [componentContext]. The
+ * root's outputs (Finished / SignIn) are logged rather than handled — the demo showcases the
+ * onboarding flow itself, not what the app does afterwards.
+ */
+fun buildOnboardingDemoBloc(componentContext: ComponentContext): OnboardingRootBloc {
+    val component = createGraphFactory<OnboardingDemoComponent.Factory>().create()
+    return component.onboardingRootBlocFactory.create(
+        context = DefaultBlocContext(componentContext = componentContext),
+        output = Consumer { output -> println("OnboardingDemo bloc output: $output") },
+    )
+}
+
+/** Renders the onboarding flow for the demo app, wrapped in the app theme. */
+@Composable
+fun OnboardingDemoApp(bloc: OnboardingRootBloc, modifier: Modifier = Modifier) {
+    ChefMateTheme { bloc.Content(modifier) }
+}

--- a/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoApp.kt
+++ b/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoApp.kt
@@ -3,27 +3,25 @@ package com.plusmobileapps.chefmate.onboarding.demo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.ComponentContext
-import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.DefaultBlocContext
-import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import dev.zacsweers.metro.createGraphFactory
 
 /**
- * Builds the real [OnboardingRootBloc] from the demo graph for the given [componentContext]. The
- * root's outputs (Finished / SignIn) are logged rather than handled — the demo showcases the
- * onboarding flow itself, not what the app does afterwards.
+ * Builds the [OnboardingDemoBloc] for the given [componentContext]. It hosts the real
+ * [com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc] (resolved from the demo Metro graph)
+ * behind a debug landing screen.
  */
-fun buildOnboardingDemoBloc(componentContext: ComponentContext): OnboardingRootBloc {
+fun buildOnboardingDemoBloc(componentContext: ComponentContext): OnboardingDemoBloc {
     val component = createGraphFactory<OnboardingDemoComponent.Factory>().create()
-    return component.onboardingRootBlocFactory.create(
+    return OnboardingDemoBlocImpl(
         context = DefaultBlocContext(componentContext = componentContext),
-        output = Consumer { output -> println("OnboardingDemo bloc output: $output") },
+        onboardingRootFactory = component.onboardingRootBlocFactory,
     )
 }
 
-/** Renders the onboarding flow for the demo app, wrapped in the app theme. */
+/** Renders the onboarding demo (landing screen + onboarding flow), wrapped in the app theme. */
 @Composable
-fun OnboardingDemoApp(bloc: OnboardingRootBloc, modifier: Modifier = Modifier) {
+fun OnboardingDemoApp(bloc: OnboardingDemoBloc, modifier: Modifier = Modifier) {
     ChefMateTheme { bloc.Content(modifier) }
 }

--- a/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoBloc.kt
+++ b/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoBloc.kt
@@ -1,0 +1,43 @@
+package com.plusmobileapps.chefmate.onboarding.demo
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.arkivanov.decompose.router.stack.ChildStack
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.essenty.backhandler.BackHandlerOwner
+import com.plusmobileapps.chefmate.BackClickBloc
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
+import com.plusmobileapps.chefmate.ui.ComposeScreen
+
+/**
+ * Root navigation BLoC for the onboarding demo app. It hosts a [OnboardingRootBloc] behind a simple
+ * debug landing screen: the landing screen opens the onboarding flow, and when the flow reports it
+ * has finished (or the user picks sign-in), the demo navigates back to the landing screen so it can
+ * be launched again. This exists only in the demo module — production has no equivalent.
+ */
+interface OnboardingDemoBloc : ComposeScreen, BackHandlerOwner, BackClickBloc {
+    val routerState: Value<ChildStack<*, Child>>
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        OnboardingDemoScreen(bloc = this, modifier = modifier)
+    }
+
+    sealed class Child {
+        abstract val bloc: ComposeScreen
+
+        data class Landing(override val bloc: LandingBloc) : Child()
+
+        data class Onboarding(override val bloc: OnboardingRootBloc) : Child()
+    }
+}
+
+/** The debug landing screen shown before the onboarding flow is launched. */
+interface LandingBloc : ComposeScreen {
+    fun onStartOnboardingClicked()
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        LandingScreen(bloc = this, modifier = modifier)
+    }
+}

--- a/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoBlocImpl.kt
+++ b/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoBlocImpl.kt
@@ -1,0 +1,82 @@
+@file:OptIn(DelicateDecomposeApi::class)
+
+package com.plusmobileapps.chefmate.onboarding.demo
+
+import com.arkivanov.decompose.DelicateDecomposeApi
+import com.arkivanov.decompose.router.stack.ChildStack
+import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.bringToFront
+import com.arkivanov.decompose.router.stack.childStack
+import com.arkivanov.decompose.router.stack.pop
+import com.arkivanov.decompose.value.Value
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
+import kotlinx.serialization.Serializable
+
+class OnboardingDemoBlocImpl(
+    context: BlocContext,
+    private val onboardingRootFactory: OnboardingRootBloc.Factory,
+) : OnboardingDemoBloc, BlocContext by context {
+
+    private val navigation = StackNavigation<Configuration>()
+
+    private val stack =
+        childStack(
+            source = navigation,
+            serializer = Configuration.serializer(),
+            initialStack = { listOf(Configuration.Landing) },
+            handleBackButton = true,
+            key = "OnboardingDemoRouter",
+            childFactory = ::createChild,
+        )
+
+    override val routerState: Value<ChildStack<*, OnboardingDemoBloc.Child>> = stack
+
+    override fun onBackClicked() {
+        navigation.pop()
+    }
+
+    private fun createChild(config: Configuration, context: BlocContext): OnboardingDemoBloc.Child =
+        when (config) {
+            Configuration.Landing ->
+                OnboardingDemoBloc.Child.Landing(
+                    bloc =
+                        LandingBlocImpl(
+                            onStartOnboarding = {
+                                navigation.bringToFront(Configuration.Onboarding)
+                            }
+                        )
+                )
+
+            Configuration.Onboarding ->
+                OnboardingDemoBloc.Child.Onboarding(
+                    bloc =
+                        onboardingRootFactory.create(
+                            context = context,
+                            output = ::handleOnboardingOutput,
+                        )
+                )
+        }
+
+    private fun handleOnboardingOutput(output: OnboardingRootBloc.Output) {
+        when (output) {
+            // Both terminal outcomes return to the debug landing screen so the flow can be
+            // relaunched; the demo has no real app or auth flow to hand off to.
+            OnboardingRootBloc.Output.Finished,
+            OnboardingRootBloc.Output.SignIn -> navigation.bringToFront(Configuration.Landing)
+        }
+    }
+
+    @Serializable
+    private sealed class Configuration {
+        @Serializable data object Landing : Configuration()
+
+        @Serializable data object Onboarding : Configuration()
+    }
+}
+
+internal class LandingBlocImpl(private val onStartOnboarding: () -> Unit) : LandingBloc {
+    override fun onStartOnboardingClicked() {
+        onStartOnboarding()
+    }
+}

--- a/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoComponent.kt
+++ b/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoComponent.kt
@@ -1,0 +1,24 @@
+package com.plusmobileapps.chefmate.onboarding.demo
+
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.SingleIn
+
+/**
+ * Metro graph for the onboarding demo app. The onboarding flow is fully self-contained — its only
+ * non-assisted dependency is `OnboardingRepository`, which auto-injects a `Settings` from
+ * `client/shared`'s `@ContributesTo(AppScope)` `SettingsComponent`. So no `@Provides` are needed;
+ * the graph just exposes the real [OnboardingRootBloc] factory. Coroutine dispatchers likewise come
+ * for free from `shared`'s `CoroutinesComponent`.
+ */
+@DependencyGraph(AppScope::class)
+@SingleIn(AppScope::class)
+interface OnboardingDemoComponent {
+    val onboardingRootBlocFactory: OnboardingRootBloc.Factory
+
+    @DependencyGraph.Factory
+    fun interface Factory {
+        fun create(): OnboardingDemoComponent
+    }
+}

--- a/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoScreen.kt
+++ b/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoScreen.kt
@@ -1,0 +1,45 @@
+package com.plusmobileapps.chefmate.onboarding.demo
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.arkivanov.decompose.extensions.compose.stack.Children
+import com.plusmobileapps.chefmate.ui.Content
+import com.plusmobileapps.chefmate.ui.backAnimation
+
+@Composable
+fun OnboardingDemoScreen(bloc: OnboardingDemoBloc, modifier: Modifier = Modifier) {
+    Children(
+        modifier = modifier.fillMaxSize(),
+        stack = bloc.routerState,
+        animation = backAnimation(backHandler = bloc.backHandler, onBack = bloc::onBackClicked),
+    ) { child ->
+        child.instance.bloc.Content()
+    }
+}
+
+@Composable
+fun LandingScreen(bloc: LandingBloc, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(text = "Onboarding Demo", style = MaterialTheme.typography.headlineMedium)
+        Text(
+            text = "Debug launcher for the onboarding flow.",
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+        )
+        Button(onClick = bloc::onStartOnboardingClicked) { Text("Start onboarding") }
+    }
+}

--- a/client/onboarding/demo/src/jvmMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/main.kt
+++ b/client/onboarding/demo/src/jvmMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/main.kt
@@ -1,0 +1,35 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.onboarding.demo
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.backhandler.BackDispatcher
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+
+fun main() {
+    // Initialize the lifecycle outside the application block, as the main composeApp does.
+    val lifecycle = LifecycleRegistry()
+    val backDispatcher = BackDispatcher()
+
+    application {
+        // Build the ComponentContext inside the application block so it runs on the main thread.
+        val bloc =
+            buildOnboardingDemoBloc(
+                componentContext =
+                    DefaultComponentContext(lifecycle = lifecycle, backHandler = backDispatcher)
+            )
+
+        Window(
+            onCloseRequest = ::exitApplication,
+            state = rememberWindowState(size = DpSize(420.dp, 800.dp)),
+            title = "Onboarding Demo",
+        ) {
+            OnboardingDemoApp(bloc)
+        }
+    }
+}

--- a/client/onboarding/demo/src/jvmMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/main.kt
+++ b/client/onboarding/demo/src/jvmMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/main.kt
@@ -10,18 +10,22 @@ import androidx.compose.ui.window.rememberWindowState
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.backhandler.BackDispatcher
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import dev.zacsweers.metro.createGraphFactory
 
 fun main() {
-    // Initialize the lifecycle outside the application block, as the main composeApp does.
+    // Initialize the lifecycle and the demo Metro graph once, outside the application block, as the
+    // main composeApp does — the graph is process-scoped, not per-window.
     val lifecycle = LifecycleRegistry()
     val backDispatcher = BackDispatcher()
+    val component = createGraphFactory<OnboardingDemoComponent.Factory>().create()
 
     application {
         // Build the ComponentContext inside the application block so it runs on the main thread.
         val bloc =
             buildOnboardingDemoBloc(
                 componentContext =
-                    DefaultComponentContext(lifecycle = lifecycle, backHandler = backDispatcher)
+                    DefaultComponentContext(lifecycle = lifecycle, backHandler = backDispatcher),
+                component = component,
             )
 
         Window(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -158,5 +158,6 @@ metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 metroDi = { id = "com.plusmobileapps.chefmate.metro" }
 kmpLibrary = { id = "com.plusmobileapps.chefmate.kmp-library" }
 compose = { id = "com.plusmobileapps.chefmate.compose" }
+plusApplication = { id = "com.plusmobileapps.chefmate.application" }
 plusKtfmt = { id = "com.plusmobileapps.chefmate.ktfmt" }
 plusTesting = { id = "com.plusmobileapps.chefmate.testing" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -104,6 +104,8 @@ include(":client:onboarding:impl-robots")
 
 include(":client:onboarding:public")
 
+include(":client:onboarding:demo")
+
 include(":client:meal:data:impl")
 
 include(":client:meal:data:public")


### PR DESCRIPTION
## Why

Feature `impl` modules can currently only be exercised through `:client:composeApp`, which depends on every feature plus Supabase, SQLDelight, Bugsnag, etc. Iterating on one screen means compiling the whole app. This adds a reusable way to build/run a single feature in isolation.

## What

### `plusApplication` convention plugin
A new `com.plusmobileapps.chefmate.application` convention for standalone, single-feature **demo apps** targeting **Android + JVM desktop**. It applies KMP (`androidTarget()` + `jvm()`) + `com.android.application` + the shared `compose` convention + ktfmt, configures the AGP application block (namespace deferred via `finalizeDsl`, mirroring `KmpLibraryConventionPlugin`), and Metro DI by default so demos run the **real** BLoCs.

`applyMetro()` now guards the KSP configs it wires, so it works for Android+JVM-only modules (no iOS configs) without affecting KMP libraries.

### `:client:onboarding:demo`
A standalone app that runs the full onboarding flow, reusing the feature's existing `OnboardingRootBloc` — so the demo gets the whole flow's navigation (Welcome → SaveRecipes → CookMode → GroceryList → MealPlanning → StartCooking) for free.

The onboarding feature is fully self-contained: its only non-assisted dependency is `OnboardingRepository`, which auto-injects `Settings` from `shared`'s `@ContributesTo(AppScope)` `SettingsComponent`. So `OnboardingDemoComponent` needs **zero `@Provides`** — it just exposes the real `OnboardingRootBloc.Factory`. Coroutine dispatchers likewise come free from `shared`'s `CoroutinesComponent`.

**Scope stays minimal:** the demo compiles only `onboarding.*` + the `shared`/`text`/`ui` public modules — no Supabase, SQLDelight, or any data-layer `impl`, and no other features.

### Docs & skill
- `.agents/seed.md` — documents the optional `demo` module type + new build commands.
- `.agents/skills/add-demo-app.md` — a playbook for adding a demo to any feature (covers the dependency-mapping rules for features that *do* have heavy leaf deps: free dispatchers, fake leaf deps from `testing` modules, stub heavy use cases, lazy Metro validation).

## Verification

- `./gradlew :client:onboarding:demo:assembleDebug` — Android APK builds (Metro graph resolves).
- `./gradlew :client:onboarding:demo:compileKotlinJvm` — desktop target compiles.
- `./gradlew :client:onboarding:demo:run` — desktop window launches and renders the onboarding flow (no exceptions).
- `./gradlew :client:onboarding:demo:ktfmtCheck` — clean.

## Notes
- Demos are standalone — **not** added to `:client:composeApp`.
- No iOS target for demos (Android + JVM only).
- A worktree needs its own gitignored `local.properties` (`sdk.dir=…`) for the Android target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)