### PR TITLE
feat: snackbar/toast service with queueing, actions, and FAB/toolbar lift

### DIFF
--- a/.agents/seed.md
+++ b/.agents/seed.md
@@ -88,6 +88,18 @@ See `docs/architecture.md` for full annotated examples of both patterns.
 - **Prefer a shared `Plus*` component over a raw Material composable when one exists.** For example, use `PlusDialog` instead of Material `AlertDialog`. Check `client/ui/public/.../components` before reaching for a Material primitive.
 - **Spacing/sizing dimensions should come from the theme (`ChefMateTheme.dimens`), not hardcoded `.dp` literals.** Use the closest `AppDimensions` token (`paddingExtraSmall` 4, `paddingSmall` 8, `paddingNormal` 16, `paddingLarge` 24, `paddingExtraLarge` 32, `rowHeight` 56, `fabClearance` 88). Only fall back to a raw `.dp` literal when the value is genuinely off-spec (no matching token); if an off-spec value recurs, add a token to `AppDimensions` instead.
 
+### Snackbars & Toasts
+
+Pick the layer by scope — **do not hand-roll a `SnackbarHostState` + `LaunchedEffect` per screen.**
+
+1. **App-wide toast (default): `ToastService`** (`client/toast/public`). Inject `ToastService` into a BLoC/ViewModel and call `toastService.show(message, actionLabel?, duration?, onAction?)`. A single global host (`ToastScaffold`, wired once in `App.kt`) renders it over every screen — **never add your own host for these.** The service is an `AppScope` singleton, so it's constructor-injectable anywhere; for a composable with no BLoC, use `LocalToastService.current.show(...)`. For an action button, pass `actionLabel` + `onAction` — but route navigation through app-scoped output, since the callback is held only for the toast's lifetime (don't capture a short-lived screen object). Worked example: `RecipeDetailBlocImpl` (added-to-grocery toast with a "View" action).
+
+2. **Screen-local snackbar (only when it must be scoped to one screen): `SnackbarQueue` + `PlusSnackbarHost`.** Hold a `SnackbarQueue` in the BLoC `Model`, `enqueue(...)` onto it from the ViewModel, expose `onSnackbarShown(id)`, and drop `PlusSnackbarHost(state.snackbars, bloc::onSnackbarShown)` into the screen. The queue's monotonic ids make dequeue correct under rapid messages. Worked example: `MealPlanScreen`.
+
+3. **Raw Material `SnackbarHost`** only for a one-off, screen-private message that never needs queueing (e.g. "copied to clipboard").
+
+**Keeping FABs & bottom toolbars clear of a shown snackbar.** A bottom-aligned element can be covered by a snackbar. The shared components handle this for you: `PlusFloatingActionButton` (FABs) and `PlusToolbar` (the bottom horizontal floating toolbar, wrapping Material's `HorizontalFloatingToolbar`) both ride up automatically. Prefer them over the raw Material primitives for bottom-aligned controls. For a **raw FAB, a custom FAB stack, or a hand-rolled bottom bar**, opt in by adding `Modifier.padding(bottom = LocalSnackbarInset.current)` (from `client/ui/public`) to its bottom-aligned root — it animates up while a snackbar is visible and back when it dismisses. Top toolbars (`PlusHeader`) are unaffected and need nothing. Worked example: `RecipeDetailScreen`'s `PlusToolbar` lifts above the added-to-grocery toast.
+
 ### Navigation Animations & Shared Elements
 
 - Navigation (root and per-feature) renders a Decompose `ChildStack` with `Children` + `predictiveBackAnimation`. Use the shared `backAnimation` helper in `client/ui/public/.../BackAnimation.kt` (a `predictiveBackAnimation` with a `slide` fallback). `RootScreen` inlines `predictiveBackAnimation` directly because it varies the fallback by child type (modal screens slide vertically). **Predictive back is the priority** — the system back gesture/animation must keep working across the whole stack.

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -116,6 +116,8 @@ kotlin {
             api(projects.client.settings.impl)
             api(projects.client.settings.root.impl)
             api(projects.client.developerSettings.impl)
+            api(projects.client.toast.impl)
+            api(projects.client.toast.public)
             api(libs.kermit)
             implementation(libs.supabase.client)
             implementation(libs.supabase.auth)

--- a/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/MainActivity.kt
+++ b/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/MainActivity.kt
@@ -23,7 +23,7 @@ class MainActivity : ComponentActivity() {
                 applicationComponent = appComponent,
                 deepLink = parseDeepLink(intent),
             )
-        setContent { App(rootBloc) }
+        setContent { App(rootBloc, appComponent.toastService) }
 
         handleShareIntent(intent)
     }

--- a/client/composeApp/src/commonMain/kotlin/com/plusmobileapps/chefmate/App.kt
+++ b/client/composeApp/src/commonMain/kotlin/com/plusmobileapps/chefmate/App.kt
@@ -7,11 +7,13 @@ import coil3.compose.setSingletonImageLoaderFactory
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import com.plusmobileapps.chefmate.root.RootBloc
 import com.plusmobileapps.chefmate.root.RootScreen
+import com.plusmobileapps.chefmate.toast.ToastScaffold
+import com.plusmobileapps.chefmate.toast.ToastService
 
 @Composable
-fun App(rootBloc: RootBloc, modifier: Modifier = Modifier) {
+fun App(rootBloc: RootBloc, toastService: ToastService, modifier: Modifier = Modifier) {
     setSingletonImageLoaderFactory { context ->
         ImageLoader.Builder(context).components { add(KtorNetworkFetcherFactory()) }.build()
     }
-    RootScreen(rootBloc, modifier)
+    ToastScaffold(toastService = toastService) { RootScreen(rootBloc, modifier) }
 }

--- a/client/composeApp/src/commonMain/kotlin/com/plusmobileapps/chefmate/ApplicationComponent.kt
+++ b/client/composeApp/src/commonMain/kotlin/com/plusmobileapps/chefmate/ApplicationComponent.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
 import com.plusmobileapps.chefmate.di.OnboardingRepository
 import com.plusmobileapps.chefmate.root.RootBloc
+import com.plusmobileapps.chefmate.toast.ToastService
 import com.russhwolf.settings.Settings
 
 interface ApplicationComponent {
@@ -10,4 +11,5 @@ interface ApplicationComponent {
     val authenticationRepository: AuthenticationRepository
     val onboardingRepository: OnboardingRepository
     val settings: Settings
+    val toastService: ToastService
 }

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
@@ -68,6 +68,6 @@ fun runRootBlocTest(
         app.onboardingRepository.setOnboardingCompleted()
     }
     beforeContent(app)
-    setContent { App(rootBloc = app.createRootBloc()) }
+    setContent { App(rootBloc = app.createRootBloc(), toastService = app.toastService) }
     block(app)
 }

--- a/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/MainViewController.kt
+++ b/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/MainViewController.kt
@@ -25,7 +25,11 @@ object MainViewController {
             },
             modifier = Modifier.fillMaxSize(),
         ) {
-            App(rootBloc = rootBloc, modifier = Modifier.fillMaxSize())
+            App(
+                rootBloc = rootBloc,
+                toastService = RootBlocProvider.toastService,
+                modifier = Modifier.fillMaxSize(),
+            )
         }
     }
 }

