### PR TITLE
fix(ui): stop iOS search caret sticking at position 0 (TextFieldState)

### DIFF
--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -42,8 +43,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import chefmate.client.auth.ui.public.generated.resources.Res
 import chefmate.client.auth.ui.public.generated.resources.auth_button_email_me_a_code
@@ -380,6 +379,13 @@ fun EmailField(
     )
 }
 
+// Masks the field's contents with bullets for the state-based text field. Replacing 1:1 keeps the
+// caret mapping identity, so the cursor stays put. Mirrors PasswordVisualTransformation from the
+// legacy value/onValueChange API.
+private val PasswordOutputTransformation = OutputTransformation {
+    replace(0, length, "•".repeat(length))
+}
+
 @Composable
 fun PasswordField(
     modifier: Modifier = Modifier,
@@ -398,8 +404,7 @@ fun PasswordField(
         label = { Text(label) },
         error = error,
         singleLine = true,
-        visualTransformation =
-            if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+        outputTransformation = if (passwordVisible) null else PasswordOutputTransformation,
         keyboardOptions =
             KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = imeAction),
         keyboardActions = KeyboardActions(onNext = { onImeAction() }, onDone = { onImeAction() }),

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusTextField.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusTextField.kt
@@ -4,23 +4,26 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActionScope
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.KeyboardActionHandler
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.input.ImeAction
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
@@ -40,27 +43,40 @@ fun PlusTextField(
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     minLines: Int = 1,
     focusRequester: FocusRequester? = null,
-    visualTransformation: VisualTransformation = VisualTransformation.None,
+    outputTransformation: OutputTransformation? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
 ) {
     val isError = error != null
 
-    // The cursor/selection is owned locally rather than driven by the hoisted `value` String. When
-    // the value round-trips through a Bloc (onValueChange -> StateFlow -> collectAsState), a
-    // controlled String field receives a one-frame-stale echo of each keystroke; on iOS that
-    // surfaces as the cursor jumping to the front of the field after typing. Keeping a local
-    // TextFieldValue means our own keystroke echoes can never move the cursor.
-    var textFieldValue by remember {
-        mutableStateOf(TextFieldValue(text = value, selection = TextRange(value.length)))
+    // Back the field with a TextFieldState so the field itself owns its text *and* its
+    // cursor/selection. This is the pairing Compose Multiplatform's native iOS text input expects:
+    // the native UIView and Compose share a single buffer, so the caret can't desync from the text.
+    //
+    // The previous value/onValueChange + local-TextFieldValue bridge kept the *logical* selection
+    // correct (text still inserted in order) but the native iOS input rendered its caret at the
+    // start of the field, because that experimental input path doesn't honor Compose-driven
+    // selection pushed through the TextFieldValue overload. TextFieldState removes that round-trip
+    // entirely.
+    val state = rememberTextFieldState(initialText = value)
+
+    // Long-lived collectors below must always see the latest hoisted value/callback without
+    // restarting, so read them through rememberUpdatedState.
+    val currentValue by rememberUpdatedState(value)
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+
+    // Push local edits out to the caller. The guard means the value catching up to what the user
+    // just typed (the Bloc round-trip echo) never re-notifies or loops.
+    LaunchedEffect(state) {
+        snapshotFlow { state.text.toString() }
+            .collect { text -> if (text != currentValue) currentOnValueChange(text) }
     }
 
-    // Only adopt genuine upstream changes (autofill, form reset, clearing) — keyed on `value` so
-    // this reacts to real changes, not every recomposition. The guard skips the case where local
-    // edits have already produced this text.
+    // Adopt genuine upstream changes (clearing the query, a form reset, autofill) without moving
+    // the cursor on ordinary keystroke round-trips.
     LaunchedEffect(value) {
-        if (value != textFieldValue.text) {
-            textFieldValue = TextFieldValue(text = value, selection = TextRange(value.length))
+        if (value != state.text.toString()) {
+            state.setTextAndPlaceCursorAtEnd(value)
         }
     }
 
@@ -69,29 +85,30 @@ fun PlusTextField(
             if (focusRequester != null) it.focusRequester(focusRequester) else it
         }
 
+    val lineLimits =
+        if (singleLine) {
+            TextFieldLineLimits.SingleLine
+        } else {
+            TextFieldLineLimits.MultiLine(minHeightInLines = minLines, maxHeightInLines = maxLines)
+        }
+
     Column(modifier = modifier) {
         OutlinedTextField(
-            value = textFieldValue,
-            onValueChange = { newValue ->
-                textFieldValue = newValue
-                if (newValue.text != value) {
-                    onValueChange(newValue.text)
-                }
-            },
+            state = state,
             modifier = fieldModifier,
-            label = label,
+            enabled = enabled,
+            readOnly = readOnly,
+            // The state-based overload's label carries a TextFieldLabelScope receiver; adapt the
+            // plain slot callers pass so PlusTextField's public API stays receiver-free.
+            label = label?.let { slot -> { slot() } },
             placeholder = placeholder,
             leadingIcon = leadingIcon,
             trailingIcon = trailingIcon,
             isError = isError,
-            enabled = enabled,
-            readOnly = readOnly,
-            singleLine = singleLine,
-            maxLines = maxLines,
-            minLines = minLines,
-            visualTransformation = visualTransformation,
+            lineLimits = lineLimits,
+            outputTransformation = outputTransformation,
             keyboardOptions = keyboardOptions.withNativeTextInput(),
-            keyboardActions = keyboardActions,
+            onKeyboardAction = keyboardActions.toKeyboardActionHandler(keyboardOptions.imeAction),
         )
         AnimatedVisibility(visible = isError) {
             error?.let {
@@ -107,5 +124,30 @@ fun PlusTextField(
                 )
             }
         }
+    }
+}
+
+/**
+ * Bridges the legacy [KeyboardActions] callbacks onto the [androidx.compose.foundation.text.input]
+ * API's single [KeyboardActionHandler], dispatching to the lambda that matches the field's
+ * [imeAction]. Returns null when no matching action is set, so the platform default runs.
+ */
+private fun KeyboardActions.toKeyboardActionHandler(imeAction: ImeAction): KeyboardActionHandler? {
+    val action: (KeyboardActionScope.() -> Unit) =
+        when (imeAction) {
+            ImeAction.Done -> onDone
+            ImeAction.Go -> onGo
+            ImeAction.Next -> onNext
+            ImeAction.Previous -> onPrevious
+            ImeAction.Search -> onSearch
+            ImeAction.Send -> onSend
+            else -> null
+        } ?: return null
+    return KeyboardActionHandler { performDefault ->
+        val scope =
+            object : KeyboardActionScope {
+                override fun defaultKeyboardAction(imeAction: ImeAction) = performDefault()
+            }
+        scope.action()
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #351. That PR fixed **out-of-order** typing on iOS (by having `PlusTextField` own a local `TextFieldValue`) and then opted the field into Compose Multiplatform 1.11's **experimental native iOS text input**. The two halves don't cooperate:

- The native UIView-backed input **doesn't honor selection pushed through the `value`/`onValueChange` `TextFieldValue` overload**.
- So the *logical* cursor stayed correct — text still inserted in order — while the **rendered caret snapped back to position 0** after each keystroke.

It's most visible on the **recipe-list search**, which is auto-focused (`LaunchedEffect(Unit){ requestFocus() }`) and round-trips its value through a Bloc `StateFlow` — the exact conditions that expose the desync.

## Fix

Re-implement `PlusTextField` on the **`TextFieldState` API** — the pairing Compose Multiplatform's native iOS input actually expects. The field owns a single text + selection buffer shared with the native UIView, so the caret can't desync from the text.

- Local edits are pushed out to callers via `snapshotFlow` (guarded through `rememberUpdatedState` so the Bloc round-trip echo can't loop or re-notify).
- Genuine upstream changes (clearing the query, form reset, autofill) are adopted with `setTextAndPlaceCursorAtEnd`.
- Native input **stays enabled** via `keyboardOptions.withNativeTextInput()` — this keeps the native selection handles / system context menu that #351 added.

### Call-site impact

Public API is unchanged except `visualTransformation` → `outputTransformation`:

- Only the auth **password field** used `visualTransformation`; migrated to a 1:1 bullet-masking `OutputTransformation` (1:1 replacement keeps caret mapping identity).
- `singleLine` / `maxLines` / `minLines` now map to `lineLimits`, and `KeyboardActions` bridges onto the new `onKeyboardAction` handler internally — so **every existing `PlusTextField` call site keeps working untouched**.

## Testing

- `./gradlew :client:ui:public:compileKotlinJvm :client:ui:public:compileKotlinIosSimulatorArm64 :client:ui:public:compileAndroidMain` — BUILD SUCCESSFUL
- Compiled every `PlusTextField` consumer (auth, feature flags, grocery, profile, recipe categories/core/list, recipe book edit) on JVM; auth on iOS + Android.
- ktfmt clean.
- ⚠️ Not yet verified on an iOS device/simulator at runtime — the caret behavior should be confirmed manually on the recipe-list search before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)