### PR TITLE
feat(ui): add PlusOnboardingTooltip coach mark, anchored to cook mode

### DIFF
--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsBlocImpl.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsBlocImpl.kt
@@ -76,6 +76,14 @@ class DeveloperSettingsBlocImpl(
         output.onNext(Output.OpenFeatureFlags)
     }
 
+    override fun onClearCoachMarksClicked() {
+        viewModel.clearCoachMarks()
+    }
+
+    override fun onCoachMarksResetConfirmationDismissed() {
+        viewModel.dismissCoachMarksResetConfirmation()
+    }
+
     @Composable
     override fun Content(modifier: Modifier) {
         DeveloperSettingsScreen(bloc = this, modifier = modifier)

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsViewModel.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/DeveloperSettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.plusmobileapps.chefmate.auth.usecase.SignOutUseCase
 import com.plusmobileapps.chefmate.devsettings.DeveloperPreferences
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.devsettings.TestUser
+import com.plusmobileapps.chefmate.di.CoachMarkController
 import com.plusmobileapps.chefmate.di.Main
 import dev.zacsweers.metro.Inject
 import kotlin.coroutines.CoroutineContext
@@ -29,6 +30,7 @@ class DeveloperSettingsViewModel(
     private val authenticationRepository: AuthenticationRepository,
     private val signOutUseCase: SignOutUseCase,
     private val fakeRecipeSeeder: FakeRecipeSeeder,
+    private val coachMarkController: CoachMarkController,
 ) : ViewModel(mainContext) {
 
     private val _state =
@@ -117,5 +119,15 @@ class DeveloperSettingsViewModel(
             preferences.setSelectedUserIndex(null)
             signOutUseCase()
         }
+    }
+
+    /** Forget every coach mark so they show again on the next visit to their screens. */
+    fun clearCoachMarks() {
+        coachMarkController.clearAllSeen()
+        _state.update { it.copy(showCoachMarksResetConfirmation = true) }
+    }
+
+    fun dismissCoachMarksResetConfirmation() {
+        _state.update { it.copy(showCoachMarksResetConfirmation = false) }
     }
 }

--- a/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/ui/DeveloperSettingsScreen.kt
+++ b/client/developer-settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/impl/ui/DeveloperSettingsScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import chefmate.client.developer_settings.public.generated.resources.Res
+import chefmate.client.developer_settings.public.generated.resources.dev_coach_marks_reset_message
+import chefmate.client.developer_settings.public.generated.resources.dev_coach_marks_reset_title
 import chefmate.client.developer_settings.public.generated.resources.dev_env_fake
 import chefmate.client.developer_settings.public.generated.resources.dev_env_prod
 import chefmate.client.developer_settings.public.generated.resources.dev_env_testing
@@ -35,6 +37,7 @@ import chefmate.client.developer_settings.public.generated.resources.dev_login_a
 import chefmate.client.developer_settings.public.generated.resources.dev_no_test_users
 import chefmate.client.developer_settings.public.generated.resources.dev_no_test_users_message
 import chefmate.client.developer_settings.public.generated.resources.dev_picker_dismiss
+import chefmate.client.developer_settings.public.generated.resources.dev_reset_coach_marks
 import chefmate.client.developer_settings.public.generated.resources.dev_restart_required_message
 import chefmate.client.developer_settings.public.generated.resources.dev_restart_required_title
 import chefmate.client.developer_settings.public.generated.resources.dev_sign_in_error_title
@@ -87,6 +90,15 @@ fun DeveloperSettingsScreen(bloc: DeveloperSettingsBloc, modifier: Modifier = Mo
         )
     }
 
+    if (state.showCoachMarksResetConfirmation) {
+        PlusDialog(
+            title = Res.string.dev_coach_marks_reset_title.asTextData(),
+            message = Res.string.dev_coach_marks_reset_message.asTextData(),
+            onConfirmClick = bloc::onCoachMarksResetConfirmationDismissed,
+            onDismissRequest = bloc::onCoachMarksResetConfirmationDismissed,
+        )
+    }
+
     state.signInError?.let { rawMessage ->
         val message: TextData =
             if (rawMessage.isBlank()) Res.string.dev_sign_in_error_unknown.asTextData()
@@ -131,6 +143,11 @@ fun DeveloperSettingsScreen(bloc: DeveloperSettingsBloc, modifier: Modifier = Mo
                 DeveloperRow(
                     title = Res.string.dev_feature_flags.asTextData(),
                     onClick = bloc::onFeatureFlagsClicked,
+                )
+                HorizontalDivider()
+                DeveloperRow(
+                    title = Res.string.dev_reset_coach_marks.asTextData(),
+                    onClick = bloc::onClearCoachMarksClicked,
                 )
             },
         )
@@ -321,6 +338,10 @@ val previewDeveloperSettingsBloc =
         override fun onSignInErrorDismissed() = Unit
 
         override fun onFeatureFlagsClicked() = Unit
+
+        override fun onClearCoachMarksClicked() = Unit
+
+        override fun onCoachMarksResetConfirmationDismissed() = Unit
 
         @Composable
         override fun Content(modifier: Modifier) = DeveloperSettingsScreen(this, modifier)

--- a/client/developer-settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/developer-settings/public/src/commonMain/composeResources/values/strings.xml
@@ -16,4 +16,7 @@
     <string name="dev_restart_required_message">Environment changed. Local data was wiped and you were signed out. Force-stop and reopen the app for the new environment to take effect.</string>
     <string name="dev_picker_dismiss">Cancel</string>
     <string name="dev_feature_flags">Feature flags</string>
+    <string name="dev_reset_coach_marks">Reset coach marks</string>
+    <string name="dev_coach_marks_reset_title">Coach marks reset</string>
+    <string name="dev_coach_marks_reset_message">All coach marks will show again next time you visit their screens.</string>
 </resources>