--- a/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/RootBlocProvider.kt
+++ b/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/RootBlocProvider.kt
@@ -4,10 +4,20 @@ import com.arkivanov.decompose.ComponentContext
 import com.plusmobileapps.chefmate.di.IosApplicationComponent
 import com.plusmobileapps.chefmate.root.DeepLink
 import com.plusmobileapps.chefmate.root.RootBloc
+import com.plusmobileapps.chefmate.toast.ToastService
 import dev.zacsweers.metro.createGraphFactory
 import platform.UIKit.UIApplication
 
 object RootBlocProvider {
+    /**
+     * The app-scoped [ToastService] from the same graph that built the [RootBloc]. Set by
+     * [buildRootBloc] (always called before the UI is created) and read by [MainViewController] so
+     * the toast host observes the very instance BLoCs enqueue onto. Threaded this way to avoid
+     * widening the Swift glue signatures.
+     */
+    lateinit var toastService: ToastService
+        private set
+
     fun buildRootBloc(
         componentContext: ComponentContext,
         application: UIApplication,
@@ -15,6 +25,7 @@ object RootBlocProvider {
     ): RootBloc {
         val applicationComponent =
             createGraphFactory<IosApplicationComponent.Factory>().create(application)
+        toastService = applicationComponent.toastService
         return applicationComponent.rootBlocFactory.create(
             context = DefaultBlocContext(componentContext = componentContext),
             deepLink = DeepLink.parse(deepLinkUrl),

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/main.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/main.kt
@@ -116,7 +116,7 @@ fun main(args: Array<String>) {
                 }
             },
         ) {
-            App(rootBloc = rootBloc)
+            App(rootBloc = rootBloc, toastService = appComponent.toastService)
         }
     }
 }

--- a/client/meal/core/impl/build.gradle.kts
+++ b/client/meal/core/impl/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             implementation(projects.client.recipe.core.public)
             implementation(projects.client.recipe.data.public)
             implementation(projects.client.ui.public)
+            implementation(projects.client.toast.public)
             implementation(libs.arkivanov.decompose.core)
             implementation(libs.arkivanov.decompose.compose.extensions)
             implementation(libs.kotlinx.serialization.json)
@@ -23,6 +24,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(projects.client.util.testing)
+            implementation(projects.client.toast.testing)
             implementation(libs.multiplatform.settings.test)
         }
     }

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocImpl.kt
@@ -58,7 +58,6 @@ class MealPlanBlocImpl(
                 cookingRecipeCount = it.cookingRecipeIds.size,
                 showDoneCookingDialog = it.showDoneCookingDialog,
                 pendingReplaceCookMode = it.pendingReplaceCookMode?.toImmutableList(),
-                snackbarMessage = it.snackbarMessage,
                 activeCoachMark = it.activeCoachMark,
             )
         }
