### PR TITLE
feat(recipe): fan out tablet detail top-bar actions

### DIFF
--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -482,71 +482,107 @@ private fun RecipeDetailActions(
     onShare: (String) -> Unit,
 ) {
     if (inlineActions) {
-        IconButton(onClick = onEdit) {
+        InlineRecipeActions(
+            recipe = recipe,
+            onEdit = onEdit,
+            onDelete = onDelete,
+            onShare = onShare,
+        )
+    } else {
+        OverflowRecipeActions(
+            recipe = recipe,
+            expanded = showOverflowMenu,
+            onExpandedChange = onShowOverflowMenuChange,
+            onEdit = onEdit,
+            onDelete = onDelete,
+            onShare = onShare,
+        )
+    }
+}
+
+/** Tablet/wide layout: Edit, Share, and Delete laid out directly in the app bar. */
+@Composable
+private fun InlineRecipeActions(
+    recipe: Recipe,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    onShare: (String) -> Unit,
+) {
+    IconButton(onClick = onEdit) {
+        Icon(
+            imageVector = Icons.Default.Edit,
+            contentDescription = stringResource(Res.string.recipe_detail_edit),
+        )
+    }
+    ShareActionButton(recipe = recipe, onShare = onShare)
+    IconButton(onClick = onDelete) {
+        Icon(
+            imageVector = Icons.Default.Delete,
+            contentDescription = stringResource(Res.string.recipe_detail_delete),
+        )
+    }
+}
+
+/** Share icon button that owns its own dropdown for picking the source URL or the recipe text. */
+@Composable
+private fun ShareActionButton(recipe: Recipe, onShare: (String) -> Unit) {
+    Box {
+        var showShareMenu by remember { mutableStateOf(false) }
+        IconButton(onClick = { showShareMenu = true }) {
             Icon(
-                imageVector = Icons.Default.Edit,
+                imageVector = Icons.Default.Share,
+                contentDescription = stringResource(Res.string.recipe_detail_share),
+            )
+        }
+        DropdownMenu(expanded = showShareMenu, onDismissRequest = { showShareMenu = false }) {
+            RecipeShareMenuItems(
+                recipe = recipe,
+                onClose = { showShareMenu = false },
+                onShare = onShare,
+            )
+        }
+    }
+}
+
+/** Compact layout: every action collapsed behind a single three-dot overflow menu. */
+@Composable
+private fun OverflowRecipeActions(
+    recipe: Recipe,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    onShare: (String) -> Unit,
+) {
+    Box {
+        IconButton(onClick = { onExpandedChange(true) }) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
                 contentDescription = stringResource(Res.string.recipe_detail_edit),
             )
         }
-        Box {
-            var showShareMenu by remember { mutableStateOf(false) }
-            IconButton(onClick = { showShareMenu = true }) {
-                Icon(
-                    imageVector = Icons.Default.Share,
-                    contentDescription = stringResource(Res.string.recipe_detail_share),
-                )
-            }
-            DropdownMenu(
-                expanded = showShareMenu,
-                onDismissRequest = { showShareMenu = false },
-            ) {
-                RecipeShareMenuItems(
-                    recipe = recipe,
-                    onClose = { showShareMenu = false },
-                    onShare = onShare,
-                )
-            }
-        }
-        IconButton(onClick = onDelete) {
-            Icon(
-                imageVector = Icons.Default.Delete,
-                contentDescription = stringResource(Res.string.recipe_detail_delete),
+        DropdownMenu(expanded = expanded, onDismissRequest = { onExpandedChange(false) }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.recipe_detail_edit)) },
+                leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                onClick = {
+                    onExpandedChange(false)
+                    onEdit()
+                },
             )
