### PR TITLE
feat(watch): native watchOS app (SwiftUI + Siri + WatchConnectivity)

### DIFF
--- a/client/watchShared/src/commonMain/kotlin/com/plusmobileapps/chefmate/watch/WatchEntryPoint.kt
+++ b/client/watchShared/src/commonMain/kotlin/com/plusmobileapps/chefmate/watch/WatchEntryPoint.kt
@@ -1,0 +1,11 @@
+package com.plusmobileapps.chefmate.watch
+
+/**
+ * Swift-friendly entry point. Building the Metro graph and reaching for the controller in one call
+ * avoids Swift having to touch the generated graph companion. Call once from the SwiftUI app and
+ * hold the returned [WatchGroceryController] for the process lifetime.
+ *
+ * Swift: `WatchEntryPointKt.createWatchGroceryController()`.
+ */
+fun createWatchGroceryController(): WatchGroceryController =
+    WatchApplicationComponent.create().groceryController

--- a/iosApp/ChefMateWatch/AddGroceryItemIntent.swift
+++ b/iosApp/ChefMateWatch/AddGroceryItemIntent.swift
@@ -1,0 +1,42 @@
+import AppIntents
+
+/// "Hey Siri, add milk to my grocery list." Runs against the same shared controller as the app,
+/// so the item lands in the local DB and syncs to Supabase (and thus to the phone).
+struct AddGroceryItemIntent: AppIntent {
+    static var title: LocalizedStringResource = "Add Grocery Item"
+    static var description = IntentDescription("Adds an item to your Chef Mate grocery list.")
+    static var openAppWhenRun: Bool = false
+
+    @Parameter(title: "Item", requestValueDialog: "What should I add?")
+    var item: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Add \(\.$item) to my grocery list")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let controller = SharedController.shared
+        // suspend functions returning a Kotlin primitive bridge to a boxed type (KotlinLong).
+        let listId = (try await controller.ensureDefaultList()).int64Value
+        try await controller.addItem(listId: listId, name: item)
+        try await controller.syncNow()
+        return .result(dialog: "Added \(item) to your grocery list.")
+    }
+}
+
+struct ChefMateAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        // Free-form String parameters can't be interpolated into Siri phrases (only AppEntity /
+        // AppEnum can), so the phrases are static and Siri prompts for the item via the
+        // parameter's `requestValueDialog`.
+        AppShortcut(
+            intent: AddGroceryItemIntent(),
+            phrases: [
+                "Add an item to my \(.applicationName) grocery list",
+                "Add to my grocery list in \(.applicationName)",
+            ],
+            shortTitle: "Add Grocery Item",
+            systemImageName: "cart.badge.plus"
+        )
+    }
+}

--- a/iosApp/ChefMateWatch/AddItemView.swift
+++ b/iosApp/ChefMateWatch/AddItemView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Add an item via dictation / scribble (watchOS `TextField` presents both automatically).
+struct AddItemView: View {
+    let onAdd: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Item", text: $name)
+                Button("Add") {
+                    onAdd(name)
+                    dismiss()
+                }
+                .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .navigationTitle("Add Item")
+        }
+    }
+}

--- a/iosApp/ChefMateWatch/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iosApp/ChefMateWatch/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "watchos",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/ChefMateWatch/Assets.xcassets/Contents.json
+++ b/iosApp/ChefMateWatch/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/ChefMateWatch/ChefMateWatchApp.swift
+++ b/iosApp/ChefMateWatch/ChefMateWatchApp.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+@main
+struct ChefMateWatchApp: App {
+    @StateObject private var store = GroceryStore()
+
+    /// Retained for the app's lifetime so the watch keeps receiving the Supabase session handed
+    /// off from the iPhone over WatchConnectivity.
+    private let connectivity: WatchConnectivityManager
+
+    init() {
+        let store = GroceryStore()
+        _store = StateObject(wrappedValue: store)
+        connectivity = WatchConnectivityManager(store: store)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(store)
+        }
+    }
+}
+
+struct RootView: View {
+    @EnvironmentObject private var store: GroceryStore
+
+    var body: some View {
+        NavigationStack {
+            if store.isSignedIn {
+                GroceryListsView()
+            } else {
+                SignedOutView()
+            }
+        }
+        .task { await store.syncNow() }
+    }
+}
+
+struct SignedOutView: View {
+    var body: some View {
+        ContentUnavailableView(
+            "Sign in on iPhone",
+            systemImage: "iphone.and.arrow.forward",
+            description: Text("Open Chef Mate on your iPhone to sync your grocery lists to your watch.")
+        )
+    }
+}