@@ -119,10 +118,6 @@ class MealPlanBlocImpl(
 
     override fun onAddToCookModeClicked(meals: List<MealPlanItem>) {
         viewModel.addToCookMode(meals)
-    }
-
-    override fun onSnackbarShown() {
-        viewModel.clearSnackbar()
     }
 
     override fun onContinueCookingClicked() {

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanViewModel.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanViewModel.kt
@@ -18,6 +18,7 @@ import com.plusmobileapps.chefmate.meal.data.MealType
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.toast.ToastService
 import com.plusmobileapps.chefmate.util.DateTimeUtil
 import dev.zacsweers.metro.Inject
 import kotlin.coroutines.CoroutineContext
@@ -40,6 +41,7 @@ class MealPlanViewModel(
     private val cookingSessionRepository: CookingSessionRepository,
     private val dateTimeUtil: DateTimeUtil,
     private val coachMarkController: CoachMarkController,
+    private val toastService: ToastService,
 ) : ViewModel(mainContext) {
 
     private val _state = MutableStateFlow(State())
@@ -161,9 +163,8 @@ class MealPlanViewModel(
 
     fun confirmReplaceCookMode() {
         val meals = _state.value.pendingReplaceCookMode ?: return
-        _state.update {
-            it.copy(pendingReplaceCookMode = null, snackbarMessage = replacedCookModeMessage(meals))
-        }
+        _state.update { it.copy(pendingReplaceCookMode = null) }
+        toastService.show(replacedCookModeMessage(meals))
         val recipeIds = meals.map { it.recipeId }.distinct()
         scope.launch { cookingSessionRepository.replaceAll(recipeIds) }
     }
@@ -175,15 +176,11 @@ class MealPlanViewModel(
     fun addToCookMode(meals: List<MealPlanItem>) {
         val recipeIds = meals.map { it.recipeId }.distinct()
         if (recipeIds.isEmpty()) return
-        _state.update { it.copy(snackbarMessage = addedToCookModeMessage(meals)) }
+        toastService.show(addedToCookModeMessage(meals))
         scope.launch {
             recipeIds.forEach { cookingSessionRepository.start(it) }
             cookingSessionRepository.markSelected(recipeIds.first())
         }
-    }
-
-    fun clearSnackbar() {
-        _state.update { it.copy(snackbarMessage = null) }
     }
 
     private fun addedToCookModeMessage(meals: List<MealPlanItem>): TextData =
@@ -326,7 +323,6 @@ class MealPlanViewModel(
         val cookingRecipeIds: List<Long> = emptyList(),
         val showDoneCookingDialog: Boolean = false,
         val pendingReplaceCookMode: List<MealPlanItem>? = null,
-        val snackbarMessage: TextData? = null,
         val activeCoachMark: String? = null,
     )
 }

--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/ui/MealPlanPreviews.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/ui/MealPlanPreviews.kt
@@ -84,8 +84,6 @@ private fun mealPlanBloc(model: MealPlanBloc.Model): MealPlanBloc =
 
         override fun onAddToCookModeClicked(meals: List<MealPlanItem>) = Unit
 
-        override fun onSnackbarShown() = Unit
-
         override fun onContinueCookingClicked() = Unit
 
         override fun onDoneCookingClicked() = Unit

--- a/client/meal/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocTest.kt
+++ b/client/meal/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocTest.kt
@@ -20,6 +20,7 @@ import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
+import com.plusmobileapps.chefmate.toast.testing.FakeToastService
 import com.plusmobileapps.chefmate.util.testing.FakeDateTimeUtil
 import com.russhwolf.settings.MapSettings
 import dev.mokkery.answering.returns
@@ -59,6 +60,8 @@ class MealPlanBlocTest {
         everySuspend { stopAll() } returns Unit
     }
 
+    val toastService = FakeToastService()
+
     val bloc =
         MealPlanBlocImpl(
             context = context,
@@ -70,6 +73,7 @@ class MealPlanBlocTest {
                     cookingSessionRepository = cookingSessionRepository,
                     dateTimeUtil = dateTimeUtil,
                     coachMarkController = coachMarkController,
+                    toastService = toastService,
                 )
             },
         )
@@ -287,15 +291,12 @@ class MealPlanBlocTest {
             bloc.onReplaceCookModeClicked(meals)
             bloc.onReplaceCookModeConfirmed()
 
-            bloc.state.test {
-                val state = awaitItem()
-                state.pendingReplaceCookMode shouldBe null
-                state.snackbarMessage shouldBe
-                    PhraseModel(
-                        Res.string.meal_plan_replaced_cook_mode_multiple,
-                        "count" to FixedString("2"),
-                    )
-            }
+            bloc.state.test { awaitItem().pendingReplaceCookMode shouldBe null }
+            toastService.shown.last() shouldBe
+                PhraseModel(
+                    Res.string.meal_plan_replaced_cook_mode_multiple,
+                    "count" to FixedString("2"),
+                )
             verifySuspend { cookingSessionRepository.replaceAll(listOf(10L, 20L)) }
         }
 
@@ -317,13 +318,11 @@ class MealPlanBlocTest {
             bloc.onReplaceCookModeClicked(meals)
             bloc.onReplaceCookModeConfirmed()
 
-            bloc.state.test {
-                awaitItem().snackbarMessage shouldBe
-                    PhraseModel(
-                        Res.string.meal_plan_replaced_cook_mode_single,
-                        "name" to FixedString("Pancakes"),
-                    )
-            }
+            toastService.shown.last() shouldBe
+                PhraseModel(
+                    Res.string.meal_plan_replaced_cook_mode_single,
+                    "name" to FixedString("Pancakes"),
+                )
         }
 
     @Test
@@ -362,14 +361,11 @@ class MealPlanBlocTest {
 
         bloc.onAddToCookModeClicked(meals)
 
-        bloc.state.test {
-            val message = awaitItem().snackbarMessage
-            message shouldBe
-                PhraseModel(
-                    Res.string.meal_plan_added_to_cook_mode_single,
-                    "name" to FixedString("Pancakes"),
-                )
-        }
+        toastService.shown.last() shouldBe
+            PhraseModel(
+                Res.string.meal_plan_added_to_cook_mode_single,
+                "name" to FixedString("Pancakes"),
+            )
         verifySuspend { cookingSessionRepository.start(10) }
         verifySuspend { cookingSessionRepository.markSelected(10) }
     }
@@ -398,33 +394,11 @@ class MealPlanBlocTest {
 
         bloc.onAddToCookModeClicked(meals)
 
-        bloc.state.test {
-            val message = awaitItem().snackbarMessage
-            message shouldBe
-                PhraseModel(
-                    Res.string.meal_plan_added_to_cook_mode_multiple,
-                    "count" to FixedString("2"),
-                )
-        }
-    }
-
-    @Test
-    fun WHEN_snackbar_shown_THEN_message_cleared() = runTest {
-        bloc.onAddToCookModeClicked(
-            listOf(
-                MealPlanItem(
-                    id = 1,
-                    recipeId = 10,
-                    recipeTitle = "Pancakes",
-                    recipeImageUrl = null,
-                    date = "2026-04-17",
-                    mealType = MealType.BREAKFAST,
-                )
+        toastService.shown.last() shouldBe
+            PhraseModel(
+                Res.string.meal_plan_added_to_cook_mode_multiple,
+                "count" to FixedString("2"),
             )
-        )
-        bloc.onSnackbarShown()
-
-        bloc.state.test { awaitItem().snackbarMessage shouldBe null }
     }
 
     @Test
@@ -445,6 +419,7 @@ class MealPlanBlocTest {
                             cookingSessionRepository = sessionRepo,
                             dateTimeUtil = dateTimeUtil,
                             coachMarkController = CoachMarkController(MapSettings()),
+                            toastService = toastService,
                         )
                     },
                 )

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanBloc.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanBloc.kt
@@ -50,8 +50,6 @@ interface MealPlanBloc : ComposeScreen {
 
     fun onAddToCookModeClicked(meals: List<MealPlanItem>)
 
-    fun onSnackbarShown()
-
     fun onContinueCookingClicked()
 
     fun onDoneCookingClicked()
@@ -75,7 +73,6 @@ interface MealPlanBloc : ComposeScreen {
         val cookingRecipeCount: Int = 0,
         val showDoneCookingDialog: Boolean = false,
         val pendingReplaceCookMode: ImmutableList<MealPlanItem>? = null,
-        val snackbarMessage: TextData? = null,
         /** Id of the first-run coach mark currently allowed to show, or null when none. */
         val activeCoachMark: String? = null,
     )

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
@@ -44,16 +44,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
@@ -101,6 +97,7 @@ import com.plusmobileapps.chefmate.meal.data.SyncStatus
 import com.plusmobileapps.chefmate.text.ResourceString
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.LocalSnackbarInset
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
@@ -118,18 +115,6 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun MealPlanScreen(bloc: MealPlanBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
-    val snackbarHostState = remember { SnackbarHostState() }
-    val snackbarText = state.snackbarMessage?.localized()
-
-    LaunchedEffect(snackbarText) {
-        if (snackbarText != null) {
-            try {
-                snackbarHostState.showSnackbar(snackbarText)
-            } finally {
-                bloc.onSnackbarShown()
-            }
-        }
-    }
 
     state.mealToDelete?.let {
         PlusDialog(
@@ -250,7 +235,10 @@ fun MealPlanScreen(bloc: MealPlanBloc, modifier: Modifier = Modifier) {
             CookingSessionFabStack(
                 onContinueClicked = bloc::onContinueCookingClicked,
                 onDoneCookingClicked = bloc::onDoneCookingClicked,
-                modifier = Modifier.align(Alignment.BottomEnd),
+                // Ride up so the app-wide cook-mode toast never covers the FAB stack.
+                modifier =
+                    Modifier.align(Alignment.BottomEnd)
+                        .padding(bottom = LocalSnackbarInset.current),
             )
         }
 
@@ -260,11 +248,6 @@ fun MealPlanScreen(bloc: MealPlanBloc, modifier: Modifier = Modifier) {
                 onDismiss = bloc::onDoneCookingDismissed,
             )
         }
-
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 96.dp),
-        )
     }
 }
 

--- a/client/recipe/core/impl/build.gradle.kts
+++ b/client/recipe/core/impl/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
             implementation(projects.client.recipe.core.public)
             implementation(projects.client.recipe.categories.public)
             implementation(projects.client.ui.public)
+            implementation(projects.client.toast.public)
             implementation(libs.arkivanov.decompose.core)
             implementation(libs.arkivanov.decompose.compose.extensions)
             implementation(projects.client.shared)
@@ -27,6 +28,7 @@ kotlin {
             implementation(projects.client.util.testing)
             implementation(projects.client.recipe.data.testing)
             implementation(projects.client.recipebook.data.testing)
+            implementation(projects.client.toast.testing)
             implementation(libs.multiplatform.settings.test)
         }
     }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -1,5 +1,9 @@
 package com.plusmobileapps.chefmate.recipe.core.impl.detail
 