-        }
-    } else {
-        Box {
-            IconButton(onClick = { onShowOverflowMenuChange(true) }) {
-                Icon(
-                    imageVector = Icons.Default.MoreVert,
-                    contentDescription = stringResource(Res.string.recipe_detail_edit),
-                )
-            }
-            DropdownMenu(
-                expanded = showOverflowMenu,
-                onDismissRequest = { onShowOverflowMenuChange(false) },
-            ) {
-                DropdownMenuItem(
-                    text = { Text(stringResource(Res.string.recipe_detail_edit)) },
-                    leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
-                    onClick = {
-                        onShowOverflowMenuChange(false)
-                        onEdit()
-                    },
-                )
-                RecipeShareMenuItems(
-                    recipe = recipe,
-                    onClose = { onShowOverflowMenuChange(false) },
-                    onShare = onShare,
-                )
-                DropdownMenuItem(
-                    text = { Text(stringResource(Res.string.recipe_detail_delete)) },
-                    leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
-                    onClick = {
-                        onShowOverflowMenuChange(false)
-                        onDelete()
-                    },
-                )
-            }
+            RecipeShareMenuItems(
+                recipe = recipe,
+                onClose = { onExpandedChange(false) },
+                onShare = onShare,
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.recipe_detail_delete)) },
+                leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                onClick = {
+                    onExpandedChange(false)
+                    onDelete()
+                },
+            )
         }
     }
 }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -140,6 +140,7 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_kcal
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_prep_time
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_remove_favorite
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_servings
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_text
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_url
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_source
@@ -286,92 +287,21 @@ private fun RecipeDetailBody(
                         onBackClick = bloc::onBackClicked,
                         trailingAccessory =
                             PlusHeaderData.TrailingAccessory.Custom {
-                                Box {
-                                    IconButton(onClick = { onShowOverflowMenuChange(true) }) {
-                                        Icon(
-                                            imageVector = Icons.Default.MoreVert,
-                                            contentDescription =
-                                                stringResource(Res.string.recipe_detail_edit),
-                                        )
-                                    }
-                                    DropdownMenu(
-                                        expanded = showOverflowMenu,
-                                        onDismissRequest = { onShowOverflowMenuChange(false) },
-                                    ) {
-                                        DropdownMenuItem(
-                                            text = {
-                                                Text(stringResource(Res.string.recipe_detail_edit))
-                                            },
-                                            leadingIcon = {
-                                                Icon(Icons.Default.Edit, contentDescription = null)
-                                            },
-                                            onClick = {
-                                                onShowOverflowMenuChange(false)
-                                                bloc.onEditClicked()
-                                            },
-                                        )
-                                        state.recipe.sourceUrl?.let { url ->
-                                            DropdownMenuItem(
-                                                text = {
-                                                    Text(
-                                                        stringResource(
-                                                            Res.string.recipe_detail_share_url
-                                                        )
-                                                    )
-                                                },
-                                                leadingIcon = {
-                                                    Icon(
-                                                        Icons.Default.Share,
-                                                        contentDescription = null,
-                                                    )
-                                                },
-                                                onClick = {
-                                                    onShowOverflowMenuChange(false)
-                                                    if (shareLauncher(url)) {
-                                                        toastService.show(copiedMessage)
-                                                    }
-                                                },
-                                            )
+                                RecipeDetailActions(
+                                    recipe = state.recipe,
+                                    // Compact collapses into the three-dot overflow; wider windows
+                                    // have the app-bar room to surface the actions directly.
+                                    inlineActions = !isCompact,
+                                    showOverflowMenu = showOverflowMenu,
+                                    onShowOverflowMenuChange = onShowOverflowMenuChange,
+                                    onEdit = bloc::onEditClicked,
+                                    onDelete = bloc::onDeleteClicked,
+                                    onShare = { content ->
+                                        if (shareLauncher(content)) {
+                                            toastService.show(copiedMessage)
                                         }
-                                        DropdownMenuItem(
-                                            text = {
-                                                Text(
-                                                    stringResource(
-                                                        Res.string.recipe_detail_share_text
-                                                    )
-                                                )
-                                            },
-                                            leadingIcon = {
-                                                Icon(Icons.Default.Share, contentDescription = null)
-                                            },
-                                            onClick = {
-                                                onShowOverflowMenuChange(false)
-                                                if (
-                                                    shareLauncher(formatRecipeAsText(state.recipe))
-                                                ) {
-                                                    toastService.show(copiedMessage)
-                                                }
-                                            },
-                                        )
-                                        DropdownMenuItem(
-                                            text = {
-                                                Text(
-                                                    stringResource(Res.string.recipe_detail_delete)
-                                                )
-                                            },
-                                            leadingIcon = {
-                                                Icon(
-                                                    Icons.Default.Delete,
-                                                    contentDescription = null,
-                                                )
-                                            },
-                                            onClick = {
-                                                onShowOverflowMenuChange(false)
-                                                bloc.onDeleteClicked()
-                                            },
-                                        )
-                                    }
-                                }
+                                    },
+                                )
                             },
                     ),
                 verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingNormal),
