### PR TITLE
fix(ios): unblock the iOS release (watch SKIP_INSTALL + Xcode 26 export method)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,11 +70,21 @@ platform :ios do
       api_key: api_key,
     )
 
+    # Xcode 26 renamed the App Store export method to "app-store-connect", but fastlane's gym still
+    # validates export_method against the pre-Xcode-16 names (and always forces the
+    # exportOptionsPlist `method` to whatever export_method is). Relax that one validation so we can
+    # pass the new value; otherwise `xcodebuild -exportArchive` fails with
+    # `exportOptionsPlist error for key "method" ... found app-store`.
+    require "gym"
+    Gym::Options.available_options
+      .find { |option| option.key == :export_method }
+      &.instance_variable_set(:@verify_block, nil)
+
     build_app(
       project: "iosApp/iosApp.xcodeproj",
       scheme: "iosApp",
       configuration: "Release",
-      export_method: "app-store",
+      export_method: "app-store-connect",
       output_directory: "build/ios",
       xcargs: "TEAM_ID=#{ENV['TEAM_ID']} DEVELOPMENT_TEAM=#{ENV['TEAM_ID']}",
       export_options: {

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				PRODUCT_NAME = ChefMateWatch;
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=watchos*]" = "match AppStore com.plusmobileapps.chefmate.ChefMate.watchkitapp";
 				SDKROOT = watchos;
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -661,7 +661,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.plusmobileapps.chefmate.ChefMate.watchkitapp;
 				PRODUCT_NAME = ChefMateWatch;
 				SDKROOT = watchos;
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;

--- a/scripts/add_watch_target.rb
+++ b/scripts/add_watch_target.rb
@@ -63,7 +63,7 @@ watch.build_configurations.each do |config|
   bs['MARKETING_VERSION'] = '1.0.0'
   bs['OTHER_LDFLAGS'] = ['$(inherited)']
   bs['LD_RUNPATH_SEARCH_PATHS'] = ['$(inherited)', '@executable_path/Frameworks']
-  bs['SKIP_INSTALL'] = 'NO'
+  bs['SKIP_INSTALL'] = 'YES' # embedded in the iOS app; must not be a top-level archive product
   bs['ENABLE_PREVIEWS'] = 'YES'
   bs['SWIFT_EMIT_LOC_STRINGS'] = 'YES'
 


### PR DESCRIPTION
Two separate blockers stopped the iOS release once the watch was back in the archive (#347). Both fixed here; verified by reproducing the archive + export locally with Xcode 26.5.

## 1. Watch app broke the archive (the real cause of "Unknown Distribution Error")

`ChefMateWatch` had `SKIP_INSTALL = NO`, so the archive placed `ChefMateWatch.app` as a **top-level** product in `Products/Applications` alongside `Chef Mate.app`. With two top-level apps, Xcode can't pick the primary app and writes **no `ApplicationProperties`** into the archive `Info.plist`. `xcodebuild -exportArchive` then can't enumerate any distribution methods:

```
IDEDistributionMethodManager … "Unknown Distribution Error"
error: exportArchive exportOptionsPlist error for key "method" expected one {} but found …
```

Fix: `SKIP_INSTALL = YES` on the watch target (like `ShareExtension`). It's embedded via "Embed Watch Content", so it must not be a standalone archive product.

**Verified:** archive now has only `Chef Mate.app` at top level, carries `ApplicationProperties`, and nests the watch at `Chef Mate.app/Watch/`.

## 2. Xcode 26 renamed the export method

Xcode 26's `-exportArchive` uses `app-store-connect`, not `app-store` (confirmed by a prior successful export log). fastlane's gym still validates `export_method` against the old names and forces the plist `method` to it, so the release lane relaxes that one validation and passes `app-store-connect`.

## After merge

Re-dispatch the release workflow (from this branch to test first, or from main after merge). With a signed archive the export should now enumerate `app-store-connect` and proceed to upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)