+import androidx.compose.material3.SnackbarDuration
+import chefmate.client.recipe.core.public.generated.resources.Res
+import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_added
+import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_view
 import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.router.slot.SlotNavigation
 import com.arkivanov.decompose.router.slot.activate
@@ -17,6 +21,8 @@ import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryList
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc.Output
 import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.ResourceString
+import com.plusmobileapps.chefmate.toast.ToastService
 import com.plusmobileapps.chefmate.util.DateTimeUtil
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
 import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
@@ -39,6 +45,7 @@ class RecipeDetailBlocImpl(
     private val dateTimeUtil: DateTimeUtil,
     private val timeFormatterUtil: TimeFormatterUtil,
     private val addToGroceryList: AddRecipeToGroceryListBloc.Factory,
+    private val toastService: ToastService,
 ) : RecipeDetailBloc, BlocContext by context {
     private val scope = createScope()
 
@@ -109,7 +116,6 @@ class RecipeDetailBlocImpl(
                     it.recipe.cookTime?.let { time -> timeFormatterUtil.formatMinutes(time) },
                 formattedTotalTime =
                     it.recipe.totalTime?.let { time -> timeFormatterUtil.formatMinutes(time) },
-                showGroceryAddedSnackbar = it.showGroceryAddedSnackbar,
                 activeCoachMark = it.activeCoachMark,
             )
         }
@@ -174,15 +180,6 @@ class RecipeDetailBlocImpl(
         sheetNavigation.dismiss()
     }
 
