### PR TITLE
feat: first-run onboarding tooltips across the main screens

### DIFF
--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserLandingBlocImpl.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserLandingBlocImpl.kt
@@ -1,12 +1,17 @@
 package com.plusmobileapps.chefmate.browser.impl
 
+import com.arkivanov.essenty.lifecycle.doOnDestroy
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.browser.BrowserLandingBloc
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
+import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.flow.StateFlow
 
 @AssistedInject
 @ContributesAssistedFactory(
@@ -16,9 +21,33 @@ import dev.zacsweers.metro.AssistedInject
 class BrowserLandingBlocImpl(
     @Assisted context: BlocContext,
     @Assisted private val output: Consumer<BrowserLandingBloc.Output>,
+    private val coachMarkController: CoachMarkController,
 ) : BrowserLandingBloc, BlocContext by context {
 
+    override val state: StateFlow<BrowserLandingBloc.Model> =
+        coachMarkController.activeCoachMark.mapState {
+            BrowserLandingBloc.Model(activeCoachMark = it)
+        }
+
+    init {
+        coachMarkController.request(CoachMarkId.BROWSER_SEARCH)
+        // Leaving the screen without dismissing frees the queue so other coach marks can show.
+        lifecycle.doOnDestroy { coachMarkController.release(CoachMarkId.BROWSER_SEARCH) }
+    }
+
     override fun onSearchFieldFocused() {
+        dismissCoachMark(CoachMarkId.BROWSER_SEARCH)
         output.onNext(BrowserLandingBloc.Output.OpenEditQuery)
+    }
+
+    override fun onCoachMarkDismissed(id: String) {
+        dismissCoachMark(id)
+    }
+
+    /** Mark a coach mark seen, but only if it's the one currently showing. */
+    private fun dismissCoachMark(id: String) {
+        if (coachMarkController.activeCoachMark.value == id) {
+            coachMarkController.dismiss(id)
+        }
     }
 }

--- a/client/browser/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserLandingBlocImplTest.kt
+++ b/client/browser/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/browser/impl/BrowserLandingBlocImplTest.kt
@@ -3,8 +3,11 @@
 package com.plusmobileapps.chefmate.browser.impl
 
 import com.plusmobileapps.chefmate.browser.BrowserLandingBloc
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
+import com.russhwolf.settings.MapSettings
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
@@ -12,11 +15,30 @@ class BrowserLandingBlocImplTest {
 
     private val context = TestBlocContext.create()
     private val output = TestConsumer<BrowserLandingBloc.Output>()
-    private val bloc = BrowserLandingBlocImpl(context = context, output = output)
+    private val coachMarkController = CoachMarkController(MapSettings())
+    private val bloc =
+        BrowserLandingBlocImpl(
+            context = context,
+            output = output,
+            coachMarkController = coachMarkController,
+        )
 
     @Test
     fun When_search_field_focused_Then_open_edit_query_emitted() {
         bloc.onSearchFieldFocused()
         output.lastValue shouldBe BrowserLandingBloc.Output.OpenEditQuery
+    }
+
+    @Test
+    fun When_screen_opens_Then_search_coach_mark_active() {
+        bloc.state.value.activeCoachMark shouldBe CoachMarkId.BROWSER_SEARCH
+    }
+
+    @Test
+    fun When_search_field_focused_Then_coach_mark_dismissed_and_persisted() {
+        bloc.onSearchFieldFocused()
+
+        coachMarkController.hasSeen(CoachMarkId.BROWSER_SEARCH) shouldBe true
+        bloc.state.value.activeCoachMark shouldBe null
     }
 }

--- a/client/browser/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/browser/public/src/commonMain/composeResources/values/strings.xml
@@ -12,5 +12,7 @@
     <string name="browser_download">Download</string>
     <string name="browser_landing_hint">Search Google or type a URL</string>
     <string name="browser_landing_tagline">Find your favorite recipes online, click download, and start cooking!</string>
+    <!-- First-run coach mark -->
+    <string name="browser_search_onboarding">Search the web to import recipes from any site</string>
     <string name="browser_history_delete">Delete history entry</string>
 </resources>

--- a/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserLandingBloc.kt
+++ b/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserLandingBloc.kt
@@ -5,8 +5,10 @@ import androidx.compose.ui.Modifier
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.ui.ComposeScreen
+import kotlinx.coroutines.flow.StateFlow
 
 interface BrowserLandingBloc : ComposeScreen {
+    val state: StateFlow<Model>
 
     @Composable
     override fun Content(modifier: Modifier) {
@@ -14,6 +16,14 @@ interface BrowserLandingBloc : ComposeScreen {
     }
 
     fun onSearchFieldFocused()
+
+    /** Marks the first-run coach mark with [id] as seen so it never shows again. */
+    fun onCoachMarkDismissed(id: String)
+
+    data class Model(
+        /** Id of the first-run coach mark currently allowed to show, or null when none. */
+        val activeCoachMark: String? = null
+    )
 
     sealed class Output {
         data object OpenEditQuery : Output()

--- a/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserLandingScreen.kt
+++ b/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserLandingScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
@@ -31,6 +33,11 @@ import androidx.compose.ui.unit.dp
 import chefmate.client.browser.public.generated.resources.Res
 import chefmate.client.browser.public.generated.resources.browser_landing_hint
 import chefmate.client.browser.public.generated.resources.browser_landing_tagline
+import chefmate.client.browser.public.generated.resources.browser_search_onboarding
+import com.plusmobileapps.chefmate.di.CoachMarkId
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
+import com.plusmobileapps.chefmate.ui.components.PlusTooltipPlacement
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -41,6 +48,7 @@ fun BrowserLandingScreen(
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    val state by bloc.state.collectAsState()
 
     val sharedFieldModifier =
         if (sharedTransitionScope != null && animatedVisibilityScope != null) {
@@ -68,22 +76,30 @@ fun BrowserLandingScreen(
         Text(text = "Chef Mate", style = MaterialTheme.typography.headlineLarge)
         Spacer(Modifier.height(32.dp))
 
-        OutlinedTextField(
-            value = "",
-            onValueChange = {},
-            readOnly = true,
-            modifier =
-                Modifier.fillMaxWidth().then(sharedFieldModifier).onFocusChanged { focusState ->
-                    if (focusState.isFocused) {
-                        keyboardController?.hide()
-                        bloc.onSearchFieldFocused()
-                    }
-                },
-            placeholder = { Text(stringResource(Res.string.browser_landing_hint)) },
-            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-            singleLine = true,
-            shape = RoundedCornerShape(28.dp),
-        )
+        PlusOnboardingTooltip(
+            text = Res.string.browser_search_onboarding.asTextData(),
+            visible = state.activeCoachMark == CoachMarkId.BROWSER_SEARCH,
+            onDismiss = { bloc.onCoachMarkDismissed(CoachMarkId.BROWSER_SEARCH) },
+            placement = PlusTooltipPlacement.BELOW,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            OutlinedTextField(
+                value = "",
+                onValueChange = {},
+                readOnly = true,
+                modifier =
+                    Modifier.fillMaxWidth().then(sharedFieldModifier).onFocusChanged { focusState ->
+                        if (focusState.isFocused) {
+                            keyboardController?.hide()
+                            bloc.onSearchFieldFocused()
+                        }
+                    },
+                placeholder = { Text(stringResource(Res.string.browser_landing_hint)) },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                singleLine = true,
+                shape = RoundedCornerShape(28.dp),
+            )
+        }
 
         Text(
             text = stringResource(Res.string.browser_landing_tagline),

--- a/client/cook/impl/build.gradle.kts
+++ b/client/cook/impl/build.gradle.kts
@@ -19,7 +19,10 @@ kotlin {
             implementation(libs.multiplatform.settings)
             implementation(compose.components.resources)
         }
-        commonTest.dependencies { implementation(libs.multiplatform.settings.test) }
+        commonTest.dependencies {
+            implementation(libs.multiplatform.settings.test)
+            implementation(projects.client.recipe.data.testing)
+        }
     }
 }
 

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeBlocImpl.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeBlocImpl.kt
@@ -5,6 +5,7 @@ import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.cook.WhatsCookingBloc
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
@@ -48,6 +49,7 @@ class CookModeBlocImpl(
                         .toImmutableList(),
                 layoutMode = vm.layoutMode,
                 keepScreenOn = vm.keepScreenOn,
+                activeCoachMark = vm.activeCoachMark,
             )
         }
 
@@ -60,11 +62,17 @@ class CookModeBlocImpl(
     }
 
     override fun onLayoutToggled() {
+        viewModel.dismissCoachMark(CoachMarkId.COOK_MODE_LAYOUT)
         viewModel.toggleLayout()
     }
 
     override fun onKeepScreenOnToggled() {
+        viewModel.dismissCoachMark(CoachMarkId.COOK_MODE_KEEP_SCREEN_ON)
         viewModel.toggleKeepScreenOn()
+    }
+
+    override fun onCoachMarkDismissed(id: String) {
+        viewModel.dismissCoachMark(id)
     }
 
     override fun onBackClicked() {

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModel.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModel.kt
@@ -1,8 +1,11 @@
 package com.plusmobileapps.chefmate.cook.impl
 
 import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.combineStates
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.cook.data.CookingSessionRepository
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.KeepScreenOnRepository
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.Recipe
@@ -15,7 +18,6 @@ import dev.zacsweers.metro.AssistedInject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -28,6 +30,7 @@ class CookModeViewModel(
     private val sessionRepository: CookingSessionRepository,
     settings: Settings,
     private val keepScreenOnRepository: KeepScreenOnRepository,
+    private val coachMarkController: CoachMarkController,
 ) : ViewModel(mainContext) {
 
     // Split view is the default; users can toggle to the scrolling (Stacked) list, which persists.
@@ -42,9 +45,17 @@ class CookModeViewModel(
                 keepScreenOn = keepScreenOnRepository.keepScreenOn.value,
             )
         )
-    val state: StateFlow<State> = _state.asStateFlow()
+
+    // Fold the shared controller's active mark into state so the screen shows at most one coach
+    // mark at a time across the whole app.
+    val state: StateFlow<State> =
+        combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
+            state.copy(activeCoachMark = activeCoachMark)
+        }
 
     init {
+        // Queue every cook-mode coach mark in order; the controller shows them one at a time.
+        CoachMarkId.cookModeSequence.forEach(coachMarkController::request)
         scope.launch {
             sessionRepository.start(initialRecipeId)
             sessionRepository.markSelected(initialRecipeId)
@@ -93,12 +104,29 @@ class CookModeViewModel(
         keepScreenOnRepository.toggle()
     }
 
+    /**
+     * Mark a coach mark seen, but only if it's the one currently showing, so tapping a control
+     * dismisses its own tip without consuming tips further down the queue.
+     */
+    fun dismissCoachMark(id: String) {
+        if (coachMarkController.activeCoachMark.value == id) {
+            coachMarkController.dismiss(id)
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        // Leaving the screen without dismissing frees the queue so other coach marks can show.
+        CoachMarkId.cookModeSequence.forEach(coachMarkController::release)
+    }
+
     data class State(
         val isLoading: Boolean = true,
         val cookingRecipes: List<Recipe> = emptyList(),
         val activeRecipeId: Long? = null,
         val layoutMode: CookModeBloc.LayoutMode = CookModeBloc.LayoutMode.Split,
         val keepScreenOn: Boolean = true,
+        val activeCoachMark: String? = null,
     )
 
     @AssistedFactory

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/ui/CookModePreviews.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/ui/CookModePreviews.kt
@@ -47,6 +47,8 @@ private fun cookBloc(model: CookModeBloc.Model): CookModeBloc =
 
         override fun onKeepScreenOnToggled() = Unit
 
+        override fun onCoachMarkDismissed(id: String) = Unit
+
         override fun onBackClicked() = Unit
     }
 

--- a/client/cook/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModelTest.kt
+++ b/client/cook/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModelTest.kt
@@ -1,0 +1,74 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.plusmobileapps.chefmate.cook.impl
+
+import com.plusmobileapps.chefmate.cook.data.CookingSessionRepository
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
+import com.plusmobileapps.chefmate.di.KeepScreenOnRepository
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
+import com.russhwolf.settings.MapSettings
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+class CookModeViewModelTest {
+
+    private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
+    private val recipeRepository = FakeRecipeRepository(recipes)
+    private val sessionRepository: CookingSessionRepository = mock {
+        every { observeRecipeIds() } returns MutableStateFlow(emptyList())
+        everySuspend { start(any()) } returns Unit
+        everySuspend { markSelected(any()) } returns Unit
+    }
+
+    private fun createViewModel(
+        coachMarkController: CoachMarkController = CoachMarkController(MapSettings())
+    ) =
+        CookModeViewModel(
+            initialRecipeId = 1L,
+            mainContext = UnconfinedTestDispatcher(),
+            recipeRepository = recipeRepository,
+            sessionRepository = sessionRepository,
+            settings = MapSettings(),
+            keepScreenOnRepository = KeepScreenOnRepository(MapSettings()),
+            coachMarkController = coachMarkController,
+        )
+
+    @Test
+    fun When_screen_opens_Then_first_coach_mark_active() {
+        val vm = createViewModel()
+        vm.state.value.activeCoachMark shouldBe CoachMarkId.COOK_MODE_KEEP_SCREEN_ON
+    }
+
+    @Test
+    fun When_active_coach_mark_dismissed_Then_persisted_and_next_shown() {
+        val controller = CoachMarkController(MapSettings())
+        val vm = createViewModel(coachMarkController = controller)
+
+        vm.dismissCoachMark(CoachMarkId.COOK_MODE_KEEP_SCREEN_ON)
+
+        controller.hasSeen(CoachMarkId.COOK_MODE_KEEP_SCREEN_ON) shouldBe true
+        vm.state.value.activeCoachMark shouldBe CoachMarkId.COOK_MODE_LAYOUT
+    }
+
+    @Test
+    fun When_inactive_coach_mark_dismissed_Then_ignored() {
+        val controller = CoachMarkController(MapSettings())
+        val vm = createViewModel(coachMarkController = controller)
+
+        vm.dismissCoachMark(CoachMarkId.COOK_MODE_LAYOUT)
+
+        controller.hasSeen(CoachMarkId.COOK_MODE_LAYOUT) shouldBe false
+        vm.state.value.activeCoachMark shouldBe CoachMarkId.COOK_MODE_KEEP_SCREEN_ON
+    }
+}

--- a/client/cook/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/cook/public/src/commonMain/composeResources/values/strings.xml
@@ -10,6 +10,9 @@
     <string name="cook_mode_layout_split">Show ingredients and directions side by side</string>
     <string name="cook_mode_keep_screen_on">Keep screen on</string>
     <string name="cook_mode_allow_screen_off">Allow screen to turn off</string>
+    <!-- First-run coach marks -->
+    <string name="cook_mode_keep_screen_on_onboarding">Keep the screen awake while you cook</string>
+    <string name="cook_mode_layout_onboarding">Switch between side-by-side and single-list views</string>
     <string name="whats_cooking_title">What’s Cooking</string>
     <string name="whats_cooking_select">Select recipes</string>
     <string name="whats_cooking_cancel_select">Cancel selection</string>

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeBloc.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeBloc.kt
@@ -29,6 +29,9 @@ interface CookModeBloc : BackClickBloc, ComposeScreen {
 
     fun onKeepScreenOnToggled()
 
+    /** Marks the first-run coach mark with [id] as seen so it never shows again. */
+    fun onCoachMarkDismissed(id: String)
+
     @Composable
     override fun Content(modifier: Modifier) {
         CookModeScreen(bloc = this, modifier = modifier)
@@ -45,6 +48,8 @@ interface CookModeBloc : BackClickBloc, ComposeScreen {
         val activeSessions: ImmutableList<Chip> = persistentListOf(),
         val layoutMode: LayoutMode = LayoutMode.Split,
         val keepScreenOn: Boolean = true,
+        /** Id of the first-run coach mark currently allowed to show, or null when none. */
+        val activeCoachMark: String? = null,
     ) {
         data class Chip(val recipeId: Long, val title: String, val isActive: Boolean)
     }

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/ui/CookModeScreen.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/ui/CookModeScreen.kt
@@ -94,6 +94,8 @@ import chefmate.client.cook.public.generated.resources.cook_mode_allow_screen_of
 import chefmate.client.cook.public.generated.resources.cook_mode_directions
 import chefmate.client.cook.public.generated.resources.cook_mode_ingredients
 import chefmate.client.cook.public.generated.resources.cook_mode_keep_screen_on
+import chefmate.client.cook.public.generated.resources.cook_mode_keep_screen_on_onboarding
+import chefmate.client.cook.public.generated.resources.cook_mode_layout_onboarding
 import chefmate.client.cook.public.generated.resources.cook_mode_layout_split
 import chefmate.client.cook.public.generated.resources.cook_mode_layout_stacked
 import chefmate.client.cook.public.generated.resources.cook_mode_loading
@@ -101,12 +103,17 @@ import chefmate.client.cook.public.generated.resources.cook_mode_no_active_recip
 import chefmate.client.cook.public.generated.resources.cook_mode_whats_cooking
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.cook.WhatsCookingBloc
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.recipe.data.IngredientSection
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.KeepScreenOn
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
+import com.plusmobileapps.chefmate.ui.components.PlusTooltipPlacement
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.coroutines.launch
@@ -141,6 +148,28 @@ fun CookModeScreen(bloc: CookModeBloc, modifier: Modifier = Modifier) {
     }
 }
 
+/**
+ * Wraps a header control in a first-run coach mark that points up at it (the cook-mode header sits
+ * at the top of the screen). The bubble only shows while [id] is the shared controller's active
+ * mark.
+ */
+@Composable
+private fun CookModeCoachMark(
+    id: String,
+    text: TextData,
+    activeCoachMark: String?,
+    onDismiss: (String) -> Unit,
+    anchor: @Composable () -> Unit,
+) {
+    PlusOnboardingTooltip(
+        text = text,
+        visible = activeCoachMark == id,
+        onDismiss = { onDismiss(id) },
+        placement = PlusTooltipPlacement.BELOW,
+        anchor = anchor,
+    )
+}
+
 @Composable
 private fun CookModeTabletLayout(
     bloc: CookModeBloc,
@@ -167,32 +196,49 @@ private fun CookModeTabletLayout(
                                     )
                                 }
                             }
-                            IconButton(onClick = bloc::onKeepScreenOnToggled) {
-                                Icon(
-                                    imageVector =
-                                        if (state.keepScreenOn) Icons.Default.Visibility
-                                        else Icons.Default.VisibilityOff,
-                                    contentDescription =
-                                        stringResource(
-                                            if (state.keepScreenOn)
-                                                Res.string.cook_mode_allow_screen_off
-                                            else Res.string.cook_mode_keep_screen_on
-                                        ),
-                                )
+                            CookModeCoachMark(
+                                id = CoachMarkId.COOK_MODE_KEEP_SCREEN_ON,
+                                text = Res.string.cook_mode_keep_screen_on_onboarding.asTextData(),
+                                activeCoachMark = state.activeCoachMark,
+                                onDismiss = bloc::onCoachMarkDismissed,
+                            ) {
+                                IconButton(onClick = bloc::onKeepScreenOnToggled) {
+                                    Icon(
+                                        imageVector =
+                                            if (state.keepScreenOn) Icons.Default.Visibility
+                                            else Icons.Default.VisibilityOff,
+                                        contentDescription =
+                                            stringResource(
+                                                if (state.keepScreenOn)
+                                                    Res.string.cook_mode_allow_screen_off
+                                                else Res.string.cook_mode_keep_screen_on
+                                            ),
+                                    )
+                                }
                             }
-                            IconButton(onClick = bloc::onLayoutToggled) {
-                                Icon(
-                                    imageVector =
-                                        if (state.layoutMode == CookModeBloc.LayoutMode.Stacked)
-                                            Icons.Default.ViewWeek
-                                        else Icons.Default.ViewAgenda,
-                                    contentDescription =
-                                        stringResource(
+                            CookModeCoachMark(
+                                id = CoachMarkId.COOK_MODE_LAYOUT,
+                                text = Res.string.cook_mode_layout_onboarding.asTextData(),
+                                activeCoachMark = state.activeCoachMark,
+                                onDismiss = bloc::onCoachMarkDismissed,
+                            ) {
+                                IconButton(onClick = bloc::onLayoutToggled) {
+                                    Icon(
+                                        imageVector =
                                             if (state.layoutMode == CookModeBloc.LayoutMode.Stacked)
-                                                Res.string.cook_mode_layout_split
-                                            else Res.string.cook_mode_layout_stacked
-                                        ),
-                                )
+                                                Icons.Default.ViewWeek
+                                            else Icons.Default.ViewAgenda,
+                                        contentDescription =
+                                            stringResource(
+                                                if (
+                                                    state.layoutMode ==
+                                                        CookModeBloc.LayoutMode.Stacked
+                                                )
+                                                    Res.string.cook_mode_layout_split
+                                                else Res.string.cook_mode_layout_stacked
+                                            ),
+                                    )
+                                }
                             }
                         },
                 ),
@@ -299,35 +345,53 @@ private fun CookModeMobileLayout(
                         onCloseClick = bloc::onCloseClicked,
                         trailingAccessory =
                             PlusHeaderData.TrailingAccessory.Custom {
-                                IconButton(onClick = bloc::onKeepScreenOnToggled) {
-                                    Icon(
-                                        imageVector =
-                                            if (state.keepScreenOn) Icons.Default.Visibility
-                                            else Icons.Default.VisibilityOff,
-                                        contentDescription =
-                                            stringResource(
-                                                if (state.keepScreenOn)
-                                                    Res.string.cook_mode_allow_screen_off
-                                                else Res.string.cook_mode_keep_screen_on
-                                            ),
-                                    )
+                                CookModeCoachMark(
+                                    id = CoachMarkId.COOK_MODE_KEEP_SCREEN_ON,
+                                    text =
+                                        Res.string.cook_mode_keep_screen_on_onboarding.asTextData(),
+                                    activeCoachMark = state.activeCoachMark,
+                                    onDismiss = bloc::onCoachMarkDismissed,
+                                ) {
+                                    IconButton(onClick = bloc::onKeepScreenOnToggled) {
+                                        Icon(
+                                            imageVector =
+                                                if (state.keepScreenOn) Icons.Default.Visibility
+                                                else Icons.Default.VisibilityOff,
+                                            contentDescription =
+                                                stringResource(
+                                                    if (state.keepScreenOn)
+                                                        Res.string.cook_mode_allow_screen_off
+                                                    else Res.string.cook_mode_keep_screen_on
+                                                ),
+                                        )
+                                    }
                                 }
-                                IconButton(onClick = bloc::onLayoutToggled) {
-                                    Icon(
-                                        imageVector =
-                                            if (state.layoutMode == CookModeBloc.LayoutMode.Stacked)
-                                                Icons.Default.ViewWeek
-                                            else Icons.Default.ViewAgenda,
-                                        contentDescription =
-                                            stringResource(
+                                CookModeCoachMark(
+                                    id = CoachMarkId.COOK_MODE_LAYOUT,
+                                    text = Res.string.cook_mode_layout_onboarding.asTextData(),
+                                    activeCoachMark = state.activeCoachMark,
+                                    onDismiss = bloc::onCoachMarkDismissed,
+                                ) {
+                                    IconButton(onClick = bloc::onLayoutToggled) {
+                                        Icon(
+                                            imageVector =
                                                 if (
                                                     state.layoutMode ==
                                                         CookModeBloc.LayoutMode.Stacked
                                                 )
-                                                    Res.string.cook_mode_layout_split
-                                                else Res.string.cook_mode_layout_stacked
-                                            ),
-                                    )
+                                                    Icons.Default.ViewWeek
+                                                else Icons.Default.ViewAgenda,
+                                            contentDescription =
+                                                stringResource(
+                                                    if (
+                                                        state.layoutMode ==
+                                                            CookModeBloc.LayoutMode.Stacked
+                                                    )
+                                                        Res.string.cook_mode_layout_split
+                                                    else Res.string.cook_mode_layout_stacked
+                                                ),
+                                        )
+                                    }
                                 }
                             },
                     ),
@@ -813,7 +877,10 @@ private fun DirectionRow(text: String, highlighted: Boolean, onClick: () -> Unit
                         Modifier
                     }
                 )
-                .padding(vertical = dimens.paddingExtraSmall, horizontal = dimens.paddingExtraSmall),
+                .padding(
+                    vertical = dimens.paddingExtraSmall,
+                    horizontal = dimens.paddingExtraSmall,
+                ),
     )
 }
 

--- a/client/meal/core/impl/build.gradle.kts
+++ b/client/meal/core/impl/build.gradle.kts
@@ -21,7 +21,10 @@ kotlin {
             implementation(projects.client.util.public)
             implementation(compose.components.resources)
         }
-        commonTest.dependencies { implementation(projects.client.util.testing) }
+        commonTest.dependencies {
+            implementation(projects.client.util.testing)
+            implementation(libs.multiplatform.settings.test)
+        }
     }
 }
 

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.meal.core.impl
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.chefmate.meal.core.MealPlanBloc
@@ -58,10 +59,12 @@ class MealPlanBlocImpl(
                 showDoneCookingDialog = it.showDoneCookingDialog,
                 pendingReplaceCookMode = it.pendingReplaceCookMode?.toImmutableList(),
                 snackbarMessage = it.snackbarMessage,
+                activeCoachMark = it.activeCoachMark,
             )
         }
 
     override fun onViewModeSelected(mode: MealPlanBloc.ViewMode) {
+        viewModel.dismissCoachMark(CoachMarkId.MEAL_PLAN_VIEW_MODE)
         viewModel.selectViewMode(mode)
     }
 
@@ -94,6 +97,7 @@ class MealPlanBlocImpl(
     }
 
     override fun onAddMealClicked() {
+        viewModel.dismissCoachMark(CoachMarkId.MEAL_PLAN_ADD_MEAL)
         output.onNext(Output.OpenMealPlanner(MealPlannerRootBloc.Props.FromMealPlanner))
     }
 
@@ -137,5 +141,9 @@ class MealPlanBlocImpl(
 
     override fun onDoneCookingDismissed() {
         viewModel.dismissDoneCookingDialog()
+    }
+
+    override fun onCoachMarkDismissed(id: String) {
+        viewModel.dismissCoachMark(id)
     }
 }

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanViewModel.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanViewModel.kt
@@ -6,7 +6,10 @@ import chefmate.client.meal.core.public.generated.resources.meal_plan_added_to_c
 import chefmate.client.meal.core.public.generated.resources.meal_plan_replaced_cook_mode_multiple
 import chefmate.client.meal.core.public.generated.resources.meal_plan_replaced_cook_mode_single
 import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.combineStates
 import com.plusmobileapps.chefmate.cook.data.CookingSessionRepository
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.meal.core.MealPlanBloc
 import com.plusmobileapps.chefmate.meal.data.MealPlanItem
@@ -22,7 +25,6 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
@@ -37,14 +39,23 @@ class MealPlanViewModel(
     private val repository: MealPlanRepository,
     private val cookingSessionRepository: CookingSessionRepository,
     private val dateTimeUtil: DateTimeUtil,
+    private val coachMarkController: CoachMarkController,
 ) : ViewModel(mainContext) {
 
     private val _state = MutableStateFlow(State())
-    val state: StateFlow<State> = _state.asStateFlow()
+
+    // Fold the shared controller's active mark into state so the screen shows at most one coach
+    // mark at a time across the whole app.
+    val state: StateFlow<State> =
+        combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
+            state.copy(activeCoachMark = activeCoachMark)
+        }
 
     private var observeJob: Job? = null
 
     init {
+        // Queue every meal-plan coach mark in order; the controller shows them one at a time.
+        CoachMarkId.mealPlanSequence.forEach(coachMarkController::request)
         val today = dateTimeUtil.today()
         _state.update { it.copy(currentDate = today, selectedMonthDay = today) }
         observeMeals()
@@ -100,6 +111,22 @@ class MealPlanViewModel(
 
     fun onMonthDaySelected(date: LocalDate) {
         _state.update { it.copy(selectedMonthDay = date) }
+    }
+
+    /**
+     * Mark a coach mark seen, but only if it's the one currently showing, so tapping a control
+     * dismisses its own tip without consuming tips further down the queue.
+     */
+    fun dismissCoachMark(id: String) {
+        if (coachMarkController.activeCoachMark.value == id) {
+            coachMarkController.dismiss(id)
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        // Leaving the screen without dismissing frees the queue so other coach marks can show.
+        CoachMarkId.mealPlanSequence.forEach(coachMarkController::release)
     }
 
     fun requestRemoveMeal(item: MealPlanItem) {
@@ -300,5 +327,6 @@ class MealPlanViewModel(
         val showDoneCookingDialog: Boolean = false,
         val pendingReplaceCookMode: List<MealPlanItem>? = null,
         val snackbarMessage: TextData? = null,
+        val activeCoachMark: String? = null,
     )
 }

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/ui/MealPlanPreviews.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/ui/MealPlanPreviews.kt
@@ -56,6 +56,8 @@ private fun mealPlanBloc(model: MealPlanBloc.Model): MealPlanBloc =
 
         override fun onViewModeSelected(mode: MealPlanBloc.ViewMode) = Unit
 
+        override fun onCoachMarkDismissed(id: String) = Unit
+
         override fun onPreviousClicked() = Unit
 
         override fun onNextClicked() = Unit

--- a/client/meal/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocTest.kt
+++ b/client/meal/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocTest.kt
@@ -10,6 +10,8 @@ import chefmate.client.meal.core.public.generated.resources.meal_plan_added_to_c
 import chefmate.client.meal.core.public.generated.resources.meal_plan_replaced_cook_mode_multiple
 import chefmate.client.meal.core.public.generated.resources.meal_plan_replaced_cook_mode_single
 import com.plusmobileapps.chefmate.cook.data.CookingSessionRepository
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.meal.core.MealPlanBloc
 import com.plusmobileapps.chefmate.meal.data.MealPlanItem
 import com.plusmobileapps.chefmate.meal.data.MealPlanRepository
@@ -19,6 +21,7 @@ import com.plusmobileapps.chefmate.testing.TestConsumer
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.util.testing.FakeDateTimeUtil
+import com.russhwolf.settings.MapSettings
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -40,6 +43,7 @@ class MealPlanBlocTest {
     val mealsFlow = MutableSharedFlow<List<MealPlanItem>>()
     val fakeDate = LocalDate(2026, 4, 17)
     val dateTimeUtil = FakeDateTimeUtil(fakeToday = fakeDate)
+    val coachMarkController = CoachMarkController(MapSettings())
 
     val repository: MealPlanRepository = mock {
         every { getMealsByDate("2026-04-17") } returns mealsFlow
@@ -65,9 +69,31 @@ class MealPlanBlocTest {
                     repository = repository,
                     cookingSessionRepository = cookingSessionRepository,
                     dateTimeUtil = dateTimeUtil,
+                    coachMarkController = coachMarkController,
                 )
             },
         )
+
+    @Test
+    fun WHEN_screen_opens_THEN_first_coach_mark_active() = runTest {
+        bloc.state.value.activeCoachMark shouldBe CoachMarkId.MEAL_PLAN_ADD_MEAL
+    }
+
+    @Test
+    fun WHEN_active_coach_mark_dismissed_THEN_persisted_and_next_shown() = runTest {
+        bloc.onCoachMarkDismissed(CoachMarkId.MEAL_PLAN_ADD_MEAL)
+
+        coachMarkController.hasSeen(CoachMarkId.MEAL_PLAN_ADD_MEAL) shouldBe true
+        bloc.state.value.activeCoachMark shouldBe CoachMarkId.MEAL_PLAN_VIEW_MODE
+    }
+
+    @Test
+    fun WHEN_inactive_coach_mark_dismissed_THEN_ignored() = runTest {
+        bloc.onCoachMarkDismissed(CoachMarkId.MEAL_PLAN_VIEW_MODE)
+
+        coachMarkController.hasSeen(CoachMarkId.MEAL_PLAN_VIEW_MODE) shouldBe false
+        bloc.state.value.activeCoachMark shouldBe CoachMarkId.MEAL_PLAN_ADD_MEAL
+    }
 
     @Test
     fun WHEN_meals_loaded_THEN_state_is_updated_with_day_meals() = runTest {
@@ -418,6 +444,7 @@ class MealPlanBlocTest {
                             repository = repository,
                             cookingSessionRepository = sessionRepo,
                             dateTimeUtil = dateTimeUtil,
+                            coachMarkController = CoachMarkController(MapSettings()),
                         )
                     },
                 )

--- a/client/meal/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/meal/core/public/src/commonMain/composeResources/values/strings.xml
@@ -16,6 +16,9 @@
     <string name="meal_plan_delete_confirm">Remove</string>
     <string name="meal_plan_delete_cancel">Cancel</string>
     <string name="meal_plan_add_meal">Add Meal</string>
+    <!-- First-run coach marks -->
+    <string name="meal_plan_add_meal_onboarding">Tap here to plan a meal for this day</string>
+    <string name="meal_plan_view_mode_onboarding">Switch between day, week, and month views</string>
     <string name="meal_plan_select_recipe">Select a Recipe</string>
     <string name="meal_plan_search_recipes">Search recipes</string>
     <string name="meal_plan_sync_not_synced">Not synced</string>

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanBloc.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanBloc.kt
@@ -60,6 +60,9 @@ interface MealPlanBloc : ComposeScreen {
 
     fun onDoneCookingDismissed()
 
+    /** Marks the first-run coach mark with [id] as seen so it never shows again. */
+    fun onCoachMarkDismissed(id: String)
+
     data class Model(
         val isLoading: Boolean = true,
         val isSyncing: Boolean = false,
@@ -73,6 +76,8 @@ interface MealPlanBloc : ComposeScreen {
         val showDoneCookingDialog: Boolean = false,
         val pendingReplaceCookMode: ImmutableList<MealPlanItem>? = null,
         val snackbarMessage: TextData? = null,
+        /** Id of the first-run coach mark currently allowed to show, or null when none. */
+        val activeCoachMark: String? = null,
     )
 
     data class DayMeals(

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import chefmate.client.meal.core.public.generated.resources.Res
 import chefmate.client.meal.core.public.generated.resources.meal_plan_add_meal
+import chefmate.client.meal.core.public.generated.resources.meal_plan_add_meal_onboarding
 import chefmate.client.meal.core.public.generated.resources.meal_plan_add_to_cook_mode
 import chefmate.client.meal.core.public.generated.resources.meal_plan_breakfast
 import chefmate.client.meal.core.public.generated.resources.meal_plan_continue_cooking
@@ -91,16 +92,21 @@ import chefmate.client.meal.core.public.generated.resources.meal_plan_sync_not_s
 import chefmate.client.meal.core.public.generated.resources.meal_plan_sync_synced
 import chefmate.client.meal.core.public.generated.resources.meal_plan_sync_syncing
 import chefmate.client.meal.core.public.generated.resources.meal_plan_title
+import chefmate.client.meal.core.public.generated.resources.meal_plan_view_mode_onboarding
 import chefmate.client.meal.core.public.generated.resources.meal_plan_week
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.meal.data.MealPlanItem
 import com.plusmobileapps.chefmate.meal.data.MealType
 import com.plusmobileapps.chefmate.meal.data.SyncStatus
 import com.plusmobileapps.chefmate.text.ResourceString
+import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
+import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
+import com.plusmobileapps.chefmate.ui.components.PlusTooltipPlacement
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.datetime.DateTimeUnit
@@ -154,23 +160,38 @@ fun MealPlanScreen(bloc: MealPlanBloc, modifier: Modifier = Modifier) {
                     title = Res.string.meal_plan_title.asTextData(),
                     trailingAccessory =
                         PlusHeaderData.TrailingAccessory.Custom {
-                            IconButton(onClick = bloc::onAddMealClicked) {
-                                Icon(
-                                    imageVector = Icons.Default.Add,
-                                    contentDescription =
-                                        stringResource(Res.string.meal_plan_add_meal),
-                                )
+                            MealPlanCoachMark(
+                                id = CoachMarkId.MEAL_PLAN_ADD_MEAL,
+                                text = Res.string.meal_plan_add_meal_onboarding.asTextData(),
+                                activeCoachMark = state.activeCoachMark,
+                                onDismiss = bloc::onCoachMarkDismissed,
+                            ) {
+                                IconButton(onClick = bloc::onAddMealClicked) {
+                                    Icon(
+                                        imageVector = Icons.Default.Add,
+                                        contentDescription =
+                                            stringResource(Res.string.meal_plan_add_meal),
+                                    )
+                                }
                             }
                         },
                 ),
             scrollEnabled = false,
             content = {
                 Column(modifier = Modifier.fillMaxSize()) {
-                    ViewModeSegmentedControl(
-                        selectedMode = state.viewMode,
-                        onModeSelected = bloc::onViewModeSelected,
-                        modifier = Modifier.padding(horizontal = ChefMateTheme.dimens.paddingNormal),
-                    )
+                    MealPlanCoachMark(
+                        id = CoachMarkId.MEAL_PLAN_VIEW_MODE,
+                        text = Res.string.meal_plan_view_mode_onboarding.asTextData(),
+                        activeCoachMark = state.activeCoachMark,
+                        onDismiss = bloc::onCoachMarkDismissed,
+                    ) {
+                        ViewModeSegmentedControl(
+                            selectedMode = state.viewMode,
+                            onModeSelected = bloc::onViewModeSelected,
+                            modifier =
+                                Modifier.padding(horizontal = ChefMateTheme.dimens.paddingNormal),
+                        )
+                    }
 
                     DateNavigationRow(
                         dateLabel = state.dateLabel.localized(),
@@ -303,6 +324,28 @@ private fun DoneCookingDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
                 Text(stringResource(Res.string.meal_plan_done_cooking_cancel))
             }
         },
+    )
+}
+
+/**
+ * Wraps a control in a first-run coach mark that points up at it (the meal-plan header and
+ * view-mode control both sit near the top of the screen). The bubble only shows while [id] is the
+ * shared controller's active mark.
+ */
+@Composable
+private fun MealPlanCoachMark(
+    id: String,
+    text: TextData,
+    activeCoachMark: String?,
+    onDismiss: (String) -> Unit,
+    anchor: @Composable () -> Unit,
+) {
+    PlusOnboardingTooltip(
+        text = text,
+        visible = activeCoachMark == id,
+        onDismiss = { onDismiss(id) },
+        placement = PlusTooltipPlacement.BELOW,
+        anchor = anchor,
     )
 }
 

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeBlocImpl.kt
@@ -7,6 +7,7 @@ import chefmate.client.recipe.core.impl.generated.resources.edit_recipe_upload_f
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc
@@ -56,6 +57,7 @@ class EditRecipeBlocImpl(
                 showDiscardChangesDialog = it.showDiscardChangesDialog,
                 uploadError =
                     it.uploadError?.let { ResourceString(Res.string.edit_recipe_upload_failed) },
+                activeCoachMark = it.activeCoachMark,
             )
         }
     override val title: StateFlow<String> = viewModel.title
@@ -111,6 +113,7 @@ class EditRecipeBlocImpl(
     }
 
     override fun onDirectionsChanged(directions: String) {
+        viewModel.dismissCoachMark(CoachMarkId.EDIT_RECIPE_RICH_TEXT)
         viewModel.updateDirections(directions)
     }
 
@@ -183,6 +186,7 @@ class EditRecipeBlocImpl(
     }
 
     override fun onSaveClicked() {
+        viewModel.dismissCoachMark(CoachMarkId.EDIT_RECIPE_SAVE)
         viewModel.save()
     }
 
@@ -195,7 +199,12 @@ class EditRecipeBlocImpl(
     }
 
     override fun onRichTextEditorModeChanged(richTextMode: Boolean) {
+        viewModel.dismissCoachMark(CoachMarkId.EDIT_RECIPE_RICH_TEXT)
         viewModel.updateRichTextEditorMode(richTextMode)
+    }
+
+    override fun onCoachMarkDismissed(id: String) {
+        viewModel.dismissCoachMark(id)
     }
 
     override fun onBackClicked() {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModel.kt
@@ -4,6 +4,9 @@ package com.plusmobileapps.chefmate.recipe.core.impl.edit
 
 import co.touchlab.kermit.Logger
 import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.combineStates
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.di.MarkdownEditorModeRepository
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
@@ -47,11 +50,18 @@ class EditRecipeViewModel(
     private val photoStorage: RecipePhotoStorage,
     private val pendingRecipePhotoStore: PendingRecipePhotoStore,
     private val markdownEditorModeRepository: MarkdownEditorModeRepository,
+    private val coachMarkController: CoachMarkController,
 ) : ViewModel(mainContext) {
     private val _output = Channel<Output>(Channel.BUFFERED)
     val output: Flow<Output> = _output.receiveAsFlow()
     private val _state = MutableStateFlow(State())
-    val state: StateFlow<State> = _state.asStateFlow()
+
+    // Fold the shared controller's active mark into state so the screen shows at most one coach
+    // mark at a time across the whole app.
+    val state: StateFlow<State> =
+        combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
+            state.copy(activeCoachMark = activeCoachMark)
+        }
 
     private val _title = MutableStateFlow("")
     val title: StateFlow<String> = _title.asStateFlow()
@@ -119,6 +129,8 @@ class EditRecipeViewModel(
     val richTextEditorMode: StateFlow<Boolean> = markdownEditorModeRepository.richTextMode
 
     init {
+        // Queue every edit-recipe coach mark in order; the controller shows them one at a time.
+        CoachMarkId.editRecipeSequence.forEach(coachMarkController::request)
         // A new recipe defaults to the active book; an existing one loads its current membership.
         if (recipeId == null) {
             scope.launch {
@@ -203,6 +215,16 @@ class EditRecipeViewModel(
 
     fun updateRichTextEditorMode(value: Boolean) {
         markdownEditorModeRepository.setRichTextMode(value)
+    }
+
+    /**
+     * Mark a coach mark seen, but only if it's the one currently showing, so tapping a control
+     * dismisses its own tip without consuming tips further down the queue.
+     */
+    fun dismissCoachMark(id: String) {
+        if (coachMarkController.activeCoachMark.value == id) {
+            coachMarkController.dismiss(id)
+        }
     }
 
     fun updateStarRating(value: Int?) {
@@ -349,6 +371,8 @@ class EditRecipeViewModel(
 
     override fun onCleared() {
         super.onCleared()
+        // Leaving the screen without dismissing frees the queue so other coach marks can show.
+        CoachMarkId.editRecipeSequence.forEach(coachMarkController::release)
         _output.close()
     }
 
@@ -443,6 +467,7 @@ class EditRecipeViewModel(
         val showDiscardChangesDialog: Boolean = false,
         val recipe: Recipe? = null,
         val uploadError: Throwable? = null,
+        val activeCoachMark: String? = null,
     )
 
     sealed class Output {

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModelTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModelTest.kt
@@ -3,6 +3,8 @@
 
 package com.plusmobileapps.chefmate.recipe.core.impl.edit
 
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.MarkdownEditorModeRepository
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.Category
@@ -34,12 +36,14 @@ class EditRecipeViewModelTest {
     private val photoStorage = FakeRecipePhotoStorage()
     private val pendingPhotoStore = FakePendingRecipePhotoStore()
     private val mainContext = UnconfinedTestDispatcher()
+    private val coachMarkController = CoachMarkController(MapSettings())
 
     private fun createViewModel(
         recipeId: Long? = null,
         extractedRecipe: ExtractedRecipeData? = null,
         fromAi: Boolean = false,
         consumePendingPhoto: Boolean = false,
+        coachMarkController: CoachMarkController = this.coachMarkController,
     ) =
         EditRecipeViewModel(
             recipeId = recipeId,
@@ -53,7 +57,25 @@ class EditRecipeViewModelTest {
             photoStorage = photoStorage,
             pendingRecipePhotoStore = pendingPhotoStore,
             markdownEditorModeRepository = MarkdownEditorModeRepository(MapSettings()),
+            coachMarkController = coachMarkController,
         )
+
+    @Test
+    fun When_screen_opens_Then_first_coach_mark_active() {
+        val vm = createViewModel()
+        vm.state.value.activeCoachMark shouldBe CoachMarkId.EDIT_RECIPE_RICH_TEXT
+    }
+
+    @Test
+    fun When_active_coach_mark_dismissed_Then_persisted_and_next_shown() {
+        val controller = CoachMarkController(MapSettings())
+        val vm = createViewModel(coachMarkController = controller)
+
+        vm.dismissCoachMark(CoachMarkId.EDIT_RECIPE_RICH_TEXT)
+
+        controller.hasSeen(CoachMarkId.EDIT_RECIPE_RICH_TEXT) shouldBe true
+        vm.state.value.activeCoachMark shouldBe CoachMarkId.EDIT_RECIPE_SAVE
+    }
 
     @Test
     fun When_no_recipe_id_or_extracted_data_Then_all_fields_start_empty() {

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -67,6 +67,9 @@
     <string name="edit_recipe_title">Edit Recipe</string>
     <string name="edit_recipe_back">Back</string>
     <string name="edit_recipe_save">Save</string>
+    <!-- First-run coach marks -->
+    <string name="edit_recipe_rich_text_onboarding">Write your steps here — tap the toggle for rich-text formatting</string>
+    <string name="edit_recipe_save_onboarding">Tap save when your recipe is ready</string>
     <string name="edit_recipe_field_title">Title</string>
     <string name="edit_recipe_field_title_placeholder">Enter recipe title</string>
     <string name="edit_recipe_field_description">Description</string>

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeBloc.kt
@@ -135,12 +135,17 @@ interface EditRecipeBloc : BackClickBloc, ComposeScreen {
     /** Persists the editor-mode preference (true = rich text, false = markdown). */
     fun onRichTextEditorModeChanged(richTextMode: Boolean)
 
+    /** Marks the first-run coach mark with [id] as seen so it never shows again. */
+    fun onCoachMarkDismissed(id: String)
+
     data class Model(
         val title: TextData,
         val isLoading: Boolean,
         val isSaving: Boolean,
         val showDiscardChangesDialog: Boolean,
         val uploadError: TextData? = null,
+        /** Id of the first-run coach mark currently allowed to show, or null when none. */
+        val activeCoachMark: String? = null,
     )
 
     sealed class Output {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
@@ -86,20 +86,27 @@ import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_title_placeholder
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_total_time
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_field_total_time_placeholder
+import chefmate.client.recipe.core.public.generated.resources.edit_recipe_rich_text_onboarding
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_save
+import chefmate.client.recipe.core.public.generated.resources.edit_recipe_save_onboarding
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_section_more_details
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_upload_photo
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_upload_photo_dismiss
 import coil3.compose.AsyncImage
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.recipe.categories.pickerLabelRes
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.components.PlusMarkdownEditor
+import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
 import com.plusmobileapps.chefmate.ui.components.PlusOutlinedContainer
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
+import com.plusmobileapps.chefmate.ui.components.PlusTooltipPlacement
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import com.plusmobileapps.chefmate.util.cropImageToSquare
@@ -145,7 +152,12 @@ fun EditRecipeScreen(
             verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal),
             maxContentWidth = if (isExpanded) Dp.Unspecified else 600.dp,
             floatingActionButton = {
-                SaveRecipeFab(isSaving = state.isSaving, onSaveClicked = bloc::onSaveClicked)
+                SaveRecipeFab(
+                    isSaving = state.isSaving,
+                    onSaveClicked = bloc::onSaveClicked,
+                    activeCoachMark = state.activeCoachMark,
+                    onCoachMarkDismissed = bloc::onCoachMarkDismissed,
+                )
             },
         ) {
             if (state.isLoading) {
@@ -171,16 +183,51 @@ fun EditRecipeScreen(
 private fun SaveRecipeFab(
     isSaving: Boolean,
     onSaveClicked: () -> Unit,
+    activeCoachMark: String?,
+    onCoachMarkDismissed: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    ExtendedFloatingActionButton(onClick = onSaveClicked, modifier = modifier) {
-        if (isSaving) {
-            PlusLoadingIndicator(
-                modifier = Modifier.padding(end = ChefMateTheme.dimens.paddingSmall)
-            )
+    EditRecipeCoachMark(
+        id = CoachMarkId.EDIT_RECIPE_SAVE,
+        text = Res.string.edit_recipe_save_onboarding.asTextData(),
+        activeCoachMark = activeCoachMark,
+        onDismiss = onCoachMarkDismissed,
+        modifier = modifier,
+    ) {
+        ExtendedFloatingActionButton(onClick = onSaveClicked) {
+            if (isSaving) {
+                PlusLoadingIndicator(
+                    modifier = Modifier.padding(end = ChefMateTheme.dimens.paddingSmall)
+                )
+            }
+            Text(stringResource(Res.string.edit_recipe_save))
         }
-        Text(stringResource(Res.string.edit_recipe_save))
     }
+}
+
+/**
+ * Wraps a control in a first-run coach mark. The bubble only shows while [id] is the shared
+ * controller's active mark. Defaults to [PlusTooltipPlacement.ABOVE] since the anchored controls
+ * (the Save FAB, the directions field) sit toward the bottom of the form.
+ */
+@Composable
+private fun EditRecipeCoachMark(
+    id: String,
+    text: TextData,
+    activeCoachMark: String?,
+    onDismiss: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placement: PlusTooltipPlacement = PlusTooltipPlacement.ABOVE,
+    anchor: @Composable () -> Unit,
+) {
+    PlusOnboardingTooltip(
+        text = text,
+        visible = activeCoachMark == id,
+        onDismiss = { onDismiss(id) },
+        placement = placement,
+        modifier = modifier,
+        anchor = anchor,
+    )
 }
 
 @Composable
@@ -691,18 +738,26 @@ private fun RecipeIngredientsField(bloc: EditRecipeBloc, modifier: Modifier = Mo
 private fun RecipeDirectionsField(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
     val directions by bloc.directions.collectAsState()
     val richTextMode by bloc.richTextEditorMode.collectAsState()
+    val model by bloc.state.collectAsState()
 
-    PlusMarkdownEditor(
-        value = directions,
-        onValueChange = bloc::onDirectionsChanged,
-        label = stringResource(Res.string.edit_recipe_field_directions),
-        placeholder = stringResource(Res.string.edit_recipe_field_directions_placeholder),
-        richTextMode = richTextMode,
-        onRichTextModeChange = bloc::onRichTextEditorModeChanged,
+    EditRecipeCoachMark(
+        id = CoachMarkId.EDIT_RECIPE_RICH_TEXT,
+        text = Res.string.edit_recipe_rich_text_onboarding.asTextData(),
+        activeCoachMark = model.activeCoachMark,
+        onDismiss = bloc::onCoachMarkDismissed,
         modifier = modifier,
-        initialHeight = 320.dp,
-        maxHeight = 640.dp,
-    )
+    ) {
+        PlusMarkdownEditor(
+            value = directions,
+            onValueChange = bloc::onDirectionsChanged,
+            label = stringResource(Res.string.edit_recipe_field_directions),
+            placeholder = stringResource(Res.string.edit_recipe_field_directions_placeholder),
+            richTextMode = richTextMode,
+            onRichTextModeChange = bloc::onRichTextEditorModeChanged,
+            initialHeight = 320.dp,
+            maxHeight = 640.dp,
+        )
+    }
 }
 
 @Composable
@@ -853,6 +908,8 @@ Salt for pasta water"""
         override fun onUploadErrorDismissed() {}
 
         override fun onRichTextEditorModeChanged(richTextMode: Boolean) {}
+
+        override fun onCoachMarkDismissed(id: String) {}
 
         override fun onBackClicked() {}
 

--- a/client/recipe/list/impl/build.gradle.kts
+++ b/client/recipe/list/impl/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
             implementation(projects.client.recipe.data.testing)
             implementation(projects.client.featureflag.testing)
             implementation(projects.client.recipebook.data.testing)
+            implementation(libs.multiplatform.settings.test)
         }
     }
 }

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.recipe.list.impl
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
@@ -70,6 +71,7 @@ class RecipeListBlocImpl(
                 isAllRecipesSelected = it.isAllRecipesSelected,
                 isBookPickerOpen = it.isBookPickerOpen,
                 pendingInvites = it.pendingInvites,
+                activeCoachMark = it.activeCoachMark,
             )
         }
 
@@ -82,10 +84,12 @@ class RecipeListBlocImpl(
     }
 
     override fun onAddRecipeClicked() {
+        viewModel.dismissCoachMark(CoachMarkId.RECIPE_LIST_ADD)
         output.onNext(Output.AddNewRecipe)
     }
 
     override fun onScanRecipePhotoPicked(bytes: ByteArray, fileExtension: String) {
+        viewModel.dismissCoachMark(CoachMarkId.RECIPE_LIST_ADD)
         viewModel.scanRecipeFromPhoto(bytes = bytes, fileExtension = fileExtension)
     }
 
@@ -110,6 +114,7 @@ class RecipeListBlocImpl(
     }
 
     override fun onToggleViewMode() {
+        viewModel.dismissCoachMark(CoachMarkId.RECIPE_LIST_VIEW_MODE)
         viewModel.toggleViewMode()
     }
 
@@ -222,6 +227,10 @@ class RecipeListBlocImpl(
 
     override fun onDeclineInvite(memberId: String) {
         viewModel.declineInvite(memberId)
+    }
+
+    override fun onCoachMarkDismissed(id: String) {
+        viewModel.dismissCoachMark(id)
     }
 
     private fun Recipe.toRecipeListItem(): RecipeListItem =

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
@@ -4,7 +4,10 @@ import chefmate.client.recipe.list.public.generated.resources.Res
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scan_failed
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scan_no_api_key
 import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.combineStates
 import com.plusmobileapps.chefmate.cook.data.CookingSessionRepository
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.featureflag.FeatureFlags
@@ -40,7 +43,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -61,6 +63,7 @@ class RecipeListViewModel(
     private val pendingPhotoStore: PendingRecipePhotoStore,
     featureFlags: FeatureFlags,
     settings: Settings,
+    private val coachMarkController: CoachMarkController,
 ) : ViewModel(mainContext) {
     private val scanFromPhotoEnabled =
         featureFlags.isEnabled(FeatureFlagRegistry.ScanRecipeFromPhoto)
@@ -98,7 +101,13 @@ class RecipeListViewModel(
                         .toSet(),
             )
         )
-    val state: StateFlow<State> = _state.asStateFlow()
+
+    // Fold the shared controller's active mark into state so the screen shows at most one coach
+    // mark at a time across the whole app.
+    val state: StateFlow<State> =
+        combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
+            state.copy(activeCoachMark = activeCoachMark)
+        }
 
     private val _scannedRecipe =
         MutableSharedFlow<ExtractedRecipeData>(
@@ -114,6 +123,8 @@ class RecipeListViewModel(
     val scannedRecipe: SharedFlow<ExtractedRecipeData> = _scannedRecipe.asSharedFlow()
 
     init {
+        // Queue every recipe-list coach mark in order; the controller shows them one at a time.
+        CoachMarkId.recipeListSequence.forEach(coachMarkController::request)
         scope.launch { observeRecipes() }
         scope.launch { observeCookingSession() }
         scope.launch { observeUserCategories() }
@@ -285,6 +296,22 @@ class RecipeListViewModel(
         isGridViewPref = _state.value.isGridView
     }
 
+    /**
+     * Mark a coach mark seen, but only if it's the one currently showing, so tapping a control
+     * dismisses its own tip without consuming tips further down the queue.
+     */
+    fun dismissCoachMark(id: String) {
+        if (coachMarkController.activeCoachMark.value == id) {
+            coachMarkController.dismiss(id)
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        // Leaving the screen without dismissing frees the queue so other coach marks can show.
+        CoachMarkId.recipeListSequence.forEach(coachMarkController::release)
+    }
+
     fun updateSearchQuery(query: String) {
         _state.update { it.copy(searchQuery = query) }
     }
@@ -417,6 +444,7 @@ class RecipeListViewModel(
         val isAllRecipesSelected: Boolean = false,
         val isBookPickerOpen: Boolean = false,
         val pendingInvites: List<RecipeBookInvite> = emptyList(),
+        val activeCoachMark: String? = null,
     ) {
         val isSearchActive: Boolean
             get() = searchQuery.isNotBlank()

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
@@ -82,6 +82,8 @@ private fun recipeListBloc(model: RecipeListBloc.Model): RecipeListBloc =
 
         override fun onToggleViewMode() = Unit
 
+        override fun onCoachMarkDismissed(id: String) = Unit
+
         override fun onSearchQueryChanged(query: String) = Unit
 
         override fun onClearFilters() = Unit

--- a/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImplTest.kt
+++ b/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImplTest.kt
@@ -5,6 +5,7 @@ package com.plusmobileapps.chefmate.recipe.list.impl
 
 import app.cash.turbine.test
 import com.plusmobileapps.chefmate.cook.data.CookingSessionRepository
+import com.plusmobileapps.chefmate.di.CoachMarkController
 import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.SyncStatus
@@ -22,6 +23,7 @@ import com.plusmobileapps.chefmate.testing.TestConsumer
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
+import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.Settings
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -80,6 +82,7 @@ class RecipeListBlocImplTest {
                     pendingPhotoStore = pendingPhotoStore,
                     featureFlags = featureFlags,
                     settings = settings,
+                    coachMarkController = CoachMarkController(MapSettings()),
                 )
             },
             timeFormatterUtil = timeFormatterUtil,

--- a/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
+++ b/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
@@ -5,6 +5,8 @@ package com.plusmobileapps.chefmate.recipe.list.impl
 
 import app.cash.turbine.test
 import com.plusmobileapps.chefmate.cook.data.CookingSessionRepository
+import com.plusmobileapps.chefmate.di.CoachMarkController
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
@@ -23,6 +25,7 @@ import com.plusmobileapps.chefmate.recipe.list.RecipeSortOption
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookCollaborationRepository
 import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookRepository
+import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.Settings
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -60,6 +63,7 @@ class RecipeListViewModelTest {
     private val featureFlags = FakeFeatureFlags()
     private val recipeBookRepository = FakeRecipeBookRepository(MutableStateFlow(emptyList()))
     private val collaborationRepository = FakeRecipeBookCollaborationRepository()
+    private val coachMarkController = CoachMarkController(MapSettings())
     private val viewModel =
         RecipeListViewModel(
             mainContext = UnconfinedTestDispatcher(),
@@ -72,6 +76,7 @@ class RecipeListViewModelTest {
             pendingPhotoStore = pendingPhotoStore,
             featureFlags = featureFlags,
             settings = settings,
+            coachMarkController = coachMarkController,
         )
 
     @Test
@@ -141,6 +146,7 @@ class RecipeListViewModelTest {
                     pendingPhotoStore = pendingPhotoStore,
                     featureFlags = featureFlags,
                     settings = settings,
+                    coachMarkController = CoachMarkController(MapSettings()),
                 )
 
             vm.state.value.pendingInvites.map { it.memberId } shouldBe listOf("m1")
@@ -186,6 +192,7 @@ class RecipeListViewModelTest {
                 pendingPhotoStore = pendingPhotoStore,
                 featureFlags = flags,
                 settings = settings,
+                coachMarkController = CoachMarkController(MapSettings()),
             )
 
         vm.state.value.isScanFromPhotoEnabled shouldBe true
@@ -402,6 +409,7 @@ class RecipeListViewModelTest {
                 pendingPhotoStore = pendingPhotoStore,
                 featureFlags = featureFlags,
                 settings = gridSettings,
+                coachMarkController = CoachMarkController(MapSettings()),
             )
         vm.state.value.isGridView shouldBe true
     }
@@ -435,6 +443,28 @@ class RecipeListViewModelTest {
         viewModel.state.value.isSearchActive shouldBe true
     }
 
+    @Test
+    fun When_screen_opens_Then_first_coach_mark_active() {
+        viewModel.state.value.activeCoachMark shouldBe CoachMarkId.RECIPE_LIST_ADD
+    }
+
+    @Test
+    fun When_active_coach_mark_dismissed_Then_persisted_and_next_shown() {
+        viewModel.dismissCoachMark(CoachMarkId.RECIPE_LIST_ADD)
+
+        coachMarkController.hasSeen(CoachMarkId.RECIPE_LIST_ADD) shouldBe true
+        viewModel.state.value.activeCoachMark shouldBe CoachMarkId.RECIPE_LIST_VIEW_MODE
+    }
+
+    @Test
+    fun When_dismissing_a_coach_mark_that_is_not_active_Then_ignored() {
+        // The view-mode mark is queued behind the add mark, so dismissing it does nothing yet.
+        viewModel.dismissCoachMark(CoachMarkId.RECIPE_LIST_VIEW_MODE)
+
+        coachMarkController.hasSeen(CoachMarkId.RECIPE_LIST_VIEW_MODE) shouldBe false
+        viewModel.state.value.activeCoachMark shouldBe CoachMarkId.RECIPE_LIST_ADD
+    }
+
     // region Recipe-book scope / "All recipes"
 
     /** Books id 1 & 3 from the sample set, with one recipe filed under each. */
@@ -455,6 +485,7 @@ class RecipeListViewModelTest {
             pendingPhotoStore = pendingPhotoStore,
             featureFlags = featureFlags,
             settings = settings,
+            coachMarkController = CoachMarkController(MapSettings()),
         )
     }
 
@@ -555,6 +586,7 @@ class RecipeListViewModelTest {
                 pendingPhotoStore = pendingPhotoStore,
                 featureFlags = featureFlags,
                 settings = sortSettings,
+                coachMarkController = CoachMarkController(MapSettings()),
             )
         vm.state.value.currentSort shouldBe RecipeSortOption.TOP_RATED
     }
@@ -587,6 +619,7 @@ class RecipeListViewModelTest {
                 pendingPhotoStore = pendingPhotoStore,
                 featureFlags = featureFlags,
                 settings = filterSettings,
+                coachMarkController = CoachMarkController(MapSettings()),
             )
         vm.state.value.activeFilters shouldBe
             setOf(RecipeFilterOption.FAVORITES, RecipeFilterOption.RATED)
@@ -776,6 +809,7 @@ class RecipeListViewModelTest {
                 pendingPhotoStore = pendingPhotoStore,
                 featureFlags = featureFlags,
                 settings = catSettings,
+                coachMarkController = CoachMarkController(MapSettings()),
             )
         vm.state.value.activeCategories shouldBe
             setOf(BuiltinCategory.BREAKFAST, BuiltinCategory.DINNER)

--- a/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
@@ -3,6 +3,10 @@
     <string name="recipe_list_title">Recipes</string>
     <string name="recipe_list_add_recipe">Add recipe</string>
     <string name="recipe_list_create_recipe">Create recipe</string>
+    <!-- First-run coach marks -->
+    <string name="recipe_list_add_onboarding">Tap here to add your first recipe</string>
+    <string name="recipe_list_view_mode_onboarding">Switch between grid and list views</string>
+    <string name="recipe_list_filter_onboarding">Sort and filter to find recipes fast</string>
     <string name="recipe_list_scan_from_photo">Scan from photo</string>
     <string name="recipe_list_scanning_title">Scanning photo…</string>
     <string name="recipe_list_scanning_message">Reading the recipe from your photo.</string>

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
@@ -114,6 +114,9 @@ interface RecipeListBloc : ComposeScreen {
     /** Declines the pending recipe-book invite with remote [memberId]. */
     fun onDeclineInvite(memberId: String)
 
+    /** Marks the first-run coach mark with [id] as seen so it never shows again. */
+    fun onCoachMarkDismissed(id: String)
+
     data class Model(
         val recipes: ImmutableList<RecipeListItem> = persistentListOf(),
         val totalRecipeCount: Int = 0,
@@ -149,6 +152,8 @@ interface RecipeListBloc : ComposeScreen {
         val isBookPickerOpen: Boolean = false,
         /** Pending recipe-book invites addressed to the current user (the list banner). */
         val pendingInvites: List<RecipeBookInvite> = emptyList(),
+        /** Id of the first-run coach mark currently allowed to show, or null when none. */
+        val activeCoachMark: String? = null,
     ) {
         /** Total number of active filter chips: legacy filters + preset + user category filters. */
         val totalActiveFilterCount: Int

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -99,6 +99,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import chefmate.client.recipe.list.public.generated.resources.Res
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_add_onboarding
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_add_recipe
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_apply
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_all_recipes
@@ -134,6 +135,7 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_list_filter
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_filter_empty_description
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_filter_empty_title
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_filter_favorites
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_filter_onboarding
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_filter_quick_recipes
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_filter_rated
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_invite_accept
@@ -171,21 +173,26 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_list_sort_z
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_title
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_view_grid
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_view_list
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_view_mode_onboarding
 import chefmate.client.recipe.list.public.generated.resources.recipe_sync_not_synced
 import chefmate.client.recipe.list.public.generated.resources.recipe_sync_synced
 import chefmate.client.recipe.list.public.generated.resources.recipe_sync_syncing
+import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.letIfTrue
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.SyncStatus
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.ResourceString
+import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusDialogScaffold
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
+import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
+import com.plusmobileapps.chefmate.ui.components.PlusTooltipPlacement
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.text.toInlineMarkdownAnnotatedString
@@ -317,45 +324,71 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                                         stringResource(Res.string.recipe_list_search),
                                 )
                             }
-                            IconButton(onClick = bloc::onToggleViewMode) {
-                                Icon(
-                                    imageVector =
-                                        if (state.isGridView) Icons.AutoMirrored.Filled.ViewList
-                                        else Icons.Default.GridView,
-                                    contentDescription =
-                                        stringResource(
-                                            if (state.isGridView) {
-                                                Res.string.recipe_list_view_list
-                                            } else {
-                                                Res.string.recipe_list_view_grid
-                                            }
-                                        ),
-                                )
+                            RecipeListCoachMark(
+                                id = CoachMarkId.RECIPE_LIST_VIEW_MODE,
+                                text = Res.string.recipe_list_view_mode_onboarding.asTextData(),
+                                activeCoachMark = state.activeCoachMark,
+                                onDismiss = bloc::onCoachMarkDismissed,
+                            ) {
+                                IconButton(onClick = bloc::onToggleViewMode) {
+                                    Icon(
+                                        imageVector =
+                                            if (state.isGridView) Icons.AutoMirrored.Filled.ViewList
+                                            else Icons.Default.GridView,
+                                        contentDescription =
+                                            stringResource(
+                                                if (state.isGridView) {
+                                                    Res.string.recipe_list_view_list
+                                                } else {
+                                                    Res.string.recipe_list_view_grid
+                                                }
+                                            ),
+                                    )
+                                }
                             }
-                            IconButton(onClick = { showSortFilterSheet = true }) {
-                                val filterCount = state.totalActiveFilterCount
-                                if (filterCount > 0) {
-                                    BadgedBox(badge = { Badge { Text("$filterCount") } }) {
+                            RecipeListCoachMark(
+                                id = CoachMarkId.RECIPE_LIST_FILTER,
+                                text = Res.string.recipe_list_filter_onboarding.asTextData(),
+                                activeCoachMark = state.activeCoachMark,
+                                onDismiss = bloc::onCoachMarkDismissed,
+                            ) {
+                                IconButton(
+                                    onClick = {
+                                        bloc.onCoachMarkDismissed(CoachMarkId.RECIPE_LIST_FILTER)
+                                        showSortFilterSheet = true
+                                    }
+                                ) {
+                                    val filterCount = state.totalActiveFilterCount
+                                    if (filterCount > 0) {
+                                        BadgedBox(badge = { Badge { Text("$filterCount") } }) {
+                                            Icon(
+                                                imageVector = Icons.Default.FilterList,
+                                                contentDescription =
+                                                    stringResource(Res.string.recipe_list_filter),
+                                                tint = MaterialTheme.colorScheme.primary,
+                                            )
+                                        }
+                                    } else {
                                         Icon(
                                             imageVector = Icons.Default.FilterList,
                                             contentDescription =
                                                 stringResource(Res.string.recipe_list_filter),
-                                            tint = MaterialTheme.colorScheme.primary,
                                         )
                                     }
-                                } else {
-                                    Icon(
-                                        imageVector = Icons.Default.FilterList,
-                                        contentDescription =
-                                            stringResource(Res.string.recipe_list_filter),
-                                    )
                                 }
                             }
-                            AddRecipeMenu(
-                                scanEnabled = state.isScanFromPhotoEnabled,
-                                onCreateClicked = bloc::onAddRecipeClicked,
-                                onScanPicked = bloc::onScanRecipePhotoPicked,
-                            )
+                            RecipeListCoachMark(
+                                id = CoachMarkId.RECIPE_LIST_ADD,
+                                text = Res.string.recipe_list_add_onboarding.asTextData(),
+                                activeCoachMark = state.activeCoachMark,
+                                onDismiss = bloc::onCoachMarkDismissed,
+                            ) {
+                                AddRecipeMenu(
+                                    scanEnabled = state.isScanFromPhotoEnabled,
+                                    onCreateClicked = bloc::onAddRecipeClicked,
+                                    onScanPicked = bloc::onScanRecipePhotoPicked,
+                                )
+                            }
                             OverflowMenu(
                                 onSelectClicked = bloc::onEnterSelectionMode,
                                 onExportAllClicked = bloc::onExportClicked,
@@ -515,6 +548,27 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
  * a photo via Gemini vision (the image picker launches directly from the scan item). When disabled
  * it opens the blank editor directly with no menu, preserving the original add-recipe behaviour.
  */
+/**
+ * Wraps a header control in a first-run coach mark that points up at it (the header sits at the top
+ * of the screen). The bubble only shows while [id] is the shared controller's active mark.
+ */
+@Composable
+private fun RecipeListCoachMark(
+    id: String,
+    text: TextData,
+    activeCoachMark: String?,
+    onDismiss: (String) -> Unit,
+    anchor: @Composable () -> Unit,
+) {
+    PlusOnboardingTooltip(
+        text = text,
+        visible = activeCoachMark == id,
+        onDismiss = { onDismiss(id) },
+        placement = PlusTooltipPlacement.BELOW,
+        anchor = anchor,
+    )
+}
+
 @Composable
 private fun AddRecipeMenu(
     scanEnabled: Boolean,

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkId.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkId.kt
@@ -20,6 +20,30 @@ object CoachMarkId {
     /** The sync button on the grocery list screen. */
     const val GROCERY_LIST_SYNC: String = "grocery_list_sync"
 
+    /** The add-recipe (create/scan) menu on the recipe list screen. */
+    const val RECIPE_LIST_ADD: String = "recipe_list_add"
+
+    /** The grid/list view-mode toggle on the recipe list screen. */
+    const val RECIPE_LIST_VIEW_MODE: String = "recipe_list_view_mode"
+
+    /** The sort/filter button on the recipe list screen. */
+    const val RECIPE_LIST_FILTER: String = "recipe_list_filter"
+
+    /** The add-meal button on the meal plan screen. */
+    const val MEAL_PLAN_ADD_MEAL: String = "meal_plan_add_meal"
+
+    /** The day/week/month view-mode control on the meal plan screen. */
+    const val MEAL_PLAN_VIEW_MODE: String = "meal_plan_view_mode"
+
+    /** The search field on the in-app browser landing screen. */
+    const val BROWSER_SEARCH: String = "browser_search"
+
+    /** The rich-text mode toggle on the edit recipe screen. */
+    const val EDIT_RECIPE_RICH_TEXT: String = "edit_recipe_rich_text"
+
+    /** The save button on the edit recipe screen. */
+    const val EDIT_RECIPE_SAVE: String = "edit_recipe_save"
+
     /**
      * The recipe detail coach marks in the order they should be shown to a first-time user. The
      * controller shows them one at a time, advancing as each is dismissed.
@@ -31,4 +55,17 @@ object CoachMarkId {
             RECIPE_DETAIL_FAVORITE,
             RECIPE_DETAIL_ADD_TO_MEAL_PLAN,
         )
+
+    /** The recipe list coach marks, shown one at a time in order. */
+    val recipeListSequence: List<String> =
+        listOf(RECIPE_LIST_ADD, RECIPE_LIST_VIEW_MODE, RECIPE_LIST_FILTER)
+
+    /** The meal plan coach marks, shown one at a time in order. */
+    val mealPlanSequence: List<String> = listOf(MEAL_PLAN_ADD_MEAL, MEAL_PLAN_VIEW_MODE)
+
+    /** The browser coach marks, shown one at a time in order. */
+    val browserSequence: List<String> = listOf(BROWSER_SEARCH)
+
+    /** The edit recipe coach marks, shown one at a time in order. */
+    val editRecipeSequence: List<String> = listOf(EDIT_RECIPE_RICH_TEXT, EDIT_RECIPE_SAVE)
 }

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkId.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/di/CoachMarkId.kt
@@ -44,6 +44,12 @@ object CoachMarkId {
     /** The save button on the edit recipe screen. */
     const val EDIT_RECIPE_SAVE: String = "edit_recipe_save"
 
+    /** The keep-screen-on (always-on display) toggle on the cook mode screen. */
+    const val COOK_MODE_KEEP_SCREEN_ON: String = "cook_mode_keep_screen_on"
+
+    /** The stacked/split layout (view mode) toggle on the cook mode screen. */
+    const val COOK_MODE_LAYOUT: String = "cook_mode_layout"
+
     /**
      * The recipe detail coach marks in the order they should be shown to a first-time user. The
      * controller shows them one at a time, advancing as each is dismissed.
@@ -68,4 +74,7 @@ object CoachMarkId {
 
     /** The edit recipe coach marks, shown one at a time in order. */
     val editRecipeSequence: List<String> = listOf(EDIT_RECIPE_RICH_TEXT, EDIT_RECIPE_SAVE)
+
+    /** The cook mode coach marks, shown one at a time in order. */
+    val cookModeSequence: List<String> = listOf(COOK_MODE_KEEP_SCREEN_ON, COOK_MODE_LAYOUT)
 }


### PR DESCRIPTION
## What

Extends the existing first-run **coach-mark** system (`CoachMarkController` + `PlusOnboardingTooltip`, already used on Recipe Detail and Grocery List) to the four most-used screens, so a new user gets pointed at each screen's primary actions exactly once.

| Screen | Tooltips (shown one at a time, in order) |
|---|---|
| **Recipe list** | add-recipe menu → grid/list toggle → sort/filter |
| **Meal plan** | add-meal button → day/week/month switcher |
| **Browser** | search field (import recipes from any site) |
| **Edit recipe** | directions field (rich-text formatting) → save |

## How

No new infrastructure — each screen follows the established pattern:

- The view model requests its `CoachMarkId.*Sequence` on open, folds `coachMarkController.activeCoachMark` into state via `combineStates`, dismisses a mark when its control is tapped (only if it's the active one), and `release`s the queue on leave so other screens' marks aren't blocked.
- Screens wrap each anchor in `PlusOnboardingTooltip` via a small per-screen helper.
- The shared controller still guarantees **at most one** tooltip is visible app-wide, and each is persisted as seen so it never shows again. Clear via Developer Settings → "clear all seen".
- The browser landing bloc was stateless, so it gained minimal controller-driven state and releases on `lifecycle.doOnDestroy`.

## Testing

- Per-screen bloc/view-model unit tests cover: first mark active on open, dismiss persists + advances the queue, and inactive-mark dismissals are ignored.
- `:client:recipe:list:impl`, `:client:meal:core:impl`, `:client:browser:impl`, `:client:recipe:core:impl`, and `:client:shared` JVM tests pass.
- `validateDebugScreenshotTest` passes unchanged — the coach-mark bubble renders in a `Popup` (not captured by the screenshot plugin), and previews default to no active mark, so existing screen snapshots are unaffected. The bubble visual itself is already covered by `PlusOnboardingTooltipScreenshotTest`.

## Notes

Commits are split per screen (each bloc with its unit tests), preceded by the shared `CoachMarkId` additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)