### PR TITLE
feat(onboarding): add feature-tour screens + sign-in/skip from welcome

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -155,6 +155,7 @@ kotlin {
             implementation(projects.client.settings.implRobots)
             implementation(projects.client.settings.root.implRobots)
             implementation(projects.client.profile.implRobots)
+            implementation(projects.client.onboarding.implRobots)
         }
         val jvmTest by getting {
             dependencies {

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
@@ -12,6 +12,7 @@ import com.plusmobileapps.chefmate.App
 import com.plusmobileapps.chefmate.DefaultBlocContext
 import com.plusmobileapps.chefmate.di.TestApplicationComponent
 import com.plusmobileapps.chefmate.di.createTestApplicationComponent
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.fixtures.TestRecipes
 import com.plusmobileapps.chefmate.root.DeepLink
 import com.plusmobileapps.chefmate.root.RootBloc
@@ -49,14 +50,23 @@ fun TestApplicationComponent.createRootBloc(
 fun runRootBlocTest(
     userState: TestUserState =
         TestUserState.Authenticated(recipes = listOf(TestRecipes.fullyPopulated)),
+    showOnboarding: Boolean = false,
     beforeContent: (TestApplicationComponent) -> Unit = {},
     block: suspend ComposeUiTest.(TestApplicationComponent) -> Unit,
 ): TestResult = runComposeUiTest {
     val app = createTestApplicationComponent()
+    // The production Settings() is backed by a process-global store (JVM Preferences), so persisted
+    // flags leak across tests. Clear it up front for deterministic, isolated runs.
+    app.settings.clear()
     app.applyUserState(userState)
-    // Default to a returning user so tests boot straight into the main app. Onboarding-specific
-    // tests can assert the first-run flow before flipping this in their own setup.
-    app.onboardingRepository.setOnboardingCompleted()
+    if (showOnboarding) {
+        // First-run state: enable the gating flag and leave onboarding incomplete so the root
+        // boots into the onboarding flow.
+        app.testFeatureFlags.set(FeatureFlagRegistry.Onboarding, true)
+    } else {
+        // Default to a returning user so tests boot straight into the main app.
+        app.onboardingRepository.setOnboardingCompleted()
+    }
     beforeContent(app)
     setContent { App(rootBloc = app.createRootBloc()) }
     block(app)

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/OnboardingFlowUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/OnboardingFlowUiTest.kt
@@ -1,0 +1,46 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package com.plusmobileapps.chefmate.tests
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import com.plusmobileapps.chefmate.fixtures.TestRecipes
+import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.onboarding.robots.onboarding
+import com.plusmobileapps.chefmate.recipe.list.robots.recipeList
+import kotlin.test.Test
+
+class OnboardingFlowUiTest {
+
+    @Test
+    fun walking_through_the_full_tour_loads_the_main_app() =
+        runRootBlocTest(showOnboarding = true) {
+            onboarding()
+                .assertWelcomeDisplayed()
+                .clickGetStarted()
+                .assertSaveRecipesDisplayed()
+                .clickSaveRecipesNext()
+                .assertCookModeDisplayed()
+                .clickCookModeNext()
+                .assertGroceryListDisplayed()
+                .clickGroceryListNext()
+                .assertMealPlanningDisplayed()
+                .clickMealPlanningNext()
+                .assertStartCookingDisplayed()
+                .clickStartCooking()
+
+            // Finishing replaces the onboarding stack with the bottom nav (recipes tab).
+            waitUntilExactlyOneExists(hasText(TestRecipes.fullyPopulated.title))
+            recipeList().assertRecipeIsDisplayed(TestRecipes.fullyPopulated.title)
+        }
+
+    @Test
+    fun skipping_from_the_welcome_screen_loads_the_main_app() =
+        runRootBlocTest(showOnboarding = true) {
+            onboarding().assertWelcomeDisplayed().clickSkip()
+
+            waitUntilExactlyOneExists(hasText(TestRecipes.fullyPopulated.title))
+            recipeList().assertRecipeIsDisplayed(TestRecipes.fullyPopulated.title)
+        }
+}

--- a/client/onboarding/impl-robots/build.gradle.kts
+++ b/client/onboarding/impl-robots/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets { commonMain.dependencies { implementation(projects.client.onboarding.public) } }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.onboarding.robots"
+    uiTest = true
+}

--- a/client/onboarding/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/robots/OnboardingRobot.kt
+++ b/client/onboarding/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/robots/OnboardingRobot.kt
@@ -1,0 +1,64 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package com.plusmobileapps.chefmate.onboarding.robots
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import com.plusmobileapps.chefmate.onboarding.OnboardingTestTags
+
+/**
+ * Robot for the onboarding flow. Each step is matched by its screen root test tag, and each action
+ * clicks the step's button by tag, so the test reads as the user walking through the tour.
+ */
+class OnboardingRobot(private val test: ComposeUiTest) {
+
+    fun assertWelcomeDisplayed(): OnboardingRobot =
+        assertDisplayed(OnboardingTestTags.WELCOME_SCREEN)
+
+    fun clickGetStarted(): OnboardingRobot = click(OnboardingTestTags.WELCOME_GET_STARTED_BUTTON)
+
+    fun clickSignIn(): OnboardingRobot = click(OnboardingTestTags.WELCOME_SIGN_IN_BUTTON)
+
+    fun clickSkip(): OnboardingRobot = click(OnboardingTestTags.WELCOME_SKIP_BUTTON)
+
+    fun assertSaveRecipesDisplayed(): OnboardingRobot =
+        assertDisplayed(OnboardingTestTags.SAVE_RECIPES_SCREEN)
+
+    fun clickSaveRecipesNext(): OnboardingRobot = click(OnboardingTestTags.SAVE_RECIPES_NEXT_BUTTON)
+
+    fun assertCookModeDisplayed(): OnboardingRobot =
+        assertDisplayed(OnboardingTestTags.COOK_MODE_SCREEN)
+
+    fun clickCookModeNext(): OnboardingRobot = click(OnboardingTestTags.COOK_MODE_NEXT_BUTTON)
+
+    fun assertGroceryListDisplayed(): OnboardingRobot =
+        assertDisplayed(OnboardingTestTags.GROCERY_LIST_SCREEN)
+
+    fun clickGroceryListNext(): OnboardingRobot = click(OnboardingTestTags.GROCERY_LIST_NEXT_BUTTON)
+
+    fun assertMealPlanningDisplayed(): OnboardingRobot =
+        assertDisplayed(OnboardingTestTags.MEAL_PLANNING_SCREEN)
+
+    fun clickMealPlanningNext(): OnboardingRobot =
+        click(OnboardingTestTags.MEAL_PLANNING_NEXT_BUTTON)
+
+    fun assertStartCookingDisplayed(): OnboardingRobot =
+        assertDisplayed(OnboardingTestTags.START_COOKING_SCREEN)
+
+    fun clickStartCooking(): OnboardingRobot = click(OnboardingTestTags.START_COOKING_BUTTON)
+
+    private fun assertDisplayed(tag: String): OnboardingRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(tag))
+    }
+
+    private fun click(tag: String): OnboardingRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(tag))
+        test.onNodeWithTag(tag).performClick()
+    }
+}
+
+fun ComposeUiTest.onboarding(): OnboardingRobot = OnboardingRobot(this)

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/CookModeBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/CookModeBlocImpl.kt
@@ -1,0 +1,29 @@
+package com.plusmobileapps.chefmate.onboarding.impl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.onboarding.CookModeBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.CookModeScreen
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+
+@AssistedInject
+@ContributesAssistedFactory(scope = AppScope::class, assistedFactory = CookModeBloc.Factory::class)
+class CookModeBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<CookModeBloc.Output>,
+) : CookModeBloc, BlocContext by context {
+
+    override fun onNextClicked() {
+        output.onNext(CookModeBloc.Output.Next)
+    }
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        CookModeScreen(bloc = this, modifier = modifier)
+    }
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/GroceryListBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/GroceryListBlocImpl.kt
@@ -1,0 +1,32 @@
+package com.plusmobileapps.chefmate.onboarding.impl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.onboarding.GroceryListBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.GroceryListScreen
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+
+@AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = GroceryListBloc.Factory::class,
+)
+class GroceryListBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<GroceryListBloc.Output>,
+) : GroceryListBloc, BlocContext by context {
+
+    override fun onNextClicked() {
+        output.onNext(GroceryListBloc.Output.Next)
+    }
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        GroceryListScreen(bloc = this, modifier = modifier)
+    }
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/MealPlanningBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/MealPlanningBlocImpl.kt
@@ -1,0 +1,32 @@
+package com.plusmobileapps.chefmate.onboarding.impl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.onboarding.MealPlanningBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.MealPlanningScreen
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+
+@AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = MealPlanningBloc.Factory::class,
+)
+class MealPlanningBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<MealPlanningBloc.Output>,
+) : MealPlanningBloc, BlocContext by context {
+
+    override fun onNextClicked() {
+        output.onNext(MealPlanningBloc.Output.Next)
+    }
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        MealPlanningScreen(bloc = this, modifier = modifier)
+    }
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/OnboardingRootBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/OnboardingRootBlocImpl.kt
@@ -15,8 +15,12 @@ import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.di.OnboardingRepository
+import com.plusmobileapps.chefmate.onboarding.CookModeBloc
+import com.plusmobileapps.chefmate.onboarding.GroceryListBloc
+import com.plusmobileapps.chefmate.onboarding.MealPlanningBloc
 import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc.Output