-    override fun onViewGroceryListClicked() {
-        viewModel.dismissGroceryAddedSnackbar()
-        output.onNext(Output.OpenGroceryList)
-    }
-
-    override fun onGrocerySnackbarDismissed() {
-        viewModel.dismissGroceryAddedSnackbar()
-    }
-
     override fun onBackClicked() {
         if (fullImageRouter.value.child != null) {
             fullImageNavigation.dismiss()
@@ -205,7 +202,18 @@ class RecipeDetailBlocImpl(
                                         sheetNavigation.dismiss()
                                     AddRecipeToGroceryListBloc.Output.Added -> {
                                         sheetNavigation.dismiss()
-                                        viewModel.showGroceryAddedSnackbar()
+                                        toastService.show(
+                                            message =
+                                                ResourceString(
+                                                    Res.string.recipe_add_to_grocery_list_added
+                                                ),
+                                            actionLabel =
+                                                ResourceString(
+                                                    Res.string.recipe_add_to_grocery_list_view
+                                                ),
+                                            duration = SnackbarDuration.Long,
+                                            onAction = { output.onNext(Output.OpenGroceryList) },
+                                        )
                                     }
                                 }
                             },

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -82,14 +82,6 @@ class RecipeDetailViewModel(
         _output.close()
     }
 
-    fun showGroceryAddedSnackbar() {
-        _state.update { it.copy(showGroceryAddedSnackbar = true) }
-    }
-
-    fun dismissGroceryAddedSnackbar() {
-        _state.update { it.copy(showGroceryAddedSnackbar = false) }
-    }
-
     /**
      * Mark a coach mark seen, but only if it's the one currently showing. This lets a button's tap
      * dismiss its own tip while it's visible, without prematurely consuming tips further down the
@@ -106,7 +98,6 @@ class RecipeDetailViewModel(
         val isDeleting: Boolean = false,
         val showDeleteConfirmationDialog: Boolean = false,
         val recipe: Recipe = Recipe.Empty,
-        val showGroceryAddedSnackbar: Boolean = false,
         val activeCoachMark: String? = null,
     )
 

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
@@ -14,6 +14,7 @@ import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
 import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.toast.testing.FakeToastService
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
 import com.plusmobileapps.chefmate.util.testing.FakeDateTimeUtil
 import com.russhwolf.settings.MapSettings
@@ -93,6 +94,7 @@ class RecipeDetailBlocImplTest {
             dateTimeUtil = dateTimeUtil,
             timeFormatterUtil = timeFormatterUtil,
             addToGroceryList = groceryFactory,
+            toastService = FakeToastService(),
         )
     }
 

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -52,10 +52,6 @@ interface RecipeDetailBloc : BackClickBloc, ComposeScreen {
 
     fun onDismissSheet()
 
-    fun onViewGroceryListClicked()
-
-    fun onGrocerySnackbarDismissed()
-
     data class Model(
         val isLoading: Boolean,
         val isDeleting: Boolean,
@@ -66,7 +62,6 @@ interface RecipeDetailBloc : BackClickBloc, ComposeScreen {
         val formattedPrepTime: TextData? = null,
         val formattedCookTime: TextData? = null,
         val formattedTotalTime: TextData? = null,
-        val showGroceryAddedSnackbar: Boolean = false,
         /** Id of the coach mark currently allowed to show on this screen, or null. */
         val activeCoachMark: String? = null,
     )

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -73,16 +73,13 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SecondaryTabRow
-import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
@@ -117,8 +114,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import chefmate.client.recipe.core.public.generated.resources.Res
-import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_added
-import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_view
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_favorite
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_grocery
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_grocery_onboarding
@@ -177,6 +172,7 @@ import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
+import com.plusmobileapps.chefmate.ui.components.PlusToolbar
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
 import com.plusmobileapps.chefmate.ui.text.toInlineMarkdownAnnotatedString
@@ -199,23 +195,9 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val copiedMessage = stringResource(Res.string.recipe_detail_copied_to_clipboard)
-    val groceryAddedMessage = stringResource(Res.string.recipe_add_to_grocery_list_added)
-    val groceryViewLabel = stringResource(Res.string.recipe_add_to_grocery_list_view)
 
-    LaunchedEffect(state.showGroceryAddedSnackbar) {
-        if (state.showGroceryAddedSnackbar) {
-            val result =
-                snackbarHostState.showSnackbar(
-                    message = groceryAddedMessage,
-                    actionLabel = groceryViewLabel,
-                    duration = SnackbarDuration.Long,
-                )
-            when (result) {
-                SnackbarResult.ActionPerformed -> bloc.onViewGroceryListClicked()
-                SnackbarResult.Dismissed -> bloc.onGrocerySnackbarDismissed()
-            }
-        }
-    }
+    // The "added to grocery list" toast (with its View action) is now fired from the BLoC through
+    // the app-wide ToastService; this screen only hosts the local "copied to clipboard" snackbar.
 
     // Delete confirmation dialog
     if (state.showDeleteConfirmationDialog) {
@@ -414,7 +396,7 @@ private fun RecipeDetailBody(
                 floatingToolbar =
                     letIfTrue(showToolbar) {
                         {
-                            HorizontalFloatingToolbar(
+                            PlusToolbar(
                                 expanded = true,
                                 floatingActionButton = {
                                     RecipeDetailCoachMark(
@@ -1594,7 +1576,10 @@ private fun DirectionLineItem(
                         Modifier
                     }
                 )
-                .padding(vertical = dimens.paddingExtraSmall, horizontal = dimens.paddingExtraSmall),
+                .padding(
+                    vertical = dimens.paddingExtraSmall,
+                    horizontal = dimens.paddingExtraSmall,
+                ),
     )
 }
 
@@ -1856,14 +1841,6 @@ private val previewBloc =
         }
 
         override fun onDismissSheet() {
-            TODO("Not yet implemented")
-        }
-
-        override fun onViewGroceryListClicked() {
-            TODO("Not yet implemented")
-        }
-
-        override fun onGrocerySnackbarDismissed() {
             TODO("Not yet implemented")
         }
 

--- a/client/toast/impl/build.gradle.kts
+++ b/client/toast/impl/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins { alias(libs.plugins.kmpLibrary) }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.toast.public)
+            implementation(projects.client.text.public)
+            implementation(projects.client.ui.public)
+            implementation(projects.client.shared)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlin.coroutines.test)
+            implementation(libs.kotest.assertions)
+            implementation(libs.turbine)
+        }
+    }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.toast.impl"
+    enableDi = true
+    enableTesting = true
+}

--- a/client/toast/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/impl/ToastServiceImpl.kt
+++ b/client/toast/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/impl/ToastServiceImpl.kt
@@ -1,0 +1,36 @@
+package com.plusmobileapps.chefmate.toast.impl
+
+import androidx.compose.material3.SnackbarDuration
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.toast.ToastService
+import com.plusmobileapps.chefmate.ui.components.SnackbarQueue
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class ToastServiceImpl : ToastService {
+
+    private val _queue = MutableStateFlow(SnackbarQueue())
+    override val queue: StateFlow<SnackbarQueue> = _queue.asStateFlow()
+
+    override fun show(
+        message: TextData,
+        actionLabel: TextData?,
+        duration: SnackbarDuration,
+        onAction: (() -> Unit)?,
+    ) {
+        _queue.update { it.enqueue(message, actionLabel, duration, onAction) }
+    }
+
+    override fun onShown(id: Long) {
+        _queue.update { it.dequeue(id) }
+    }
+}

