### PR TITLE
feat(grocery): scroll to and highlight newly added item

### DIFF
--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryGroupedList.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryGroupedList.kt
@@ -1,6 +1,9 @@
 package com.plusmobileapps.chefmate.grocery.core.list
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,6 +12,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckBox
 import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
@@ -19,6 +24,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -43,6 +50,9 @@ data class GroceryDisplayItem(
 
 data class GroceryDisplayGroup(val category: GroceryCategory, val items: List<GroceryDisplayItem>)
 
+/** Peak opacity of the brief highlight shown on a freshly added grocery item. */
+private const val HIGHLIGHT_PEAK_ALPHA = 0.5f
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun GroceryGroupedList(
@@ -50,11 +60,13 @@ fun GroceryGroupedList(
     onItemClick: (Any) -> Unit,
     onCheckedChange: (Any) -> Unit,
     modifier: Modifier = Modifier,
+    state: LazyListState = rememberLazyListState(),
     showHeaders: Boolean = true,
+    highlightedKey: Any? = null,
     trailingContent: (@Composable (GroceryDisplayItem) -> Unit)? = null,
     footer: (LazyListScope.() -> Unit)? = null,
 ) {
-    LazyColumn(modifier = modifier.fillMaxSize()) {
+    LazyColumn(state = state, modifier = modifier.fillMaxSize()) {
         groups.forEach { group ->
             if (showHeaders) {
                 stickyHeader(key = "header_${group.category.name}") {
@@ -68,6 +80,7 @@ fun GroceryGroupedList(
                     onCheckedChange = { onCheckedChange(item.key) },
                     onClick = { onItemClick(item.key) },
                     trailingContent = trailingContent,
+                    highlighted = item.key == highlightedKey,
                     modifier = Modifier.animateItem(),
                 )
                 HorizontalDivider()
@@ -96,9 +109,27 @@ private fun GroceryDisplayListItem(
     onClick: () -> Unit,
     trailingContent: (@Composable (GroceryDisplayItem) -> Unit)?,
     modifier: Modifier = Modifier,
+    highlighted: Boolean = false,
 ) {
+    // Briefly tint the row when it's the freshly added item, then fade back to transparent so the
+    // user can see where it landed in the list.
+    val highlightColor = MaterialTheme.colorScheme.primaryContainer
+    val highlightAlpha = remember { Animatable(0f) }
+    LaunchedEffect(highlighted) {
+        if (highlighted) {
+            highlightAlpha.snapTo(HIGHLIGHT_PEAK_ALPHA)
+            highlightAlpha.animateTo(
+                targetValue = 0f,
+                animationSpec = tween(durationMillis = 1200, delayMillis = 400),
+            )
+        }
+    }
     Row(
-        modifier = modifier.fillMaxWidth().clickable(onClick = onClick),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(highlightColor.copy(alpha = highlightAlpha.value))
+                .clickable(onClick = onClick),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(onClick = onCheckedChange) {

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -190,6 +191,29 @@ fun GroceryListScreen(
             }
         }
 
+    // When the user adds an item from the input, scroll it into view and briefly highlight it. We
+    // can't know the new item's id up front, so we flag the pending add and, on the next state that
+    // introduces an id we hadn't seen, treat that id as the freshly added item.
+    val listState = rememberLazyListState()
+    var highlightedItemKey by remember { mutableStateOf<Long?>(null) }
+    var awaitingAddedItem by remember { mutableStateOf(false) }
+    var knownItemIds by remember { mutableStateOf<Set<Long>>(emptySet()) }
+
+    LaunchedEffect(state.groupedItems) {
+        val currentIds = state.groupedItems.flatMap { group -> group.items.map { it.id } }.toSet()
+        if (awaitingAddedItem) {
+            val addedId = (currentIds - knownItemIds).firstOrNull()
+            if (addedId != null) {
+                awaitingAddedItem = false
+                highlightedItemKey = addedId
+                val showHeaders = state.sort == GroceryListBloc.GrocerySort.AISLE
+                val index = state.groupedItems.flatIndexOfItem(addedId, showHeaders)
+                if (index >= 0) listState.animateScrollToItem(index)
+            }
+        }
+        knownItemIds = currentIds
+    }
+
     PlusResponsiveContainer(
         modifier = modifier.testTag(GroceryListTestTags.SCREEN).fillMaxSize()
     ) { windowSizeClass ->
@@ -343,7 +367,9 @@ fun GroceryListScreen(
                                     .pointerInput(Unit) {
                                         detectTapGestures(onTap = { focusManager.clearFocus() })
                                     },
+                            state = listState,
                             showHeaders = state.sort == GroceryListBloc.GrocerySort.AISLE,
+                            highlightedKey = highlightedItemKey,
                             trailingContent = { displayItem ->
                                 val item = itemLookup[displayItem.key as Long]
                                 if (item != null) {
@@ -361,7 +387,10 @@ fun GroceryListScreen(
                         name = bloc.newGroceryItemName,
                         suggestions = state.autocompleteSuggestions,
                         onNameChange = bloc::onNewGroceryItemNameChange,
-                        onAddClick = bloc::saveGroceryItem,
+                        onAddClick = {
+                            awaitingAddedItem = true
+                            bloc.saveGroceryItem()
+                        },
                         forceShowSuggestions = forceShowAutocompleteSuggestions,
                     )
                 }
@@ -410,6 +439,26 @@ fun GroceryListScreen(
 
         GroceryDetailSheet(bloc = bloc)
     }
+}
+
+/**
+ * Flattened index of the item with [id] within the lazy list, accounting for the per-category
+ * sticky headers when [showHeaders] is set. Mirrors the layout built in [GroceryGroupedList].
+ * Returns -1 when the item isn't present.
+ */
+private fun List<GroceryListBloc.GroceryGroup>.flatIndexOfItem(
+    id: Long,
+    showHeaders: Boolean,
+): Int {
+    var index = 0
+    forEach { group ->
+        if (showHeaders) index++
+        group.items.forEach { item ->
+            if (item.id == id) return index
+            index++
+        }
+    }
+    return -1
 }
 
 @Composable


### PR DESCRIPTION
## What

When an item is added from the grocery list input, the list now **scrolls the new item into view** and shows a **brief, fading highlight** on its row so the user can see where it landed.

## How

- **`GroceryGroupedList`** — hoisted a `LazyListState` parameter so callers can drive scrolling, and added a `highlightedKey` parameter. The matching row animates a `primaryContainer` tint that snaps to ~0.5 alpha and fades to transparent over ~1.2s (after a short beat), driven by an `Animatable`.
- **`GroceryListScreen`** — the Add action sets an `awaitingAddedItem` flag, then calls `bloc.saveGroceryItem()`. A `LaunchedEffect(state.groupedItems)` diffs current item ids against the previously-seen set; the first id to appear after an add becomes the `highlightedKey`, and the list animate-scrolls to its flattened index (accounting for sticky category headers in AISLE sort).

## Why this approach

`repository.addGrocery(listId, name)` returns nothing and the new DB id (`AUTOINCREMENT`) isn't surfaced anywhere. Plumbing it back would ripple through the `GroceryRepository` interface, both `addGrocery` overloads, the SQLDelight query, the fakes, and their tests. Detecting the new id by diffing keys keeps the change entirely in the UI layer and correctly handles duplicate item names (it keys on id, not text).

## Notes
- Only adds **from the input** trigger this (both the trailing "+" button and the keyboard Done action, which are already gated on non-blank text). Items arriving via sync or recipe-import just update the seen-set silently.
- If an active purchase filter would hide the just-added item, nothing highlights — and it won't false-fire, since the flag waits specifically for a *new* id to appear.

## Testing
- `:client:grocery:core:public` compiles. Not yet exercised via UI/screenshot tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)