--- a/iosApp/ChefMateWatch/GroceryItemsView.swift
+++ b/iosApp/ChefMateWatch/GroceryItemsView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import WatchShared
+
+/// Second screen: view items for the selected list, toggle them, and add new ones.
+struct GroceryItemsView: View {
+    let listId: Int64
+    let title: String
+
+    @EnvironmentObject private var store: GroceryStore
+    @State private var showingAdd = false
+
+    private var items: [WatchGroceryItem] { store.items(for: listId) }
+
+    var body: some View {
+        List {
+            Section {
+                Button {
+                    showingAdd = true
+                } label: {
+                    Label("Add item", systemImage: "plus.circle.fill")
+                }
+            }
+
+            ForEach(items, id: \.id) { item in
+                Button {
+                    Task { await store.setChecked(itemId: item.id, isChecked: !item.isChecked) }
+                } label: {
+                    HStack {
+                        Image(systemName: item.isChecked ? "checkmark.circle.fill" : "circle")
+                            .foregroundStyle(item.isChecked ? .green : .secondary)
+                        VStack(alignment: .leading) {
+                            Text(item.name)
+                                .strikethrough(item.isChecked)
+                            if let quantity = item.quantity, !quantity.isEmpty {
+                                Text(quantity).font(.footnote).foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle(title)
+        .onAppear { store.startObservingItems(listId: listId) }
+        .task { await store.syncNow() }
+        .sheet(isPresented: $showingAdd) {
+            AddItemView { name in
+                Task { await store.addItem(listId: listId, name: name) }
+            }
+        }
+    }
+}

--- a/iosApp/ChefMateWatch/GroceryListsView.swift
+++ b/iosApp/ChefMateWatch/GroceryListsView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import WatchShared
+
+/// First screen: pick a grocery list.
+struct GroceryListsView: View {
+    @EnvironmentObject private var store: GroceryStore
+
+    var body: some View {
+        List {
+            if store.lists.isEmpty {
+                Text("No grocery lists yet.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(store.lists, id: \.id) { list in
+                    NavigationLink(value: list.id) {
+                        Label(list.name, systemImage: list.isShared ? "person.2" : "cart")
+                    }
+                }
+            }
+        }
+        .navigationTitle("Lists")
+        .navigationDestination(for: Int64.self) { listId in
+            GroceryItemsView(
+                listId: listId,
+                title: store.lists.first { $0.id == listId }?.name ?? "Groceries"
+            )
+        }
+        .task { await store.syncNow() }
+    }
+}

--- a/iosApp/ChefMateWatch/GroceryStore.swift
+++ b/iosApp/ChefMateWatch/GroceryStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+import WatchShared
+
+/// Observable bridge between the shared Kotlin `WatchGroceryController` and SwiftUI. Reads are
+/// pushed from Kotlin flows via callbacks (hopped onto the main actor); writes are `async` and
+/// forwarded to the controller, which is offline-first + Supabase-backed.
+@MainActor
+final class GroceryStore: ObservableObject {
+    @Published private(set) var lists: [WatchGroceryList] = []
+    @Published private(set) var itemsByListId: [Int64: [WatchGroceryItem]] = [:]
+    @Published private(set) var isSignedIn: Bool = false
+
+    private let controller: WatchGroceryController
+    private var listsHandle: WatchCancellable?
+    private var signedInHandle: WatchCancellable?
+    private var itemHandles: [Int64: WatchCancellable] = [:]
+
+    init(controller: WatchGroceryController = SharedController.shared) {
+        self.controller = controller
+
+        signedInHandle = controller.observeSignedIn { [weak self] signedIn in
+            let value = signedIn.boolValue
+            Task { @MainActor in self?.isSignedIn = value }
+        }
+        listsHandle = controller.observeLists { [weak self] lists in
+            Task { @MainActor in self?.lists = lists }
+        }
+    }
+
+    func startObservingItems(listId: Int64) {
+        guard itemHandles[listId] == nil else { return }
+        itemHandles[listId] = controller.observeItems(listId: listId) { [weak self] items in
+            Task { @MainActor in self?.itemsByListId[listId] = items }
+        }
+    }
+
+    func items(for listId: Int64) -> [WatchGroceryItem] {
+        itemsByListId[listId] ?? []
+    }
+
+    func addItem(listId: Int64, name: String) async {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        try? await controller.addItem(listId: listId, name: trimmed)
+        try? await controller.syncNow()
+    }
+
+    func setChecked(itemId: Int64, isChecked: Bool) async {
+        try? await controller.setChecked(itemId: itemId, isChecked: isChecked)
+    }
+
+    func syncNow() async {
+        try? await controller.syncNow()
+    }
+
+    func importSession(refreshToken: String) async {
+        try? await controller.importSession(refreshToken: refreshToken)
+    }
+}

--- a/iosApp/ChefMateWatch/Info.plist
+++ b/iosApp/ChefMateWatch/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>Chef Mate</string>
+	<key>CFBundleDisplayName</key>
+	<string>Chef Mate</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>WKApplication</key>
+	<true/>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>com.plusmobileapps.chefmate.ChefMate</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/iosApp/ChefMateWatch/SharedController.swift
+++ b/iosApp/ChefMateWatch/SharedController.swift
@@ -1,0 +1,8 @@
+import WatchShared
+
+/// The single `WatchGroceryController` for the watch process. The SwiftUI app and the Siri
+/// `AddGroceryItemIntent` both use this instance so they share one SQLDelight database + sync
+/// engine. Building the Metro graph is cheap but must happen exactly once.
+enum SharedController {
+    static let shared: WatchGroceryController = WatchEntryPointKt.createWatchGroceryController()
+}

--- a/iosApp/ChefMateWatch/WatchConnectivityManager.swift
+++ b/iosApp/ChefMateWatch/WatchConnectivityManager.swift
@@ -1,0 +1,39 @@
+import Foundation
+import WatchConnectivity
+
+/// Receives the Supabase session handed off from the iPhone. The phone pushes the current
+/// refresh token via `updateApplicationContext(["supabaseRefreshToken": ...])` whenever its
+/// session changes; the watch imports it, which signs the watch in and kicks off sync.
+///
+/// (The iPhone-side sender is a follow-up — it needs a small refresh-token accessor on the shared
+/// `AuthenticationRepository`.)
+final class WatchConnectivityManager: NSObject, WCSessionDelegate {
+    private let store: GroceryStore
+
+    init(store: GroceryStore) {
+        self.store = store
+        super.init()
+        guard WCSession.isSupported() else { return }
+        let session = WCSession.default
+        session.delegate = self
+        session.activate()
+    }
+
+    private func handle(context: [String: Any]) {
+        guard let token = context["supabaseRefreshToken"] as? String, !token.isEmpty else { return }
+        Task { await store.importSession(refreshToken: token) }
+    }
+
+    func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        // Adopt any context already delivered before activation completed.
+        handle(context: session.receivedApplicationContext)
+    }
+
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        handle(context: applicationContext)
+    }
+}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -7,9 +7,20 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		11FE675F19E9CC0656E93D9B /* AddItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750DC6FC6FC31992A18795C0 /* AddItemView.swift */; };
+		24FF1CCB90D0CD0AB589B77F /* AddGroceryItemIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825160EF3E8D371F08DD6532 /* AddGroceryItemIntent.swift */; };
+		45271137CF1F716C66193C8B /* WatchConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F2A7A6357964DEE24CC265 /* WatchConnectivityManager.swift */; };
+		4937AE697F9348F50E9030D7 /* ChefMateWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEF74BEACFD1A2B404CE647 /* ChefMateWatchApp.swift */; };
+		4BA24F0A3D82A194319FD800 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9C41D88FCAFE935A1F2856A /* Foundation.framework */; };
+		5DA185BE6CE5D2A755647382 /* GroceryListsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205D39F6B226E5F6DD48DF53 /* GroceryListsView.swift */; };
+		72B99845AB05682D56D1513E /* SharedController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23090A19EBF22FAF83D7F78C /* SharedController.swift */; };
+		7B98E0F5B887BC1A44E24940 /* GroceryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B1047D42000AA001D2B573 /* GroceryStore.swift */; };
 		853E04942F8986CD00955A73 /* Bugsnag in Frameworks */ = {isa = PBXBuildFile; productRef = 853E04932F8986CD00955A73 /* Bugsnag */; };
 		853E04962F8986CD00955A73 /* BugsnagNetworkRequestPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 853E04952F8986CD00955A73 /* BugsnagNetworkRequestPlugin */; };
 		854859222F9B4505001123A9 /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 854859182F9B4505001123A9 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		89742D4D1B03A972EF804763 /* ChefMateWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 8725AFBF3A257499229E57E1 /* ChefMateWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		B7E9C9113F8FBD3BF7F3AFFC /* GroceryItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6706F1DC1D7DE83A34FB8DCD /* GroceryItemsView.swift */; };
