### PR TITLE
fix(watch): await WCSession activation before Siri add

### DIFF
--- a/iosApp/ChefMateWatch/AddGroceryItemIntent.swift
+++ b/iosApp/ChefMateWatch/AddGroceryItemIntent.swift
@@ -16,8 +16,14 @@ struct AddGroceryItemIntent: AppIntent {
     }
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        WatchConnectivityManager.shared.sendAddItem(listId: nil, name: item)
-        return .result(dialog: "Added \(item) to your grocery list.")
+        let name = item.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            return .result(dialog: "I didn't catch what to add.")
+        }
+        // Await WCSession activation: on a cold Siri launch the session isn't activated yet, and
+        // firing the transfer before then drops the add.
+        await WatchConnectivityManager.shared.sendAddItemAwaitingActivation(listId: nil, name: name)
+        return .result(dialog: "Added \(name) to your grocery list.")
     }
 }
 

--- a/iosApp/ChefMateWatch/WatchConnectivityManager.swift
+++ b/iosApp/ChefMateWatch/WatchConnectivityManager.swift
@@ -57,10 +57,33 @@ final class WatchConnectivityManager: NSObject, WCSessionDelegate {
     }
 
     /// `listId == nil` tells the phone to use the default list (used by the Siri intent).
+    ///
+    /// Guards on activation state because `transferUserInfo` before the session is activated is a
+    /// programmer error (it throws). On a cold Siri launch use `sendAddItemAwaitingActivation`, which
+    /// waits for activation first.
     func sendAddItem(listId: Int64?, name: String) {
+        guard WCSession.default.activationState == .activated else {
+            log.info("sendAddItem skipped: session not activated")
+            return
+        }
         var info: [String: Any] = ["type": "addItem", "name": name]
         if let listId { info["listId"] = listId }
         WCSession.default.transferUserInfo(info)
+    }
+
+    /// Adds an item, waiting up to ~5s for the session to activate first.
+    ///
+    /// The Siri `AddGroceryItemIntent` can cold-launch the watch app in the background. In that case
+    /// the singleton's `activate()` (in `init`) hasn't finished — activation completes asynchronously
+    /// in `activationDidCompleteWith` — so a plain `sendAddItem` would hit the not-activated guard and
+    /// silently drop the add. Awaiting activation also keeps the intent's `perform()` alive until the
+    /// transfer is handed to the system daemon, which is what makes queued delivery reliable.
+    func sendAddItemAwaitingActivation(listId: Int64?, name: String) async {
+        for _ in 0 ..< 50 {  // up to ~5s
+            if WCSession.default.activationState == .activated { break }
+            try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1s
+        }
+        sendAddItem(listId: listId, name: name)
     }
 
     private func decode(_ payload: [String: Any]) {


### PR DESCRIPTION
## Problem

The watch Siri **Add Grocery Item** intent doesn't work on a cold launch. `AddGroceryItemIntent.perform()` called `sendAddItem` → `WCSession.transferUserInfo` **immediately**. When Siri background-launches the watch app, the shared `WCSession`'s `activate()` (in the singleton `init`) hasn't completed yet — activation finishes asynchronously in `activationDidCompleteWith`. So the transfer fired before the session was `.activated` and the item was silently dropped (calling `transferUserInfo` before activation is a programmer error).

Note the existing asymmetry: `requestSnapshot()` already guarded on `activationState == .activated`, and the phone intent carefully `awaitBridge()`s the DI graph — but `sendAddItem` had no such wait.

## Fix

- Add `sendAddItemAwaitingActivation(listId:name:)`, which polls up to ~5s for the session to reach `.activated` before transferring — mirroring the phone intent's `awaitBridge` pattern. Awaiting also keeps `perform()` alive until the transfer is handed to the system daemon, which is what makes queued delivery reliable.
- Guard `sendAddItem` on activation state so a stray pre-activation call logs instead of throwing.
- The watch intent now trims/guards the item name (matching the phone intent) and awaits activation.

## Not covered here

- **One-shot dictation** ("add eggs" without the "what to add?" prompt) isn't fixable via App Shortcuts — Siri only captures in-phrase parameters from a finite `AppEnum`/`AppEntity` value set, not free-form strings.
- **Shortcut registration:** the watch App Shortcut only registers after the watch app is opened at least once; there's no separate per-app Siri toggle on watchOS.

## Testing

Manual only (no automated coverage for the native watch target). Verify by triggering the watch Siri phrase with the watch app cold (not foregrounded) and confirming the item reaches the phone's default list and syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)