### PR TITLE
Clear a batch of client build warnings

### DIFF
--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KmpLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KmpLibraryConventionPlugin.kt
@@ -109,6 +109,11 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
                 // Remove once kotlin.time is stable in 2.3.0
                 compilerOptions.optIn.add("kotlin.time.ExperimentalTime")
 
+                // Acknowledge the still-Beta expect/actual classes feature (KT-61573) so
+                // modules with `expect`/`actual` classes (e.g. DriverFactory) don't emit a
+                // warning on every compile. Drop once the feature is stabilized.
+                compilerOptions.freeCompilerArgs.add("-Xexpect-actual-classes")
+
                 // Default source sets configuration
                 sourceSets.apply {
                     val commonMain = getByName("commonMain")

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -66,6 +66,11 @@ kotlin {
 
     jvm()
 
+    // Acknowledge the still-Beta expect/actual classes feature (KT-61573) so modules with
+    // `expect`/`actual` classes (e.g. BugsnagStartup) don't warn on every compile. Drop once
+    // the feature is stabilized. Mirrors the same flag in KmpLibraryConventionPlugin.
+    compilerOptions { freeCompilerArgs.add("-Xexpect-actual-classes") }
+
     sourceSets {
         commonMain.dependencies {
             api(libs.arkivanov.decompose.core)

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/ui/CookModeScreen.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/ui/CookModeScreen.kt
@@ -59,10 +59,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -607,7 +607,7 @@ private fun SplitCompactLayout(
                     bottom = contentPadding.calculateBottomPadding(),
                 )
     ) {
-        TabRow(selectedTabIndex = pagerState.currentPage) {
+        SecondaryTabRow(selectedTabIndex = pagerState.currentPage) {
             tabs.forEachIndexed { index, title ->
                 Tab(
                     selected = pagerState.currentPage == index,

--- a/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
+++ b/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
@@ -520,7 +520,7 @@ class GroceryRepositoryImpl(
             for (list in dirtyLists) {
                 if (list.role != "owner") continue
                 try {
-                    val remoteId = list.remoteId ?: continue
+                    val remoteId = list.remoteId
                     remoteDataSource.updateGroceryList(
                         RemoteGroceryList(id = remoteId, name = list.name, ownerId = userId)
                     )
@@ -586,7 +586,7 @@ class GroceryRepositoryImpl(
                     }
                 for (item in dirty) {
                     try {
-                        val remoteId = item.remoteId ?: continue
+                        val remoteId = item.remoteId
                         val itemListId = item.listRemoteId ?: listRemoteId
                         syncingIds.update { it + item.id }
                         try {

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
@@ -373,11 +373,10 @@ private fun MonthView(
 
     val dayMeals = monthModel.selectedDayMeals
     val allEmpty =
-        dayMeals == null ||
-            (dayMeals.breakfast.isEmpty() &&
-                dayMeals.lunch.isEmpty() &&
-                dayMeals.dinner.isEmpty() &&
-                dayMeals.snacks.isEmpty())
+        dayMeals.breakfast.isEmpty() &&
+            dayMeals.lunch.isEmpty() &&
+            dayMeals.dinner.isEmpty() &&
+            dayMeals.snacks.isEmpty()
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
@@ -406,7 +405,7 @@ private fun MonthView(
                     )
                 }
             }
-        } else if (dayMeals != null) {
+        } else {
             if (dayMeals.breakfast.isNotEmpty()) {
                 stickyHeader(key = "month_breakfast") {
                     MealSectionHeader(

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -78,13 +78,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -726,7 +726,7 @@ private fun RecipeDetailCompactContent(
 
         // Sticky TabRow
         stickyHeader(key = "tab_row") {
-            TabRow(selectedTabIndex = pagerState.currentPage) {
+            SecondaryTabRow(selectedTabIndex = pagerState.currentPage) {
                 tabs.forEachIndexed { index, title ->
                     Tab(
                         selected = pagerState.currentPage == index,
@@ -898,7 +898,7 @@ private fun ColumnScope.RecipeDetailLandscapeContent(
         // Right ~60%: sticky tab row + pager. Each page scrolls independently so swiping
         // between Ingredients and Directions does not affect the other tab's scroll position.
         Column(modifier = Modifier.weight(0.6f).fillMaxHeight()) {
-            TabRow(selectedTabIndex = pagerState.currentPage) {
+            SecondaryTabRow(selectedTabIndex = pagerState.currentPage) {
                 tabs.forEachIndexed { index, title ->
                     Tab(
                         selected = pagerState.currentPage == index,

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/CategoryRepositoryImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/CategoryRepositoryImpl.kt
@@ -246,7 +246,7 @@ class CategoryRepositoryImpl(
             val dirty = withContext(ioContext) { db.getDirty().executeAsList() }
             for (cat in dirty) {
                 try {
-                    val remoteId = cat.remoteId ?: continue
+                    val remoteId = cat.remoteId
                     remoteDataSource.upsertCategory(
                         RemoteCategory(
                             id = remoteId,

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
@@ -314,7 +314,7 @@ class RecipeRepositoryImpl(
             // failure on one leaves the tombstone in place and continues with the rest of sync.
             val pendingDeletes = withContext(ioContext) { db.getPendingDeletes().executeAsList() }
             for (recipe in pendingDeletes) {
-                val remoteId = recipe.remoteId ?: continue
+                val remoteId = recipe.remoteId
                 try {
                     remoteDataSource.deleteRecipe(remoteId)
                     withContext(ioContext) { db.delete(recipe.id) }
@@ -374,7 +374,7 @@ class RecipeRepositoryImpl(
             val dirty = withContext(ioContext) { db.getDirty().executeAsList() }
             for (recipe in dirty) {
                 try {
-                    val remoteId = recipe.remoteId ?: continue
+                    val remoteId = recipe.remoteId
                     remoteDataSource.upsertRecipe(
                         RemoteRecipe(
                             id = remoteId,

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
@@ -57,10 +57,10 @@ class RecipeBookCollaborationRepositoryImpl(
                 email = it.email,
                 role = RecipeBookRole.fromWire(it.role),
                 accepted = it.status == "accepted",
-                name = if (isCurrentUser) me?.userName ?: it.name else it.name,
+                name = if (isCurrentUser) me.userName else it.name,
                 isOwner = it.isOwner,
                 avatarUrl =
-                    if (isCurrentUser) me?.userProfileImageUrl ?: it.avatarUrl else it.avatarUrl,
+                    if (isCurrentUser) me.userProfileImageUrl ?: it.avatarUrl else it.avatarUrl,
             )
         }
     }

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImpl.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImpl.kt
@@ -220,7 +220,7 @@ class RecipeBookRepositoryImpl(
             // Retry remote deletes for any locally tombstoned books.
             val pendingDeletes = withContext(ioContext) { db.getPendingDeletes().executeAsList() }
             for (book in pendingDeletes) {
-                val remoteId = book.remoteId ?: continue
+                val remoteId = book.remoteId
                 try {
                     remoteDataSource.deleteRecipeBook(remoteId)
                     withContext(ioContext) { db.delete(book.id) }
@@ -257,7 +257,7 @@ class RecipeBookRepositoryImpl(
             val dirty = withContext(ioContext) { db.getDirty().executeAsList() }
             for (book in dirty) {
                 try {
-                    val remoteId = book.remoteId ?: continue
+                    val remoteId = book.remoteId
                     remoteDataSource.upsertRecipeBook(
                         RemoteRecipeBook(
                             id = remoteId,


### PR DESCRIPTION
## Summary

Clears a batch of build warnings surfaced by `./gradlew :client:composeApp:run`. Grouped into three commits by concern; no user-facing behavior change.

### 1. `refactor(client)` — redundant null-handling
Dead-code removals the Kotlin compiler flags:
- **Elvis always returns left operand** — drop `?: continue` on non-null `remoteId` columns in the dirty/pending-delete sync loops of `GroceryRepositoryImpl`, `RecipeRepositoryImpl`, `RecipeBookRepositoryImpl`, `CategoryRepositoryImpl`.
- **Unnecessary safe call** — in `RecipeBookCollaborationRepositoryImpl`, the `isCurrentUser` branch already smart-casts the current user non-null, so `me?.userName`/`me?.userProfileImageUrl` become `me.userName`/`me.userProfileImageUrl` (plus the now-dead `?: it.name`).
- **Always-true/false conditions** — in `MealPlanScreen.MonthView`, `selectedDayMeals` is non-null, so the `dayMeals == null ||` guard and the `else if (dayMeals != null)` branch are simplified.

### 2. `chore(build)` — expect/actual opt-in
The `expect`/`actual` classes feature is still Beta (KT-61573), warning on every compile of modules like `DriverFactory`/`BugsnagStartup`. Adds the `-Xexpect-actual-classes` compiler flag at the convention-plugin level (`KmpLibraryConventionPlugin`) and in `composeApp` (which configures its own `kotlin { }`).

### 3. `refactor(ui)` — TabRow → SecondaryTabRow
Material3 deprecated bare `TabRow`. `SecondaryTabRow` keeps the legacy full-width thin indicator, so it's a pixel-faithful swap — CookMode and RecipeDetail screenshot references **validate unchanged**. Covers the cook-mode tabs and both recipe-detail layouts.

## Out of scope (tracked separately)
- **AGP 9 / KMP `com.android.application` migration** — the larger project-structure split for `composeApp`; coming as a **stacked PR** on top of this branch.
- Compose `compose.components.resources` / `compose.uiTest` version-catalog deprecations, `painterResource` migration, and assorted kotlinx-datetime/`LocalClipboardManager` deprecations.

## Testing
- `compileKotlinJvm` on all touched modules — BUILD SUCCESSFUL, every targeted warning gone.
- `./gradlew :client:ui:screenshot-test:validateDebugScreenshotTest` — BUILD SUCCESSFUL (no snapshot diffs from the TabRow swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)