### PR TITLE
fix(watch): install app delegate so the phone pushes grocery snapshots

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -16,8 +16,7 @@ struct ComposeView: UIViewControllerRepresentable {
 }
 
 struct ContentView: View {
-    @UIApplicationDelegateAdaptor(AppDelegate.self)
-    var appDelegate: AppDelegate
+    let appDelegate: AppDelegate
 
     var body: some View {
         ComposeView(

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -3,9 +3,14 @@ import ComposeApp
 
 @main
 struct iOSApp: App {
+    // Must live on the `App` struct: `@UIApplicationDelegateAdaptor` is only honored here, not on a
+    // child `View`. Placed on a `View` it silently no-ops ("used outside of an App or Scene"), so
+    // `didFinishLaunchingWithOptions` never fires and the watch data bridge never starts.
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate: AppDelegate
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(appDelegate: appDelegate)
         }
     }
 }


### PR DESCRIPTION
## Problem

The watchOS companion was permanently stuck on the **"Open Chef Mate on iPhone"** prompt and never loaded any grocery lists — on every device, not just the simulator.

## Root cause

`@UIApplicationDelegateAdaptor(AppDelegate.self)` was declared on `ContentView` (a child `View`). The adaptor is only honored when it's a property of the `@main` `App` struct; on a `View` SwiftUI silently ignores it and logs:

```
@UIApplicationDelegateAdaptor was used outside of an App or Scene; this will not instantiate the delegate.
```

So `AppDelegate` was never installed as the `UIApplication` delegate and `application(_:didFinishLaunchingWithOptions:)` never ran. That method is the **only** place `watchDataSender` is created, so the phone-side `WCSession` delegate and `observeSnapshot` observer never activated — the phone never pushed grocery snapshots. The watch's `receivedApplicationContext` stayed `nil`, so `hasLoaded` never flipped and the prompt never went away.

The app otherwise appeared to work because `ContentView` reads `appDelegate.root` directly, which lazily builds the Compose UI without needing the lifecycle callback.

This also explains why #357 (recover snapshot sync when the phone is unreachable) couldn't help: the phone side was never running in the first place.

## Fix

Move the adaptor onto the `iOSApp` `App` struct and pass the delegate into `ContentView`. Now `didFinishLaunchingWithOptions` fires, `watchDataSender` starts, and the phone pushes snapshots to the watch.

Bonus: this restores **cold-launch deep-link handling**, which was dead for the same reason (`launchDeepLinkUrl` is set in `didFinishLaunchingWithOptions`).

## Verification

- The `@UIApplicationDelegateAdaptor was used outside of an App or Scene` warning no longer appears in the iPhone log (subsystem `com.plusmobileapps.chefmate`).
- Opening the watch app populates its grocery lists instead of showing the prompt.
- Best tested on a real device — WatchConnectivity is unreliable in the simulator — but the disappearance of the delegate warning is the key signal the wiring is now live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)