+		CF419526CBA2B9512C25EB14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C9D044ECA48AE60D90F4FCE2 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -19,6 +30,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 854859172F9B4505001123A9;
 			remoteInfo = ShareExtension;
+		};
+		9C8A6AC1AFD54FA71724960C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CDB0B4ADAA143F5F0B669BBA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CBF9AFC8E8726D886BBB926C;
+			remoteInfo = ChefMateWatch;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -34,11 +52,34 @@
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CF216F6CBEE5BAF9E26F051A /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				89742D4D1B03A972EF804763 /* ChefMateWatch.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		205D39F6B226E5F6DD48DF53 /* GroceryListsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroceryListsView.swift; sourceTree = "<group>"; };
+		23090A19EBF22FAF83D7F78C /* SharedController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharedController.swift; sourceTree = "<group>"; };
+		4BEF74BEACFD1A2B404CE647 /* ChefMateWatchApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChefMateWatchApp.swift; sourceTree = "<group>"; };
+		64F2A7A6357964DEE24CC265 /* WatchConnectivityManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchConnectivityManager.swift; sourceTree = "<group>"; };
+		6706F1DC1D7DE83A34FB8DCD /* GroceryItemsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroceryItemsView.swift; sourceTree = "<group>"; };
+		750DC6FC6FC31992A18795C0 /* AddItemView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddItemView.swift; sourceTree = "<group>"; };
+		825160EF3E8D371F08DD6532 /* AddGroceryItemIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddGroceryItemIntent.swift; sourceTree = "<group>"; };
 		854859182F9B4505001123A9 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		8725AFBF3A257499229E57E1 /* ChefMateWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChefMateWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		98B1047D42000AA001D2B573 /* GroceryStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroceryStore.swift; sourceTree = "<group>"; };
 		A54AB85DFC2E74BAA712FE7C /* Chef Mate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Chef Mate.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B9C41D88FCAFE935A1F2856A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS11.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		C9D044ECA48AE60D90F4FCE2 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E84435B955C3CE5732B9C29B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -61,6 +102,8 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		847E4258837F74B255B86409 /* Configuration */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = Configuration;
 			sourceTree = "<group>";
 		};
