### PR TITLE
refactor(toast): migrate remaining SnackbarHost usages to ToastService

### DIFF
--- a/client/recipe/core/public/build.gradle.kts
+++ b/client/recipe/core/public/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation(projects.client.shared)
             implementation(projects.client.ui.public)
+            implementation(projects.client.toast.public)
             implementation(projects.client.util.public)
             implementation(projects.client.grocery.data.public)
             implementation(projects.client.grocery.core.public)

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -78,8 +78,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SecondaryTabRow
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
@@ -161,8 +159,10 @@ import com.plusmobileapps.chefmate.recipe.data.IngredientSection
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
+import com.plusmobileapps.chefmate.text.ResourceString
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.toast.LocalToastService
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.LocalAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.LocalSecondaryAnimatedVisibilityScope
@@ -180,7 +180,6 @@ import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import com.plusmobileapps.chefmate.util.rememberShareLauncher
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -192,12 +191,9 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val shareLauncher = rememberShareLauncher()
-    val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
-    val copiedMessage = stringResource(Res.string.recipe_detail_copied_to_clipboard)
 
-    // The "added to grocery list" toast (with its View action) is now fired from the BLoC through
-    // the app-wide ToastService; this screen only hosts the local "copied to clipboard" snackbar.
+    // The "added to grocery list" toast (with its View action) is fired from the BLoC through the
+    // app-wide ToastService; the "copied to clipboard" toast below goes through the same service.
 
     // Delete confirmation dialog
     if (state.showDeleteConfirmationDialog) {
@@ -256,10 +252,7 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
                             onShowOverflowMenuChange = { showOverflowMenu = it },
                             metadataCollapsed = metadataCollapsed,
                             onMetadataCollapsedChange = { metadataCollapsed = it },
-                            snackbarHostState = snackbarHostState,
                             shareLauncher = shareLauncher,
-                            copiedMessage = copiedMessage,
-                            scope = scope,
                         )
                     }
                 }
