### PR TITLE
fix(onboarding): keep coach mark until OK is tapped, not on navigate-away

### DIFF
--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusOnboardingTooltip.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusOnboardingTooltip.kt
@@ -55,13 +55,16 @@ enum class PlusTooltipPlacement {
  * floating toolbar) and can overlay other content. The popup is non-focusable, so taps still reach
  * the underlying control — a user can tap the highlighted control directly.
  *
- * Visibility is fully caller-controlled. Pass [visible] = true to show it and handle [onDismiss]
- * (called when the user taps the bubble's dismiss button) to hide it. Callers that want it shown
- * only once should persist that decision themselves — e.g. via the shared coach-mark controller.
+ * Visibility is fully caller-controlled. Pass [visible] = true to show it and handle [onDismiss] to
+ * hide it. [onDismiss] fires only when the user taps the bubble's dismiss button — never when the
+ * popup goes away for other reasons (outside interaction, or the anchor leaving composition as the
+ * user navigates away). Callers that want it shown only once should persist that decision in
+ * [onDismiss] — e.g. via the shared coach-mark controller — so that merely leaving the screen
+ * mid-tooltip lets it reappear on the next visit rather than dismissing it forever.
  *
  * @param text the message shown in the bubble.
  * @param visible whether the bubble is currently shown.
- * @param onDismiss invoked when the user taps the bubble's dismiss button.
+ * @param onDismiss invoked only when the user taps the bubble's dismiss button.
  * @param placement which side of the anchor the bubble sits on. Defaults to [ABOVE].
  * @param anchor the control the tooltip points at; always laid out, tooltip or not.
  */
@@ -99,7 +102,12 @@ fun PlusOnboardingTooltip(
 
             Popup(
                 popupPositionProvider = positionProvider,
-                onDismissRequest = onDismiss,
+                // Deliberately a no-op: only the bubble's dismiss button should mark the coach mark
+                // as seen. The popup auto-dismissing for any other reason (outside interaction, the
+                // anchor leaving composition when navigating away) must NOT consume it — otherwise
+                // leaving the screen mid-tooltip would hide it forever. Visibility is caller-driven
+                // via [visible], so the tip simply reappears the next time the screen requests it.
+                onDismissRequest = {},
                 properties = PopupProperties(focusable = false, clippingEnabled = false),
             ) {
                 PlusTooltipBubble(


### PR DESCRIPTION
## What

Navigating away from a screen while an onboarding coach mark (tooltip) is visible no longer dismisses it forever. The tooltip now reappears on the next visit to that screen and is only permanently dismissed when the user taps the **OK / dismiss** button on the bubble.

## Why

`PlusOnboardingTooltip` wired its single `onDismiss` callback to **both** the bubble's dismiss button **and** the `Popup`'s `onDismissRequest`. Every screen routes `onDismiss` to `CoachMarkController.dismiss()`, which marks a coach mark *seen forever*.

`CoachMarkController` already distinguishes the two cases correctly:
- `release()` — called on screen destroy (navigate away): drops the mark **without** marking it seen, so it can be requested again later.
- `dismiss()` — the only thing that marks a mark seen forever.

But because `onDismissRequest` also reached `dismiss()`, the popup auto-dismissing for any reason other than the OK button (outside interaction, or the anchor leaving composition as the user navigates away) marked the mark seen — so it never showed again. This also contradicted the component's own documented contract ("onDismiss invoked when the user taps the bubble's dismiss button").

## Change

- Make the `Popup`'s `onDismissRequest` a no-op so only the bubble's dismiss button reaches `onDismiss` → `dismiss()`.
- Visibility remains fully caller-driven via `visible = activeCoachMark == id`, so leaving the screen triggers only `release()` (not seen) and the tip reappears on the next visit.
- Updated the KDoc to make the contract explicit.

## Behavior after fix

- **Navigate away mid-tooltip** → popup disposed, `release()` runs on destroy → not marked seen → reappears on return.
- **Tap OK** → `dismiss()` → marked seen forever → never shows again.

## Notes for reviewers

No screen-level changes were needed — every screen already routed `onDismiss` correctly; the bug was the tooltip conflating "user acknowledged" with "popup went away." I did not add an automated test because the behavior lives in a Compose `Popup` dismiss path that's awkward to drive in the existing harness, but `CoachMarkControllerTest` already covers the `release` vs `dismiss` distinction this fix relies on. Happy to add a navigate-away-and-back UI test if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)