@@ -83,6 +126,14 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0F8842F01A3B3A272E0624BF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4BA24F0A3D82A194319FD800 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		854859152F9B4505001123A9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -102,11 +153,38 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1529A7F27D2B97A5C4E2D981 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				B28D6F34D0BD3862DB9F1938 /* watchOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		27347867344F580F81BD0966 /* ChefMateWatch */ = {
+			isa = PBXGroup;
+			children = (
+				825160EF3E8D371F08DD6532 /* AddGroceryItemIntent.swift */,
+				750DC6FC6FC31992A18795C0 /* AddItemView.swift */,
+				4BEF74BEACFD1A2B404CE647 /* ChefMateWatchApp.swift */,
+				6706F1DC1D7DE83A34FB8DCD /* GroceryItemsView.swift */,
+				205D39F6B226E5F6DD48DF53 /* GroceryListsView.swift */,
+				98B1047D42000AA001D2B573 /* GroceryStore.swift */,
+				23090A19EBF22FAF83D7F78C /* SharedController.swift */,
+				64F2A7A6357964DEE24CC265 /* WatchConnectivityManager.swift */,
+				C9D044ECA48AE60D90F4FCE2 /* Assets.xcassets */,
+				E84435B955C3CE5732B9C29B /* Info.plist */,
+			);
+			name = ChefMateWatch;
+			path = ChefMateWatch;
+			sourceTree = "<group>";
+		};
 		2CB41F1E2ADF003F3F88F01A /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				A54AB85DFC2E74BAA712FE7C /* Chef Mate.app */,
 				854859182F9B4505001123A9 /* ShareExtension.appex */,
