### PR TITLE
feat(ios): add phone Siri App Intent to add grocery items

### DIFF
--- a/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/RootBlocProvider.kt
+++ b/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/RootBlocProvider.kt
@@ -27,6 +27,14 @@ object RootBlocProvider {
     lateinit var watchDataBridge: WatchDataBridge
         private set
 
+    /**
+     * Non-throwing view of [watchDataBridge] for callers that may run before the graph is built —
+     * e.g. the Siri "add grocery item" App Intent, which can background-launch the app. Null until
+     * [buildRootBloc] has run; reading [watchDataBridge] directly in that window would crash.
+     */
+    val watchDataBridgeOrNull: WatchDataBridge?
+        get() = if (::watchDataBridge.isInitialized) watchDataBridge else null
+
     fun buildRootBloc(
         componentContext: ComponentContext,
         application: UIApplication,

--- a/iosApp/iosApp/AddGroceryItemIntent.swift
+++ b/iosApp/iosApp/AddGroceryItemIntent.swift
@@ -1,0 +1,73 @@
+import AppIntents
+import ComposeApp
+
+/// "Hey Siri, add milk to my Chef Mate grocery list." Runs on the phone (no watch required): it adds
+/// the item to the default list through the shared `WatchDataBridge`, which persists it and syncs to
+/// Supabase — the same path the watch's add action flows through.
+///
+/// Runs without opening the app (`openAppWhenRun = false`). When Siri triggers this while the app is
+/// not running, the system background-launches it, which builds the DI graph in `AppDelegate` before
+/// `perform()` runs. `awaitBridge()` still guards the cold-launch race so we never touch the
+/// `lateinit` bridge before it exists.
+struct AddGroceryItemIntent: AppIntent {
+    static var title: LocalizedStringResource = "Add Grocery Item"
+    static var description = IntentDescription("Adds an item to your Chef Mate grocery list.")
+    static var openAppWhenRun: Bool = false
+
+    @Parameter(title: "Item", requestValueDialog: "What should I add?")
+    var item: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Add \(\.$item) to my grocery list")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let name = item.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            return .result(dialog: "I didn't catch what to add.")
+        }
+
+        guard let bridge = await Self.awaitBridge() else {
+            return .result(dialog: "Open Chef Mate once, then try adding that again.")
+        }
+
+        await withCheckedContinuation { continuation in
+            bridge.ensureDefaultList { listId in
+                bridge.addItem(listId: listId.int64Value, name: name)
+                continuation.resume()
+            }
+        }
+
+        return .result(dialog: "Added \(name) to your grocery list.")
+    }
+
+    /// Waits briefly for the DI graph to finish building on a cold background launch. Returns nil if
+    /// the bridge never appears (app never fully launched), so the caller can prompt the user.
+    private static func awaitBridge() async -> WatchDataBridge? {
+        for _ in 0 ..< 50 {  // up to ~5s
+            if let bridge = RootBlocProvider.shared.watchDataBridgeOrNull {
+                return bridge
+            }
+            try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1s
+        }
+        return RootBlocProvider.shared.watchDataBridgeOrNull
+    }
+}
+
+/// The iPhone app's single App Shortcuts entry. Each phrase must include the app name (Siri routes
+/// generic "add to my grocery list" wording to Reminders), so all phrases reference `Chef Mate` via
+/// `\(.applicationName)`.
+struct ChefMateAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: AddGroceryItemIntent(),
+            phrases: [
+                "Add an item to my \(.applicationName) grocery list",
+                "Add to my grocery list in \(.applicationName)",
+                "Add to my \(.applicationName) grocery list",
+            ],
+            shortTitle: "Add Grocery Item",
+            systemImageName: "cart.badge.plus"
+        )
+    }
+}


### PR DESCRIPTION
## What

Adds an **iPhone-side** App Intent + App Shortcut so you can say to Siri on the phone:

- "Add milk to my Chef Mate grocery list" (one-shot)
- "Add an item to my Chef Mate grocery list" → Siri asks *"What should I add?"*

Previously only a **watch-side** intent existed. Saying generic grocery-list phrasing to Siri routed to Apple's Reminders app ("I didn't find a Chef Mate list"), because App Shortcut phrases must include the app name to disambiguate — all phrases here reference `\(.applicationName)` = "Chef Mate".

## How

- `iosApp/iosApp/AddGroceryItemIntent.swift` (new): the `AppIntent` + the app's single `AppShortcutsProvider`. It reuses the shared `WatchDataBridge` (`ensureDefaultList` → `addItem` → Supabase sync) — the exact path the watch's add action already flows through. Runs with `openAppWhenRun = false` so it adds silently without launching the UI.
- `RootBlocProvider.kt`: adds a non-throwing `watchDataBridgeOrNull` accessor. `watchDataBridge` is `lateinit`; when Siri background-launches the app for the intent there's a brief window before `AppDelegate` builds the DI graph, so the intent waits (up to ~5s) instead of crashing.

No `project.pbxproj` changes: the `iosApp` target is a synchronized-folder group, so the new Swift file is compiled automatically (same as `WatchDataSender.swift`). No Siri entitlement/usage-description is required for App Intents App Shortcuts.

## Testing

- Compiled the `iosApp` scheme for the iOS Simulator: the Kotlin framework and all iosApp Swift (including the new intent) build with **zero errors**. The Swift references the new Kotlin `watchDataBridgeOrNull`/`ensureDefaultList`/`addItem` against the freshly-built framework, cross-validating the interop.
  - Note: the CLI umbrella build reports a failure in the `ChefMateWatch` target only (`WCSessionDelegate` conformance / `AppIcon` asset catalog), which is an artifact of the command line compiling the watchOS target against the iPhone-simulator SDK. It does not occur in a normal Xcode build and is unrelated to this change.
- **Not yet run on-device.** App Shortcuts/Siri are unreliable in the simulator. Recommended manual test: run on a real device, launch the app once so iOS indexes the shortcut, then try the phrases above. It should also appear in the iPhone Shortcuts app under "Chef Mate."

🤖 Generated with [Claude Code](https://claude.com/claude-code)