### PR TITLE
feat(cook): default cook mode to split view

### DIFF
--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModel.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModel.kt
@@ -30,7 +30,8 @@ class CookModeViewModel(
     private val keepScreenOnRepository: KeepScreenOnRepository,
 ) : ViewModel(mainContext) {
 
-    private var splitLayoutPref by settings.boolean(KEY_LAYOUT_SPLIT, defaultValue = false)
+    // Split view is the default; users can toggle to the scrolling (Stacked) list, which persists.
+    private var splitLayoutPref by settings.boolean(KEY_LAYOUT_SPLIT, defaultValue = true)
 
     private val _state =
         MutableStateFlow(
@@ -96,7 +97,7 @@ class CookModeViewModel(
         val isLoading: Boolean = true,
         val cookingRecipes: List<Recipe> = emptyList(),
         val activeRecipeId: Long? = null,
-        val layoutMode: CookModeBloc.LayoutMode = CookModeBloc.LayoutMode.Stacked,
+        val layoutMode: CookModeBloc.LayoutMode = CookModeBloc.LayoutMode.Split,
         val keepScreenOn: Boolean = true,
     )
 

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeBloc.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeBloc.kt
@@ -35,7 +35,7 @@ interface CookModeBloc : BackClickBloc, BlocScreen {
         val isLoading: Boolean = true,
         val activeRecipe: Recipe? = null,
         val activeSessions: ImmutableList<Chip> = persistentListOf(),
-        val layoutMode: LayoutMode = LayoutMode.Stacked,
+        val layoutMode: LayoutMode = LayoutMode.Split,
         val keepScreenOn: Boolean = true,
     ) {
         data class Chip(val recipeId: Long, val title: String, val isActive: Boolean)


### PR DESCRIPTION
## Summary

Cook mode now opens in the **Split** layout by default. The scrolling (Stacked) list becomes an opt-in toggle, and the user's choice continues to persist across cook-mode sessions.

The persistence and toggle logic already existed via the `cook_mode_layout_split` setting — this change only flips the default for users who have never toggled, and updates the corresponding `State`/`Model` defaults for consistency.

## Changes
- `CookModeViewModel`: `splitLayoutPref` now defaults to `true`; `State.layoutMode` default is `Split`.
- `CookModeBloc.Model`: default `layoutMode` is `Split`.

## Behavior
- New users (or anyone who never toggled) get Split.
- Anyone who previously toggled has an explicit stored value, which is preserved as-is.
- The toggle button label/icon is already driven by the current `layoutMode`, so it adapts automatically.

## Testing
- Snapshot previews explicitly set both `Stacked` and `Split` modes, so no reference snapshots change as a result of the default flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)