### PR TITLE
fix(watch): recover snapshot sync when the phone app is unreachable

### DIFF
--- a/iosApp/ChefMateWatch/WatchConnectivityManager.swift
+++ b/iosApp/ChefMateWatch/WatchConnectivityManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import WatchConnectivity
 
 /// The watch's only link to its data: WatchConnectivity to the iPhone. The phone pushes grocery
@@ -11,6 +12,8 @@ import WatchConnectivity
 final class WatchConnectivityManager: NSObject, WCSessionDelegate {
     static let shared = WatchConnectivityManager()
 
+    private let log = Logger(subsystem: "com.plusmobileapps.chefmate.watch", category: "connectivity")
+
     /// Set by the store; invoked on the main queue whenever a fresh snapshot arrives.
     var onSnapshot: ((WatchSnapshot) -> Void)?
 
@@ -22,12 +25,31 @@ final class WatchConnectivityManager: NSObject, WCSessionDelegate {
     }
 
     /// Ask the phone for the latest snapshot (call when the watch becomes active).
+    ///
+    /// When the phone is reachable we use `sendMessage` for an immediate reply. When it isn't (the
+    /// common case — the phone app is backgrounded or killed), we fall back to a queued
+    /// `transferUserInfo` request so the phone still wakes, pushes a fresh snapshot, and the watch
+    /// can recover on its own instead of getting stuck on the "Open Chef Mate on iPhone" prompt.
     func requestSnapshot() {
         let session = WCSession.default
-        guard session.activationState == .activated, session.isReachable else { return }
-        session.sendMessage(["type": "requestSnapshot"], replyHandler: { [weak self] reply in
-            self?.decode(reply)
-        }, errorHandler: nil)
+        guard session.activationState == .activated else {
+            log.info("requestSnapshot skipped: session not activated")
+            return
+        }
+        if session.isReachable {
+            session.sendMessage(["type": "requestSnapshot"], replyHandler: { [weak self] reply in
+                self?.decode(reply)
+            }, errorHandler: { [weak self] error in
+                self?.log.error("sendMessage failed, falling back to userInfo: \(error.localizedDescription)")
+                self?.requestSnapshotViaUserInfo()
+            })
+        } else {
+            requestSnapshotViaUserInfo()
+        }
+    }
+
+    private func requestSnapshotViaUserInfo() {
+        WCSession.default.transferUserInfo(["type": "requestSnapshot"])
     }
 
     func sendSetChecked(itemId: Int64, isChecked: Bool) {

--- a/iosApp/iosApp/WatchDataSender.swift
+++ b/iosApp/iosApp/WatchDataSender.swift
@@ -1,4 +1,5 @@
 import ComposeApp
+import os
 import WatchConnectivity
 
 /// iPhone side of the watch companion. The phone is the source of truth: it pushes grocery
@@ -7,6 +8,7 @@ import WatchConnectivity
 final class WatchDataSender: NSObject, WCSessionDelegate {
     private let bridge: WatchDataBridge
     private var cancelObserve: (() -> Void)?
+    private let log = Logger(subsystem: "com.plusmobileapps.chefmate", category: "watch")
 
     init(bridge: WatchDataBridge) {
         self.bridge = bridge
@@ -17,8 +19,20 @@ final class WatchDataSender: NSObject, WCSessionDelegate {
     }
 
     private func push(_ json: String) {
-        guard WCSession.default.activationState == .activated else { return }
-        try? WCSession.default.updateApplicationContext(["snapshot": json])
+        let session = WCSession.default
+        guard session.activationState == .activated else {
+            log.info("push skipped: session not activated")
+            return
+        }
+        // Surface failures instead of swallowing them: a thrown error here (e.g. the phone thinks
+        // the watch app isn't installed) is exactly why the watch can silently never sync.
+        do {
+            try session.updateApplicationContext(["snapshot": json])
+        } catch {
+            log.error(
+                "updateApplicationContext failed (paired=\(session.isPaired), watchAppInstalled=\(session.isWatchAppInstalled)): \(error.localizedDescription)"
+            )
+        }
     }
 
     func session(
@@ -26,6 +40,9 @@ final class WatchDataSender: NSObject, WCSessionDelegate {
         activationDidCompleteWith activationState: WCSessionActivationState,
         error: Error?
     ) {
+        if let error {
+            log.error("activation failed: \(error.localizedDescription)")
+        }
         // Push a fresh snapshot to the watch on every grocery data change.
         cancelObserve = bridge.observeSnapshot { [weak self] json in self?.push(json) }
     }
@@ -43,9 +60,13 @@ final class WatchDataSender: NSObject, WCSessionDelegate {
         }
     }
 
-    // Watch toggle/add actions (queued, reliable).
+    // Watch toggle/add actions plus its queued snapshot request (all reliable, delivered even when
+    // the phone was unreachable when the watch acted).
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any]) {
         switch userInfo["type"] as? String {
+        case "requestSnapshot":
+            // Watch asked while we were unreachable; push the current snapshot so it can load.
+            bridge.currentSnapshot { [weak self] json in self?.push(json) }
         case "setChecked":
             if let itemId = (userInfo["itemId"] as? NSNumber)?.int64Value,
                let isChecked = userInfo["isChecked"] as? Bool {


### PR DESCRIPTION
## Problem

The watchOS companion could get **permanently stuck** on the "Open Chef Mate on iPhone" prompt and never load grocery lists, even after opening the phone app.

Root cause is a gap between the two data paths in the WatchConnectivity bridge:

- **Pull path** — `WatchConnectivityManager.requestSnapshot()` bailed out silently unless `session.isReachable`, which is only true when the phone app is in the foreground. In real use (phone in pocket, app backgrounded/killed) this path never fired, so the watch couldn't ask for data.
- **Push path** — the phone's `WatchDataSender.push()` swallowed every `updateApplicationContext` error with `try?`. If the phone thought the watch app wasn't installed (`isWatchAppInstalled == false`) — plausible given the recent watch install/archive churn — the push threw and was hidden, leaving no way to diagnose or recover.

With the pull path dead and push failures invisible, the watch had no self-recovery path.

## Fix

- **Watch:** when the phone isn't reachable (or `sendMessage` errors), fall back to a queued `transferUserInfo(["type": "requestSnapshot"])` so the phone still wakes, pushes a fresh snapshot, and the watch recovers on its own.
- **Phone:** handle that queued `requestSnapshot` in `didReceiveUserInfo` by pushing the current snapshot.
- **Phone:** replace `try?` with a logged `do/catch` reporting `isPaired` / `isWatchAppInstalled`, and log activation errors — so if the real cause is install-detection (vs. the data flow never emitting), it shows up in device logs.

## Testing

Not yet verified on a paired device — needs a manual check that opening the watch cold (phone app backgrounded) loads lists, and a device-log read of the `com.plusmobileapps.chefmate`/`.watch` subsystems if it still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)