+				8725AFBF3A257499229E57E1 /* ChefMateWatch.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -118,7 +196,17 @@
 				F940F28EAB4E596F4D32FBD2 /* iosApp */,
 				854859192F9B4505001123A9 /* ShareExtension */,
 				2CB41F1E2ADF003F3F88F01A /* Products */,
+				1529A7F27D2B97A5C4E2D981 /* Frameworks */,
+				27347867344F580F81BD0966 /* ChefMateWatch */,
 			);
+			sourceTree = "<group>";
+		};
+		B28D6F34D0BD3862DB9F1938 /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				B9C41D88FCAFE935A1F2856A /* Foundation.framework */,
+			);
+			name = watchOS;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -133,11 +221,13 @@
 				D48F16A3AF4709DEED6E1963 /* Frameworks */,
 				CAF1FC802341ECF352B35550 /* Resources */,
 				854859232F9B4505001123A9 /* Embed Foundation Extensions */,
+				CF216F6CBEE5BAF9E26F051A /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				854859212F9B4505001123A9 /* PBXTargetDependency */,
+				AB294C3639D80CD6988AAC3C /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				F940F28EAB4E596F4D32FBD2 /* iosApp */,
@@ -167,11 +257,27 @@
 				854859192F9B4505001123A9 /* ShareExtension */,
 			);
 			name = ShareExtension;
-			packageProductDependencies = (
-			);
 			productName = ShareExtension;
 			productReference = 854859182F9B4505001123A9 /* ShareExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
+		};
+		CBF9AFC8E8726D886BBB926C /* ChefMateWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7D0CB3CB0B357CBD682D2E61 /* Build configuration list for PBXNativeTarget "ChefMateWatch" */;
+			buildPhases = (
+				935045027029126D8DF14705 /* Compile Kotlin Framework */,
+				F8987A537A351F3685548B0A /* Sources */,
+				0F8842F01A3B3A272E0624BF /* Frameworks */,
+				E4921239CA63268FAD350665 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ChefMateWatch;
+			productName = ChefMateWatch;
+			productReference = 8725AFBF3A257499229E57E1 /* ChefMateWatch.app */;
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
@@ -210,6 +316,7 @@
 			targets = (
 				5342D87862510584B561D3EB /* iosApp */,
 				854859172F9B4505001123A9 /* ShareExtension */,
+				CBF9AFC8E8726D886BBB926C /* ChefMateWatch */,
 			);
 		};
 /* End PBXProject section */
