### PR TITLE
fix(recipe): unique ids for add-to-grocery ingredients

### DIFF
--- a/client/recipe/core/impl/build.gradle.kts
+++ b/client/recipe/core/impl/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
             implementation(projects.client.util.testing)
             implementation(projects.client.recipe.data.testing)
             implementation(projects.client.recipebook.data.testing)
+            implementation(projects.client.grocery.data.testing)
             implementation(projects.client.toast.testing)
             implementation(libs.multiplatform.settings.test)
         }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListViewModel.kt
@@ -129,10 +129,10 @@ class AddRecipeToGroceryListViewModel(
                 recipe.ingredients
                     .split("\n")
                     .filter { it.isNotBlank() && !IngredientSection.isHeader(it) }
-                    .map { raw ->
+                    .mapIndexed { index, raw ->
                         val parsed = IngredientParser.parse(raw)
                         ListItem(
-                            id = raw.hashCode(),
+                            id = index,
                             name = raw,
                             displayName = parsed.name,
                             quantity = parsed.quantity,

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListViewModelTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListViewModelTest.kt
@@ -1,0 +1,79 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
+
+package com.plusmobileapps.chefmate.recipe.core.impl.addgrocery
+
+import com.plusmobileapps.chefmate.grocery.data.testing.FakeGroceryRepository
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
+import com.russhwolf.settings.MapSettings
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+class AddRecipeToGroceryListViewModelTest {
+
+    private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
+    private val recipeRepository = FakeRecipeRepository(recipes)
+    private val groceryRepository = FakeGroceryRepository()
+
+    private fun recipe(ingredients: String): Recipe =
+        Recipe(
+            id = 1L,
+            title = "Soup",
+            description = null,
+            ingredients = ingredients,
+            directions = "cook",
+            imageUrl = null,
+            sourceUrl = null,
+            servings = 2,
+            prepTime = 5,
+            cookTime = 10,
+            totalTime = 15,
+            calories = 100,
+            starRating = null,
+            isFavorite = false,
+            createdAt = Instant.parse("2024-01-01T00:00:00Z"),
+            updatedAt = Instant.parse("2024-01-02T00:00:00Z"),
+        )
+
+    private fun createViewModel(recipe: Recipe): AddRecipeToGroceryListViewModel {
+        recipes.value = listOf(recipe)
+        return AddRecipeToGroceryListViewModel(
+            recipeId = recipe.id,
+            mainContext = UnconfinedTestDispatcher(),
+            recipeRepository = recipeRepository,
+            groceryRepository = groceryRepository,
+            settings = MapSettings(),
+        )
+    }
+
+    @Test
+    fun When_recipe_has_duplicate_ingredient_lines_Then_each_item_has_a_unique_id() {
+        // Two identical lines previously collided on raw.hashCode(), producing a duplicate
+        // LazyColumn key and crashing the screen.
+        val viewModel = createViewModel(recipe(ingredients = "Salt\nSalt"))
+
+        val items = viewModel.state.value.groupedIngredients.flatMap { it.items }
+
+        items.size shouldBe 2
+        items.map { it.id }.toSet().size shouldBe 2
+    }
+
+    @Test
+    fun When_one_of_two_duplicate_ingredients_toggled_Then_only_that_item_changes() {
+        // Sharing an id between duplicates would have toggled both rows at once.
+        val viewModel = createViewModel(recipe(ingredients = "Salt\nSalt"))
+        val items = viewModel.state.value.groupedIngredients.flatMap { it.items }
+
+        viewModel.toggleIngredient(items.first().id)
+
+        val updated = viewModel.state.value.groupedIngredients.flatMap { it.items }
+        updated.map { it.isSelected } shouldContainExactly listOf(false, true)
+    }
+}


### PR DESCRIPTION
## Problem

The add-to-grocery-list screen crashes with:

```
kotlin.IllegalArgumentException: Key "-1039138716" was already used.
If you are using LazyColumn/Row please make sure you provide a unique key for each item.
```

Ingredient ids were derived from `raw.hashCode()`. When a recipe has two identical ingredient lines (e.g. `Salt` twice), both map to the same id. That id is used as the `LazyColumn` item key in `GroceryGroupedList`, so the duplicate key throws and crashes the screen. The crash key `-1039138716` is exactly such a hash value.

The shared id also caused a latent bug: because `toggleIngredient` matches by id, toggling one duplicate row would toggle every row with the same text.

## Fix

Use the ingredient's filtered index as the id (`mapIndexed`) — unique and stable for a given recipe — instead of the content hash.

## Test

Adds `AddRecipeToGroceryListViewModelTest` covering:
- duplicate ingredient lines each get a unique id (the crash invariant)
- toggling one of two duplicate rows changes only that row

🤖 Generated with [Claude Code](https://claude.com/claude-code)