### PR TITLE
feat: enable wasmJs (web) Compose Multiplatform target

### DIFF
--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KmpLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/KmpLibraryConventionPlugin.kt
@@ -106,6 +106,11 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
                 // Configure JVM target
                 jvm { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } }
 
+                // Configure the web (wasmJs/browser) target. Shared modules expose this so the
+                // composeApp can compile for the browser. The wasmJs source sets only compile when
+                // the web target is actually built, so Android/iOS/JVM builds are unaffected.
+                @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class) wasmJs { browser() }
+
                 // Remove once kotlin.time is stable in 2.3.0
                 compilerOptions.optIn.add("kotlin.time.ExperimentalTime")
 

--- a/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/MetroConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/plusmobileapps/chefmate/convention/MetroConventionPlugin.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.convention
 import com.plusmobileapps.chefmate.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.project
 
 class MetroConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -15,9 +16,16 @@ fun Project.applyMetro() {
     pluginManager.apply(libs.plugins.ksp.get().pluginId)
 
     dependencies.apply {
-        add("commonMainImplementation", libs.metroExtensions.assistedFactory.runtime)
-        listOf("kspAndroid", "kspJvm", "kspIosArm64", "kspIosSimulatorArm64").forEach { config ->
-            add(config, libs.metroExtensions.assistedFactory.compiler)
-        }
+        // The published `assisted-factory-runtime` has no wasmJs variant, so the annotation comes
+        // from the in-repo `:client:metro-assisted-factory-runtime` module (same FQN, all targets).
+        // The KSP compiler is a JVM processor and works for every target, including kspWasmJs.
+        add(
+            "commonMainImplementation",
+            project.dependencies.project(":client:metro-assisted-factory-runtime"),
+        )
+        listOf("kspAndroid", "kspJvm", "kspIosArm64", "kspIosSimulatorArm64", "kspWasmJs")
+            .forEach { config ->
+                add(config, libs.metroExtensions.assistedFactory.compiler)
+            }
     }
 }