@@ -229,9 +336,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E4921239CA63268FAD350665 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CF419526CBA2B9512C25EB14 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		935045027029126D8DF14705 /* Compile Kotlin Framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Compile Kotlin Framework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\ncd \"$SRCROOT/..\"\nif [ -z \"$JAVA_HOME\" ]; then\n  export JAVA_HOME=\"$HOME/.sdkman/candidates/java/current\"\nfi\n./gradlew :client:watchShared:embedAndSignAppleFrameworkForXcode\n";
+		};
 		E61EFD183216E09BDCB678AC /* Compile Kotlin Framework */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -268,6 +402,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F8987A537A351F3685548B0A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24FF1CCB90D0CD0AB589B77F /* AddGroceryItemIntent.swift in Sources */,
+				11FE675F19E9CC0656E93D9B /* AddItemView.swift in Sources */,
+				4937AE697F9348F50E9030D7 /* ChefMateWatchApp.swift in Sources */,
+				B7E9C9113F8FBD3BF7F3AFFC /* GroceryItemsView.swift in Sources */,
+				5DA185BE6CE5D2A755647382 /* GroceryListsView.swift in Sources */,
+				7B98E0F5B887BC1A44E24940 /* GroceryStore.swift in Sources */,
+				72B99845AB05682D56D1513E /* SharedController.swift in Sources */,
+				45271137CF1F716C66193C8B /* WatchConnectivityManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -276,9 +425,48 @@
 			target = 854859172F9B4505001123A9 /* ShareExtension */;
 			targetProxy = 854859202F9B4505001123A9 /* PBXContainerItemProxy */;
 		};
+		AB294C3639D80CD6988AAC3C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ChefMateWatch;
+			target = CBF9AFC8E8726D886BBB926C /* ChefMateWatch */;
+			targetProxy = 9C8A6AC1AFD54FA71724960C /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		37956D9F7780560CC3A29E75 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Y89258SF5P;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ChefMateWatch/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lsqlite3",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.plusmobileapps.chefmate.ChefMate.watchkitapp;
+				PRODUCT_NAME = ChefMateWatch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Release;
+		};
 		50C837BD97BE4CCFFA99F137 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -472,6 +660,38 @@
 			};
 			name = Debug;
 		};
+		C01F19EEBFA935F451570D05 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Y89258SF5P;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ChefMateWatch/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lsqlite3",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.plusmobileapps.chefmate.ChefMate.watchkitapp;
+				PRODUCT_NAME = ChefMateWatch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Debug;
+		};
 		C6CC46FB88C80DF4FB55F1DA /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 847E4258837F74B255B86409 /* Configuration */;
