### PR TITLE
fix(recipe): make search clear button close the search on iOS

### DIFF
--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -1194,23 +1194,31 @@ private fun SearchBar(
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
-    PlusTextField(
-        value = query,
-        onValueChange = onQueryChanged,
+    Row(
         modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-        focusRequester = focusRequester,
-        placeholder = { Text(stringResource(Res.string.recipe_list_search_placeholder)) },
-        leadingIcon = { Icon(imageVector = Icons.Default.Search, contentDescription = null) },
-        trailingIcon = {
-            IconButton(onClick = onClear) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(Res.string.recipe_list_search_clear),
-                )
-            }
-        },
-        singleLine = true,
-    )
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        PlusTextField(
+            value = query,
+            onValueChange = onQueryChanged,
+            modifier = Modifier.weight(1f),
+            focusRequester = focusRequester,
+            placeholder = { Text(stringResource(Res.string.recipe_list_search_placeholder)) },
+            leadingIcon = { Icon(imageVector = Icons.Default.Search, contentDescription = null) },
+            singleLine = true,
+        )
+        // The clear/close control lives OUTSIDE PlusTextField rather than in its trailing slot. On
+        // iOS the field renders through the native text input (usingNativeTextInput), whose UIView
+        // covers the field's bounds and swallows taps landing on any control drawn inside it — so a
+        // trailing IconButton there never fired and the search wouldn't close. As a sibling it sits
+        // outside that native view and reliably clears the query and dismisses the search bar.
+        IconButton(onClick = onClear) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(Res.string.recipe_list_search_clear),
+            )
+        }
+    }
 }
 
 @Composable

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSearchEmptyDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSearchEmptyDarkScreenshot_805fa67c_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3632115ccefbc0db9f2dbde687c8c3180cbef948279165c664191f6440d7633
-size 54565
+oid sha256:fbd59a5147a552dfa741946eda0fc59eced6ae867218a12c7004f84eff1ea991
+size 54542

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSearchEmptyLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSearchEmptyLightScreenshot_73588fdf_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd41cf863a15fc8a684d669bf1789cbd87e7041f907d0ceb1b7604cfeb8a3f18
-size 54171
+oid sha256:c97e7de4789660e41385cddfd49178654bb62ed425f59c4484a14c7b96a3ad8e
+size 54232


### PR DESCRIPTION
Fixes #360.

## Problem

The trailing-end close (✕) button in the recipe list search field didn't close the search. The header search toggle worked fine, but tapping the ✕ inside the field did nothing.

## Root cause

The search field renders through iOS's native text input (`usingNativeTextInput(true)`, introduced in #351). That native `UITextField` overlay covers the field's bounds, so a tap landing on any control drawn *inside* the field — including an `IconButton` in the `trailingIcon` slot — is swallowed by the native view and never fires its `onClick`. The header toggle closes the search because it lives in the app bar, outside the field. The `onClear` logic itself was already correct.

## Fix

Restructured `SearchBar` so the clear/close `IconButton` is a **sibling** of `PlusTextField` in a `Row` (the field takes `weight(1f)`), instead of sitting in the field's trailing slot. As a sibling the button is outside the native input's touch region, so its tap reliably clears the query and dismisses the search bar. The behavior is uniform across platforms.

## Screenshots

The ✕ now sits just outside the field's rounded outline. Regenerated the two affected references (`RecipeListSearchEmpty` light + dark) and confirmed a clean `validateDebugScreenshotTest`.

## Reviewer notes

- I couldn't run an iOS simulator, so the root cause is a strong inference from the header-vs-trailing behavior difference plus the recent native-input history (#351, #358) — not a device repro. The fix is defensive regardless of the exact mechanism, since the control is now unambiguously outside any native-input region.
- The alpha `com.android.compose.screenshot` plugin's `updateDebugScreenshotTest` would not rewrite the existing references (a config-cache/plugin quirk), so the reference PNGs were synced from the freshly-rendered output — the same operation the task performs — then verified with a clean `validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)