--- a/client/toast/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/toast/impl/ToastServiceImplTest.kt
+++ b/client/toast/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/toast/impl/ToastServiceImplTest.kt
@@ -1,0 +1,42 @@
+package com.plusmobileapps.chefmate.toast.impl
+
+import com.plusmobileapps.chefmate.text.FixedString
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class ToastServiceImplTest {
+
+    @Test
+    fun WHEN_show_called_THEN_message_enqueued() = runTest {
+        val service = ToastServiceImpl()
+
+        service.show(FixedString("Saved"))
+
+        service.queue.value.head?.text shouldBe FixedString("Saved")
+    }
+
+    @Test
+    fun WHEN_multiple_shown_THEN_queued_in_order_with_distinct_ids() = runTest {
+        val service = ToastServiceImpl()
+
+        service.show(FixedString("First"))
+        service.show(FixedString("Second"))
+
+        val messages = service.queue.value.messages
+        messages.map { it.text } shouldBe listOf(FixedString("First"), FixedString("Second"))
+        (messages[0].id == messages[1].id) shouldBe false
+    }
+
+    @Test
+    fun WHEN_onShown_THEN_only_that_message_dequeued() = runTest {
+        val service = ToastServiceImpl()
+        service.show(FixedString("First"))
+        service.show(FixedString("Second"))
+        val firstId = service.queue.value.head?.id ?: error("expected a queued message")
+
+        service.onShown(firstId)
+
+        service.queue.value.head?.text shouldBe FixedString("Second")
+    }
+}

--- a/client/toast/public/build.gradle.kts
+++ b/client/toast/public/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(projects.client.text.public)
+            api(projects.client.ui.public)
+        }
+    }
+}
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.toast" }

--- a/client/toast/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/ToastScaffold.kt
+++ b/client/toast/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/ToastScaffold.kt
@@ -1,0 +1,55 @@
+package com.plusmobileapps.chefmate.toast
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import com.plusmobileapps.chefmate.ui.components.LocalSnackbarInset
+
+/**
+ * App-root wrapper that renders [content] with a single global [ToastServiceHost] overlaid at the
+ * bottom, and makes the toast reachable to everything below it:
+ * - [LocalToastService] so no-BLoC composables can call `show(...)`.
+ * - [LocalSnackbarInset] — the live height of the shown snackbar (animated, `0.dp` when none) — so
+ *   bottom-aligned FABs and toolbars can ride up instead of being covered. See [LocalSnackbarInset]
+ *   for how consumers apply it.
+ *
+ * Place this once, at the app root, around the root navigation.
+ */
+@Composable
+fun ToastScaffold(
+    toastService: ToastService,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    var hostHeight by remember { mutableStateOf(0.dp) }
+    val density = LocalDensity.current
+    // Animate so FABs/toolbars glide up and back rather than jumping as snackbars come and go.
+    val inset by animateDpAsState(hostHeight, label = "snackbarInset")
+
+    CompositionLocalProvider(
+        LocalToastService provides toastService,
+        LocalSnackbarInset provides inset,
+    ) {
+        Box(modifier = modifier.fillMaxSize()) {
+            content()
+            ToastServiceHost(
+                service = toastService,
+                modifier =
+                    Modifier.align(Alignment.BottomCenter).onSizeChanged {
+                        hostHeight = with(density) { it.height.toDp() }
+                    },
+            )
+        }
+    }
+}

--- a/client/toast/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/ToastService.kt
+++ b/client/toast/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/ToastService.kt
@@ -1,0 +1,51 @@
+package com.plusmobileapps.chefmate.toast
+
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.ui.components.SnackbarQueue
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * App-scoped service for enqueuing snackbar ("toast") messages from anywhere — a BLoC, a ViewModel,
+ * or a composable. A single [ToastServiceHost] near the app root drains [queue] and renders the
+ * messages over every screen.
+ *
+ * BLoCs and ViewModels obtain this by constructor injection (it is bound as a singleton in
+ * `AppScope`). Composables that have no BLoC can reach the same instance through
+ * [LocalToastService].
+ */
+interface ToastService {
+    /** The pending messages. Observed by [ToastServiceHost]; not meant for general consumption. */
+    val queue: StateFlow<SnackbarQueue>
+
+    /**
+     * Enqueue a message to be shown. Messages are shown one at a time, in order, none dropped.
+     *
+     * Pass [actionLabel] to add a button; [onAction] runs when it is tapped (never on plain
+     * dismissal). [onAction] is held only until the message is shown and dequeued — for a
+     * navigation action, route through something app-scoped rather than capturing a short-lived
+     * screen object.
+     */
+    fun show(
+        message: TextData,
+        actionLabel: TextData? = null,
+        duration: SnackbarDuration = SnackbarDuration.Short,
+        onAction: (() -> Unit)? = null,
+    )
+
+    /** Called by the host once a message has been displayed and dismissed, so it can be removed. */
+    fun onShown(id: Long)
+}
+
+/**
+ * Hands composables the same [ToastService] singleton DI provides to BLoCs. Provided once at the
+ * app root via `CompositionLocalProvider`. BLoCs/ViewModels should inject [ToastService] directly
+ * rather than reach for this — a CompositionLocal is unreachable from those layers anyway.
+ */
+val LocalToastService =
+    staticCompositionLocalOf<ToastService> {
+        error(
+            "LocalToastService not provided — wrap content in CompositionLocalProvider at App root"
+        )
+    }

--- a/client/toast/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/ToastServiceHost.kt
+++ b/client/toast/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/ToastServiceHost.kt
@@ -1,0 +1,18 @@
+package com.plusmobileapps.chefmate.toast
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.ui.components.PlusSnackbarHost
+
+/**
+ * The single host that displays toasts enqueued through [ToastService]. Place it once near the app
+ * root, above the navigation stack, so messages float over whatever screen is showing. Drains the
+ * service's queue through [PlusSnackbarHost], so messages play in sequence with none dropped.
+ */
+@Composable
+fun ToastServiceHost(service: ToastService, modifier: Modifier = Modifier) {
+    val queue by service.queue.collectAsState()
+    PlusSnackbarHost(queue = queue, onSnackbarShown = service::onShown, modifier = modifier)
+}

--- a/client/toast/testing/build.gradle.kts
+++ b/client/toast/testing/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins { alias(libs.plugins.kmpLibrary) }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.toast.public)
+            implementation(projects.client.text.public)
+            implementation(projects.client.ui.public)
+        }
+    }
+}
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.toast.testing" }