@@ -533,6 +463,122 @@ private fun RecipeDetailBody(
             }
         }
     }
+}
+
+/**
+ * Recipe-detail top-bar actions. On compact widths everything collapses into a single overflow
+ * (three-dot) menu; on wider windows ([inlineActions]) the otherwise-empty app-bar space is used to
+ * surface Edit / Share / Delete directly, with Share opening its own small menu to pick between the
+ * source URL and the full recipe text.
+ */
+@Composable
+private fun RecipeDetailActions(
+    recipe: Recipe,
+    inlineActions: Boolean,
+    showOverflowMenu: Boolean,
+    onShowOverflowMenuChange: (Boolean) -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    onShare: (String) -> Unit,
+) {
+    if (inlineActions) {
+        IconButton(onClick = onEdit) {
+            Icon(
+                imageVector = Icons.Default.Edit,
+                contentDescription = stringResource(Res.string.recipe_detail_edit),
+            )
+        }
+        Box {
+            var showShareMenu by remember { mutableStateOf(false) }
+            IconButton(onClick = { showShareMenu = true }) {
+                Icon(
+                    imageVector = Icons.Default.Share,
+                    contentDescription = stringResource(Res.string.recipe_detail_share),
+                )
+            }
+            DropdownMenu(
+                expanded = showShareMenu,
+                onDismissRequest = { showShareMenu = false },
+            ) {
+                RecipeShareMenuItems(
+                    recipe = recipe,
+                    onClose = { showShareMenu = false },
+                    onShare = onShare,
+                )
+            }
+        }
+        IconButton(onClick = onDelete) {
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = stringResource(Res.string.recipe_detail_delete),
+            )
+        }
+    } else {
+        Box {
+            IconButton(onClick = { onShowOverflowMenuChange(true) }) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = stringResource(Res.string.recipe_detail_edit),
+                )
+            }
+            DropdownMenu(
+                expanded = showOverflowMenu,
+                onDismissRequest = { onShowOverflowMenuChange(false) },
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(Res.string.recipe_detail_edit)) },
+                    leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                    onClick = {
+                        onShowOverflowMenuChange(false)
+                        onEdit()
+                    },
+                )
+                RecipeShareMenuItems(
+                    recipe = recipe,
+                    onClose = { onShowOverflowMenuChange(false) },
+                    onShare = onShare,
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource(Res.string.recipe_detail_delete)) },
+                    leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                    onClick = {
+                        onShowOverflowMenuChange(false)
+                        onDelete()
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The two share entries — the source URL (only when present) and the full recipe text — shared by
+ * both the compact overflow menu and the tablet Share button's own dropdown.
+ */
+@Composable
+private fun RecipeShareMenuItems(
+    recipe: Recipe,
+    onClose: () -> Unit,
+    onShare: (String) -> Unit,
+) {
+    recipe.sourceUrl?.let { url ->
+        DropdownMenuItem(
+            text = { Text(stringResource(Res.string.recipe_detail_share_url)) },
+            leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
+            onClick = {
+                onClose()
+                onShare(url)
+            },
+        )
+    }
+    DropdownMenuItem(
+        text = { Text(stringResource(Res.string.recipe_detail_share_text)) },
+        leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
+        onClick = {
+            onClose()
+            onShare(formatRecipeAsText(recipe))
+        },
+    )
 }
 
 /**
@@ -1708,7 +1754,7 @@ private fun DeletingDialog(modifier: Modifier = Modifier) {
     )
 }
 
-private val previewBloc =
+val previewRecipeDetailBloc: RecipeDetailBloc =
     object : RecipeDetailBloc {
         override val state: StateFlow<RecipeDetailBloc.Model> =
             MutableStateFlow(
@@ -1834,11 +1880,11 @@ private val previewBloc =
 @Preview(heightDp = 1100)
 @Composable
 private fun RecipeDetailContentPreview() {
-    ChefMateTheme { RecipeDetailScreen(bloc = previewBloc) }
+    ChefMateTheme { RecipeDetailScreen(bloc = previewRecipeDetailBloc) }
 }
 
 @Preview(heightDp = 1100)
 @Composable
 private fun RecipeDetailContentDarkPreview() {
-    ChefMateTheme(darkTheme = true) { RecipeDetailScreen(bloc = previewBloc) }
+    ChefMateTheme(darkTheme = true) { RecipeDetailScreen(bloc = previewRecipeDetailBloc) }
 }

--- a/client/ui/screenshot-test/build.gradle.kts
+++ b/client/ui/screenshot-test/build.gradle.kts
@@ -64,6 +64,8 @@ dependencies {
     implementation(project(":client:settings:root:public"))
     implementation(project(":client:profile:public"))
     implementation(project(":client:profile:impl"))
+    implementation(project(":client:toast:public"))
+    implementation(project(":client:toast:testing"))
     implementation(libs.arkivanov.decompose.core)
 
     screenshotTestImplementation(libs.screenshot.validation.api)

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTest.kt
@@ -1,0 +1,51 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailScreen
+import com.plusmobileapps.chefmate.recipe.core.detail.previewRecipeDetailBloc
+import com.plusmobileapps.chefmate.toast.LocalToastService
+import com.plusmobileapps.chefmate.toast.testing.FakeToastService
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+// RecipeDetailScreen reads LocalToastService.current directly, so it must be provided for the
+// screen to compose at all.
+@Composable
+private fun RecipeDetailPreview(darkTheme: Boolean = false) {
+    CompositionLocalProvider(LocalToastService provides FakeToastService()) {
+        ChefMateTheme(darkTheme = darkTheme) {
+            RecipeDetailScreen(bloc = previewRecipeDetailBloc)
+        }
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1000)
+@Composable
+fun RecipeDetailCompactScreenshot() {
+    RecipeDetailPreview()
+}
+
+// Wide window: the top-bar actions fan out into dedicated Edit / Share / Delete buttons instead of
+// the compact three-dot overflow.
+@PreviewTest
+@Preview(showBackground = true, widthDp = 900, heightDp = 800)
+@Composable
+fun RecipeDetailTabletScreenshot() {
+    RecipeDetailPreview()
+}
+
+@PreviewTest
+@Preview(
+    showBackground = true,
+    widthDp = 900,
+    heightDp = 800,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun RecipeDetailTabletDarkScreenshot() {
+    RecipeDetailPreview(darkTheme = true)
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailCompactScreenshot_39ac46f6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailCompactScreenshot_39ac46f6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:970e0fc0df74c13a44ec0b6051a5d412c924e46d723e1c42d0ba83800eb92e86
+size 130763

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailTabletDarkScreenshot_1f3c2a8a_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailTabletDarkScreenshot_1f3c2a8a_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89fa2e4406ae250a9330577b0d15a4c5c36f3a46b4aef8ecf3d0a6ef62d065d7
+size 223417

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailTabletScreenshot_f0f0faa5_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailTabletScreenshot_f0f0faa5_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c25854d80facfb12fc1b55dfa0ad90966e335892133678bb6f682f242a24d50
+size 228772


### PR DESCRIPTION
## Summary

On the tablet (wide) recipe-detail layout, the nav bar previously collapsed every action into a single three-dot overflow menu, wasting the available app-bar space. This surfaces the actions directly when there's room.

- **Compact (phone):** unchanged — single ⋮ overflow with Edit / Share URL / Share text / Delete.
- **Wider windows (tablet, large landscape):** **Edit / Share / Delete** appear directly in the nav bar. **Share** opens its own dropdown to pick **Share recipe URL** (only when a source URL exists) or **Share recipe text**.

The two share entries are factored into a shared `RecipeShareMenuItems` so the compact overflow and the tablet Share button stay in sync. Delete still routes through the existing confirmation dialog.

## Implementation

- Extracted top-bar actions into a `RecipeDetailActions` composable keyed on window size (`!isCompact` → inline actions).
- Made the in-file preview bloc public (`previewRecipeDetailBloc`) so the screenshot test can reuse it.

## Testing

- `:client:recipe:core:public:compileAndroidMain` compiles clean.
- Added `RecipeDetailScreenshotTest` (compact + tablet light/dark) and recorded references; `validateDebugScreenshotTest` passes. Because the screen reads `LocalToastService.current` directly, the test provides a `FakeToastService` (added `:client:toast:public` + `:client:toast:testing` deps to the screenshot module).

## Notes

- Both modes keep the original `MoreVert` content description (`recipe_detail_edit`), a pre-existing a11y mislabel left untouched to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)