### PR TITLE
feat(grocery): keep keyboard open on add, anchor bottom nav

### DIFF
--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -3,11 +3,8 @@
 package com.plusmobileapps.chefmate.recipe.bottomnav
 
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -26,7 +23,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import chefmate.client.bottomnav.public.generated.resources.Res
 import chefmate.client.bottomnav.public.generated.resources.tab_browser
@@ -71,8 +67,7 @@ fun BottomNavigationScreen(bloc: BottomNavBloc, modifier: Modifier = Modifier) {
                 else -> NavigationLayout.SIDE_EXPANDED
             }
         when (layout) {
-            NavigationLayout.BOTTOM ->
-                MobileBottomNavContent(modifier = Modifier.imePadding(), bloc = bloc)
+            NavigationLayout.BOTTOM -> MobileBottomNavContent(bloc = bloc)
             NavigationLayout.SIDE_COMPACT ->
                 SideNavContent(modifier = Modifier.imePadding(), bloc = bloc, expandedItems = false)
             NavigationLayout.SIDE_EXPANDED ->
@@ -113,23 +108,17 @@ private fun SideNavContent(
 @Composable
 private fun MobileBottomNavContent(bloc: BottomNavBloc, modifier: Modifier = Modifier) {
     val state = bloc.state.collectAsState()
-    val density = LocalDensity.current
-    val isImeVisible = WindowInsets.ime.getBottom(density) > 0
     Scaffold(
         modifier = modifier.fillMaxSize(),
-        bottomBar = {
-            if (!isImeVisible) {
-                PlusBottomBar(state = state.value, onClick = bloc::onTabSelected)
-            }
-        },
+        bottomBar = { PlusBottomBar(state = state.value, onClick = bloc::onTabSelected) },
     ) { paddingValues ->
-        val contentPadding =
-            if (isImeVisible) {
-                PaddingValues(top = paddingValues.calculateTopPadding())
-            } else {
-                paddingValues
-            }
-        BottomNavContentContainer(modifier = Modifier.padding(contentPadding), bloc = bloc)
+        // The bottom bar stays anchored at the bottom of the screen; only the content gets ime
+        // padding so an open keyboard pushes the content (e.g. the grocery input) up and shrinks
+        // the scrollable area above the bar instead of hiding the navigation.
+        BottomNavContentContainer(
+            modifier = Modifier.padding(paddingValues).imePadding(),
+            bloc = bloc,
+        )
     }
 }
 

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -3,6 +3,7 @@
 package com.plusmobileapps.chefmate.recipe.bottomnav
 
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -115,8 +116,14 @@ private fun MobileBottomNavContent(bloc: BottomNavBloc, modifier: Modifier = Mod
         // The bottom bar stays anchored at the bottom of the screen; only the content gets ime
         // padding so an open keyboard pushes the content (e.g. the grocery input) up and shrinks
         // the scrollable area above the bar instead of hiding the navigation.
+        //
+        // consumeWindowInsets marks the bottom-bar/navigation-bar inset (already applied via
+        // paddingValues) as consumed, so imePadding only adds the *remaining* keyboard height.
+        // Without this, the open keyboard would be padded on top of the nav-bar inset that it
+        // already covers, leaving a gap the size of the bottom bar between the input and keyboard.
         BottomNavContentContainer(
-            modifier = Modifier.padding(paddingValues).imePadding(),
+            modifier =
+                Modifier.padding(paddingValues).consumeWindowInsets(paddingValues).imePadding(),
             bloc = bloc,
         )
     }

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -806,6 +806,10 @@ private fun GroceryListInput(
     val focusManager = LocalFocusManager.current
     var isFocused by remember { mutableStateOf(false) }
     val expanded = (isFocused || forceShowSuggestions) && suggestions.isNotEmpty()
+    val dismissKeyboard: () -> Unit = {
+        focusManager.clearFocus()
+        keyboardController?.hide()
+    }
 
     Column(modifier = modifier) {
         // Suggestions render directly above the field rather than as a downward dropdown: the input
@@ -822,6 +826,7 @@ private fun GroceryListInput(
                 onValueChange = onNameChange,
                 onFocusChanged = { isFocused = it },
                 onAddClick = onAddClick,
+                onDismissKeyboard = dismissKeyboard,
                 modifier = Modifier.weight(1f),
             )
             AnimatedVisibility(
@@ -829,12 +834,7 @@ private fun GroceryListInput(
                 enter = fadeIn() + expandHorizontally(),
                 exit = fadeOut() + shrinkHorizontally(),
             ) {
-                TextButton(
-                    onClick = {
-                        focusManager.clearFocus()
-                        keyboardController?.hide()
-                    }
-                ) {
+                TextButton(onClick = dismissKeyboard) {
                     Text(stringResource(Res.string.grocery_done))
                 }
             }
@@ -874,6 +874,7 @@ private fun GroceryItemNameTextField(
     onValueChange: (String) -> Unit,
     onFocusChanged: (Boolean) -> Unit,
     onAddClick: () -> Unit,
+    onDismissKeyboard: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     OutlinedTextField(
@@ -891,9 +892,13 @@ private fun GroceryItemNameTextField(
                 capitalization = KeyboardCapitalization.Sentences,
                 imeAction = ImeAction.Send,
             ),
-        // Submits the item but keeps the keyboard open so the user can keep entering items. The
-        // keyboard is dismissed via the Done button or by scrolling the list instead.
-        keyboardActions = KeyboardActions(onSend = { if (value.isNotBlank()) onAddClick() }),
+        // Submits the item and keeps the keyboard open so the user can keep entering items. On an
+        // empty field the action instead dismisses the keyboard, matching the Done button and
+        // scroll-to-dismiss gestures.
+        keyboardActions =
+            KeyboardActions(
+                onSend = { if (value.isNotBlank()) onAddClick() else onDismissKeyboard() }
+            ),
         trailingIcon = {
             IconButton(onClick = onAddClick, enabled = value.isNotBlank()) {
                 Icon(

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -46,10 +46,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuAnchorType
-import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -75,6 +72,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -794,7 +792,6 @@ private fun DeleteItemsDialog(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun GroceryListInput(
     name: StateFlow<String>,
@@ -811,39 +808,19 @@ private fun GroceryListInput(
     val expanded = (isFocused || forceShowSuggestions) && suggestions.isNotEmpty()
 
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
-        if (forceShowSuggestions && suggestions.isNotEmpty()) {
-            Column(modifier = Modifier.weight(1f)) {
+        // Suggestions render directly above the field rather than as a downward dropdown: the input
+        // is anchored at the bottom of the screen, so a dropdown would open behind the keyboard
+        // (especially on iOS, where it doesn't flip above the anchor).
+        Column(modifier = Modifier.weight(1f)) {
+            if (expanded) {
                 AutocompleteSuggestionRows(suggestions = suggestions, onNameChange = onNameChange)
-                GroceryItemNameTextField(
-                    value = state.value,
-                    onValueChange = onNameChange,
-                    onFocusChanged = { isFocused = it },
-                    onAddClick = onAddClick,
-                )
             }
-        } else {
-            ExposedDropdownMenuBox(
-                expanded = expanded,
-                onExpandedChange = {},
-                modifier = Modifier.weight(1f),
-            ) {
-                GroceryItemNameTextField(
-                    value = state.value,
-                    onValueChange = onNameChange,
-                    onFocusChanged = { isFocused = it },
-                    onAddClick = onAddClick,
-                    modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable),
-                )
-                ExposedDropdownMenu(expanded = expanded, onDismissRequest = {}) {
-                    suggestions.forEach { suggestion ->
-                        DropdownMenuItem(
-                            text = { Text(suggestion) },
-                            onClick = { onNameChange(suggestion) },
-                            modifier = Modifier.testTag(GroceryListTestTags.ITEM_SUGGESTION),
-                        )
-                    }
-                }
-            }
+            GroceryItemNameTextField(
+                value = state.value,
+                onValueChange = onNameChange,
+                onFocusChanged = { isFocused = it },
+                onAddClick = onAddClick,
+            )
         }
         AnimatedVisibility(
             visible = isFocused,
@@ -874,8 +851,13 @@ private fun AutocompleteSuggestionRows(suggestions: List<String>, onNameChange: 
             suggestions.forEach { suggestion ->
                 ListItem(
                     headlineContent = { Text(suggestion) },
+                    // canFocus = false keeps the row clickable without stealing focus from the text
+                    // field. Otherwise tapping a suggestion unfocuses the field, which collapses
+                    // the
+                    // list (it's gated on focus) and removes the row before the tap can register.
                     modifier =
-                        Modifier.clickable { onNameChange(suggestion) }
+                        Modifier.focusProperties { canFocus = false }
+                            .clickable { onNameChange(suggestion) }
                             .testTag(GroceryListTestTags.ITEM_SUGGESTION),
                 )
             }
@@ -904,11 +886,11 @@ private fun GroceryItemNameTextField(
         keyboardOptions =
             KeyboardOptions(
                 capitalization = KeyboardCapitalization.Sentences,
-                imeAction = ImeAction.Done,
+                imeAction = ImeAction.Send,
             ),
-        // Adds the item but keeps the keyboard open so the user can keep entering items. The
+        // Submits the item but keeps the keyboard open so the user can keep entering items. The
         // keyboard is dismissed via the Done button or by scrolling the list instead.
-        keyboardActions = KeyboardActions(onDone = { if (value.isNotBlank()) onAddClick() }),
+        keyboardActions = KeyboardActions(onSend = { if (value.isNotBlank()) onAddClick() }),
         trailingIcon = {
             IconButton(onClick = onAddClick, enabled = value.isNotBlank()) {
                 Icon(

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -807,33 +807,36 @@ private fun GroceryListInput(
     var isFocused by remember { mutableStateOf(false) }
     val expanded = (isFocused || forceShowSuggestions) && suggestions.isNotEmpty()
 
-    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+    Column(modifier = modifier) {
         // Suggestions render directly above the field rather than as a downward dropdown: the input
         // is anchored at the bottom of the screen, so a dropdown would open behind the keyboard
-        // (especially on iOS, where it doesn't flip above the anchor).
-        Column(modifier = Modifier.weight(1f)) {
-            if (expanded) {
-                AutocompleteSuggestionRows(suggestions = suggestions, onNameChange = onNameChange)
-            }
+        // (especially on iOS, where it doesn't flip above the anchor). They sit above the
+        // field/Done row so the Done button only centers against the field, not the suggestion
+        // list.
+        if (expanded) {
+            AutocompleteSuggestionRows(suggestions = suggestions, onNameChange = onNameChange)
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
             GroceryItemNameTextField(
                 value = state.value,
                 onValueChange = onNameChange,
                 onFocusChanged = { isFocused = it },
                 onAddClick = onAddClick,
+                modifier = Modifier.weight(1f),
             )
-        }
-        AnimatedVisibility(
-            visible = isFocused,
-            enter = fadeIn() + expandHorizontally(),
-            exit = fadeOut() + shrinkHorizontally(),
-        ) {
-            TextButton(
-                onClick = {
-                    focusManager.clearFocus()
-                    keyboardController?.hide()
-                }
+            AnimatedVisibility(
+                visible = isFocused,
+                enter = fadeIn() + expandHorizontally(),
+                exit = fadeOut() + shrinkHorizontally(),
             ) {
-                Text(stringResource(Res.string.grocery_done))
+                TextButton(
+                    onClick = {
+                        focusManager.clearFocus()
+                        keyboardController?.hide()
+                    }
+                ) {
+                    Text(stringResource(Res.string.grocery_done))
+                }
             }
         }
     }

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -84,8 +84,10 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import chefmate.client.grocery.core.public.generated.resources.Res
@@ -877,9 +879,21 @@ private fun GroceryItemNameTextField(
     onDismissKeyboard: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var fieldValue by remember { mutableStateOf(TextFieldValue(value, TextRange(value.length))) }
+    // The name is owned externally (the BLoC). When it changes from outside the field — a
+    // suggestion tap or the clear after adding — sync it in and move the cursor to the end. Normal
+    // typing keeps text and value equal, so this leaves the user's cursor alone.
+    LaunchedEffect(value) {
+        if (value != fieldValue.text) {
+            fieldValue = TextFieldValue(value, TextRange(value.length))
+        }
+    }
     OutlinedTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = fieldValue,
+        onValueChange = {
+            fieldValue = it
+            onValueChange(it.text)
+        },
         modifier =
             modifier
                 .fillMaxWidth()
@@ -897,10 +911,12 @@ private fun GroceryItemNameTextField(
         // scroll-to-dismiss gestures.
         keyboardActions =
             KeyboardActions(
-                onSend = { if (value.isNotBlank()) onAddClick() else onDismissKeyboard() }
+                onSend = {
+                    if (fieldValue.text.isNotBlank()) onAddClick() else onDismissKeyboard()
+                }
             ),
         trailingIcon = {
-            IconButton(onClick = onAddClick, enabled = value.isNotBlank()) {
+            IconButton(onClick = onAddClick, enabled = fieldValue.text.isNotBlank()) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = stringResource(Res.string.grocery_add_item),

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -76,6 +76,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -153,7 +157,6 @@ import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveModal
 import com.plusmobileapps.chefmate.ui.components.PlusTooltipPlacement
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
-import com.plusmobileapps.chefmate.ui.isIosPlatform
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.coroutines.flow.StateFlow
 import org.jetbrains.compose.resources.stringResource
@@ -175,6 +178,17 @@ fun GroceryListScreen(
             (if (hasNonDefaultSort) 1 else 0) +
             (if (hasRecipeFilter) 1 else 0)
     val focusManager = LocalFocusManager.current
+    // Scrolling the list dismisses the keyboard, mirroring the tap-to-dismiss gesture below. The
+    // connection never consumes the scroll so pull-to-refresh and the list itself keep scrolling.
+    val dismissKeyboardOnScroll =
+        remember(focusManager) {
+            object : NestedScrollConnection {
+                override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                    if (available.y != 0f) focusManager.clearFocus()
+                    return Offset.Zero
+                }
+            }
+        }
 
     PlusResponsiveContainer(
         modifier = modifier.testTag(GroceryListTestTags.SCREEN).fillMaxSize()
@@ -237,7 +251,8 @@ fun GroceryListScreen(
                         IconButton(onClick = bloc::onDeleteClicked) {
                             Icon(
                                 Icons.Default.DeleteSweep,
-                                contentDescription = stringResource(Res.string.grocery_delete_items),
+                                contentDescription =
+                                    stringResource(Res.string.grocery_delete_items),
                             )
                         }
                         if (state.isSyncing) {
@@ -323,9 +338,11 @@ fun GroceryListScreen(
                                 }
                             },
                             modifier =
-                                Modifier.fillMaxSize().pointerInput(Unit) {
-                                    detectTapGestures(onTap = { focusManager.clearFocus() })
-                                },
+                                Modifier.fillMaxSize()
+                                    .nestedScroll(dismissKeyboardOnScroll)
+                                    .pointerInput(Unit) {
+                                        detectTapGestures(onTap = { focusManager.clearFocus() })
+                                    },
                             showHeaders = state.sort == GroceryListBloc.GrocerySort.AISLE,
                             trailingContent = { displayItem ->
                                 val item = itemLookup[displayItem.key as Long]
@@ -790,7 +807,6 @@ private fun GroceryListInput(
     val state = name.collectAsState()
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
-    val isIos = isIosPlatform()
     var isFocused by remember { mutableStateOf(false) }
     val expanded = (isFocused || forceShowSuggestions) && suggestions.isNotEmpty()
 
@@ -803,7 +819,6 @@ private fun GroceryListInput(
                     onValueChange = onNameChange,
                     onFocusChanged = { isFocused = it },
                     onAddClick = onAddClick,
-                    keyboardController = keyboardController,
                 )
             }
         } else {
@@ -817,7 +832,6 @@ private fun GroceryListInput(
                     onValueChange = onNameChange,
                     onFocusChanged = { isFocused = it },
                     onAddClick = onAddClick,
-                    keyboardController = keyboardController,
                     modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable),
                 )
                 ExposedDropdownMenu(expanded = expanded, onDismissRequest = {}) {
@@ -832,7 +846,7 @@ private fun GroceryListInput(
             }
         }
         AnimatedVisibility(
-            visible = isIos && isFocused,
+            visible = isFocused,
             enter = fadeIn() + expandHorizontally(),
             exit = fadeOut() + shrinkHorizontally(),
         ) {
@@ -875,7 +889,6 @@ private fun GroceryItemNameTextField(
     onValueChange: (String) -> Unit,
     onFocusChanged: (Boolean) -> Unit,
     onAddClick: () -> Unit,
-    keyboardController: androidx.compose.ui.platform.SoftwareKeyboardController?,
     modifier: Modifier = Modifier,
 ) {
     OutlinedTextField(
@@ -893,13 +906,9 @@ private fun GroceryItemNameTextField(
                 capitalization = KeyboardCapitalization.Sentences,
                 imeAction = ImeAction.Done,
             ),
-        keyboardActions =
-            KeyboardActions(
-                onDone = {
-                    if (value.isNotBlank()) onAddClick()
-                    keyboardController?.hide()
-                }
-            ),
+        // Adds the item but keeps the keyboard open so the user can keep entering items. The
+        // keyboard is dismissed via the Done button or by scrolling the list instead.
+        keyboardActions = KeyboardActions(onDone = { if (value.isNotBlank()) onAddClick() }),
         trailingIcon = {
             IconButton(onClick = onAddClick, enabled = value.isNotBlank()) {
                 Icon(
@@ -1035,7 +1044,8 @@ private fun FilteredEmptyGroceryListState(
             Spacer(Modifier.height(dimens.paddingLarge))
             Button(
                 onClick = onClearFiltersClicked,
-                modifier = Modifier.testTag(GroceryListTestTags.CLEAR_FILTERS_BUTTON).fillMaxWidth(),
+                modifier =
+                    Modifier.testTag(GroceryListTestTags.CLEAR_FILTERS_BUTTON).fillMaxWidth(),
             ) {
                 Text(stringResource(Res.string.grocery_list_filtered_empty_clear_filters))
             }


### PR DESCRIPTION
## What changed

Reworks the grocery list input so adding items is faster and the layout stays stable while the keyboard is open.

- **IME action adds without dismissing.** The keyboard action now adds the current text to the list and clears the field, but keeps the keyboard open so items can be entered one after another (instead of dismissing after each add).
- **"Done" button dismisses the keyboard on all platforms.** Previously the dismiss button next to the input was iOS-only. It now appears whenever the input is focused and is the explicit way to close the keyboard.
- **Scrolling the list dismisses the keyboard.** Added a `NestedScrollConnection` that clears focus on vertical scroll without consuming it, so pull-to-refresh and list scrolling keep working. This complements the existing tap-to-dismiss gesture.
- **Bottom nav stays anchored when the keyboard opens.** Previously the whole screen got `imePadding()` and the bottom bar was removed from composition while the IME was visible. Now the bar stays mounted/anchored at the bottom and `imePadding()` is applied only to the content, so an open keyboard pushes the input up and shrinks the scrollable list above it rather than hiding the nav.

## Why

The old flow dismissed the keyboard on every add, which made entering several items in a row tedious, and the bottom nav popping in/out on focus was jarring.

## Reviewer notes

- The bottom-nav change in `BottomNavScreen.kt` affects all tabs (the disappearing nav was a global bottom-nav concern). Side-nav layouts keep their existing `imePadding()` behavior.
- With the bar anchored at screen bottom, it sits *behind* the keyboard while typing and reappears the instant the keyboard closes — matching "stay anchored at the bottom." If a floating-above-keyboard bar is preferred instead, that's a different layout approach.
- Best verified on a device/simulator with the soft keyboard, since this is keyboard/inset behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)