@@ -539,6 +759,15 @@
 			buildConfigurations = (
 				61D8019E398CAAE4612427A7 /* Debug */,
 				C6CC46FB88C80DF4FB55F1DA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7D0CB3CB0B357CBD682D2E61 /* Build configuration list for PBXNativeTarget "ChefMateWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				37956D9F7780560CC3A29E75 /* Release */,
+				C01F19EEBFA935F451570D05 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/ChefMateWatch.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/ChefMateWatch.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CBF9AFC8E8726D886BBB926C"
+               BuildableName = "ChefMateWatch.app"
+               BlueprintName = "ChefMateWatch"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CBF9AFC8E8726D886BBB926C"
+            BuildableName = "ChefMateWatch.app"
+            BlueprintName = "ChefMateWatch"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CBF9AFC8E8726D886BBB926C"
+            BuildableName = "ChefMateWatch.app"
+            BlueprintName = "ChefMateWatch"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CBF9AFC8E8726D886BBB926C"
+            BuildableName = "ChefMateWatch.app"
+            BlueprintName = "ChefMateWatch"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/scripts/add_watch_target.rb
+++ b/scripts/add_watch_target.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Wires the "ChefMateWatch" watchOS app target into iosApp/iosApp.xcodeproj.
+#
+# Idempotent: if the target already exists it aborts without changes. Re-run after `bundle install`
+# so the `xcodeproj` gem (a fastlane dependency) is available:
+#
+#   bundle exec ruby scripts/add_watch_target.rb
+#
+# Mirrors the iOS app's KMP integration: a "Compile Kotlin Framework" run-script phase builds and
+# embeds the WatchShared framework via Gradle, and `import WatchShared` auto-links it (static
+# framework, same as ComposeApp on the phone).
+
+require 'xcodeproj'
+
+PROJECT_PATH = File.expand_path('../iosApp/iosApp.xcodeproj', __dir__)
+WATCH_DIR = 'ChefMateWatch' # relative to SRCROOT (iosApp/)
+TARGET_NAME = 'ChefMateWatch'
+WATCH_BUNDLE_ID = 'com.plusmobileapps.chefmate.ChefMate.watchkitapp'
+IOS_BUNDLE_ID = 'com.plusmobileapps.chefmate.ChefMate'
+TEAM_ID = 'Y89258SF5P'
+DEPLOYMENT_TARGET = '10.0'
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+if project.targets.any? { |t| t.name == TARGET_NAME }
+  abort("Target '#{TARGET_NAME}' already exists — nothing to do.")
+end
+
+ios_target = project.targets.find { |t| t.name == 'iosApp' }
+abort('Could not find the iosApp target.') unless ios_target
+
+# --- watchOS app target -------------------------------------------------------------------------
+watch = project.new_target(:application, TARGET_NAME, :watchos, DEPLOYMENT_TARGET, nil, :swift)
+
+# Group + source files (explicit refs — the folder is not a synchronized group).
+group = project.main_group.new_group(TARGET_NAME, WATCH_DIR)
+Dir.glob(File.join(__dir__, '..', 'iosApp', WATCH_DIR, '*.swift')).sort.each do |file|
+  ref = group.new_reference(File.basename(file))
+  watch.add_file_references([ref])
+end
+assets = group.new_reference('Assets.xcassets')
+watch.resources_build_phase.add_file_reference(assets)
+group.new_reference('Info.plist') # referenced via INFOPLIST_FILE, not a build phase
+
+# "Compile Kotlin Framework" run-script phase, run first (mirrors the iOS app).
+kotlin_phase = watch.new_shell_script_build_phase('Compile Kotlin Framework')
+kotlin_phase.shell_script = <<~SH
+  if [ "YES" = "$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED" ]; then
+    echo "Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\"YES\\""
+    exit 0
+  fi
+  cd "$SRCROOT/.."
+  if [ -z "$JAVA_HOME" ]; then
+    export JAVA_HOME="$HOME/.sdkman/candidates/java/current"
+  fi
+  ./gradlew :client:watchShared:embedAndSignAppleFrameworkForXcode
+SH
+kotlin_phase.always_out_of_date = '1'
+watch.build_phases.delete(kotlin_phase)
+watch.build_phases.insert(0, kotlin_phase)
+
+# Build settings.
+watch.build_configurations.each do |config|
+  bs = config.build_settings
+  bs['PRODUCT_BUNDLE_IDENTIFIER'] = WATCH_BUNDLE_ID
+  # Distinct product name from the phone app ("Chef Mate.app") so both targets don't produce the
+  # same bundle. The user-visible name comes from CFBundleDisplayName in Info.plist.
+  bs['PRODUCT_NAME'] = 'ChefMateWatch'
+  bs['SDKROOT'] = 'watchos'
+  bs['WATCHOS_DEPLOYMENT_TARGET'] = DEPLOYMENT_TARGET
+  bs['TARGETED_DEVICE_FAMILY'] = '4'
+  bs['SWIFT_VERSION'] = '5.0'
+  bs['GENERATE_INFOPLIST_FILE'] = 'NO'
+  bs['INFOPLIST_FILE'] = "#{WATCH_DIR}/Info.plist"
+  bs['ASSETCATALOG_COMPILER_APPICON_NAME'] = 'AppIcon'
+  bs['CODE_SIGN_STYLE'] = 'Automatic'
+  bs['DEVELOPMENT_TEAM'] = TEAM_ID
+  bs['CURRENT_PROJECT_VERSION'] = '1'
+  bs['MARKETING_VERSION'] = '1.0.0'
+  bs['OTHER_LDFLAGS'] = ['$(inherited)', '-lsqlite3']
+  bs['LD_RUNPATH_SEARCH_PATHS'] = ['$(inherited)', '@executable_path/Frameworks']
+  bs['SKIP_INSTALL'] = 'NO'
+  bs['ENABLE_PREVIEWS'] = 'YES'
+  bs['SWIFT_EMIT_LOC_STRINGS'] = 'YES'
+end
+
+# --- embed the watch app into the iOS app -------------------------------------------------------
+ios_target.add_dependency(watch)
+embed = ios_target.new_copy_files_build_phase('Embed Watch Content')
+embed.dst_subfolder_spec = '16' # $(CONTENTS_FOLDER_PATH)-relative
+embed.dst_path = '$(CONTENTS_FOLDER_PATH)/Watch'
+build_file = embed.add_file_reference(watch.product_reference)
+build_file.settings = { 'ATTRIBUTES' => ['RemoveHeadersOnCopy'] }
+
+# --- shared scheme so `xcodebuild -scheme ChefMateWatch` works ----------------------------------
+scheme = Xcodeproj::XCScheme.new
+scheme.add_build_target(watch)
+scheme.set_launch_target(watch)
+scheme.save_as(PROJECT_PATH, TARGET_NAME, true)
+
+project.save
+puts "Added '#{TARGET_NAME}' watchOS target and embedded it in the iOS app."


### PR DESCRIPTION
## Context

The native watchOS companion app, built on the shared Kotlin foundation from #338. This is the user-facing half: a SwiftUI watch app that drives the reused grocery data/sync layer through the `WatchShared` framework — pick a list, view/toggle items, add items (on-watch or via Siri).

**This was build-verified** — `xcodebuild` and the `xcodeproj` Ruby gem (a fastlane dependency) are available, so the watch app and its embedding into the iOS app were compiled, linked, and confirmed, not just scaffolded.

## What's here

**Swift app** (`iosApp/ChefMateWatch/`, single-target watchOS / `WKApplication`)
- Lists screen → items screen (tap to toggle) → add sheet (dictation/scribble).
- `GroceryStore` — an `ObservableObject` wrapping `WatchGroceryController`: callback flows hopped onto the main actor, `async` mutations, offline-first + Supabase sync.
- `AddGroceryItemIntent` + `ChefMateAppShortcuts` — "add an item to my grocery list" via Siri (Siri prompts for the item; free-form `String` params can't be interpolated into shortcut phrases). Shares one controller with the app, so items land in the same DB and sync.
- `WatchConnectivityManager` — receives the Supabase session handed off from the iPhone and imports it.

**Kotlin** — a Swift-friendly `createWatchGroceryController()` entry point on `:client:watchShared`.

**Xcode wiring** — a committed, idempotent `scripts/add_watch_target.rb` (xcodeproj gem) adds the target, the "Compile Kotlin Framework" run-script phase (`:client:watchShared:embedAndSignAppleFrameworkForXcode`), embeds the watch app into the iOS app, and creates a shared scheme. `import WatchShared` auto-links the static framework (same pattern as ComposeApp on the phone).

## Verification (built, not just parsed)

- `xcodebuild -scheme ChefMateWatch -sdk watchsimulator ARCHS=arm64 CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED** (Swift compiles + links against the real WatchShared framework; App Intents metadata exports).
- `xcodebuild -scheme iosApp -destination 'generic/platform=iOS Simulator' ARCHS=arm64 CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED** (iOS app embeds the watch app).

Interop issues found and fixed during verification: suspend-returning-`Long` bridges to Swift `KotlinLong` (`.int64Value`); App Intents free-form param phrase constraint; arm64-sim-only framework (matches the existing iOS setup — no Intel sim target).

## Follow-up (own PR)

The **iPhone-side WatchConnectivity sender** (push the refresh token when the phone's session changes) plus a small `currentRefreshToken()` accessor on the shared `AuthenticationRepository` (ripples through the interface + impls/fakes). Until then the watch shows a "Sign in on iPhone" state. Also: a real match provisioning profile for the watch bundle id and app icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)