+import com.plusmobileapps.chefmate.onboarding.SaveRecipesBloc
 import com.plusmobileapps.chefmate.onboarding.StartCookingBloc
 import com.plusmobileapps.chefmate.onboarding.WelcomeBloc
 import com.plusmobileapps.chefmate.onboarding.impl.ui.OnboardingRootScreen
@@ -35,6 +39,10 @@ class OnboardingRootBlocImpl(
     @Assisted private val output: Consumer<Output>,
     private val onboardingRepository: OnboardingRepository,
     private val welcome: WelcomeBloc.Factory,
+    private val saveRecipes: SaveRecipesBloc.Factory,
+    private val cookMode: CookModeBloc.Factory,
+    private val groceryList: GroceryListBloc.Factory,
+    private val mealPlanning: MealPlanningBloc.Factory,
     private val startCooking: StartCookingBloc.Factory,
 ) : OnboardingRootBloc, BlocContext by context {
 
@@ -68,6 +76,27 @@ class OnboardingRootBlocImpl(
                     bloc = welcome.create(context = context, output = ::handleWelcomeOutput)
                 )
 
+            Configuration.SaveRecipes ->
+                OnboardingRootBloc.Child.SaveRecipes(
+                    bloc = saveRecipes.create(context = context, output = ::handleSaveRecipesOutput)
+                )
+
+            Configuration.CookMode ->
+                OnboardingRootBloc.Child.CookMode(
+                    bloc = cookMode.create(context = context, output = ::handleCookModeOutput)
+                )
+
+            Configuration.GroceryList ->
+                OnboardingRootBloc.Child.GroceryList(
+                    bloc = groceryList.create(context = context, output = ::handleGroceryListOutput)
+                )
+
+            Configuration.MealPlanning ->
+                OnboardingRootBloc.Child.MealPlanning(
+                    bloc =
+                        mealPlanning.create(context = context, output = ::handleMealPlanningOutput)
+                )
+
             Configuration.StartCooking ->
                 OnboardingRootBloc.Child.StartCooking(
                     bloc =
@@ -75,27 +104,68 @@ class OnboardingRootBlocImpl(
                 )
         }
 
+    /** Brings the next step to the front of the onboarding stack. */
+    private fun advanceTo(configuration: Configuration) {
+        navigation.bringToFront(configuration)
+    }
+
     private fun handleWelcomeOutput(output: WelcomeBloc.Output) {
         when (output) {
-            WelcomeBloc.Output.GetStarted -> navigation.bringToFront(Configuration.StartCooking)
+            WelcomeBloc.Output.GetStarted -> advanceTo(Configuration.SaveRecipes)
+            // The root opens the auth flow; on success it tears down onboarding for us.
+            WelcomeBloc.Output.SignIn -> this.output.onNext(Output.SignIn)
+            // Skipping is the same as finishing: mark complete so it never shows again.
+            WelcomeBloc.Output.Skip -> finishOnboarding()
+        }
+    }
+
+    private fun handleSaveRecipesOutput(output: SaveRecipesBloc.Output) {
+        when (output) {
+            SaveRecipesBloc.Output.Next -> advanceTo(Configuration.CookMode)
+        }
+    }
+
+    private fun handleCookModeOutput(output: CookModeBloc.Output) {
+        when (output) {
+            CookModeBloc.Output.Next -> advanceTo(Configuration.GroceryList)
+        }
+    }
+
+    private fun handleGroceryListOutput(output: GroceryListBloc.Output) {
+        when (output) {
+            GroceryListBloc.Output.Next -> advanceTo(Configuration.MealPlanning)
+        }
+    }
+
+    private fun handleMealPlanningOutput(output: MealPlanningBloc.Output) {
+        when (output) {
+            MealPlanningBloc.Output.Next -> advanceTo(Configuration.StartCooking)
         }
     }
 
     private fun handleStartCookingOutput(output: StartCookingBloc.Output) {
         when (output) {
-            StartCookingBloc.Output.StartCooking -> {
-                // Persist completion so the flow is never shown again, then hand control back to
-                // the
-                // root to load the rest of the app.
-                onboardingRepository.setOnboardingCompleted()
-                this.output.onNext(Output.Finished)
-            }
+            StartCookingBloc.Output.StartCooking -> finishOnboarding()
         }
+    }
+
+    /** Persist completion so the flow is never shown again, then hand control back to the root. */
+    private fun finishOnboarding() {
+        onboardingRepository.setOnboardingCompleted()
+        output.onNext(Output.Finished)
     }
 
     @Serializable
     private sealed class Configuration {
         @Serializable data object Welcome : Configuration()
+
+        @Serializable data object SaveRecipes : Configuration()
+
+        @Serializable data object CookMode : Configuration()
+
+        @Serializable data object GroceryList : Configuration()
+
+        @Serializable data object MealPlanning : Configuration()
 
         @Serializable data object StartCooking : Configuration()
     }

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/SaveRecipesBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/SaveRecipesBlocImpl.kt
@@ -1,0 +1,32 @@
+package com.plusmobileapps.chefmate.onboarding.impl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.onboarding.SaveRecipesBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.SaveRecipesScreen
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+
+@AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = SaveRecipesBloc.Factory::class,
+)
+class SaveRecipesBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<SaveRecipesBloc.Output>,
+) : SaveRecipesBloc, BlocContext by context {
+
+    override fun onNextClicked() {
+        output.onNext(SaveRecipesBloc.Output.Next)
+    }
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        SaveRecipesScreen(bloc = this, modifier = modifier)
+    }
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/WelcomeBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/WelcomeBlocImpl.kt
@@ -22,6 +22,14 @@ class WelcomeBlocImpl(
         output.onNext(WelcomeBloc.Output.GetStarted)
     }
 