--- a/client/toast/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/testing/FakeToastService.kt
+++ b/client/toast/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/testing/FakeToastService.kt
@@ -1,0 +1,41 @@
+package com.plusmobileapps.chefmate.toast.testing
+
+import androidx.compose.material3.SnackbarDuration
+import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.toast.ToastService
+import com.plusmobileapps.chefmate.ui.components.SnackbarQueue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * In-memory [ToastService] for tests. Behaves like the real one (a working queue) and additionally
+ * records every message passed to [show] in [shown] so BLoC/ViewModel tests can assert what was
+ * enqueued without driving the UI host.
+ */
+class FakeToastService : ToastService {
+
+    private val _queue = MutableStateFlow(SnackbarQueue())
+    override val queue: StateFlow<SnackbarQueue> = _queue.asStateFlow()
+
+    /** Every message passed to [show], in order. */
+    val shown: List<TextData>
+        get() = _shown
+
+    private val _shown = mutableListOf<TextData>()
+
+    override fun show(
+        message: TextData,
+        actionLabel: TextData?,
+        duration: SnackbarDuration,
+        onAction: (() -> Unit)?,
+    ) {
+        _shown += message
+        _queue.update { it.enqueue(message, actionLabel, duration, onAction) }
+    }
+
+    override fun onShown(id: Long) {
+        _queue.update { it.dequeue(id) }
+    }
+}

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusFloatingActionButton.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusFloatingActionButton.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.ui.components
 
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
@@ -19,7 +20,8 @@ fun PlusFloatingActionButton(
     icon: Painter? = null,
 ) {
     ExtendedFloatingActionButton(
-        modifier = modifier,
+        // Ride up so a shown snackbar never covers the FAB.
+        modifier = modifier.padding(bottom = LocalSnackbarInset.current),
         onClick = onClick,
         shape = ChefMateTheme.shapes.extraLarge,
     ) {
@@ -39,7 +41,8 @@ fun PlusFloatingActionButton(
     icon: ImageVector? = null,
 ) {
     ExtendedFloatingActionButton(
-        modifier = modifier,
+        // Ride up so a shown snackbar never covers the FAB.
+        modifier = modifier.padding(bottom = LocalSnackbarInset.current),
         onClick = onClick,
         shape = ChefMateTheme.shapes.extraLarge,
     ) {

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusSnackbarHost.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusSnackbarHost.kt
@@ -1,0 +1,123 @@
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.plusmobileapps.chefmate.text.TextData
+
+/**
+ * The vertical space the currently-shown snackbar occupies at the bottom of the screen, or `0.dp`
+ * when none is showing. Provided by the app-root toast scaffold and animated as snackbars come and
+ * go.
+ *
+ * Apply it as bottom padding on any element that would otherwise sit *under* a snackbar — a
+ * bottom-aligned FAB, a bottom toolbar/nav bar — so it rides up while a snackbar is visible:
+ * `Modifier.padding(bottom = LocalSnackbarInset.current)`. [PlusFloatingActionButton] already does
+ * this; raw FABs and bottom bars must opt in.
+ */
+val LocalSnackbarInset: ProvidableCompositionLocal<Dp> = compositionLocalOf { 0.dp }
+
+/**
+ * A single queued snackbar. [id] is stable so the UI can dequeue exactly what it showed.
+ *
+ * Optionally carries an action: when [actionLabel] is non-null the snackbar shows a button, and
+ * tapping it invokes [onAction]. [onAction] runs only on tap, never on plain dismissal. The lambda
+ * is held for the message's lifetime only (until shown + dequeued), so keep what it captures cheap.
+ */
+@Immutable
+data class SnackbarMessage(
+    val id: Long,
+    val text: TextData,
+    val actionLabel: TextData? = null,
+    val duration: SnackbarDuration = SnackbarDuration.Short,
+    val onAction: (() -> Unit)? = null,
+)
+
+/**
+ * Immutable snackbar queue intended to live in a BLoC `Model`. Holds pending messages plus an
+ * internal monotonic id counter, so enqueue/dequeue stay correct even when the queue empties and
+ * refills — two concurrently-queued messages can never collide on an id.
+ *
+ * BLoC/ViewModel side:
+ * ```
+ * _state.update { it.copy(snackbars = it.snackbars.enqueue(message)) }   // emit
+ * fun onSnackbarShown(id: Long) =
+ *     _state.update { it.copy(snackbars = it.snackbars.dequeue(id)) }     // consume
+ * ```
+ *
+ * Screen side: drop [PlusSnackbarHost] into a `snackbarHost` slot (see [PlusNavContainer]).
+ */
+@Immutable
+data class SnackbarQueue(
+    val messages: List<SnackbarMessage> = emptyList(),
+    private val nextId: Long = 0L,
+) {
+    /** The message currently due to be shown, or null when the queue is empty. */
+    val head: SnackbarMessage?
+        get() = messages.firstOrNull()
+
+    fun enqueue(
+        text: TextData,
+        actionLabel: TextData? = null,
+        duration: SnackbarDuration = SnackbarDuration.Short,
+        onAction: (() -> Unit)? = null,
+    ): SnackbarQueue =
+        copy(
+            messages = messages + SnackbarMessage(nextId, text, actionLabel, duration, onAction),
+            nextId = nextId + 1,
+        )
+
+    fun dequeue(id: Long): SnackbarQueue = copy(messages = messages.filterNot { it.id == id })
+}
+
+/**
+ * Drains a [SnackbarQueue] through a single Material [SnackbarHost]. Shows the
+ * [SnackbarQueue.head], waits for dismissal (Material already serializes display), then calls
+ * [onSnackbarShown] so the BLoC can dequeue and the next message plays. No messages are dropped.
+ *
+ * If the head carries an [SnackbarMessage.actionLabel], its button is shown and tapping it runs
+ * [SnackbarMessage.onAction] before the message is dequeued.
+ *
+ * @param queue the queue from BLoC state.
+ * @param onSnackbarShown called with the shown message's id once it is dismissed.
+ */
+@Composable
+fun PlusSnackbarHost(
+    queue: SnackbarQueue,
+    onSnackbarShown: (id: Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val hostState = remember { SnackbarHostState() }
+    val head = queue.head
+    // localized() must resolve in composition; capture results for the effect below.
+    val text = head?.text?.localized()
+    val actionLabel = head?.actionLabel?.localized()
+
+    LaunchedEffect(head?.id) {
+        if (head != null && text != null) {
+            try {
+                val result =
+                    hostState.showSnackbar(
+                        message = text,
+                        actionLabel = actionLabel,
+                        duration = head.duration,
+                    )
+                if (result == SnackbarResult.ActionPerformed) head.onAction?.invoke()
+            } finally {
+                onSnackbarShown(head.id)
+            }
+        }
+    }
+
+    SnackbarHost(hostState = hostState, modifier = modifier)
+}

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusToolbar.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusToolbar.kt
@@ -1,0 +1,47 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * A bottom-anchored horizontal floating toolbar that automatically rides up above a shown snackbar,
+ * so it is never covered. Wraps Material's [HorizontalFloatingToolbar] and bakes in the
+ * [LocalSnackbarInset] bottom padding — the toolbar equivalent of [PlusFloatingActionButton].
+ * Prefer this over a raw `HorizontalFloatingToolbar` for a screen's bottom action toolbar.
+ *
+ * @param expanded whether the toolbar is expanded; forwarded to [HorizontalFloatingToolbar].
+ * @param floatingActionButton optional FAB shown alongside the toolbar (rides up with it).
+ * @param content the toolbar's action items, laid out in a `Row`.
+ */
+@Composable
+fun PlusToolbar(
+    modifier: Modifier = Modifier,
+    expanded: Boolean = true,
+    floatingActionButton: (@Composable () -> Unit)? = null,
+    content: @Composable RowScope.() -> Unit,
+) {
+    // Lift the toolbar above any shown snackbar.
+    val toolbarModifier = modifier.padding(bottom = LocalSnackbarInset.current)
+    // HorizontalFloatingToolbar exposes the FAB via a separate overload (non-null param), so route
+    // to whichever matches.
+    if (floatingActionButton != null) {
+        HorizontalFloatingToolbar(
+            expanded = expanded,
+            floatingActionButton = floatingActionButton,
+            modifier = toolbarModifier,
+            content = content,
+        )
+    } else {
+        HorizontalFloatingToolbar(
+            expanded = expanded,
+            modifier = toolbarModifier,
+            content = content,
+        )
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -190,6 +190,12 @@ include(":client:testing")
 
 include(":client:text:public")
 
+include(":client:toast:impl")
+
+include(":client:toast:public")
+
+include(":client:toast:testing")
+
 include(":client:ui:public")
 
 include(":client:ui:screenshot-test")


### PR DESCRIPTION
## Summary

Introduces a reusable snackbar/toast system for the app and adopts it on two screens. Builds up from a per-screen queue helper to an app-wide injectable `ToastService`, adds action + duration support, and makes bottom-anchored FABs and toolbars ride up so they're never covered by a shown snackbar.

## What's included

**1. Queue helper (`client/ui/public`)**
- `SnackbarQueue` — an `@Immutable` value type holding pending messages plus a monotonic id counter so enqueue/dequeue stay correct under rapid messages.
- `PlusSnackbarHost` — drains the queue through a single Material `SnackbarHost`; messages play in order, none dropped. This is the building block the `ToastService` host is built on.
- `SnackbarMessage` carries optional `actionLabel`, `duration`, and an `onAction` callback (run only on tap).

**2. App-wide `ToastService` (`client/toast/{public,impl,testing}`)**
- `ToastService` — `AppScope` singleton (`@ContributesBinding`), injectable into any BLoC/ViewModel: `toastService.show(message, actionLabel?, duration?, onAction?)`.
- `ToastServiceHost` / `ToastScaffold` — a single host wired once at the app root (`App.kt`) renders toasts over every screen and exposes `LocalToastService` (for no-BLoC composables) and `LocalSnackbarInset`.
- `FakeToastService` for tests; `ToastServiceImpl` unit-tested.

**3. FAB / toolbar lift**
- `LocalSnackbarInset` — the live, animated height of the shown snackbar (`0.dp` when none), driven by the global toast host.
- `PlusFloatingActionButton` and the new `PlusToolbar` (wraps Material `HorizontalFloatingToolbar`) bake in the inset, so they glide up while a snackbar is visible. Raw/custom controls opt in with `Modifier.padding(bottom = LocalSnackbarInset.current)`.

**4. Adoptions (both go through `ToastService`)**
- `RecipeDetailScreen`'s "added to grocery list" toast (with its **View** action + Long duration); its bottom `PlusToolbar` lifts above it.
- `MealPlanScreen`'s add/replace cook-mode toasts; its cooking FAB stack consumes `LocalSnackbarInset` to lift above them.

**5. Docs** — a "Snackbars & Toasts" section in `.agents/seed.md` documenting when to use each layer and how to keep FABs/toolbars clear.

## Commits
- `feat(ui): add PlusSnackbarHost queue helper`
- `refactor(meal): adopt PlusSnackbarHost queue helper` *(superseded by the ToastService migration below)*
- `feat(toast): add injectable ToastService with app-root host`
- `feat(toast): support snackbar actions and duration`
- `refactor(recipe): show grocery-added toast via ToastService`
- `feat(toast): lift FABs and bottom bars above shown snackbars`
- `docs(agents): document snackbar/toast patterns for new screens`
- `feat(ui): add PlusToolbar that lifts above shown snackbars`
- `refactor(meal): show cook-mode toasts via ToastService`

## Verification
Compiles on JVM (incl. the DI graph), iOS, and JVM test sources. `ToastServiceImplTest`, `RecipeDetailBlocImplTest`, and `MealPlanBlocTest` pass.

## Notes for review
- Both adopted toasts are now **global** (float over whatever screen is showing) rather than screen-scoped. Their actions/navigation route through still-alive root output, so they remain correct across navigation.
- `LocalSnackbarInset` is driven by the **global** toast host, so the FAB/toolbar lift applies to `ToastService` toasts.
- No new screenshot tests (the touched screens render identically at `inset = 0` with no toast shown). A `PlusToolbar` snapshot (toast visible vs not) is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)