### PR TITLE
fix(ios): share iosApp/ShareExtension schemes so the iOS release resolves them

### DIFF
--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/ShareExtension.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/ShareExtension.xcscheme
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "854859172F9B4505001123A9"
+               BuildableName = "ShareExtension.appex"
+               BlueprintName = "ShareExtension"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5342D87862510584B561D3EB"
+               BuildableName = "Chef Mate.app"
+               BlueprintName = "iosApp"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5342D87862510584B561D3EB"
+            BuildableName = "Chef Mate.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5342D87862510584B561D3EB"
+            BuildableName = "Chef Mate.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5342D87862510584B561D3EB"
+            BuildableName = "Chef Mate.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/scripts/add_watch_target.rb
+++ b/scripts/add_watch_target.rb
@@ -106,11 +106,24 @@ embed.dst_path = '$(CONTENTS_FOLDER_PATH)/Watch'
 build_file = embed.add_file_reference(watch.product_reference)
 build_file.settings = { 'ATTRIBUTES' => ['RemoveHeadersOnCopy'] }
 
-# --- shared scheme so `xcodebuild -scheme ChefMateWatch` works ----------------------------------
-scheme = Xcodeproj::XCScheme.new
-scheme.add_build_target(watch)
-scheme.set_launch_target(watch)
-scheme.save_as(PROJECT_PATH, TARGET_NAME, true)
+# --- shared schemes -----------------------------------------------------------------------------
+# Adding the watch scheme makes it the project's first *shared* scheme, which disables Xcode's
+# on-demand generation of the (unshared) iosApp / ShareExtension schemes. In CI (fresh checkout,
+# no user schemes) `fastlane build_app --scheme iosApp` would then fail to find it and fall back to
+# the only scheme present. So share every runnable target's scheme.
+{ watch => true, ios_target => true }.each do |target, launch|
+  scheme = Xcodeproj::XCScheme.new
+  scheme.add_build_target(target)
+  scheme.set_launch_target(target) if launch
+  scheme.save_as(PROJECT_PATH, target.name, true)
+end
+# ShareExtension can't launch standalone — a build-only shared scheme is enough.
+share_ext = project.targets.find { |t| t.name == 'ShareExtension' }
+if share_ext
+  scheme = Xcodeproj::XCScheme.new
+  scheme.add_build_target(share_ext)
+  scheme.save_as(PROJECT_PATH, share_ext.name, true)
+end
 
 project.save
 puts "Added '#{TARGET_NAME}' watchOS target and embedded it in the iOS app."


### PR DESCRIPTION
## What broke

The **v1.9.0 iOS Release** failed in the `build_app` step:

```
xcodebuild -scheme ChefMateWatch ... -destination 'generic/platform=iOS' ... archive
xcodebuild: error: Unable to find a destination matching the provided destination specifier
```

gym is configured with `scheme: "iosApp"`, but it ended up trying to archive the **ChefMateWatch** (watchOS) scheme against an iOS destination.

## Root cause

Before the watch work, the project had **no shared schemes**, so Xcode auto-generated the `iosApp` scheme on demand — which is how the release found it. The watch app added `ChefMateWatch.xcscheme` as the project's **first shared scheme**, and that disables on-demand generation of the still-unshared `iosApp` / `ShareExtension` schemes. In CI (fresh checkout, no per-user schemes) the only scheme present was `ChefMateWatch`, so gym couldn't find `iosApp` and fell back to it.

(The `iOS Simulator` test job was unaffected — it runs `./gradlew iosSimulatorArm64Test`, not an Xcode scheme.)

## Fix

Share the `iosApp` and `ShareExtension` schemes too, so every runnable target resolves deterministically in CI. Also updates `scripts/add_watch_target.rb` to emit all shared schemes on future regens (so this can't recur).

## Verification

`xcodebuild -showBuildSettings -scheme iosApp -configuration Release` resolves cleanly to **Chef Mate.app** (`com.plusmobileapps.chefmate.ChefMate`), with `ArchiveAction` on `Release` — i.e. gym will now archive the correct app for a valid iOS destination.

## After merge

v1.9.0's tag points at the broken commit, so re-cut the release (bump to v1.9.1, or re-run the release workflow from an updated commit) to pick up this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)