--- a/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsBloc.kt
+++ b/client/developer-settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/devsettings/DeveloperSettingsBloc.kt
@@ -33,6 +33,10 @@ interface DeveloperSettingsBloc : BlocScreen {
 
     fun onFeatureFlagsClicked()
 
+    fun onClearCoachMarksClicked()
+
+    fun onCoachMarksResetConfirmationDismissed()
+
     data class Model(
         val currentEnvironment: Environment = Environment.PROD,
         val availableUsers: ImmutableList<TestUser> = persistentListOf(),
@@ -43,6 +47,7 @@ interface DeveloperSettingsBloc : BlocScreen {
         val showUserPicker: Boolean = false,
         val showRestartPrompt: Boolean = false,
         val signInError: String? = null,
+        val showCoachMarksResetConfirmation: Boolean = false,
     )
 
     sealed class Output {

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
@@ -81,6 +81,7 @@ class GroceryListBlocImpl(
                 showListSelector = it.showListSelector,
                 pendingInvitations = it.pendingInvitations,
                 currentUserRole = it.currentUserRole,
+                showSyncTooltip = it.showSyncTooltip,
             )
         }
 
@@ -116,6 +117,10 @@ class GroceryListBlocImpl(
 
     override fun onSyncClicked() {
         viewModel.onSyncClicked()
+    }
+
+    override fun onSyncTooltipDismissed() {
+        viewModel.dismissSyncTooltip()
     }
 
     override fun onListSelected(list: GroceryListModel) {

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
@@ -3,6 +3,9 @@
 package com.plusmobileapps.chefmate.grocery.core.impl.list
 
 import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.combineStates
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryFilter
@@ -34,6 +37,7 @@ class GroceryListViewModel(
     @Main mainContext: CoroutineContext,
     private val repository: GroceryRepository,
     settings: Settings,
+    private val coachMarkController: CoachMarkController,
 ) : ViewModel(mainContext) {
     private var sortPref by settings.string(KEY_SORT, GrocerySort.AISLE.name)
     private var filterPref by settings.string(KEY_FILTER, GroceryFilter.ALL.name)
@@ -49,11 +53,18 @@ class GroceryListViewModel(
     private val _filter = MutableStateFlow(initialFilter)
     private val _recipeFilter = MutableStateFlow<String?>(null)
 
-    val state: StateFlow<State> = _state.asStateFlow()
+    // The sync coach mark only shows while it's the active mark in the shared controller, so at
+    // most one coach mark is ever visible across the app at a time.
+    val state: StateFlow<State> =
+        combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
+            state.copy(showSyncTooltip = activeCoachMark == CoachMarkId.GROCERY_LIST_SYNC)
+        }
 
     val newGroceryItemName: StateFlow<String> = _newGroceryItemName.asStateFlow()
 
     init {
+        coachMarkController.request(CoachMarkId.GROCERY_LIST_SYNC)
+
         scope.launch {
             val defaultListId = repository.ensureDefaultList()
             if (selectedListId.value == null) {
@@ -182,6 +193,7 @@ class GroceryListViewModel(
     }
 
     fun onSyncClicked() {
+        coachMarkController.dismiss(CoachMarkId.GROCERY_LIST_SYNC)
         scope.launch {
             _state.update { it.copy(isSyncing = true) }
             try {
@@ -190,6 +202,17 @@ class GroceryListViewModel(
                 _state.update { it.copy(isSyncing = false) }
             }
         }
+    }
+
+    /** Hide the sync coach mark and remember the dismissal so it never shows again. */
+    fun dismissSyncTooltip() {
+        coachMarkController.dismiss(CoachMarkId.GROCERY_LIST_SYNC)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        // Leaving the screen without dismissing frees the queue so other coach marks can show.
+        coachMarkController.release(CoachMarkId.GROCERY_LIST_SYNC)
     }
 
     fun onListSelected(list: GroceryListModel) {
@@ -325,6 +348,7 @@ class GroceryListViewModel(
         val showListSelector: Boolean = false,
         val pendingInvitations: List<GroceryListInvite> = emptyList(),
         val currentUserRole: ListRole = ListRole.OWNER,
+        val showSyncTooltip: Boolean = false,
     )
 
     private data class GroceryListContent(

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListPreviews.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListPreviews.kt
@@ -84,6 +84,8 @@ private fun groceryListBloc(
 
         override fun onSyncClicked() = Unit
 
+        override fun onSyncTooltipDismissed() = Unit
+
         override fun onListSelected(list: GroceryListModel) = Unit
 
         override fun onCreateListClicked() = Unit

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListScreen.kt
@@ -132,6 +132,7 @@ import chefmate.client.grocery.core.public.generated.resources.grocery_sort_and_
 import chefmate.client.grocery.core.public.generated.resources.grocery_sort_by
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_all
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_not_synced
+import chefmate.client.grocery.core.public.generated.resources.grocery_sync_onboarding
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_synced
 import chefmate.client.grocery.core.public.generated.resources.grocery_sync_syncing
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
@@ -152,8 +153,10 @@ import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
+import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveModal
+import com.plusmobileapps.chefmate.ui.components.PlusTooltipPlacement
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.isIosPlatform
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -249,12 +252,19 @@ fun GroceryListScreen(
                                 strokeWidth = 2.dp,
                             )
                         } else {
-                            IconButton(onClick = bloc::onSyncClicked) {
-                                Icon(
-                                    Icons.Default.Sync,
-                                    contentDescription =
-                                        stringResource(Res.string.grocery_sync_all),
-                                )
+                            PlusOnboardingTooltip(
+                                text = Res.string.grocery_sync_onboarding.asTextData(),
+                                visible = state.showSyncTooltip,
+                                onDismiss = bloc::onSyncTooltipDismissed,
+                                placement = PlusTooltipPlacement.BELOW,
+                            ) {
+                                IconButton(onClick = bloc::onSyncClicked) {
+                                    Icon(
+                                        Icons.Default.Sync,
+                                        contentDescription =
+                                            stringResource(Res.string.grocery_sync_all),
+                                    )
+                                }
                             }
                         }
                     },

--- a/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
+++ b/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
@@ -5,6 +5,8 @@ package com.plusmobileapps.chefmate.grocery.core.impl.list
 
 import app.cash.turbine.test
 import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.grocery.core.detail.GroceryDetailBloc
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc.GroceryGroup
@@ -54,6 +56,11 @@ class GroceryListBlocTest {
         mock(MockMode.autoUnit)
     }
 
+    // Seed the sync coach mark as already seen so the default-state assertions below aren't
+    // affected by the tooltip. The unseen path has its own dedicated test.
+    val coachMarkController =
+        CoachMarkController(MapSettings()).apply { dismiss(CoachMarkId.GROCERY_LIST_SYNC) }
+
     val bloc =
         GroceryListBlocImpl(
             context = context,
@@ -63,6 +70,7 @@ class GroceryListBlocTest {
                     mainContext = context.mainContext,
                     repository = repository,
                     settings = settings,
+                    coachMarkController = coachMarkController,
                 )
             },
             groceryDetailFactory = groceryDetailFactory,
@@ -477,6 +485,31 @@ class GroceryListBlocTest {
         bloc.childSlot.value.child shouldNotBe null
         bloc.onDismissSheet()
         bloc.childSlot.value.child shouldBe null
+    }
+
+    @Test
+    fun When_sync_coach_mark_unseen_Then_shown_and_dismiss_persists() = runTest {
+        val freshContext = TestBlocContext.Companion.create()
+        val controller = CoachMarkController(MapSettings())
+        val tooltipBloc =
+            GroceryListBlocImpl(
+                context = freshContext,
+                output = output,
+                viewModelFactory = {
+                    GroceryListViewModel(
+                        mainContext = freshContext.mainContext,
+                        repository = repository,
+                        settings = MapSettings(),
+                        coachMarkController = controller,
+                    )
+                },
+                groceryDetailFactory = groceryDetailFactory,
+            )
+
+        tooltipBloc.state.value.showSyncTooltip shouldBe true
+        tooltipBloc.onSyncTooltipDismissed()
+        tooltipBloc.state.value.showSyncTooltip shouldBe false
+        controller.hasSeen(CoachMarkId.GROCERY_LIST_SYNC) shouldBe true
     }
 
     @Test

--- a/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="grocery_sync_syncing">Syncing</string>
     <string name="grocery_sync_synced">Synced</string>
     <string name="grocery_sync_all">Sync all</string>
+    <string name="grocery_sync_onboarding">Tap to sync this list across your devices</string>
     <string name="grocery_select_list">Select list</string>
     <string name="grocery_create_new_list">Create new list…</string>
     <string name="grocery_create_list_title">New Grocery List</string>

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
@@ -36,6 +36,8 @@ interface GroceryListBloc : BlocScreen {
 
     fun onSyncClicked()
 
+    fun onSyncTooltipDismissed()
+
     fun onListSelected(list: GroceryListModel)
 
     fun onCreateListClicked()
@@ -99,6 +101,7 @@ interface GroceryListBloc : BlocScreen {
         val showListSelector: Boolean = false,
         val pendingInvitations: List<GroceryListInvite> = emptyList(),
         val currentUserRole: ListRole = ListRole.OWNER,
+        val showSyncTooltip: Boolean = false,
     )
 
     sealed class Output {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -112,6 +112,7 @@ class RecipeDetailBlocImpl(
                 formattedTotalTime =
                     it.recipe.totalTime?.let { time -> timeFormatterUtil.formatMinutes(time) },
                 showGroceryAddedSnackbar = it.showGroceryAddedSnackbar,
+                showCookModeTooltip = it.showCookModeTooltip,
             )
         }
 
@@ -156,7 +157,12 @@ class RecipeDetailBlocImpl(
     }
 
     override fun onCookModeClicked() {
+        viewModel.dismissCookModeTooltip()
         output.onNext(Output.OpenCookMode(recipeId))
+    }
+
+    override fun onCookModeTooltipDismissed() {
+        viewModel.dismissCookModeTooltip()
     }
 
     override fun onSourceUrlClicked(url: String) {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -12,6 +12,7 @@ import com.arkivanov.essenty.backhandler.BackCallback
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
@@ -112,7 +113,7 @@ class RecipeDetailBlocImpl(
                 formattedTotalTime =
                     it.recipe.totalTime?.let { time -> timeFormatterUtil.formatMinutes(time) },
                 showGroceryAddedSnackbar = it.showGroceryAddedSnackbar,
-                showCookModeTooltip = it.showCookModeTooltip,
+                activeCoachMark = it.activeCoachMark,
             )
         }
 
@@ -133,10 +134,12 @@ class RecipeDetailBlocImpl(
     }
 
     override fun onFavoriteToggled() {
+        viewModel.dismissCoachMark(CoachMarkId.RECIPE_DETAIL_FAVORITE)
         viewModel.toggleFavorite()
     }
 
     override fun onAddToGroceryListClicked() {
+        viewModel.dismissCoachMark(CoachMarkId.RECIPE_DETAIL_ADD_TO_GROCERY)
         sheetNavigation.activate(SheetConfig.AddToGroceryList(recipeId))
     }
 
@@ -153,16 +156,17 @@ class RecipeDetailBlocImpl(
     }
 
     override fun onAddToMealPlanClicked() {
+        viewModel.dismissCoachMark(CoachMarkId.RECIPE_DETAIL_ADD_TO_MEAL_PLAN)
         output.onNext(Output.OpenMealPlanner(recipeId))
     }
 
     override fun onCookModeClicked() {
-        viewModel.dismissCookModeTooltip()
+        viewModel.dismissCoachMark(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
         output.onNext(Output.OpenCookMode(recipeId))
     }
 
-    override fun onCookModeTooltipDismissed() {
-        viewModel.dismissCookModeTooltip()
+    override fun onCoachMarkDismissed(id: String) {
+        viewModel.dismissCoachMark(id)
     }
 
     override fun onSourceUrlClicked(url: String) {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -33,15 +33,16 @@ class RecipeDetailViewModel(
 
     private val _state = MutableStateFlow(State())
 
-    // The cook-mode coach mark only shows while it's the active mark in the shared controller, so
-    // at most one coach mark is ever visible across the app at a time.
+    // Surface the shared controller's active mark so the screen can show one coach mark at a time;
+    // only ids in CoachMarkId.recipeDetailSequence are anchored on this screen.
     val state: StateFlow<State> =
         combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
-            state.copy(showCookModeTooltip = activeCoachMark == CoachMarkId.RECIPE_DETAIL_COOK_MODE)
+            state.copy(activeCoachMark = activeCoachMark)
         }
 
     init {
-        coachMarkController.request(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
+        // Queue every recipe-detail coach mark in order; the controller shows them one at a time.
+        CoachMarkId.recipeDetailSequence.forEach(coachMarkController::request)
         scope.launch { observeRecipe() }
     }
 
@@ -77,7 +78,7 @@ class RecipeDetailViewModel(
     override fun onCleared() {
         super.onCleared()
         // Leaving the screen without dismissing frees the queue so other coach marks can show.
-        coachMarkController.release(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
+        CoachMarkId.recipeDetailSequence.forEach(coachMarkController::release)
         _output.close()
     }
 
@@ -89,9 +90,15 @@ class RecipeDetailViewModel(
         _state.update { it.copy(showGroceryAddedSnackbar = false) }
     }
 
-    /** Hide the cook-mode coach mark and remember the dismissal so it never shows again. */
-    fun dismissCookModeTooltip() {
-        coachMarkController.dismiss(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
+    /**
+     * Mark a coach mark seen, but only if it's the one currently showing. This lets a button's tap
+     * dismiss its own tip while it's visible, without prematurely consuming tips further down the
+     * queue when their button is tapped early.
+     */
+    fun dismissCoachMark(id: String) {
+        if (coachMarkController.activeCoachMark.value == id) {
+            coachMarkController.dismiss(id)
+        }
     }
 
     data class State(
@@ -100,7 +107,7 @@ class RecipeDetailViewModel(
         val showDeleteConfirmationDialog: Boolean = false,
         val recipe: Recipe = Recipe.Empty,
         val showGroceryAddedSnackbar: Boolean = false,
-        val showCookModeTooltip: Boolean = false,
+        val activeCoachMark: String? = null,
     )
 
     sealed class Output {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -1,11 +1,12 @@
 package com.plusmobileapps.chefmate.recipe.core.impl.detail
 
 import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.combineStates
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
-import com.russhwolf.settings.Settings
-import com.russhwolf.settings.boolean
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
@@ -14,7 +15,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
@@ -25,20 +25,23 @@ class RecipeDetailViewModel(
     @Assisted private val recipeId: Long,
     @Main mainContext: CoroutineContext,
     private val repository: RecipeRepository,
-    settings: Settings,
+    private val coachMarkController: CoachMarkController,
 ) : ViewModel(mainContext) {
-
-    // Whether the user has dismissed the cook-mode coach mark. Persisted via multiplatform-settings
-    // so the tip is only ever shown once per install.
-    private var cookModeTooltipSeen by settings.boolean(KEY_COOK_MODE_TOOLTIP_SEEN, false)
 
     private val _output = Channel<Output>(Channel.BUFFERED)
     val output: Flow<Output> = _output.receiveAsFlow()
 
-    private val _state = MutableStateFlow(State(showCookModeTooltip = !cookModeTooltipSeen))
-    val state: StateFlow<State> = _state.asStateFlow()
+    private val _state = MutableStateFlow(State())
+
+    // The cook-mode coach mark only shows while it's the active mark in the shared controller, so
+    // at most one coach mark is ever visible across the app at a time.
+    val state: StateFlow<State> =
+        combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
+            state.copy(showCookModeTooltip = activeCoachMark == CoachMarkId.RECIPE_DETAIL_COOK_MODE)
+        }
 
     init {
+        coachMarkController.request(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
         scope.launch { observeRecipe() }
     }
 
@@ -73,6 +76,8 @@ class RecipeDetailViewModel(
 
     override fun onCleared() {
         super.onCleared()
+        // Leaving the screen without dismissing frees the queue so other coach marks can show.
+        coachMarkController.release(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
         _output.close()
     }
 
@@ -86,9 +91,7 @@ class RecipeDetailViewModel(
 
     /** Hide the cook-mode coach mark and remember the dismissal so it never shows again. */
     fun dismissCookModeTooltip() {
-        if (cookModeTooltipSeen) return
-        cookModeTooltipSeen = true
-        _state.update { it.copy(showCookModeTooltip = false) }
+        coachMarkController.dismiss(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
     }
 
     data class State(
@@ -109,5 +112,3 @@ class RecipeDetailViewModel(
         fun create(recipeId: Long): RecipeDetailViewModel
     }
 }
-
-private const val KEY_COOK_MODE_TOOLTIP_SEEN = "recipe_detail_cook_mode_tooltip_seen"

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -4,6 +4,8 @@ import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.boolean
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
@@ -23,12 +25,17 @@ class RecipeDetailViewModel(
     @Assisted private val recipeId: Long,
     @Main mainContext: CoroutineContext,
     private val repository: RecipeRepository,
+    settings: Settings,
 ) : ViewModel(mainContext) {
+
+    // Whether the user has dismissed the cook-mode coach mark. Persisted via multiplatform-settings
+    // so the tip is only ever shown once per install.
+    private var cookModeTooltipSeen by settings.boolean(KEY_COOK_MODE_TOOLTIP_SEEN, false)
 
     private val _output = Channel<Output>(Channel.BUFFERED)
     val output: Flow<Output> = _output.receiveAsFlow()
 
-    private val _state = MutableStateFlow(State())
+    private val _state = MutableStateFlow(State(showCookModeTooltip = !cookModeTooltipSeen))
     val state: StateFlow<State> = _state.asStateFlow()
 
     init {
@@ -77,12 +84,20 @@ class RecipeDetailViewModel(
         _state.update { it.copy(showGroceryAddedSnackbar = false) }
     }
 
+    /** Hide the cook-mode coach mark and remember the dismissal so it never shows again. */
+    fun dismissCookModeTooltip() {
+        if (cookModeTooltipSeen) return
+        cookModeTooltipSeen = true
+        _state.update { it.copy(showCookModeTooltip = false) }
+    }
+
     data class State(
         val isLoading: Boolean = true,
         val isDeleting: Boolean = false,
         val showDeleteConfirmationDialog: Boolean = false,
         val recipe: Recipe = Recipe.Empty,
         val showGroceryAddedSnackbar: Boolean = false,
+        val showCookModeTooltip: Boolean = false,
     )
 
     sealed class Output {
@@ -94,3 +109,5 @@ class RecipeDetailViewModel(
         fun create(recipeId: Long): RecipeDetailViewModel
     }
 }
+
+private const val KEY_COOK_MODE_TOOLTIP_SEEN = "recipe_detail_cook_mode_tooltip_seen"

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/ui/RecipeDetailScreen.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/ui/RecipeDetailScreen.kt
@@ -121,7 +121,9 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_groc
 import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_view
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_favorite
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_grocery
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_grocery_onboarding
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_meal_plan
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_meal_plan_onboarding
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_calories
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_mode
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_mode_onboarding
@@ -139,6 +141,7 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_desc
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_details
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_directions
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_edit
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_favorite_onboarding
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_ingredients
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_kcal
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_prep_time
@@ -154,6 +157,7 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.letIfTrue
 import com.plusmobileapps.chefmate.recipe.categories.pickerLabelRes
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
@@ -415,12 +419,14 @@ private fun RecipeDetailBody(
                             HorizontalFloatingToolbar(
                                 expanded = true,
                                 floatingActionButton = {
-                                    PlusOnboardingTooltip(
+                                    RecipeDetailCoachMark(
+                                        id = CoachMarkId.RECIPE_DETAIL_COOK_MODE,
                                         text =
                                             Res.string.recipe_detail_cook_mode_onboarding
                                                 .asTextData(),
-                                        visible = state.showCookModeTooltip && !state.isLoading,
-                                        onDismiss = bloc::onCookModeTooltipDismissed,
+                                        activeCoachMark = state.activeCoachMark,
+                                        isLoading = state.isLoading,
+                                        onDismiss = bloc::onCoachMarkDismissed,
                                     ) {
                                         FloatingActionButton(
                                             onClick = bloc::onCookModeClicked,
@@ -437,41 +443,72 @@ private fun RecipeDetailBody(
                                     }
                                 },
                             ) {
-                                IconButton(onClick = bloc::onAddToGroceryListClicked) {
-                                    Icon(
-                                        imageVector = Icons.Default.AddShoppingCart,
-                                        contentDescription =
-                                            stringResource(Res.string.recipe_detail_add_to_grocery),
-                                    )
-                                }
-                                IconButton(onClick = { bloc.onFavoriteToggled() }) {
-                                    Icon(
-                                        imageVector =
-                                            if (state.recipe.isFavorite) {
-                                                Icons.Default.Favorite
-                                            } else {
-                                                Icons.Default.FavoriteBorder
-                                            },
-                                        contentDescription =
-                                            if (state.recipe.isFavorite) {
+                                RecipeDetailCoachMark(
+                                    id = CoachMarkId.RECIPE_DETAIL_ADD_TO_GROCERY,
+                                    text =
+                                        Res.string.recipe_detail_add_to_grocery_onboarding
+                                            .asTextData(),
+                                    activeCoachMark = state.activeCoachMark,
+                                    isLoading = state.isLoading,
+                                    onDismiss = bloc::onCoachMarkDismissed,
+                                ) {
+                                    IconButton(onClick = bloc::onAddToGroceryListClicked) {
+                                        Icon(
+                                            imageVector = Icons.Default.AddShoppingCart,
+                                            contentDescription =
                                                 stringResource(
-                                                    Res.string.recipe_detail_remove_favorite
-                                                )
-                                            } else {
-                                                stringResource(
-                                                    Res.string.recipe_detail_add_favorite
-                                                )
-                                            },
-                                    )
+                                                    Res.string.recipe_detail_add_to_grocery
+                                                ),
+                                        )
+                                    }
                                 }
-                                IconButton(onClick = { bloc.onAddToMealPlanClicked() }) {
-                                    Icon(
-                                        imageVector = Icons.Default.CalendarMonth,
-                                        contentDescription =
-                                            stringResource(
-                                                Res.string.recipe_detail_add_to_meal_plan
-                                            ),
-                                    )
+                                RecipeDetailCoachMark(
+                                    id = CoachMarkId.RECIPE_DETAIL_FAVORITE,
+                                    text =
+                                        Res.string.recipe_detail_favorite_onboarding.asTextData(),
+                                    activeCoachMark = state.activeCoachMark,
+                                    isLoading = state.isLoading,
+                                    onDismiss = bloc::onCoachMarkDismissed,
+                                ) {
+                                    IconButton(onClick = { bloc.onFavoriteToggled() }) {
+                                        Icon(
+                                            imageVector =
+                                                if (state.recipe.isFavorite) {
+                                                    Icons.Default.Favorite
+                                                } else {
+                                                    Icons.Default.FavoriteBorder
+                                                },
+                                            contentDescription =
+                                                if (state.recipe.isFavorite) {
+                                                    stringResource(
+                                                        Res.string.recipe_detail_remove_favorite
+                                                    )
+                                                } else {
+                                                    stringResource(
+                                                        Res.string.recipe_detail_add_favorite
+                                                    )
+                                                },
+                                        )
+                                    }
+                                }
+                                RecipeDetailCoachMark(
+                                    id = CoachMarkId.RECIPE_DETAIL_ADD_TO_MEAL_PLAN,
+                                    text =
+                                        Res.string.recipe_detail_add_to_meal_plan_onboarding
+                                            .asTextData(),
+                                    activeCoachMark = state.activeCoachMark,
+                                    isLoading = state.isLoading,
+                                    onDismiss = bloc::onCoachMarkDismissed,
+                                ) {
+                                    IconButton(onClick = { bloc.onAddToMealPlanClicked() }) {
+                                        Icon(
+                                            imageVector = Icons.Default.CalendarMonth,
+                                            contentDescription =
+                                                stringResource(
+                                                    Res.string.recipe_detail_add_to_meal_plan
+                                                ),
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -536,6 +573,27 @@ private fun RecipeDetailBody(
             modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 96.dp),
         )
     }
+}
+
+/**
+ * A recipe-detail toolbar coach mark: shows its tooltip above [anchor] only while [id] is the
+ * active coach mark (and the recipe has loaded), and reports dismissal back by id.
+ */
+@Composable
+private fun RecipeDetailCoachMark(
+    id: String,
+    text: TextData,
+    activeCoachMark: String?,
+    isLoading: Boolean,
+    onDismiss: (String) -> Unit,
+    anchor: @Composable () -> Unit,
+) {
+    PlusOnboardingTooltip(
+        text = text,
+        visible = !isLoading && activeCoachMark == id,
+        onDismiss = { onDismiss(id) },
+        anchor = anchor,
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -1794,7 +1852,7 @@ private val previewBloc =
             TODO("Not yet implemented")
         }
 
-        override fun onCookModeTooltipDismissed() {
+        override fun onCoachMarkDismissed(id: String) {
             TODO("Not yet implemented")
         }
 

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/ui/RecipeDetailScreen.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/ui/RecipeDetailScreen.kt
@@ -124,6 +124,7 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_meal_plan
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_calories
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_mode
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_mode_onboarding
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_time
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_copied_to_clipboard
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_created
@@ -172,6 +173,7 @@ import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
+import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
@@ -296,6 +298,11 @@ private fun RecipeDetailBody(
     copiedMessage: String,
     scope: CoroutineScope,
 ) {
+    // First-run coach mark pointing at the cook-mode button. Shows once the recipe has loaded and
+    // hides as soon as the user taps it (or the bubble). Kept in local saveable state for now —
+    // wiring it to a persisted "seen" flag is a follow-up.
+    var showCookModeTooltip by rememberSaveable { mutableStateOf(true) }
+
     Box(modifier = Modifier.fillMaxSize().testTag(RecipeDetailTestTags.SCREEN)) {
         PlusResponsiveContainer(modifier = Modifier.fillMaxSize()) { windowSizeClass ->
             val isCompact = windowSizeClass == WindowSizeClass.COMPACT
@@ -413,15 +420,28 @@ private fun RecipeDetailBody(
                             HorizontalFloatingToolbar(
                                 expanded = true,
                                 floatingActionButton = {
-                                    FloatingActionButton(
-                                        onClick = bloc::onCookModeClicked,
-                                        shape = ChefMateTheme.shapes.large,
+                                    PlusOnboardingTooltip(
+                                        text =
+                                            Res.string.recipe_detail_cook_mode_onboarding
+                                                .asTextData(),
+                                        visible = showCookModeTooltip && !state.isLoading,
+                                        onDismiss = { showCookModeTooltip = false },
                                     ) {
-                                        Icon(
-                                            imageVector = Icons.Default.SoupKitchen,
-                                            contentDescription =
-                                                stringResource(Res.string.recipe_detail_cook_mode),
-                                        )
+                                        FloatingActionButton(
+                                            onClick = {
+                                                showCookModeTooltip = false
+                                                bloc.onCookModeClicked()
+                                            },
+                                            shape = ChefMateTheme.shapes.large,
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.SoupKitchen,
+                                                contentDescription =
+                                                    stringResource(
+                                                        Res.string.recipe_detail_cook_mode
+                                                    ),
+                                            )
+                                        }
                                     }
                                 },
                             ) {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/ui/RecipeDetailScreen.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/ui/RecipeDetailScreen.kt
@@ -298,11 +298,6 @@ private fun RecipeDetailBody(
     copiedMessage: String,
     scope: CoroutineScope,
 ) {
-    // First-run coach mark pointing at the cook-mode button. Shows once the recipe has loaded and
-    // hides as soon as the user taps it (or the bubble). Kept in local saveable state for now —
-    // wiring it to a persisted "seen" flag is a follow-up.
-    var showCookModeTooltip by rememberSaveable { mutableStateOf(true) }
-
     Box(modifier = Modifier.fillMaxSize().testTag(RecipeDetailTestTags.SCREEN)) {
         PlusResponsiveContainer(modifier = Modifier.fillMaxSize()) { windowSizeClass ->
             val isCompact = windowSizeClass == WindowSizeClass.COMPACT
@@ -424,14 +419,11 @@ private fun RecipeDetailBody(
                                         text =
                                             Res.string.recipe_detail_cook_mode_onboarding
                                                 .asTextData(),
-                                        visible = showCookModeTooltip && !state.isLoading,
-                                        onDismiss = { showCookModeTooltip = false },
+                                        visible = state.showCookModeTooltip && !state.isLoading,
+                                        onDismiss = bloc::onCookModeTooltipDismissed,
                                     ) {
                                         FloatingActionButton(
-                                            onClick = {
-                                                showCookModeTooltip = false
-                                                bloc.onCookModeClicked()
-                                            },
+                                            onClick = bloc::onCookModeClicked,
                                             shape = ChefMateTheme.shapes.large,
                                         ) {
                                             Icon(
@@ -1799,6 +1791,10 @@ private val previewBloc =
         }
 
         override fun onCookModeClicked() {
+            TODO("Not yet implemented")
+        }
+
+        override fun onCookModeTooltipDismissed() {
             TODO("Not yet implemented")
         }
 

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
@@ -11,8 +11,11 @@ import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
-import com.plusmobileapps.chefmate.util.DateTimeUtil
+import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
+import com.plusmobileapps.chefmate.util.testing.FakeDateTimeUtil
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.Settings
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
@@ -51,18 +54,28 @@ class RecipeDetailBlocImplTest {
             updatedAt = Instant.parse("2024-01-02T00:00:00Z"),
         )
 
-    private fun createBloc(recipe: Recipe? = sampleRecipe): RecipeDetailBlocImpl {
+    private lateinit var settings: Settings
+
+    private fun createBloc(
+        recipe: Recipe? = sampleRecipe,
+        cookModeTooltipSeen: Boolean = false,
+    ): RecipeDetailBlocImpl {
         if (recipe != null) recipes.value = listOf(recipe)
+        settings = MapSettings()
+        if (cookModeTooltipSeen) settings.putBoolean(COOK_MODE_TOOLTIP_KEY, true)
         val viewModelFactory = RecipeDetailViewModel.Factory { id ->
             RecipeDetailViewModel(
                 recipeId = id,
                 mainContext = context.mainContext,
                 repository = repository,
+                settings = settings,
             )
         }
-        val dateTimeUtil =
-            mock<DateTimeUtil>().also { every { it.formatDateTime(any()) } returns "" }
-        val timeFormatterUtil = mock<TimeFormatterUtil>()
+        val dateTimeUtil = FakeDateTimeUtil()
+        val timeFormatterUtil =
+            mock<TimeFormatterUtil>().also {
+                every { it.formatMinutes(any()) } returns FixedString("")
+            }
         val groceryFactory =
             object : AddRecipeToGroceryListBloc.Factory {
                 override fun create(
@@ -125,4 +138,35 @@ class RecipeDetailBlocImplTest {
         bloc.onBackClicked()
         output.lastValue shouldBe RecipeDetailBloc.Output.Finished
     }
+
+    @Test
+    fun When_tooltip_not_yet_seen_Then_cook_mode_tooltip_is_shown() {
+        val bloc = createBloc(cookModeTooltipSeen = false)
+        bloc.state.value.showCookModeTooltip shouldBe true
+    }
+
+    @Test
+    fun When_tooltip_already_seen_Then_cook_mode_tooltip_is_hidden() {
+        val bloc = createBloc(cookModeTooltipSeen = true)
+        bloc.state.value.showCookModeTooltip shouldBe false
+    }
+
+    @Test
+    fun When_onCookModeTooltipDismissed_Then_tooltip_hidden_and_persisted() {
+        val bloc = createBloc(cookModeTooltipSeen = false)
+        bloc.onCookModeTooltipDismissed()
+        bloc.state.value.showCookModeTooltip shouldBe false
+        settings.getBoolean(COOK_MODE_TOOLTIP_KEY, false) shouldBe true
+    }
+
+    @Test
+    fun When_onCookModeClicked_Then_tooltip_persisted_and_output_emitted() {
+        val bloc = createBloc(cookModeTooltipSeen = false)
+        bloc.onCookModeClicked()
+        bloc.state.value.showCookModeTooltip shouldBe false
+        settings.getBoolean(COOK_MODE_TOOLTIP_KEY, false) shouldBe true
+        output.lastValue shouldBe RecipeDetailBloc.Output.OpenCookMode(sampleRecipe.id)
+    }
 }
+
+private const val COOK_MODE_TOOLTIP_KEY = "recipe_detail_cook_mode_tooltip_seen"

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
@@ -141,31 +141,40 @@ class RecipeDetailBlocImplTest {
     }
 
     @Test
-    fun When_tooltip_not_yet_seen_Then_cook_mode_tooltip_is_shown() {
-        val bloc = createBloc(cookModeTooltipSeen = false)
-        bloc.state.value.showCookModeTooltip shouldBe true
+    fun When_no_marks_seen_Then_cook_mode_coach_mark_is_active_first() {
+        val bloc = createBloc()
+        bloc.state.value.activeCoachMark shouldBe CoachMarkId.RECIPE_DETAIL_COOK_MODE
     }
 
     @Test
-    fun When_tooltip_already_seen_Then_cook_mode_tooltip_is_hidden() {
+    fun When_cook_mode_seen_Then_next_mark_in_sequence_is_active() {
         val bloc = createBloc(cookModeTooltipSeen = true)
-        bloc.state.value.showCookModeTooltip shouldBe false
+        bloc.state.value.activeCoachMark shouldBe CoachMarkId.RECIPE_DETAIL_ADD_TO_GROCERY
     }
 
     @Test
-    fun When_onCookModeTooltipDismissed_Then_tooltip_hidden_and_persisted() {
-        val bloc = createBloc(cookModeTooltipSeen = false)
-        bloc.onCookModeTooltipDismissed()
-        bloc.state.value.showCookModeTooltip shouldBe false
+    fun When_active_coach_mark_dismissed_Then_it_is_seen_and_next_advances() {
+        val bloc = createBloc()
+        bloc.onCoachMarkDismissed(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
         coachMarkController.hasSeen(CoachMarkId.RECIPE_DETAIL_COOK_MODE) shouldBe true
+        bloc.state.value.activeCoachMark shouldBe CoachMarkId.RECIPE_DETAIL_ADD_TO_GROCERY
     }
 
     @Test
-    fun When_onCookModeClicked_Then_tooltip_persisted_and_output_emitted() {
-        val bloc = createBloc(cookModeTooltipSeen = false)
+    fun When_onCookModeClicked_Then_its_mark_is_seen_and_output_emitted() {
+        val bloc = createBloc()
         bloc.onCookModeClicked()
-        bloc.state.value.showCookModeTooltip shouldBe false
         coachMarkController.hasSeen(CoachMarkId.RECIPE_DETAIL_COOK_MODE) shouldBe true
+        bloc.state.value.activeCoachMark shouldBe CoachMarkId.RECIPE_DETAIL_ADD_TO_GROCERY
         output.lastValue shouldBe RecipeDetailBloc.Output.OpenCookMode(sampleRecipe.id)
+    }
+
+    @Test
+    fun When_button_tapped_while_another_mark_active_Then_its_mark_is_not_consumed() {
+        val bloc = createBloc()
+        // Cook mode is active; tapping add-to-grocery must not prematurely consume its tip.
+        bloc.onAddToGroceryListClicked()
+        coachMarkController.hasSeen(CoachMarkId.RECIPE_DETAIL_ADD_TO_GROCERY) shouldBe false
+        bloc.state.value.activeCoachMark shouldBe CoachMarkId.RECIPE_DETAIL_COOK_MODE
     }
 }

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
@@ -5,6 +5,8 @@ package com.plusmobileapps.chefmate.recipe.core.impl.detail
 
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.data.Recipe
@@ -15,7 +17,6 @@ import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
 import com.plusmobileapps.chefmate.util.testing.FakeDateTimeUtil
 import com.russhwolf.settings.MapSettings
-import com.russhwolf.settings.Settings
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
@@ -54,21 +55,21 @@ class RecipeDetailBlocImplTest {
             updatedAt = Instant.parse("2024-01-02T00:00:00Z"),
         )
 
-    private lateinit var settings: Settings
+    private lateinit var coachMarkController: CoachMarkController
 
     private fun createBloc(
         recipe: Recipe? = sampleRecipe,
         cookModeTooltipSeen: Boolean = false,
     ): RecipeDetailBlocImpl {
         if (recipe != null) recipes.value = listOf(recipe)
-        settings = MapSettings()
-        if (cookModeTooltipSeen) settings.putBoolean(COOK_MODE_TOOLTIP_KEY, true)
+        coachMarkController = CoachMarkController(MapSettings())
+        if (cookModeTooltipSeen) coachMarkController.dismiss(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
         val viewModelFactory = RecipeDetailViewModel.Factory { id ->
             RecipeDetailViewModel(
                 recipeId = id,
                 mainContext = context.mainContext,
                 repository = repository,
-                settings = settings,
+                coachMarkController = coachMarkController,
             )
         }
         val dateTimeUtil = FakeDateTimeUtil()
@@ -156,7 +157,7 @@ class RecipeDetailBlocImplTest {
         val bloc = createBloc(cookModeTooltipSeen = false)
         bloc.onCookModeTooltipDismissed()
         bloc.state.value.showCookModeTooltip shouldBe false
-        settings.getBoolean(COOK_MODE_TOOLTIP_KEY, false) shouldBe true
+        coachMarkController.hasSeen(CoachMarkId.RECIPE_DETAIL_COOK_MODE) shouldBe true
     }
 
     @Test
@@ -164,9 +165,7 @@ class RecipeDetailBlocImplTest {
         val bloc = createBloc(cookModeTooltipSeen = false)
         bloc.onCookModeClicked()
         bloc.state.value.showCookModeTooltip shouldBe false
-        settings.getBoolean(COOK_MODE_TOOLTIP_KEY, false) shouldBe true
+        coachMarkController.hasSeen(CoachMarkId.RECIPE_DETAIL_COOK_MODE) shouldBe true
         output.lastValue shouldBe RecipeDetailBloc.Output.OpenCookMode(sampleRecipe.id)
     }
 }
-
-private const val COOK_MODE_TOOLTIP_KEY = "recipe_detail_cook_mode_tooltip_seen"

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -10,6 +10,9 @@
     <string name="recipe_detail_back">Back</string>
     <string name="recipe_detail_cook_mode">Cook this recipe</string>
     <string name="recipe_detail_cook_mode_onboarding">Tap here to cook hands-free in Cook Mode</string>
+    <string name="recipe_detail_add_to_grocery_onboarding">Add this recipe’s ingredients to your grocery list</string>
+    <string name="recipe_detail_favorite_onboarding">Save this recipe to your favorites for quick access</string>
+    <string name="recipe_detail_add_to_meal_plan_onboarding">Schedule this recipe on your meal-plan calendar</string>
     <string name="recipe_detail_add_to_grocery">Add ingredients to grocery list</string>
     <string name="recipe_detail_remove_favorite">Remove from favorites</string>
     <string name="recipe_detail_add_favorite">Add to favorites</string>

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="recipe_add_to_grocery_list_view">View</string>
     <string name="recipe_detail_back">Back</string>
     <string name="recipe_detail_cook_mode">Cook this recipe</string>
+    <string name="recipe_detail_cook_mode_onboarding">Tap here to cook hands-free in Cook Mode</string>
     <string name="recipe_detail_add_to_grocery">Add ingredients to grocery list</string>
     <string name="recipe_detail_remove_favorite">Remove from favorites</string>
     <string name="recipe_detail_add_favorite">Add to favorites</string>

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -36,6 +36,8 @@ interface RecipeDetailBloc : BackClickBloc, BlocScreen {
 
     fun onCookModeClicked()
 
+    fun onCookModeTooltipDismissed()
+
     fun onAddToMealPlanClicked()
 
     fun onSourceUrlClicked(url: String)
@@ -57,6 +59,7 @@ interface RecipeDetailBloc : BackClickBloc, BlocScreen {
         val formattedCookTime: TextData? = null,
         val formattedTotalTime: TextData? = null,
         val showGroceryAddedSnackbar: Boolean = false,
+        val showCookModeTooltip: Boolean = false,
     )
 
     sealed class Output {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -36,9 +36,10 @@ interface RecipeDetailBloc : BackClickBloc, BlocScreen {
 
     fun onCookModeClicked()
 
-    fun onCookModeTooltipDismissed()
-
     fun onAddToMealPlanClicked()
+
+    /** Dismiss the coach mark with the given [com.plusmobileapps.chefmate.di.CoachMarkId]. */
+    fun onCoachMarkDismissed(id: String)
 
     fun onSourceUrlClicked(url: String)
 
@@ -59,7 +60,8 @@ interface RecipeDetailBloc : BackClickBloc, BlocScreen {
         val formattedCookTime: TextData? = null,
         val formattedTotalTime: TextData? = null,
         val showGroceryAddedSnackbar: Boolean = false,
-        val showCookModeTooltip: Boolean = false,
+        /** Id of the coach mark currently allowed to show on this screen, or null. */
+        val activeCoachMark: String? = null,
     )
 
     sealed class Output {

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -17,7 +17,10 @@ kotlin {
             implementation(libs.multiplatform.settings.noarg)
             implementation(libs.essenty.lifecycle.coroutines)
         }
-        commonTest.dependencies { implementation(libs.kotlin.test) }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.multiplatform.settings.test)
+        }
     }
 }
 

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkController.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkController.kt
@@ -1,0 +1,59 @@
+package com.plusmobileapps.chefmate.di
+
+import com.plusmobileapps.chefmate.mapState
+import com.russhwolf.settings.Settings
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Coordinates first-run "coach mark" tooltips so that at most one is ever visible across the whole
+ * app at a time.
+ *
+ * A screen [request]s its coach mark when the anchor enters composition; the controller grants
+ * visibility to a single mark at a time via [activeCoachMark], first-come-first-served. When the
+ * visible mark is [dismiss]ed it is persisted as seen (multiplatform-settings) and never requested
+ * again, and the next queued mark — if any anchor is still on screen — becomes active.
+ *
+ * [release] drops a still-unseen request (e.g. its anchor left the screen without being dismissed)
+ * so it stops blocking the queue; it can be requested again on a later visit.
+ *
+ * Identifiers come from [CoachMarkId].
+ */
+@Inject
+@SingleIn(AppScope::class)
+class CoachMarkController(private val settings: Settings) {
+
+    /** Pending coach-mark ids in request order; the head is the one currently allowed to show. */
+    private val queue = MutableStateFlow<List<String>>(emptyList())
+
+    /** Id of the coach mark currently allowed to show, or null when none is pending. */
+    val activeCoachMark: StateFlow<String?> = queue.mapState { it.firstOrNull() }
+
+    /** Enqueue [id] to be shown when it reaches the head of the queue, unless already seen. */
+    fun request(id: String) {
+        if (hasSeen(id)) return
+        queue.update { current -> if (id in current) current else current + id }
+    }
+
+    /** Drop [id] from the queue without marking it seen — it may be requested again later. */
+    fun release(id: String) {
+        queue.update { current -> current - id }
+    }
+
+    /** Mark [id] as seen forever and remove it from the queue, letting the next mark show. */
+    fun dismiss(id: String) {
+        settings.putBoolean(seenKey(id), true)
+        queue.update { current -> current - id }
+    }
+
+    fun hasSeen(id: String): Boolean = settings.getBoolean(seenKey(id), false)
+
+    private fun seenKey(id: String): String = "$SEEN_KEY_PREFIX$id"
+
+    companion object {
+        private const val SEEN_KEY_PREFIX = "coach_mark_seen_"
+    }
+}

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkController.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkController.kt
@@ -51,6 +51,14 @@ class CoachMarkController(private val settings: Settings) {
 
     fun hasSeen(id: String): Boolean = settings.getBoolean(seenKey(id), false)
 
+    /**
+     * Forget every coach mark's seen state so they can all show again. Intended for developer
+     * tooling; leaves unrelated settings untouched.
+     */
+    fun clearAllSeen() {
+        settings.keys.filter { it.startsWith(SEEN_KEY_PREFIX) }.forEach(settings::remove)
+    }
+
     private fun seenKey(id: String): String = "$SEEN_KEY_PREFIX$id"
 
     companion object {

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkId.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkId.kt
@@ -8,6 +8,27 @@ object CoachMarkId {
     /** The cook-mode button on the recipe detail screen. */
     const val RECIPE_DETAIL_COOK_MODE: String = "recipe_detail_cook_mode"
 
+    /** The add-to-grocery-list button on the recipe detail screen. */
+    const val RECIPE_DETAIL_ADD_TO_GROCERY: String = "recipe_detail_add_to_grocery"
+
+    /** The favorite button on the recipe detail screen. */
+    const val RECIPE_DETAIL_FAVORITE: String = "recipe_detail_favorite"
+
+    /** The add-to-meal-plan button on the recipe detail screen. */
+    const val RECIPE_DETAIL_ADD_TO_MEAL_PLAN: String = "recipe_detail_add_to_meal_plan"
+
     /** The sync button on the grocery list screen. */
     const val GROCERY_LIST_SYNC: String = "grocery_list_sync"
+
+    /**
+     * The recipe detail coach marks in the order they should be shown to a first-time user. The
+     * controller shows them one at a time, advancing as each is dismissed.
+     */
+    val recipeDetailSequence: List<String> =
+        listOf(
+            RECIPE_DETAIL_COOK_MODE,
+            RECIPE_DETAIL_ADD_TO_GROCERY,
+            RECIPE_DETAIL_FAVORITE,
+            RECIPE_DETAIL_ADD_TO_MEAL_PLAN,
+        )
 }

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkId.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkId.kt
@@ -1,0 +1,13 @@
+package com.plusmobileapps.chefmate.di
+
+/**
+ * Stable identifiers for the first-run coach marks coordinated by [CoachMarkController]. Each value
+ * doubles as the persistence key suffix, so do not rename them once shipped.
+ */
+object CoachMarkId {
+    /** The cook-mode button on the recipe detail screen. */
+    const val RECIPE_DETAIL_COOK_MODE: String = "recipe_detail_cook_mode"
+
+    /** The sync button on the grocery list screen. */
+    const val GROCERY_LIST_SYNC: String = "grocery_list_sync"
+}

--- a/client/shared/src/commonTest/kotlin/com/plusmobileapps/chefmate/di/CoachMarkControllerTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/plusmobileapps/chefmate/di/CoachMarkControllerTest.kt
@@ -95,6 +95,34 @@ class CoachMarkControllerTest {
     }
 
     @Test
+    fun When_clearAllSeen_Then_previously_seen_marks_can_show_again() {
+        val controller = controller()
+        controller.dismiss(A)
+        controller.dismiss(B)
+        assertTrue(controller.hasSeen(A))
+
+        controller.clearAllSeen()
+
+        assertFalse(controller.hasSeen(A))
+        assertFalse(controller.hasSeen(B))
+        controller.request(A)
+        assertEquals(A, controller.activeCoachMark.value)
+    }
+
+    @Test
+    fun When_clearAllSeen_Then_unrelated_settings_are_untouched() {
+        val settings = MapSettings()
+        settings.putString("unrelated_key", "keep")
+        val controller = CoachMarkController(settings)
+        controller.dismiss(A)
+
+        controller.clearAllSeen()
+
+        assertFalse(controller.hasSeen(A))
+        assertTrue(settings.hasKey("unrelated_key"))
+    }
+
+    @Test
     fun When_seen_persisted_in_settings_Then_hasSeen_reads_it_back() {
         val settings = MapSettings()
         CoachMarkController(settings).dismiss(A)

--- a/client/shared/src/commonTest/kotlin/com/plusmobileapps/chefmate/di/CoachMarkControllerTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/plusmobileapps/chefmate/di/CoachMarkControllerTest.kt
@@ -1,0 +1,105 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.di
+
+import com.russhwolf.settings.MapSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val A = "a"
+private const val B = "b"
+
+class CoachMarkControllerTest {
+
+    private fun controller() = CoachMarkController(MapSettings())
+
+    @Test
+    fun When_nothing_requested_Then_no_active_coach_mark() {
+        assertNull(controller().activeCoachMark.value)
+    }
+
+    @Test
+    fun When_requested_Then_it_becomes_active() {
+        val controller = controller()
+        controller.request(A)
+        assertEquals(A, controller.activeCoachMark.value)
+    }
+
+    @Test
+    fun When_two_requested_Then_only_the_first_is_active() {
+        val controller = controller()
+        controller.request(A)
+        controller.request(B)
+        assertEquals(A, controller.activeCoachMark.value)
+    }
+
+    @Test
+    fun When_active_dismissed_Then_next_becomes_active_and_first_is_seen() {
+        val controller = controller()
+        controller.request(A)
+        controller.request(B)
+
+        controller.dismiss(A)
+
+        assertEquals(B, controller.activeCoachMark.value)
+        assertTrue(controller.hasSeen(A))
+        assertFalse(controller.hasSeen(B))
+    }
+
+    @Test
+    fun When_already_seen_Then_request_is_ignored() {
+        val controller = controller()
+        controller.dismiss(A)
+        controller.request(A)
+        assertNull(controller.activeCoachMark.value)
+    }
+
+    @Test
+    fun When_released_Then_it_is_not_seen_and_can_be_requested_again() {
+        val controller = controller()
+        controller.request(A)
+        controller.release(A)
+
+        assertNull(controller.activeCoachMark.value)
+        assertFalse(controller.hasSeen(A))
+
+        controller.request(A)
+        assertEquals(A, controller.activeCoachMark.value)
+    }
+
+    @Test
+    fun When_released_Then_the_next_mark_becomes_active() {
+        val controller = controller()
+        controller.request(A)
+        controller.request(B)
+
+        controller.release(A)
+
+        assertEquals(B, controller.activeCoachMark.value)
+        assertFalse(controller.hasSeen(A))
+    }
+
+    @Test
+    fun When_requested_twice_Then_it_is_not_duplicated_in_the_queue() {
+        val controller = controller()
+        controller.request(A)
+        controller.request(A)
+        controller.request(B)
+
+        // If A were duplicated, dismissing once would leave A still active.
+        controller.dismiss(A)
+        assertEquals(B, controller.activeCoachMark.value)
+    }
+
+    @Test
+    fun When_seen_persisted_in_settings_Then_hasSeen_reads_it_back() {
+        val settings = MapSettings()
+        CoachMarkController(settings).dismiss(A)
+
+        // A fresh controller over the same settings still reports the mark as seen.
+        assertTrue(CoachMarkController(settings).hasSeen(A))
+    }
+}

--- a/client/ui/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/ui/public/src/commonMain/composeResources/values/strings.xml
@@ -14,4 +14,5 @@
     <string name="markdown_editor_preview_empty">Nothing to preview yet</string>
     <string name="plus_outlined_container_expand_a11y">Expand %1$s</string>
     <string name="plus_outlined_container_collapse_a11y">Collapse %1$s</string>
+    <string name="coach_mark_dismiss">Got it</string>
 </resources>

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusOnboardingTooltip.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusOnboardingTooltip.kt
@@ -2,6 +2,7 @@ package com.plusmobileapps.chefmate.ui.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -18,10 +19,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -32,8 +35,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
+import chefmate.client.ui.public.generated.resources.Res
+import chefmate.client.ui.public.generated.resources.coach_mark_dismiss
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import org.jetbrains.compose.resources.stringResource
 
 /** Which side of the anchor the tooltip bubble sits on. The caret always points at the anchor. */
 enum class PlusTooltipPlacement {
@@ -50,12 +56,12 @@ enum class PlusTooltipPlacement {
  * the underlying control — a user can tap the highlighted control directly.
  *
  * Visibility is fully caller-controlled. Pass [visible] = true to show it and handle [onDismiss]
- * (called when the bubble itself is tapped) to hide it. Callers that want it shown only once should
- * persist that decision themselves.
+ * (called when the user taps the bubble's dismiss button) to hide it. Callers that want it shown
+ * only once should persist that decision themselves — e.g. via the shared coach-mark controller.
  *
  * @param text the message shown in the bubble.
  * @param visible whether the bubble is currently shown.
- * @param onDismiss invoked when the user taps the bubble to dismiss it.
+ * @param onDismiss invoked when the user taps the bubble's dismiss button.
  * @param placement which side of the anchor the bubble sits on. Defaults to [ABOVE].
  * @param anchor the control the tooltip points at; always laid out, tooltip or not.
  */
@@ -100,7 +106,7 @@ fun PlusOnboardingTooltip(
                     text = text,
                     placement = placement,
                     caretOffsetPx = caretOffsetPx,
-                    onClick = onDismiss,
+                    onDismiss = onDismiss,
                 )
             }
         }
@@ -125,7 +131,7 @@ fun PlusTooltipBubble(
     placement: PlusTooltipPlacement,
     modifier: Modifier = Modifier,
     caretOffsetPx: Int = -1,
-    onClick: () -> Unit = {},
+    onDismiss: () -> Unit = {},
 ) {
     val color = MaterialTheme.colorScheme.primaryContainer
     val caret: @Composable () -> Unit = {
@@ -138,7 +144,7 @@ fun PlusTooltipBubble(
 
     // IntrinsicSize.Max pins the column to the text surface's width so the full-width caret canvas
     // doesn't stretch the bubble to the popup window's width.
-    Column(modifier = modifier.width(IntrinsicSize.Max).clickable(onClick = onClick)) {
+    Column(modifier = modifier.width(IntrinsicSize.Max)) {
         if (placement == PlusTooltipPlacement.BELOW) caret()
         Surface(
             color = color,
@@ -146,17 +152,32 @@ fun PlusTooltipBubble(
             shape = ChefMateTheme.shapes.medium,
             shadowElevation = ChefMateTheme.dimens.paddingExtraSmall,
         ) {
-            Text(
-                text = text.localized(),
-                style = MaterialTheme.typography.bodyMedium,
-                textAlign = TextAlign.Center,
+            Column(
                 modifier =
                     Modifier.widthIn(max = MaxBubbleWidth)
                         .padding(
                             horizontal = ChefMateTheme.dimens.paddingNormal,
                             vertical = ChefMateTheme.dimens.paddingSmall,
                         ),
-            )
+                verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingExtraSmall),
+            ) {
+                Text(
+                    text = text.localized(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Text(
+                    text = stringResource(Res.string.coach_mark_dismiss),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier =
+                        Modifier.align(Alignment.End)
+                            .clickable(onClick = onDismiss)
+                            .padding(ChefMateTheme.dimens.paddingExtraSmall),
+                )
+            }
         }
         if (placement == PlusTooltipPlacement.ABOVE) caret()
     }

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusOnboardingTooltip.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusOnboardingTooltip.kt
@@ -1,0 +1,221 @@
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+/** Which side of the anchor the tooltip bubble sits on. The caret always points at the anchor. */
+enum class PlusTooltipPlacement {
+    ABOVE,
+    BELOW,
+}
+
+/**
+ * An onboarding "coach mark": a small pop-up bubble that floats next to the composable it wraps and
+ * points at it with a caret. Use it to draw a first-time user's attention to a specific control.
+ *
+ * The bubble is rendered in a [Popup] so it escapes the bounds of the anchor's parent (e.g. a
+ * floating toolbar) and can overlay other content. The popup is non-focusable, so taps still reach
+ * the underlying control — a user can tap the highlighted control directly.
+ *
+ * Visibility is fully caller-controlled. Pass [visible] = true to show it and handle [onDismiss]
+ * (called when the bubble itself is tapped) to hide it. Callers that want it shown only once should
+ * persist that decision themselves.
+ *
+ * @param text the message shown in the bubble.
+ * @param visible whether the bubble is currently shown.
+ * @param onDismiss invoked when the user taps the bubble to dismiss it.
+ * @param placement which side of the anchor the bubble sits on. Defaults to [ABOVE].
+ * @param anchor the control the tooltip points at; always laid out, tooltip or not.
+ */
+@Composable
+fun PlusOnboardingTooltip(
+    text: TextData,
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    placement: PlusTooltipPlacement = PlusTooltipPlacement.ABOVE,
+    anchor: @Composable () -> Unit,
+) {
+    Box(modifier = modifier) {
+        anchor()
+
+        if (visible) {
+            val density = LocalDensity.current
+            val gapPx = with(density) { ChefMateTheme.dimens.paddingSmall.roundToPx() }
+            val edgeMarginPx = with(density) { ChefMateTheme.dimens.paddingNormal.roundToPx() }
+
+            // -1 = "not positioned yet" → the caret renders centered. The position provider
+            // updates this to the anchor's center relative to the bubble's left edge once the
+            // popup is laid out, keeping the caret pointing at the anchor even when the bubble is
+            // clamped to a screen edge.
+            var caretOffsetPx by remember { mutableIntStateOf(-1) }
+            val positionProvider =
+                remember(placement, gapPx, edgeMarginPx) {
+                    TooltipPositionProvider(
+                        placement = placement,
+                        anchorGapPx = gapPx,
+                        edgeMarginPx = edgeMarginPx,
+                        onCaretOffset = { caretOffsetPx = it },
+                    )
+                }
+
+            Popup(
+                popupPositionProvider = positionProvider,
+                onDismissRequest = onDismiss,
+                properties = PopupProperties(focusable = false, clippingEnabled = false),
+            ) {
+                PlusTooltipBubble(
+                    text = text,
+                    placement = placement,
+                    caretOffsetPx = caretOffsetPx,
+                    onClick = onDismiss,
+                )
+            }
+        }
+    }
+}
+
+private val CaretWidth: Dp = 16.dp
+private val CaretHeight: Dp = 8.dp
+private val MaxBubbleWidth: Dp = 260.dp
+
+/**
+ * The bare tooltip bubble visual — a rounded message surface with a caret on one edge. Exposed
+ * separately from [PlusOnboardingTooltip] so it can be rendered directly (e.g. in snapshot tests)
+ * without the surrounding [Popup].
+ *
+ * @param caretOffsetPx horizontal position of the caret tip, in pixels from the bubble's left edge.
+ *   A negative value (the default) centers the caret.
+ */
+@Composable
+fun PlusTooltipBubble(
+    text: TextData,
+    placement: PlusTooltipPlacement,
+    modifier: Modifier = Modifier,
+    caretOffsetPx: Int = -1,
+    onClick: () -> Unit = {},
+) {
+    val color = MaterialTheme.colorScheme.primaryContainer
+    val caret: @Composable () -> Unit = {
+        Caret(
+            color = color,
+            pointingUp = placement == PlusTooltipPlacement.BELOW,
+            caretOffsetPx = caretOffsetPx,
+        )
+    }
+
+    // IntrinsicSize.Max pins the column to the text surface's width so the full-width caret canvas
+    // doesn't stretch the bubble to the popup window's width.
+    Column(modifier = modifier.width(IntrinsicSize.Max).clickable(onClick = onClick)) {
+        if (placement == PlusTooltipPlacement.BELOW) caret()
+        Surface(
+            color = color,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            shape = ChefMateTheme.shapes.medium,
+            shadowElevation = ChefMateTheme.dimens.paddingExtraSmall,
+        ) {
+            Text(
+                text = text.localized(),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                modifier =
+                    Modifier.widthIn(max = MaxBubbleWidth)
+                        .padding(
+                            horizontal = ChefMateTheme.dimens.paddingNormal,
+                            vertical = ChefMateTheme.dimens.paddingSmall,
+                        ),
+            )
+        }
+        if (placement == PlusTooltipPlacement.ABOVE) caret()
+    }
+}
+
+@Composable
+private fun Caret(
+    color: Color,
+    pointingUp: Boolean,
+    caretOffsetPx: Int,
+    modifier: Modifier = Modifier,
+) {
+    Canvas(modifier = modifier.fillMaxWidth().height(CaretHeight)) {
+        val halfWidth = CaretWidth.toPx() / 2f
+        // Centre the caret when the popup hasn't been positioned yet (or in preview), otherwise
+        // align it with the anchor while keeping it fully inside the bubble.
+        val centerX =
+            if (caretOffsetPx < 0) size.width / 2f
+            else caretOffsetPx.toFloat().coerceIn(halfWidth, size.width - halfWidth)
+        val path =
+            Path().apply {
+                if (pointingUp) {
+                    moveTo(centerX, 0f)
+                    lineTo(centerX - halfWidth, size.height)
+                    lineTo(centerX + halfWidth, size.height)
+                } else {
+                    moveTo(centerX, size.height)
+                    lineTo(centerX - halfWidth, 0f)
+                    lineTo(centerX + halfWidth, 0f)
+                }
+                close()
+            }
+        drawPath(path = path, color = color)
+    }
+}
+
+private class TooltipPositionProvider(
+    private val placement: PlusTooltipPlacement,
+    private val anchorGapPx: Int,
+    private val edgeMarginPx: Int,
+    private val onCaretOffset: (Int) -> Unit,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val anchorCenterX = anchorBounds.left + anchorBounds.width / 2
+        val maxX =
+            (windowSize.width - popupContentSize.width - edgeMarginPx).coerceAtLeast(edgeMarginPx)
+        val x = (anchorCenterX - popupContentSize.width / 2).coerceIn(edgeMarginPx, maxX)
+        val y =
+            when (placement) {
+                PlusTooltipPlacement.ABOVE ->
+                    anchorBounds.top - popupContentSize.height - anchorGapPx
+                PlusTooltipPlacement.BELOW -> anchorBounds.bottom + anchorGapPx
+            }
+        onCaretOffset(anchorCenterX - x)
+        return IntOffset(x, y)
+    }
+}

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTest.kt
@@ -1,0 +1,56 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusTooltipBubble
+import com.plusmobileapps.chefmate.ui.components.PlusTooltipPlacement
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@Composable
+private fun TooltipBubblePreview(placement: PlusTooltipPlacement, darkTheme: Boolean = false) {
+    ChefMateTheme(darkTheme = darkTheme) {
+        Surface(color = MaterialTheme.colorScheme.background) {
+            Box(
+                modifier = Modifier.fillMaxWidth().padding(24.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                PlusTooltipBubble(
+                    text = "Tap here to cook hands-free in Cook Mode".asTextData(),
+                    placement = placement,
+                )
+            }
+        }
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, widthDp = 360)
+@Composable
+fun PlusTooltipBubbleAboveScreenshot() {
+    TooltipBubblePreview(placement = PlusTooltipPlacement.ABOVE)
+}
+
+@PreviewTest
+@Preview(showBackground = true, widthDp = 360)
+@Composable
+fun PlusTooltipBubbleBelowScreenshot() {
+    TooltipBubblePreview(placement = PlusTooltipPlacement.BELOW)
+}
+
+@PreviewTest
+@Preview(showBackground = true, widthDp = 360, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PlusTooltipBubbleAboveDarkScreenshot() {
+    TooltipBubblePreview(placement = PlusTooltipPlacement.ABOVE, darkTheme = true)
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleAboveDarkScreenshot_4b098843_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleAboveDarkScreenshot_4b098843_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a0d8da4ad196b58019d9965f43b593c698209fd6b3aa61e7099c91a96d3e64b
-size 12304
+oid sha256:08042a03c2dd4e8f314e84436d9ddf24e83a2693ab5afd3b20022b7233cf302d
+size 14905

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleAboveDarkScreenshot_4b098843_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleAboveDarkScreenshot_4b098843_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a0d8da4ad196b58019d9965f43b593c698209fd6b3aa61e7099c91a96d3e64b
+size 12304

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleAboveScreenshot_74131fac_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleAboveScreenshot_74131fac_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7ded753a5cb1334b1e93c10b449219ec5942308a9e4f2cd9109a12fd29051ae
+size 14328

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleAboveScreenshot_74131fac_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleAboveScreenshot_74131fac_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7ded753a5cb1334b1e93c10b449219ec5942308a9e4f2cd9109a12fd29051ae
-size 14328
+oid sha256:57808999ef0694083dd9c541a273f131112368a12eff9e9cd67c0f058b13d5d1
+size 16917

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleBelowScreenshot_74131fac_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleBelowScreenshot_74131fac_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30902dd37ab6234c80dc9b8b85e16a694881f28d629e4731b1e59ea450f81dfa
-size 14353
+oid sha256:45c43234bc5523ffae699106baa6eac81ad8a1d971fb98f214167e40d6e3604c
+size 16975

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleBelowScreenshot_74131fac_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusOnboardingTooltipScreenshotTestKt/PlusTooltipBubbleBelowScreenshot_74131fac_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30902dd37ab6234c80dc9b8b85e16a694881f28d629e4731b1e59ea450f81dfa
+size 14353


### PR DESCRIPTION
## What

Adds a reusable onboarding **coach-mark** component and uses it for its first integration: prompting users to tap the cook-mode button on the recipe detail screen.

### `PlusOnboardingTooltip` (client/ui/public)
A `Plus*` component that wraps any composable ("anchor") and floats a pop-up bubble next to it with a caret pointing at the anchor.

- Renders in a **non-focusable `Popup`** so it overlays surrounding content (e.g. the floating toolbar) and lets taps pass through to the highlighted control — tapping the button dismisses the tip *and* triggers the action in one tap.
- A custom `PopupPositionProvider` places the bubble above/below the anchor, clamps it to the screen edge, and feeds back a caret offset so the caret keeps pointing at the anchor even when clamped.
- Visibility is caller-controlled (`visible` / `onDismiss`).
- The bubble visual is exposed as `PlusTooltipBubble` so it can be rendered/snapshotted without the `Popup`.

### First integration
The cook-mode `FloatingActionButton` on the recipe detail screen is wrapped in the tooltip, showing **"Tap here to cook hands-free in Cook Mode"** (new localized string `recipe_detail_cook_mode_onboarding`).

## Snapshots
Added `PlusOnboardingTooltipScreenshotTest` with above / below / dark variants and recorded the references.

| Above | Below | Dark |
|---|---|---|
| caret points down at anchor | caret points up at anchor | themed |

## Notes / follow-ups
- **Show-once is not persisted** — visibility uses local `rememberSaveable` state, so the tip reappears on a fresh navigation to the screen. There's no key-value settings store in the repo yet; wiring this to a persisted "seen" flag (or the onboarding module from #303) is a natural follow-up.
- Fixed a latent layout bug found while building: the caret's `fillMaxWidth` stretched the bubble to the full popup-window width — pinned the column to `IntrinsicSize.Max`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)