+    override fun onSignInClicked() {
+        output.onNext(WelcomeBloc.Output.SignIn)
+    }
+
+    override fun onSkipClicked() {
+        output.onNext(WelcomeBloc.Output.Skip)
+    }
+
     @Composable
     override fun Content(modifier: Modifier) {
         WelcomeScreen(bloc = this, modifier = modifier)

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/CookModeScreen.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/CookModeScreen.kt
@@ -1,0 +1,26 @@
+package com.plusmobileapps.chefmate.onboarding.impl.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SoupKitchen
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import chefmate.client.onboarding.public.generated.resources.Res
+import chefmate.client.onboarding.public.generated.resources.onboarding_cook_mode_message
+import chefmate.client.onboarding.public.generated.resources.onboarding_cook_mode_title
+import chefmate.client.onboarding.public.generated.resources.onboarding_next
+import com.plusmobileapps.chefmate.onboarding.CookModeBloc
+import com.plusmobileapps.chefmate.onboarding.OnboardingTestTags
+
+@Composable
+fun CookModeScreen(bloc: CookModeBloc, modifier: Modifier = Modifier) {
+    OnboardingInfoLayout(
+        icon = Icons.Default.SoupKitchen,
+        title = Res.string.onboarding_cook_mode_title,
+        message = Res.string.onboarding_cook_mode_message,
+        buttonText = Res.string.onboarding_next,
+        onButtonClick = bloc::onNextClicked,
+        screenTestTag = OnboardingTestTags.COOK_MODE_SCREEN,
+        buttonTestTag = OnboardingTestTags.COOK_MODE_NEXT_BUTTON,
+        modifier = modifier,
+    )
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/GroceryListScreen.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/GroceryListScreen.kt
@@ -1,0 +1,26 @@
+package com.plusmobileapps.chefmate.onboarding.impl.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddShoppingCart
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import chefmate.client.onboarding.public.generated.resources.Res
+import chefmate.client.onboarding.public.generated.resources.onboarding_grocery_list_message
+import chefmate.client.onboarding.public.generated.resources.onboarding_grocery_list_title
+import chefmate.client.onboarding.public.generated.resources.onboarding_next
+import com.plusmobileapps.chefmate.onboarding.GroceryListBloc
+import com.plusmobileapps.chefmate.onboarding.OnboardingTestTags
+
+@Composable
+fun GroceryListScreen(bloc: GroceryListBloc, modifier: Modifier = Modifier) {
+    OnboardingInfoLayout(
+        icon = Icons.Default.AddShoppingCart,
+        title = Res.string.onboarding_grocery_list_title,
+        message = Res.string.onboarding_grocery_list_message,
+        buttonText = Res.string.onboarding_next,
+        onButtonClick = bloc::onNextClicked,
+        screenTestTag = OnboardingTestTags.GROCERY_LIST_SCREEN,
+        buttonTestTag = OnboardingTestTags.GROCERY_LIST_NEXT_BUTTON,
+        modifier = modifier,
+    )
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/MealPlanningScreen.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/MealPlanningScreen.kt
@@ -1,0 +1,26 @@
+package com.plusmobileapps.chefmate.onboarding.impl.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import chefmate.client.onboarding.public.generated.resources.Res
+import chefmate.client.onboarding.public.generated.resources.onboarding_meal_planning_message
+import chefmate.client.onboarding.public.generated.resources.onboarding_meal_planning_title
+import chefmate.client.onboarding.public.generated.resources.onboarding_next
+import com.plusmobileapps.chefmate.onboarding.MealPlanningBloc
+import com.plusmobileapps.chefmate.onboarding.OnboardingTestTags
+
+@Composable
+fun MealPlanningScreen(bloc: MealPlanningBloc, modifier: Modifier = Modifier) {
+    OnboardingInfoLayout(
+        icon = Icons.Default.CalendarMonth,
+        title = Res.string.onboarding_meal_planning_title,
+        message = Res.string.onboarding_meal_planning_message,
+        buttonText = Res.string.onboarding_next,
+        onButtonClick = bloc::onNextClicked,
+        screenTestTag = OnboardingTestTags.MEAL_PLANNING_SCREEN,
+        buttonTestTag = OnboardingTestTags.MEAL_PLANNING_NEXT_BUTTON,
+        modifier = modifier,
+    )
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/OnboardingInfoLayout.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/OnboardingInfoLayout.kt
@@ -4,36 +4,44 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
-import chefmate.client.onboarding.public.generated.resources.Res
-import chefmate.client.onboarding.public.generated.resources.onboarding_welcome_get_started
-import chefmate.client.onboarding.public.generated.resources.onboarding_welcome_message
-import chefmate.client.onboarding.public.generated.resources.onboarding_welcome_sign_in
-import chefmate.client.onboarding.public.generated.resources.onboarding_welcome_skip
-import chefmate.client.onboarding.public.generated.resources.onboarding_welcome_title
-import com.plusmobileapps.chefmate.onboarding.OnboardingTestTags
-import com.plusmobileapps.chefmate.onboarding.WelcomeBloc
+import androidx.compose.ui.unit.dp
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusButton
-import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
+/**
+ * Shared layout for the informational onboarding steps: a centered icon, title, body, and a single
+ * primary "Next"-style button. Each step screen supplies its own content, icon, and test tags.
+ */
 @Composable
-fun WelcomeScreen(bloc: WelcomeBloc, modifier: Modifier = Modifier) {
+internal fun OnboardingInfoLayout(
+    icon: ImageVector,
+    title: StringResource,
+    message: StringResource,
+    buttonText: StringResource,
+    onButtonClick: () -> Unit,
+    screenTestTag: String,
+    buttonTestTag: String,
+    modifier: Modifier = Modifier,
+) {
     val dimens = ChefMateTheme.dimens
 
     PlusHeaderContainer(
-        modifier = modifier.testTag(OnboardingTestTags.WELCOME_SCREEN).fillMaxWidth(),
+        modifier = modifier.testTag(screenTestTag).fillMaxWidth(),
         data = PlusHeaderData.None,
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -43,38 +51,31 @@ fun WelcomeScreen(bloc: WelcomeBloc, modifier: Modifier = Modifier) {
             verticalArrangement = Arrangement.spacedBy(dimens.paddingNormal),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(72.dp),
+            )
             Text(
-                text = stringResource(Res.string.onboarding_welcome_title),
+                text = stringResource(title),
                 style = MaterialTheme.typography.headlineMedium,
                 textAlign = TextAlign.Center,
             )
             Text(
-                text = stringResource(Res.string.onboarding_welcome_message),
+                text = stringResource(message),
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
             )
             PlusButton(
-                text = Res.string.onboarding_welcome_get_started.asTextData(),
-                onClick = bloc::onGetStartedClicked,
+                text = buttonText.asTextData(),
+                onClick = onButtonClick,
                 modifier =
                     Modifier.fillMaxWidth()
                         .padding(top = dimens.paddingNormal)
-                        .testTag(OnboardingTestTags.WELCOME_GET_STARTED_BUTTON),
+                        .testTag(buttonTestTag),
             )
-            PlusButton(
-                text = Res.string.onboarding_welcome_sign_in.asTextData(),
-                variant = PlusButtonVariant.SECONDARY,
-                onClick = bloc::onSignInClicked,
-                modifier =
-                    Modifier.fillMaxWidth().testTag(OnboardingTestTags.WELCOME_SIGN_IN_BUTTON),
-            )
-            TextButton(
-                onClick = bloc::onSkipClicked,
-                modifier = Modifier.testTag(OnboardingTestTags.WELCOME_SKIP_BUTTON),
-            ) {
-                Text(stringResource(Res.string.onboarding_welcome_skip))
-            }
         }
     }
 }

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/OnboardingPreviews.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/OnboardingPreviews.kt
@@ -1,0 +1,97 @@
+package com.plusmobileapps.chefmate.onboarding.impl.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.plusmobileapps.chefmate.onboarding.CookModeBloc
+import com.plusmobileapps.chefmate.onboarding.GroceryListBloc
+import com.plusmobileapps.chefmate.onboarding.MealPlanningBloc
+import com.plusmobileapps.chefmate.onboarding.SaveRecipesBloc
+import com.plusmobileapps.chefmate.onboarding.StartCookingBloc
+import com.plusmobileapps.chefmate.onboarding.WelcomeBloc
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+// Public fake Blocs so the screenshot-test module can reuse them. The onboarding step screens are
+// stateless, so the fakes only need to satisfy the interface.
+
+val previewWelcomeBloc: WelcomeBloc =
+    object : WelcomeBloc {
+        override fun onGetStartedClicked() = Unit
+
+        override fun onSignInClicked() = Unit
+
+        override fun onSkipClicked() = Unit
+
+        @Composable override fun Content(modifier: Modifier) = WelcomeScreen(this, modifier)
+    }
+
+val previewSaveRecipesBloc: SaveRecipesBloc =
+    object : SaveRecipesBloc {
+        override fun onNextClicked() = Unit
+
+        @Composable override fun Content(modifier: Modifier) = SaveRecipesScreen(this, modifier)
+    }
+
+val previewCookModeBloc: CookModeBloc =
+    object : CookModeBloc {
+        override fun onNextClicked() = Unit
+
+        @Composable override fun Content(modifier: Modifier) = CookModeScreen(this, modifier)
+    }
+
+val previewGroceryListBloc: GroceryListBloc =
+    object : GroceryListBloc {
+        override fun onNextClicked() = Unit
+
+        @Composable override fun Content(modifier: Modifier) = GroceryListScreen(this, modifier)
+    }
+
+val previewMealPlanningBloc: MealPlanningBloc =
+    object : MealPlanningBloc {
+        override fun onNextClicked() = Unit
+
+        @Composable override fun Content(modifier: Modifier) = MealPlanningScreen(this, modifier)
+    }
+
+val previewStartCookingBloc: StartCookingBloc =
+    object : StartCookingBloc {
+        override fun onStartCookingClicked() = Unit
+
+        @Composable override fun Content(modifier: Modifier) = StartCookingScreen(this, modifier)
+    }
+
+@Preview
+@Composable
+internal fun WelcomeScreenPreview() {
+    ChefMateTheme { WelcomeScreen(bloc = previewWelcomeBloc) }
+}
+
+@Preview
+@Composable
+internal fun SaveRecipesScreenPreview() {
+    ChefMateTheme { SaveRecipesScreen(bloc = previewSaveRecipesBloc) }
+}
+
+@Preview
+@Composable
+internal fun CookModeScreenPreview() {
+    ChefMateTheme { CookModeScreen(bloc = previewCookModeBloc) }
+}
+
+@Preview
+@Composable
+internal fun GroceryListScreenPreview() {
+    ChefMateTheme { GroceryListScreen(bloc = previewGroceryListBloc) }
+}
+
+@Preview
+@Composable
+internal fun MealPlanningScreenPreview() {
+    ChefMateTheme { MealPlanningScreen(bloc = previewMealPlanningBloc) }
+}
+
+@Preview
+@Composable
+internal fun StartCookingScreenPreview() {
+    ChefMateTheme { StartCookingScreen(bloc = previewStartCookingBloc) }
+}

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/SaveRecipesScreen.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/SaveRecipesScreen.kt
@@ -1,0 +1,26 @@
+package com.plusmobileapps.chefmate.onboarding.impl.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FileDownload
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import chefmate.client.onboarding.public.generated.resources.Res
+import chefmate.client.onboarding.public.generated.resources.onboarding_next
+import chefmate.client.onboarding.public.generated.resources.onboarding_save_recipes_message
+import chefmate.client.onboarding.public.generated.resources.onboarding_save_recipes_title
+import com.plusmobileapps.chefmate.onboarding.OnboardingTestTags
+import com.plusmobileapps.chefmate.onboarding.SaveRecipesBloc
+
+@Composable
+fun SaveRecipesScreen(bloc: SaveRecipesBloc, modifier: Modifier = Modifier) {
+    OnboardingInfoLayout(
+        icon = Icons.Default.FileDownload,
+        title = Res.string.onboarding_save_recipes_title,
+        message = Res.string.onboarding_save_recipes_message,
+        buttonText = Res.string.onboarding_next,
+        onButtonClick = bloc::onNextClicked,
+        screenTestTag = OnboardingTestTags.SAVE_RECIPES_SCREEN,
+        buttonTestTag = OnboardingTestTags.SAVE_RECIPES_NEXT_BUTTON,
+        modifier = modifier,
+    )
+}

--- a/client/onboarding/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/onboarding/impl/OnboardingRootBlocImplTest.kt
+++ b/client/onboarding/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/onboarding/impl/OnboardingRootBlocImplTest.kt
@@ -1,0 +1,122 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.onboarding.impl
+
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.OnboardingRepository
+import com.plusmobileapps.chefmate.onboarding.CookModeBloc
+import com.plusmobileapps.chefmate.onboarding.GroceryListBloc
+import com.plusmobileapps.chefmate.onboarding.MealPlanningBloc
+import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
+import com.plusmobileapps.chefmate.onboarding.SaveRecipesBloc
+import com.plusmobileapps.chefmate.onboarding.StartCookingBloc
+import com.plusmobileapps.chefmate.onboarding.WelcomeBloc
+import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.russhwolf.settings.MapSettings
+import dev.mokkery.mock
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.instanceOf
+import kotlin.test.Test
+
+class OnboardingRootBlocImplTest {
+    val context = TestBlocContext.create()
+    val onboardingRepository = OnboardingRepository(MapSettings())
+
+    var welcomeOutput: Consumer<WelcomeBloc.Output> = Consumer {}
+    var saveRecipesOutput: Consumer<SaveRecipesBloc.Output> = Consumer {}
+    var cookModeOutput: Consumer<CookModeBloc.Output> = Consumer {}
+    var groceryListOutput: Consumer<GroceryListBloc.Output> = Consumer {}
+    var mealPlanningOutput: Consumer<MealPlanningBloc.Output> = Consumer {}
+    var startCookingOutput: Consumer<StartCookingBloc.Output> = Consumer {}
+
+    var rootOutput: OnboardingRootBloc.Output? = null
+
+    val bloc =
+        OnboardingRootBlocImpl(
+            context = context,
+            output = { rootOutput = it },
+            onboardingRepository = onboardingRepository,
+            welcome = { _, output ->
+                welcomeOutput = output
+                mock()
+            },
+            saveRecipes = { _, output ->
+                saveRecipesOutput = output
+                mock()
+            },
+            cookMode = { _, output ->
+                cookModeOutput = output
+                mock()
+            },
+            groceryList = { _, output ->
+                groceryListOutput = output
+                mock()
+            },
+            mealPlanning = { _, output ->
+                mealPlanningOutput = output
+                mock()
+            },
+            startCooking = { _, output ->
+                startCookingOutput = output
+                mock()
+            },
+        )
+
+    fun OnboardingRootBloc.instance(): OnboardingRootBloc.Child = routerState.value.active.instance
+
+    @Test
+    fun When_initialized_Then_welcome_is_shown() {
+        bloc.instance() should instanceOf<OnboardingRootBloc.Child.Welcome>()
+        bloc.routerState.value.backStack.size shouldBe 0
+    }
+
+    @Test
+    fun When_the_user_steps_through_the_tour_Then_each_screen_is_shown_in_order() {
+        welcomeOutput.onNext(WelcomeBloc.Output.GetStarted)
+        bloc.instance() should instanceOf<OnboardingRootBloc.Child.SaveRecipes>()
+
+        saveRecipesOutput.onNext(SaveRecipesBloc.Output.Next)
+        bloc.instance() should instanceOf<OnboardingRootBloc.Child.CookMode>()
+
+        cookModeOutput.onNext(CookModeBloc.Output.Next)
+        bloc.instance() should instanceOf<OnboardingRootBloc.Child.GroceryList>()
+
+        groceryListOutput.onNext(GroceryListBloc.Output.Next)
+        bloc.instance() should instanceOf<OnboardingRootBloc.Child.MealPlanning>()
+
+        mealPlanningOutput.onNext(MealPlanningBloc.Output.Next)
+        bloc.instance() should instanceOf<OnboardingRootBloc.Child.StartCooking>()
+    }
+
+    @Test
+    fun When_start_cooking_clicked_Then_onboarding_is_completed_and_finished_emitted() {
+        welcomeOutput.onNext(WelcomeBloc.Output.GetStarted)
+        saveRecipesOutput.onNext(SaveRecipesBloc.Output.Next)
+        cookModeOutput.onNext(CookModeBloc.Output.Next)
+        groceryListOutput.onNext(GroceryListBloc.Output.Next)
+        mealPlanningOutput.onNext(MealPlanningBloc.Output.Next)
+
+        startCookingOutput.onNext(StartCookingBloc.Output.StartCooking)
+
+        onboardingRepository.hasCompletedOnboarding shouldBe true
+        rootOutput shouldBe OnboardingRootBloc.Output.Finished
+    }
+
+    @Test
+    fun When_welcome_outputs_skip_Then_onboarding_is_completed_and_finished_emitted() {
+        welcomeOutput.onNext(WelcomeBloc.Output.Skip)
+
+        onboardingRepository.hasCompletedOnboarding shouldBe true
+        rootOutput shouldBe OnboardingRootBloc.Output.Finished
+    }
+
+    @Test
+    fun When_welcome_outputs_sign_in_Then_sign_in_emitted_without_completing() {
+        welcomeOutput.onNext(WelcomeBloc.Output.SignIn)
+
+        rootOutput shouldBe OnboardingRootBloc.Output.SignIn
+        // Completion is deferred to the root once auth actually succeeds.
+        onboardingRepository.hasCompletedOnboarding shouldBe false
+    }
+}

--- a/client/onboarding/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/onboarding/public/src/commonMain/composeResources/values/strings.xml
@@ -2,6 +2,22 @@
     <string name="onboarding_welcome_title">Welcome to ChefMate</string>
     <string name="onboarding_welcome_message">Your kitchen companion for saving recipes, planning meals, and building grocery lists.</string>
     <string name="onboarding_welcome_get_started">Get started</string>
+    <string name="onboarding_welcome_sign_in">I already have an account</string>
+    <string name="onboarding_welcome_skip">Skip</string>
+
+    <string name="onboarding_next">Next</string>
+
+    <string name="onboarding_save_recipes_title">Save recipes from anywhere</string>
+    <string name="onboarding_save_recipes_message">Use the in-app browser to find your favorite recipes on the web, then tap Download to save them straight to your account.</string>
+
+    <string name="onboarding_cook_mode_title">Cook hands-free</string>
+    <string name="onboarding_cook_mode_message">Open any recipe and start Cook Mode from the recipe detail screen to follow along step by step while you cook.</string>
+
+    <string name="onboarding_grocery_list_title">Build your grocery list</string>
+    <string name="onboarding_grocery_list_message">Add a recipe’s ingredients to your grocery list with a tap, so you never forget an item at the store.</string>
+
+    <string name="onboarding_meal_planning_title">Plan your week</string>
+    <string name="onboarding_meal_planning_message">Add recipes to breakfast, lunch, dinner, or snacks for any day of the week with the meal planner.</string>
 
     <string name="onboarding_start_cooking_title">You’re all set</string>
     <string name="onboarding_start_cooking_message">Everything’s ready to go. Let’s start cooking!</string>

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/CookModeBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/CookModeBloc.kt
@@ -1,0 +1,19 @@
+package com.plusmobileapps.chefmate.onboarding
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.ui.BlocScreen
+
+/** Onboarding step explaining how to start Cook Mode from the recipe detail screen. */
+interface CookModeBloc : BlocScreen {
+    fun onNextClicked()
+
+    sealed class Output {
+        /** Advance to the next onboarding step. */
+        data object Next : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): CookModeBloc
+    }
+}

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/GroceryListBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/GroceryListBloc.kt
@@ -1,0 +1,19 @@
+package com.plusmobileapps.chefmate.onboarding
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.ui.BlocScreen
+
+/** Onboarding step explaining how to add a recipe’s ingredients to the grocery list. */
+interface GroceryListBloc : BlocScreen {
+    fun onNextClicked()
+
+    sealed class Output {
+        /** Advance to the next onboarding step. */
+        data object Next : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): GroceryListBloc
+    }
+}

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/MealPlanningBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/MealPlanningBloc.kt
@@ -1,0 +1,19 @@
+package com.plusmobileapps.chefmate.onboarding
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.ui.BlocScreen
+
+/** Onboarding step explaining how to add recipes to meals across the days of the week. */
+interface MealPlanningBloc : BlocScreen {
+    fun onNextClicked()
+
+    sealed class Output {
+        /** Advance to the next onboarding step. */
+        data object Next : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): MealPlanningBloc
+    }
+}

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingRootBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingRootBloc.kt
@@ -10,12 +10,13 @@ import com.plusmobileapps.chefmate.ui.BlocScreen
 
 /**
  * Navigation BLoC that drives the first-run onboarding flow. It owns a Decompose router that walks
- * the user from the [WelcomeBloc] through to the final [StartCookingBloc]. When the user finishes,
- * it marks onboarding as completed and emits [Output.Finished] so the root can load the rest of the
- * app.
+ * the user from the [WelcomeBloc] through a series of feature tours ([SaveRecipesBloc],
+ * [CookModeBloc], [GroceryListBloc], [MealPlanningBloc]) to the final [StartCookingBloc]. When the
+ * user finishes (or skips), it marks onboarding as completed and emits [Output.Finished] so the
+ * root can load the rest of the app.
  *
- * This is currently a skeleton with only the welcome and start-cooking screens; additional steps
- * will be inserted between them in follow-up work.
+ * From the welcome screen the user can also choose to sign in; that is surfaced as [Output.SignIn]
+ * so the root can open the authentication flow.
  */
 interface OnboardingRootBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
     val routerState: Value<ChildStack<*, Child>>
@@ -26,12 +27,25 @@ interface OnboardingRootBloc : BackHandlerOwner, BackClickBloc, BlocScreen {
 
         data class Welcome(override val bloc: WelcomeBloc) : Child()
 
+        data class SaveRecipes(override val bloc: SaveRecipesBloc) : Child()
+
+        data class CookMode(override val bloc: CookModeBloc) : Child()
+
+        data class GroceryList(override val bloc: GroceryListBloc) : Child()
+
+        data class MealPlanning(override val bloc: MealPlanningBloc) : Child()
+
         data class StartCooking(override val bloc: StartCookingBloc) : Child()
     }
 
     sealed class Output {
-        /** The user reached the end of onboarding; the root should load the main app. */
+        /**
+         * The user reached the end of onboarding (or skipped); the root should load the main app.
+         */
         data object Finished : Output()
+
+        /** The user wants to sign in; the root should open the authentication flow. */
+        data object SignIn : Output()
     }
 
     fun interface Factory {

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingTestTags.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingTestTags.kt
@@ -4,6 +4,20 @@ package com.plusmobileapps.chefmate.onboarding
 object OnboardingTestTags {
     const val WELCOME_SCREEN = "onboarding_welcome_screen"
     const val WELCOME_GET_STARTED_BUTTON = "onboarding_welcome_get_started_button"
+    const val WELCOME_SIGN_IN_BUTTON = "onboarding_welcome_sign_in_button"
+    const val WELCOME_SKIP_BUTTON = "onboarding_welcome_skip_button"
+
+    const val SAVE_RECIPES_SCREEN = "onboarding_save_recipes_screen"
+    const val SAVE_RECIPES_NEXT_BUTTON = "onboarding_save_recipes_next_button"
+
+    const val COOK_MODE_SCREEN = "onboarding_cook_mode_screen"
+    const val COOK_MODE_NEXT_BUTTON = "onboarding_cook_mode_next_button"
+
+    const val GROCERY_LIST_SCREEN = "onboarding_grocery_list_screen"
+    const val GROCERY_LIST_NEXT_BUTTON = "onboarding_grocery_list_next_button"
+
+    const val MEAL_PLANNING_SCREEN = "onboarding_meal_planning_screen"
+    const val MEAL_PLANNING_NEXT_BUTTON = "onboarding_meal_planning_next_button"
 
     const val START_COOKING_SCREEN = "onboarding_start_cooking_screen"
     const val START_COOKING_BUTTON = "onboarding_start_cooking_button"

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/SaveRecipesBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/SaveRecipesBloc.kt
@@ -1,0 +1,21 @@
+package com.plusmobileapps.chefmate.onboarding
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.ui.BlocScreen
+
+/**
+ * Onboarding step explaining how to find recipes in the browser and download them to the account.
+ */
+interface SaveRecipesBloc : BlocScreen {
+    fun onNextClicked()
+
+    sealed class Output {
+        /** Advance to the next onboarding step. */
+        data object Next : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): SaveRecipesBloc
+    }
+}

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/WelcomeBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/WelcomeBloc.kt
@@ -8,9 +8,19 @@ import com.plusmobileapps.chefmate.ui.BlocScreen
 interface WelcomeBloc : BlocScreen {
     fun onGetStartedClicked()
 
+    fun onSignInClicked()
+
+    fun onSkipClicked()
+
     sealed class Output {
         /** Advance to the next onboarding step. */
         data object GetStarted : Output()
+
+        /** The user already has an account and wants to sign in. */
+        data object SignIn : Output()
+
+        /** The user wants to skip onboarding entirely. */
+        data object Skip : Output()
     }
 
     fun interface Factory {

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -288,10 +288,15 @@ class RootBlocImpl(
     private fun handleOnboardingOutput(output: OnboardingRootBloc.Output) {
         when (output) {
             // Onboarding marks itself completed; swap the whole stack for the main app so back
-            // can't
-            // return to the flow.
+            // can't return to the flow.
             OnboardingRootBloc.Output.Finished ->
                 navigation.replaceAll(Configuration.BottomNavigation)
+            // Open the auth flow on top of onboarding. On success, handleAuthenticationOutput tears
+            // the onboarding stack down for us.
+            OnboardingRootBloc.Output.SignIn ->
+                navigation.bringToFront(
+                    Configuration.Authentication(AuthenticationBloc.Props.SignIn)
+                )
         }
     }
 
@@ -495,7 +500,18 @@ class RootBlocImpl(
     private fun handleAuthenticationOutput(output: AuthenticationBloc.Output) {
         when (output) {
             AuthenticationBloc.Output.Finished -> navigation.pop()
-            AuthenticationBloc.Output.AuthenticationSuccess -> navigation.pop()
+            AuthenticationBloc.Output.AuthenticationSuccess -> {
+                val cameFromOnboarding =
+                    stack.value.items.any { it.instance is RootBloc.Child.Onboarding }
+                if (cameFromOnboarding) {
+                    // Signing in from onboarding counts as finishing it: mark complete and drop the
+                    // whole onboarding + auth stack so back can't return to the flow.
+                    onboardingRepository.setOnboardingCompleted()
+                    navigation.replaceAll(Configuration.BottomNavigation)
+                } else {
+                    navigation.pop()
+                }
+            }
             is AuthenticationBloc.Output.EmailVerificationRequired ->
                 navigation.bringToFront(
                     Configuration.OtpVerification(email = output.email, flow = OtpFlow.SignUp)

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -50,6 +50,7 @@ class RootBlocTest {
     var exportRecipesProps: ExportRecipesBloc.Props? = null
     var bottomNavInitialTab: BottomNavBloc.Tab? = null
     var onboardingOutput: Consumer<OnboardingRootBloc.Output> = Consumer {}
+    lateinit var onboardingRepository: OnboardingRepository
 
     fun createRoot(
         deepLink: DeepLink = DeepLink.None,
@@ -61,9 +62,9 @@ class RootBlocTest {
             context = context,
             deepLink = deepLink,
             onboardingRepository =
-                OnboardingRepository(MapSettings()).apply {
-                    if (onboardingCompleted) setOnboardingCompleted()
-                },
+                OnboardingRepository(MapSettings())
+                    .apply { if (onboardingCompleted) setOnboardingCompleted() }
+                    .also { onboardingRepository = it },
             onboardingRoot = { _, output ->
                 onboardingOutput = output
                 mock()
@@ -166,6 +167,27 @@ class RootBlocTest {
         bottomNavOutput.onNext(BottomNavBloc.Output.OpenOnboarding)
         rootBloc.instance() should instanceOf<RootBloc.Child.Onboarding>()
         rootBloc.state.value.backStack.size shouldBe 1
+    }
+
+    @Test
+    fun When_onboarding_outputs_sign_in_Then_authentication_is_pushed() {
+        val root = createRoot(onboardingCompleted = false)
+        onboardingOutput.onNext(OnboardingRootBloc.Output.SignIn)
+        root.instance() should instanceOf<RootBloc.Child.Authentication>()
+        authProps shouldBe AuthenticationBloc.Props.SignIn
+        root.state.value.backStack.size shouldBe 1
+    }
+
+    @Test
+    fun When_auth_succeeds_from_onboarding_Then_bottom_nav_replaces_stack_and_completes() {
+        val root = createRoot(onboardingCompleted = false)
+        onboardingOutput.onNext(OnboardingRootBloc.Output.SignIn)
+
+        authOutput.onNext(AuthenticationBloc.Output.AuthenticationSuccess)
+
+        root.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+        root.state.value.backStack.size shouldBe 0
+        onboardingRepository.hasCompletedOnboarding shouldBe true
     }
 
     @Test

--- a/client/ui/screenshot-test/build.gradle.kts
+++ b/client/ui/screenshot-test/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
     implementation(project(":client:meal:core:public"))
     implementation(project(":client:meal:core:impl"))
     implementation(project(":client:meal:data:public"))
+    implementation(project(":client:onboarding:public"))
+    implementation(project(":client:onboarding:impl"))
     implementation(project(":client:recipe:categories:public"))
     implementation(project(":client:recipe:categories:impl"))
     implementation(project(":client:recipe:core:public"))

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTest.kt
@@ -1,0 +1,123 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.onboarding.impl.ui.previewCookModeBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.previewGroceryListBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.previewMealPlanningBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.previewSaveRecipesBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.previewStartCookingBloc
+import com.plusmobileapps.chefmate.onboarding.impl.ui.previewWelcomeBloc
+import com.plusmobileapps.chefmate.ui.Content
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@Composable
+private fun OnboardingScreenshot(content: @Composable () -> Unit, darkTheme: Boolean = false) {
+    ChefMateTheme(darkTheme = darkTheme) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            content()
+        }
+    }
+}
+
+// ── Welcome ────────────────────────────────────────────────────────────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun OnboardingWelcomeLightScreenshot() {
+    OnboardingScreenshot(content = { previewWelcomeBloc.Content() })
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun OnboardingWelcomeDarkScreenshot() {
+    OnboardingScreenshot(content = { previewWelcomeBloc.Content() }, darkTheme = true)
+}
+
+// ── Save recipes ─────────────────────────────────────────────────────────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun OnboardingSaveRecipesLightScreenshot() {
+    OnboardingScreenshot(content = { previewSaveRecipesBloc.Content() })
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun OnboardingSaveRecipesDarkScreenshot() {
+    OnboardingScreenshot(content = { previewSaveRecipesBloc.Content() }, darkTheme = true)
+}
+
+// ── Cook mode ────────────────────────────────────────────────────────────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun OnboardingCookModeLightScreenshot() {
+    OnboardingScreenshot(content = { previewCookModeBloc.Content() })
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun OnboardingCookModeDarkScreenshot() {
+    OnboardingScreenshot(content = { previewCookModeBloc.Content() }, darkTheme = true)
+}
+
+// ── Grocery list ─────────────────────────────────────────────────────────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun OnboardingGroceryListLightScreenshot() {
+    OnboardingScreenshot(content = { previewGroceryListBloc.Content() })
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun OnboardingGroceryListDarkScreenshot() {
+    OnboardingScreenshot(content = { previewGroceryListBloc.Content() }, darkTheme = true)
+}
+
+// ── Meal planning ────────────────────────────────────────────────────────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun OnboardingMealPlanningLightScreenshot() {
+    OnboardingScreenshot(content = { previewMealPlanningBloc.Content() })
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun OnboardingMealPlanningDarkScreenshot() {
+    OnboardingScreenshot(content = { previewMealPlanningBloc.Content() }, darkTheme = true)
+}
+
+// ── Start cooking ────────────────────────────────────────────────────────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun OnboardingStartCookingLightScreenshot() {
+    OnboardingScreenshot(content = { previewStartCookingBloc.Content() })
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun OnboardingStartCookingDarkScreenshot() {
+    OnboardingScreenshot(content = { previewStartCookingBloc.Content() }, darkTheme = true)
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingCookModeDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingCookModeDarkScreenshot_658f3c84_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2215c19c4eb124e35ae9e56083a7e2d9af63d7089ba503e61e1bf6cdaeb331f2
+size 55007

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingCookModeLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingCookModeLightScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fb82cfefb2d857ee4648384bc699ef408797d28fa0652eb07706afad567991e
+size 54455

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingGroceryListDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingGroceryListDarkScreenshot_658f3c84_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1ce3127e842d3a79b8ebf1cfe8be2b9a8ba6467e433e6ab49dec89c2386763e
+size 51683

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingGroceryListLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingGroceryListLightScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a12e9b92981f47fa36c87c24bd81931e3abce4cbf374f335047ed61cb0483148
+size 51253

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingMealPlanningDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingMealPlanningDarkScreenshot_658f3c84_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae5a2787f665dd1bf7eb0999cb8150ca9b9f6f86ffb90d09869c3ff79e894751
+size 46524

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingMealPlanningLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingMealPlanningLightScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3033bd24e3097a3800410b5855dc493eb05ad7c53a981d020f3efad5c06ffb3b
+size 46250

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingSaveRecipesDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingSaveRecipesDarkScreenshot_658f3c84_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:726628c2fe834c4d2df7ea2f05baa282cfd84949561070c293986294f1b09b34
+size 54768

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingSaveRecipesLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingSaveRecipesLightScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d9c72fd212c4f39861ef4e1a039de57cb3f05c0458d332150119d68d3e69351
+size 54552

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingStartCookingDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingStartCookingDarkScreenshot_658f3c84_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbe2e5230298373c9f5ef23a524b46bb9b22b2c9a4bcd89d014fdd62bf59b6bc
+size 36250

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingStartCookingLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingStartCookingLightScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56901fa20cacc53c16f667af0fe4f43a5dff0249cf5d14b7bdbb66d878b2ce47
+size 36080

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingWelcomeDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingWelcomeDarkScreenshot_658f3c84_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18d8c028138b51f1e95f89ecb0d87412166a3933da430bd25da030133d0e7a96
+size 55941

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingWelcomeLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingWelcomeLightScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0ced9c119bf0e8bfd65f21e6a77c0eda0636394798a214f9fb759e5fec0d075
+size 55225

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -100,6 +100,8 @@ include(":client:meal:core:public")
 
 include(":client:onboarding:impl")
 
+include(":client:onboarding:impl-robots")
+
 include(":client:onboarding:public")
 
 include(":client:meal:data:impl")


### PR DESCRIPTION
## Overview

Builds on the merged onboarding skeleton (#303) by fleshing out the flow with feature-tour screens and giving the welcome screen sign-in / skip options.

## Flow

`Welcome → Save recipes → Cook mode → Grocery list → Meal planning → Start cooking`

## What changed

**Four new tour screens** (each a simple BLoC emitting `Next`, rendered via a shared `OnboardingInfoLayout` — centered icon + title + body + button):
- **Save recipes** — use the in-app browser to find recipes and tap Download to save them to your account.
- **Cook mode** — start Cook Mode from the recipe detail screen.
- **Grocery list** — add a recipe's ingredients to your grocery list.
- **Meal planning** — add recipes to breakfast/lunch/dinner/snack across the week.

**Welcome screen** gains two actions below "Get started":
- **"I already have an account"** → emits `OnboardingRootBloc.Output.SignIn`.
- **"Skip"** → marks onboarding completed and finishes immediately.

**Root wiring** (`RootBlocImpl`):
- `OnboardingRootBloc.Output.SignIn` pushes the `Authentication(SignIn)` config onto the root stack, on top of onboarding.
- On `AuthenticationBloc.Output.AuthenticationSuccess` *while onboarding is in the stack*, marks onboarding completed and `replaceAll`s with the bottom nav, so back can't return to onboarding or auth. Auth success elsewhere keeps its existing pop behavior.

All `Child` types use the repo's `abstract val bloc: BlocScreen` convention (post-#304).

## Testing

- `:client:composeApp:compileKotlinJvm` (full Metro DI graph) builds.
- New `OnboardingRootBlocImplTest`: tour order, skip, sign-in, and completion behavior.
- `RootBlocTest`: sign-in pushes auth; auth-success-from-onboarding clears the stack and marks completion.

## Reviewer notes

- The onboarding flow remains gated behind the `onboarding` feature flag added previously (default off).
- **Deferred (consistent with the skeleton PR):** snapshot tests and robot UI tests for the onboarding screens. Recording screenshot references needs the Android screenshot tooling; happy to add these in a follow-up (or here if you'd prefer). New stable test tags are already in place on every screen/button to make that straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)