### PR TITLE
fix(ci): point MATCH_GIT_URL at org certificates repo

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -33,7 +33,7 @@ jobs:
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-          MATCH_GIT_URL: https://github.com/plusmobileapps/certificates.git
+          MATCH_GIT_URL: https://github.com/Plus-Mobile-Apps/certificates.git
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY: ${{ secrets.ASC_API_KEY }}


### PR DESCRIPTION
## What

Updates the iOS release workflow's `MATCH_GIT_URL` to the canonical org path for the fastlane match certificates repo:

`https://github.com/plusmobileapps/certificates.git` → `https://github.com/Plus-Mobile-Apps/certificates.git`

## Why

The certificates repo was transferred from the personal `plusmobileapps` account to the `Plus-Mobile-Apps` org. The workflow still referenced the old personal path, which only resolved via GitHub's transfer redirect — fragile and confusing. The [`fastlane/Matchfile`](fastlane/Matchfile) already defaults to the org path, so this just brings the CI override in line.

Surfaced while debugging a [failed iOS Release run](https://github.com/Plus-Mobile-Apps/chef-mate/actions/runs/27622543729) that errored with `Error cloning certificates repo`.

## Note — not fixed here (secret, manual)

The primary cause of that failed run is auth, not the URL: `MATCH_GIT_BASIC_AUTHORIZATION` is base64 of `user:PAT` and the PAT belonged to a now-deleted account, so the private cert repo 404s. That secret must be regenerated manually:

```
printf 'Plus-Mobile-Apps:<NEW_PAT>' | base64
gh secret set MATCH_GIT_BASIC_AUTHORIZATION --repo Plus-Mobile-Apps/chef-mate
```

(Same deleted account also broke `RELEASE_TOKEN`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)