@@ -277,11 +270,10 @@ private fun RecipeDetailBody(
     onShowOverflowMenuChange: (Boolean) -> Unit,
     metadataCollapsed: Boolean,
     onMetadataCollapsedChange: (Boolean) -> Unit,
-    snackbarHostState: SnackbarHostState,
     shareLauncher: (String) -> Boolean,
-    copiedMessage: String,
-    scope: CoroutineScope,
 ) {
+    val toastService = LocalToastService.current
+    val copiedMessage = ResourceString(Res.string.recipe_detail_copied_to_clipboard)
     Box(modifier = Modifier.fillMaxSize().testTag(RecipeDetailTestTags.SCREEN)) {
         PlusResponsiveContainer(modifier = Modifier.fillMaxSize()) { windowSizeClass ->
             val isCompact = windowSizeClass == WindowSizeClass.COMPACT
@@ -336,11 +328,7 @@ private fun RecipeDetailBody(
                                                 onClick = {
                                                     onShowOverflowMenuChange(false)
                                                     if (shareLauncher(url)) {
-                                                        scope.launch {
-                                                            snackbarHostState.showSnackbar(
-                                                                copiedMessage
-                                                            )
-                                                        }
+                                                        toastService.show(copiedMessage)
                                                     }
                                                 },
                                             )
@@ -361,11 +349,7 @@ private fun RecipeDetailBody(
                                                 if (
                                                     shareLauncher(formatRecipeAsText(state.recipe))
                                                 ) {
-                                                    scope.launch {
-                                                        snackbarHostState.showSnackbar(
-                                                            copiedMessage
-                                                        )
-                                                    }
+                                                    toastService.show(copiedMessage)
                                                 }
                                             },
                                         )
@@ -548,10 +532,6 @@ private fun RecipeDetailBody(
                 }
             }
         }
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 96.dp),
-        )
     }
 }
 

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
@@ -186,7 +186,11 @@ private fun BottomBarBox(
                     end =
                         with(density) {
                             WindowInsets.displayCutout.getRight(density, LayoutDirection.Ltr).toDp()
-                        }
+                        },
+                    // Bottom breathing room the (now-removed) snackbar slot used to reserve below
+                    // the FAB. Kept so the FAB sits exactly where it did before the toast
+                    // migration.
+                    bottom = ChefMateTheme.dimens.paddingNormal,
                 )
         ) {
             Spacer(modifier = Modifier.weight(1f))

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
@@ -71,7 +71,6 @@ fun PlusHeaderContainer(
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     scrollEnabled: Boolean = true,
     maxContentWidth: Dp = PlusHeaderContainerDefaults.MaxContentWidth,
-    snackbarHost: @Composable () -> Unit = {},
     floatingActionButton: @Composable () -> Unit = {},
     floatingToolbar: (@Composable () -> Unit)? = null,
     floatingHeader: Boolean = false,
@@ -113,7 +112,6 @@ fun PlusHeaderContainer(
                     BottomBarBox(
                         density = density,
                         floatingActionButton = floatingActionButton,
-                        snackbarHost = snackbarHost,
                     )
                     floatingToolbar?.let {
                         Box(modifier = Modifier.align(BottomCenter).floatingToolbarPadding()) {
@@ -162,7 +160,6 @@ fun PlusHeaderContainer(
                     BottomBarBox(
                         density = density,
                         floatingActionButton = floatingActionButton,
-                        snackbarHost = snackbarHost,
                     )
 
                     floatingToolbar?.let {
@@ -180,7 +177,6 @@ fun PlusHeaderContainer(
 private fun BottomBarBox(
     density: Density,
     floatingActionButton: @Composable (() -> Unit),
-    snackbarHost: @Composable (() -> Unit),
 ) {
     Column {
         Spacer(modifier = Modifier.weight(1f))
@@ -197,13 +193,6 @@ private fun BottomBarBox(
             Box(modifier = Modifier.padding(end = ChefMateTheme.dimens.paddingNormal)) {
                 floatingActionButton()
             }
-        }
-
-        Box(
-            modifier = Modifier.fillMaxWidth().padding(top = ChefMateTheme.dimens.paddingNormal),
-            contentAlignment = Alignment.Center,
-        ) {
-            snackbarHost()
         }
         Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.systemBars))
     }

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusNavContainer.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusNavContainer.kt
@@ -7,13 +7,10 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 
 /** A container to embed with a [PlusNavContainer]. */
 @Composable
@@ -21,7 +18,6 @@ fun PlusNavContainer(
     data: PlusHeaderData,
     scrollEnabled: Boolean = true,
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
-    snackbarHost: @Composable () -> Unit = {},
     content: @Composable ColumnScope.() -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -40,9 +36,6 @@ fun PlusNavContainer(
         Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
             Column(modifier = contentModifier, verticalArrangement = verticalArrangement) {
                 content()
-            }
-            Box(modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 8.dp)) {
-                snackbarHost()
             }
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to [#319](https://github.com/Plus-Mobile-Apps/chef-mate/pull/319), which introduced the app-wide `ToastService` but left a few legacy `SnackbarHost` usages behind. This finishes the migration so **no screen hosts its own snackbar** — every toast now flows through the single app-root `ToastServiceHost`.

## What changed

- **`RecipeDetailScreen`** — the local "copied to clipboard" snackbar now fires through `LocalToastService.show(...)` instead of a screen-scoped `SnackbarHostState`. Removed the `SnackbarHost` render and the `rememberCoroutineScope`/`scope.launch` plumbing it required, plus the now-unused params (`snackbarHostState`, `copiedMessage`, `scope`) and imports.
  - Added `implementation(projects.client.toast.public)` to `client/recipe/core/public/build.gradle.kts` so the screen can reach `LocalToastService`.
- **`PlusHeaderContainer`** / **`PlusNavContainer`** — removed the now-dead `snackbarHost: @Composable () -> Unit` parameters (no callers passed them after #319's migration) and their render blocks, along with the imports they orphaned.

## Why

`#319` migrated the grocery-list and cook-mode toasts but intentionally scoped down, leaving `RecipeDetailScreen`'s clipboard snackbar and two unused container parameters. Consolidating everything onto `ToastService` removes the last bits of per-screen snackbar state and the dead API surface.

## Notes for reviewers

- The clipboard toast uses the no-BLoC path documented on `ToastService` (`LocalToastService` for composables without a BLoC), matching the service's intended usage.
- `LocalSnackbarInset` (FAB/toolbar lift) is untouched — that's part of the new toast system, not a snackbar host.
- Removing the `snackbarHost` parameters is an API change to two public UI components, but nothing in the repo passed them anymore, so it's a safe removal.

## Verification

- `:client:recipe:core:public` and `:client:ui:public` compile (JVM)
- `:client:recipe:core:impl:jvmTest` passes
- ktfmt 0.63 (pre-commit formatter) reports no changes needed
- Grep confirms no `SnackbarHost`/`snackbarHost` references remain outside the toast infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)