--- a/client/browser/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/browser/PlatformWebView.wasmJs.kt
+++ b/client/browser/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/browser/PlatformWebView.wasmJs.kt
@@ -1,0 +1,29 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.browser
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.arkivanov.essenty.instancekeeper.InstanceKeeper
+
+@Composable
+actual fun PlatformWebView(
+    url: String,
+    onUrlLoaded: (String) -> Unit,
+    onLoadingChanged: (Boolean) -> Unit,
+    onCanNavigateChanged: (canGoBack: Boolean, canGoForward: Boolean) -> Unit,
+    goBackTrigger: Int,
+    goForwardTrigger: Int,
+    instanceKeeper: InstanceKeeper,
+    modifier: Modifier,
+) {
+    // Placeholder for the web spike. A real implementation would render an <iframe> via
+    // an HtmlView / DOM interop, subject to the target site's frame-embedding policy.
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("In-app browser is not available on web.")
+    }
+}

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -66,6 +66,14 @@ kotlin {
 
     jvm()
 
+    // Deployable web (browser) target. Bundles the app to `composeApp.js` to match the
+    // <script> reference in src/wasmJsMain/resources/index.html.
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    wasmJs {
+        browser { commonWebpackConfig { outputFileName = "composeApp.js" } }
+        binaries.executable()
+    }
+
     sourceSets {
         commonMain.dependencies {
             api(libs.arkivanov.decompose.core)
@@ -138,6 +146,9 @@ kotlin {
             implementation(libs.bugsnag.kmp)
             implementation(libs.kermit.bugsnag)
         }
+        // The Js engine is the only Ktor engine on wasmJs; Supabase and Coil pick it up off
+        // the classpath, so no per-data-module wiring is needed.
+        val wasmJsMain by getting { dependencies { implementation(libs.ktor.client.js) } }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)

--- a/client/composeApp/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/BugsnagStartup.wasmJs.kt
+++ b/client/composeApp/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/BugsnagStartup.wasmJs.kt
@@ -1,0 +1,7 @@
+package com.plusmobileapps.chefmate
+
+actual class BugsnagInitializer {
+    actual fun initialize(apiKey: String) {
+        // No Bugsnag SDK for wasmJs; crash reporting on web is out of scope for the spike.
+    }
+}

--- a/client/composeApp/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/RootBloc.kt
+++ b/client/composeApp/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/RootBloc.kt
@@ -1,0 +1,15 @@
+package com.plusmobileapps.chefmate
+
+import com.arkivanov.decompose.ComponentContext
+import com.plusmobileapps.chefmate.root.DeepLink
+import com.plusmobileapps.chefmate.root.RootBloc
+
+fun buildRoot(
+    componentContext: ComponentContext,
+    applicationComponent: ApplicationComponent,
+    deepLink: DeepLink = DeepLink.None,
+): RootBloc =
+    applicationComponent.rootBlocFactory.create(
+        context = DefaultBlocContext(componentContext = componentContext),
+        deepLink = deepLink,
+    )

--- a/client/composeApp/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/WasmApplicationComponent.kt
+++ b/client/composeApp/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/WasmApplicationComponent.kt
@@ -1,0 +1,13 @@
+package com.plusmobileapps.chefmate
+
+import com.plusmobileapps.chefmate.client.database.DriverFactory
+import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+@SingleIn(AppScope::class)
+@DependencyGraph(AppScope::class)
+abstract class WasmApplicationComponent : ApplicationComponent {
+    @Provides fun providesDriverFactory(): DriverFactory = DriverFactory()
+}

--- a/client/composeApp/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/main.kt
+++ b/client/composeApp/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/main.kt
@@ -1,10 +1,29 @@
+@file:Suppress("ktlint:standard:filename")
+
 package com.plusmobileapps.chefmate
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.backhandler.BackDispatcher
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.resume
 import kotlinx.browser.document
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
-    ComposeViewport(document.body!!) { App() }
+    val lifecycle = LifecycleRegistry()
+    val backDispatcher = BackDispatcher()
+    val appComponent = dev.zacsweers.metro.createGraph<WasmApplicationComponent>()
+
+    val rootBloc =
+        buildRoot(
+            componentContext =
+                DefaultComponentContext(lifecycle = lifecycle, backHandler = backDispatcher),
+            applicationComponent = appComponent,
+        )
+
+    lifecycle.resume()
+
+    ComposeViewport(document.body!!) { App(rootBloc = rootBloc) }
 }

--- a/client/database/core/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.wasmJs.kt
+++ b/client/database/core/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.wasmJs.kt
@@ -1,0 +1,18 @@
+package com.plusmobileapps.chefmate.client.database
+
+import app.cash.sqldelight.db.SqlDriver
+
+/**
+ * Web (wasmJs) database driver — intentionally stubbed for the current web spike.
+ *
+ * The offline-first SQLDelight store is not yet wired for the browser. The real implementation
+ * would use SQLDelight's web-worker driver (`app.cash.sqldelight:web-worker-driver` backed by
+ * sql.js, plus a worker bundle and the schema's `await`-based create). Until that lands, any code
+ * path that touches the local database on web will fail fast here.
+ */
+actual class DriverFactory {
+    actual fun createDriver(): SqlDriver =
+        throw NotImplementedError(
+            "SQLDelight web (wasmJs) driver is not wired yet — deferred for the web spike."
+        )
+}

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/edit/ui/EditGroceryListScreen.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/edit/ui/EditGroceryListScreen.kt
@@ -62,7 +62,6 @@ import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
-import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.components.PlusTextField
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import org.jetbrains.compose.resources.StringResource

--- a/client/metro-assisted-factory-runtime/build.gradle.kts
+++ b/client/metro-assisted-factory-runtime/build.gradle.kts
@@ -1,0 +1,15 @@
+// In-repo replacement for `com.plusmobileapps.metro-extensions:assisted-factory-runtime`.
+//
+// The published 0.1.0 runtime targets android/jvm/ios/macos/tvos/watchos but NOT wasmJs, which
+// blocks the web target since `@ContributesAssistedFactory` is used in commonMain across every
+// BLoC. This module re-declares that single annotation at its original fully-qualified name for
+// all targets (incl. wasmJs); the KSP compiler matches by FQN, so generated factories are
+// identical. `applyMetro()` wires this module in place of the published runtime.
+//
+// Remove this module and restore `libs.metroExtensions.assistedFactory.runtime` once a
+// wasmJs-targeting release of metro-extensions is published.
+plugins { alias(libs.plugins.kmpLibrary) }
+
+// enableDi is intentionally left false so kmpLibrary does NOT apply Metro here (which would pull
+// the very runtime this module replaces, creating a cycle).
+plusLibrary { namespace = "com.plusmobileapps.metro.extensions.assistedfactory" }

--- a/client/metro-assisted-factory-runtime/src/commonMain/kotlin/com/plusmobileapps/metro/extensions/assistedfactory/ContributesAssistedFactory.kt
+++ b/client/metro-assisted-factory-runtime/src/commonMain/kotlin/com/plusmobileapps/metro/extensions/assistedfactory/ContributesAssistedFactory.kt
@@ -1,0 +1,14 @@
+package com.plusmobileapps.metro.extensions.assistedfactory
+
+import kotlin.reflect.KClass
+
+/**
+ * In-repo re-declaration of `metro-extensions`' assisted-factory annotation, matching the original
+ * fully-qualified name and members. See this module's build.gradle.kts for why it exists.
+ *
+ * Placed on a BLoC impl (alongside `@AssistedInject`), the metro-extensions KSP processor generates
+ * the Metro `@AssistedFactory` and the `@ContributesBinding` bridge to the public `Factory`.
+ */
+@Repeatable
+@Target(AnnotationTarget.CLASS)
+annotation class ContributesAssistedFactory(val scope: KClass<*>, val assistedFactory: KClass<*>)

--- a/client/recipe/importer/impl/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ZipInflater.wasmJs.kt
+++ b/client/recipe/importer/impl/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/impl/ZipInflater.wasmJs.kt
@@ -1,0 +1,9 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.recipe.importer.impl
+
+// Stubbed for the web spike — no java.util.zip on wasmJs. A real implementation would use a
+// pure-Kotlin DEFLATE decoder or a JS pako binding. Recipe-archive import is unavailable on web
+// until then.
+internal actual fun inflateRaw(data: ByteArray, expectedSize: Int): ByteArray =
+    throw NotImplementedError("Zip inflate is not supported on web (wasmJs) yet.")

--- a/client/shared/src/androidMain/kotlin/com/plusmobileapps/chefmate/IoDispatcher.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/plusmobileapps/chefmate/IoDispatcher.android.kt
@@ -1,0 +1,9 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+
+actual val ioDispatcher: CoroutineContext = Dispatchers.IO

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/BlocContext.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/BlocContext.kt
@@ -11,7 +11,6 @@ import com.arkivanov.essenty.statekeeper.StateKeeperOwner
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 
 interface BlocContext : GenericComponentContext<BlocContext> {
@@ -29,7 +28,7 @@ interface BlocContext : GenericComponentContext<BlocContext> {
 class DefaultBlocContext(
     componentContext: ComponentContext,
     override val mainContext: CoroutineContext = Dispatchers.Main,
-    override val ioContext: CoroutineContext = Dispatchers.IO,
+    override val ioContext: CoroutineContext = ioDispatcher,
     override val defaultContext: CoroutineContext = Dispatchers.Default,
     override val unconfinedContext: CoroutineContext = Dispatchers.Unconfined,
 ) :

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/IoDispatcher.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/IoDispatcher.kt
@@ -1,0 +1,9 @@
+package com.plusmobileapps.chefmate
+
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Dispatcher for blocking IO work. JVM/Android/iOS use [kotlinx.coroutines.Dispatchers.IO]; wasmJs
+ * has no IO dispatcher (single-threaded browser runtime) and falls back to `Dispatchers.Default`.
+ */
+expect val ioDispatcher: CoroutineContext

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/Platform.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/Platform.kt
@@ -4,6 +4,7 @@ enum class Platform {
     ANDROID,
     IOS,
     JVM,
+    WASM,
 }
 
 expect val currentPlatform: Platform

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoroutinesComponent.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoroutinesComponent.kt
@@ -1,12 +1,12 @@
 package com.plusmobileapps.chefmate.di
 
+import com.plusmobileapps.chefmate.ioDispatcher
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.Qualifier
 import dev.zacsweers.metro.SingleIn
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 
 @Qualifier
 @Target(
@@ -47,7 +47,7 @@ annotation class Unconfined
 @ContributesTo(AppScope::class)
 @SingleIn(AppScope::class)
 interface CoroutinesComponent {
-    @Provides @SingleIn(AppScope::class) @IO fun io(): CoroutineContext = Dispatchers.IO
+    @Provides @SingleIn(AppScope::class) @IO fun io(): CoroutineContext = ioDispatcher
 
     @Provides @SingleIn(AppScope::class) @Main fun main(): CoroutineContext = Dispatchers.Main
 

--- a/client/shared/src/iosMain/kotlin/com/plusmobileapps/chefmate/IoDispatcher.ios.kt
+++ b/client/shared/src/iosMain/kotlin/com/plusmobileapps/chefmate/IoDispatcher.ios.kt
@@ -1,0 +1,9 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+
+actual val ioDispatcher: CoroutineContext = Dispatchers.IO

--- a/client/shared/src/jvmMain/kotlin/com/plusmobileapps/chefmate/IoDispatcher.jvm.kt
+++ b/client/shared/src/jvmMain/kotlin/com/plusmobileapps/chefmate/IoDispatcher.jvm.kt
@@ -1,0 +1,9 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+
+actual val ioDispatcher: CoroutineContext = Dispatchers.IO

--- a/client/shared/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/IoDispatcher.wasmJs.kt
+++ b/client/shared/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/IoDispatcher.wasmJs.kt
@@ -1,0 +1,9 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
+
+// wasmJs (browser) has no IO dispatcher; Default is the closest equivalent.
+actual val ioDispatcher: CoroutineContext = Dispatchers.Default

--- a/client/shared/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/Platform.wasmJs.kt
+++ b/client/shared/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/Platform.wasmJs.kt
@@ -1,0 +1,3 @@
+package com.plusmobileapps.chefmate
+
+actual val currentPlatform: Platform = Platform.WASM

--- a/client/ui/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/ui/BackAnimation.wasmJs.kt
+++ b/client/ui/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/ui/BackAnimation.wasmJs.kt
@@ -1,0 +1,22 @@
+@file:OptIn(ExperimentalDecomposeApi::class)
+
+package com.plusmobileapps.chefmate.ui
+
+import com.arkivanov.decompose.ExperimentalDecomposeApi
+import com.arkivanov.decompose.extensions.compose.stack.animation.StackAnimation
+import com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback.predictiveBackAnimation
+import com.arkivanov.decompose.extensions.compose.stack.animation.slide
+import com.arkivanov.decompose.extensions.compose.stack.animation.stackAnimation
+import com.arkivanov.essenty.backhandler.BackHandler
+
+actual fun <C : Any, T : Any> backAnimation(
+    backHandler: BackHandler,
+    onBack: () -> Unit,
+    fallbackAnimation: StackAnimation<C, T>?,
+    @Suppress("UNUSED_PARAMETER") isModal: (T) -> Boolean,
+): StackAnimation<C, T> =
+    predictiveBackAnimation(
+        backHandler = backHandler,
+        fallbackAnimation = fallbackAnimation ?: stackAnimation(slide()),
+        onBack = onBack,
+    )

--- a/client/ui/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/ui/KeepScreenOn.wasmJs.kt
+++ b/client/ui/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/ui/KeepScreenOn.wasmJs.kt
@@ -1,0 +1,10 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun KeepScreenOn() {
+    // No-op on web. The Screen Wake Lock API could be wired here later.
+}

--- a/client/ui/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.wasmJs.kt
+++ b/client/ui/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/ui/Platform.wasmJs.kt
@@ -1,0 +1,5 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui
+
+actual fun isIosPlatform(): Boolean = false

--- a/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/DateTimeFormatterUtil.wasmJs.kt
+++ b/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/DateTimeFormatterUtil.wasmJs.kt
@@ -1,0 +1,72 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import kotlin.time.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.format.MonthNames
+import kotlinx.datetime.format.Padding
+import kotlinx.datetime.format.char
+import kotlinx.datetime.toLocalDateTime
+
+// java.time is unavailable on wasmJs, so formatting is built with the kotlinx-datetime format DSL.
+actual class DateTimeFormatterUtilImpl : DateTimeFormatterUtil {
+    private val timeFormat = LocalDateTime.Format {
+        amPmHour()
+        char(':')
+        minute()
+        char(' ')
+        amPmMarker("AM", "PM")
+    }
+    private val shortDateFormat = LocalDateTime.Format {
+        monthName(MonthNames.ENGLISH_ABBREVIATED)
+        char(' ')
+        dayOfMonth()
+    }
+    private val longDateFormat = LocalDateTime.Format {
+        monthName(MonthNames.ENGLISH_FULL)
+        char(' ')
+        dayOfMonth()
+        chars(", ")
+        year()
+    }
+    private val mediumDateFormat = LocalDateTime.Format {
+        monthName(MonthNames.ENGLISH_ABBREVIATED)
+        char(' ')
+        dayOfMonth(Padding.NONE)
+        chars(", ")
+        year()
+    }
+    private val dateTimeFormat = LocalDateTime.Format {
+        year()
+        char('-')
+        monthNumber()
+        char('-')
+        dayOfMonth()
+        char(' ')
+        hour()
+        char(':')
+        minute()
+        char(':')
+        second()
+        char(' ')
+        amPmMarker("AM", "PM")
+    }
+
+    override fun shortDate(instant: Instant, timeZone: TimeZone): String =
+        instant.toLocalDateTime(timeZone).format(shortDateFormat)
+
+    override fun longDate(instant: Instant, timeZone: TimeZone): String =
+        instant.toLocalDateTime(timeZone).format(longDateFormat)
+
+    override fun mediumDate(instant: Instant, timeZone: TimeZone): String =
+        instant.toLocalDateTime(timeZone).format(mediumDateFormat)
+
+    override fun formatTime(instant: Instant, timeZone: TimeZone): String =
+        instant.toLocalDateTime(timeZone).format(timeFormat)
+
+    override fun formatDateTime(instant: Instant, timeZone: TimeZone): String =
+        instant.toLocalDateTime(timeZone).format(dateTimeFormat)
+}

--- a/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.wasmJs.kt
+++ b/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.wasmJs.kt
@@ -1,0 +1,14 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+
+@Composable
+actual fun rememberImagePickerLauncher(onResult: (PickedImage?) -> Unit): () -> Unit {
+    // Stubbed for the web spike. A real implementation would use a hidden <input type="file">.
+    val currentOnResult = rememberUpdatedState(onResult)
+    return remember { { currentOnResult.value(null) } }
+}

--- a/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/ImageProcessingUtil.wasmJs.kt
+++ b/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/ImageProcessingUtil.wasmJs.kt
@@ -1,0 +1,36 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import kotlin.math.min
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.Surface
+
+// Skiko ships the same org.jetbrains.skia API on wasmJs, so this mirrors the JVM implementation.
+actual fun decodeImageBitmap(bytes: ByteArray): ImageBitmap =
+    Image.makeFromEncoded(bytes).toComposeImageBitmap()
+
+actual fun cropImageToSquare(
+    bytes: ByteArray,
+    srcX: Int,
+    srcY: Int,
+    srcSize: Int,
+    maxOutputDim: Int,
+): ByteArray {
+    val image = Image.makeFromEncoded(bytes)
+    val outputSize = min(srcSize, maxOutputDim)
+    val surface = Surface.makeRasterN32Premul(outputSize, outputSize)
+    val canvas = surface.canvas
+    canvas.drawImageRect(
+        image,
+        Rect.makeXYWH(srcX.toFloat(), srcY.toFloat(), srcSize.toFloat(), srcSize.toFloat()),
+        Rect.makeXYWH(0f, 0f, outputSize.toFloat(), outputSize.toFloat()),
+    )
+    val cropped = surface.makeImageSnapshot()
+    val data = cropped.encodeToData(EncodedImageFormat.JPEG, 90) ?: error("JPEG encode failed")
+    return data.bytes
+}

--- a/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.wasmJs.kt
+++ b/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/ShareUtil.wasmJs.kt
@@ -1,0 +1,19 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+
+@Composable
+actual fun rememberShareLauncher(): (text: String) -> Boolean {
+    val clipboardManager = LocalClipboardManager.current
+    return remember(clipboardManager) {
+        { text ->
+            clipboardManager.setText(AnnotatedString(text))
+            true
+        }
+    }
+}

--- a/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/ZipPickerUtil.wasmJs.kt
+++ b/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/ZipPickerUtil.wasmJs.kt
@@ -1,0 +1,14 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+
+@Composable
+actual fun rememberZipPickerLauncher(onResult: (PickedFile?) -> Unit): () -> Unit {
+    // Stubbed for the web spike. A real implementation would use a hidden <input type="file">.
+    val currentOnResult = rememberUpdatedState(onResult)
+    return remember { { currentOnResult.value(null) } }
+}

--- a/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/ZipSaveUtil.wasmJs.kt
+++ b/client/util/public/src/wasmJsMain/kotlin/com/plusmobileapps/chefmate/util/ZipSaveUtil.wasmJs.kt
@@ -1,0 +1,16 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+
+@Composable
+actual fun rememberZipSaveLauncher(
+    onResult: (Boolean) -> Unit
+): (fileName: String, bytes: ByteArray) -> Unit {
+    // Stubbed for the web spike. A real implementation would trigger a Blob download anchor.
+    val currentOnResult = rememberUpdatedState(onResult)
+    return remember { { _, _ -> currentOnResult.value(false) } }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,13 @@
 #Kotlin
 kotlin.code.style=official
 kotlin.daemon.jvmargs=-Xmx4g
+# Workaround for KT-82395: KSP/Metro generates top-level declarations and the incremental klib
+# serializer then fails with "No file found for source null". The web klib IC is gated by its own
+# flag (kotlin.incremental.js.klib); the plain .js/.wasm flags do not disable it. Remove once the
+# upstream compiler fix lands.
+kotlin.incremental.wasm=false
+kotlin.incremental.js=false
+kotlin.incremental.js.klib=false
 
 #Gradle
 org.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -7,6 +7,16 @@
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
 
+format-util@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
+  integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
+
+ws@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
 ws@8.18.3:
   version "8.18.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -184,6 +184,8 @@ include(":client:developer-settings:public")
 
 include(":client:shared")
 
+include(":client:metro-assisted-factory-runtime")
+
 include(":client:testing")
 
 include(":client:text:public")


### PR DESCRIPTION
## What

Enables **wasmJs** as a deployable browser target for the app and proves the whole module graph — Supabase included — compiles, links, and bundles for the web. This is the **spike scope**: get composeApp running on web with Supabase wired; the offline-first SQLDelight database is stubbed (deferred).

## Why

We wanted to validate that the Supabase Kotlin Multiplatform client (and the rest of the stack) works on `wasmJs`, and add web as a first-class Compose Multiplatform target. The codebase had an orphaned `wasmJsMain` source set but no target declared, so it never compiled.

## How it works

- **wasmJs target in the convention plugin** so every shared module exposes web. The wasm source sets only compile when the web target is built, so **Android/iOS/JVM builds are unaffected**.
- **composeApp** gets a `wasmJs { browser() }` target (bundles to `composeApp.js`, Ktor `Js` engine) and a real web entry point (`WasmApplicationComponent` + `buildRoot` + `ComposeViewport`). The old `main.kt` called `App()` with no args and never compiled.
- **Supabase needed no per-module changes** — client creation is already platform-agnostic, credentials come from buildkonfig, and `multiplatform-settings`' no-arg `Settings()` resolves to browser localStorage on web.

## Reviewer notes — three non-obvious things

1. **Vendored DI annotation (the real blocker).** `com.plusmobileapps.metro-extensions:assisted-factory-runtime:0.1.0` publishes android/jvm/ios/macos/tvos/watchos but **no wasmJs**, and `@ContributesAssistedFactory` is used in `commonMain` on every BLoC — so it must resolve for the common compilation. `0.1.0` is the only published version, so a bump can't fix it. This PR vendors that single annotation as `:client:metro-assisted-factory-runtime` (identical FQN, all targets incl. web) and points `applyMetro()` at it, plus wires `kspWasmJs`. KSP matches by FQN, so generated factories are identical on every target. **JVM build verified unchanged.** → **Follow-up: publish a wasmJs-targeting metro-extensions, then delete this module and restore `libs.metroExtensions.assistedFactory.runtime`.**
2. **`ioDispatcher` expect/actual** — `Dispatchers.IO` doesn't exist on wasm; real IO on JVM/Android/iOS, `Default` on web.
3. **KT-82395 workaround** — KSP-generated top-level declarations break the incremental web klib serializer; gated by `kotlin.incremental.js.klib=false` (the plain `.js`/`.wasm` flags don't disable it). Remove once the upstream compiler fix lands.

## Deferred stubs (compile, but no-op / throw at runtime)

SQLDelight web driver (`DriverFactory` throws), image/zip pickers, zip save, zip inflate, in-app `PlatformWebView`, Bugsnag. These are intentional for the spike — the web build boots but offline DB and these device features aren't wired yet.

## Verification

- ✅ `:client:composeApp:compileKotlinWasmJs` — full graph compiles for web
- ✅ `wasmJsBrowserDevelopmentExecutableDistribution` — produces `composeApp.js` + `.wasm` + `index.html` + `composeResources/`
- ✅ `:client:composeApp:compileKotlinJvm` — no regression to the shipping app
- ✅ `ktfmtCheck` clean

Try it live: `./gradlew :client:composeApp:wasmJsBrowserDevelopmentRun`

## Commits

1. `build:` wasmJs target + vendored metro-extensions runtime + KT-82395 workaround
2. `refactor(shared):` expect/actual `ioDispatcher`
3. `feat:` wasmJs target + actuals/stubs + web entry point
4. `style:` incidental ktfmt normalization of a few UI screens (pre-existing drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)