### PR TITLE
fix(desktop): build release DMG/MSI/Deb so developer UI is hidden

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -11,17 +11,17 @@ jobs:
       matrix:
         include:
           - os: macos-15
-            task: packageDmg
+            task: packageReleaseDmg
             artifact-name: desktop-macos
-            artifact-path: client/composeApp/build/compose/binaries/main/dmg/*.dmg
+            artifact-path: client/composeApp/build/compose/binaries/main-release/dmg/*.dmg
           - os: windows-latest
-            task: packageMsi
+            task: packageReleaseMsi
             artifact-name: desktop-windows
-            artifact-path: client/composeApp/build/compose/binaries/main/msi/*.msi
+            artifact-path: client/composeApp/build/compose/binaries/main-release/msi/*.msi
           - os: ubuntu-latest
-            task: packageDeb
+            task: packageReleaseDeb
             artifact-name: desktop-linux
-            artifact-path: client/composeApp/build/compose/binaries/main/deb/*.deb
+            artifact-path: client/composeApp/build/compose/binaries/main-release/deb/*.deb
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -247,6 +247,17 @@ compose.desktop {
         // Pass deep link URI as argument when app is launched via URL scheme
         args += listOf()
 
+        // Ship distributables via the release packaging tasks (packageReleaseDmg/Msi/Deb) so the
+        // requested task name contains "Release". That marker is what flips BuildConfig.IS_DEBUG to
+        // false and hides the developer-only UI — see client/shared/build.gradle.kts. Keep
+        // R8/ProGuard
+        // OFF: this app relies on reflection (Ktor, Supabase, kotlinx.serialization, SQLDelight,
+        // Bugsnag, Decompose) and minification would strip classes those libraries look up at
+        // runtime.
+        buildTypes.release.proguard {
+            isEnabled.set(false)
+        }
+
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Chef Mate"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -138,9 +138,15 @@ releaseStorePassword=YOUR_STORE_PASSWORD
 
 **What it does:**
 1. Builds native packages in parallel on three runners:
-   - `macos-15` — builds `.dmg` via `./gradlew :client:composeApp:packageDmg`
-   - `windows-latest` — builds `.msi` via `./gradlew :client:composeApp:packageMsi`
-   - `ubuntu-latest` — builds `.deb` via `./gradlew :client:composeApp:packageDeb`
+   - `macos-15` — builds `.dmg` via `./gradlew :client:composeApp:packageReleaseDmg`
+   - `windows-latest` — builds `.msi` via `./gradlew :client:composeApp:packageReleaseMsi`
+   - `ubuntu-latest` — builds `.deb` via `./gradlew :client:composeApp:packageReleaseDeb`
+
+   These `packageRelease*` tasks (not the plain `package*` variants) are required so the requested
+   task name contains "Release", which sets `BuildConfig.IS_DEBUG = false` and hides the developer-only
+   UI. R8/ProGuard minification is disabled for the release build type in
+   `client/composeApp/build.gradle.kts`, so the binary is functionally identical to the old debug
+   packaging — it just carries the release marker.
 2. Uploads each package as a build artifact
 3. Creates a GitHub Release from the tag with all three packages attached
 4. Auto-generates release notes from commits since the last tag
@@ -321,10 +327,12 @@ If you have a `keystore.properties` file at the project root, no environment var
 # iOS — run the full lane (requires match setup and Xcode)
 bundle exec fastlane ios release
 
-# Desktop — build packages for your current OS
-./gradlew :client:composeApp:packageDmg    # macOS
-./gradlew :client:composeApp:packageMsi    # Windows
-./gradlew :client:composeApp:packageDeb    # Linux
+# Desktop — build release packages for your current OS (hides developer-only UI).
+# Output lands in build/compose/binaries/main-release/. Use the plain package* tasks
+# only for local debug builds where you want the Developer Settings row visible.
+./gradlew :client:composeApp:packageReleaseDmg    # macOS
+./gradlew :client:composeApp:packageReleaseMsi    # Windows
+./gradlew :client:composeApp:packageReleaseDeb    # Linux
 ```
 
 ## Version Management

--- a/docs/developer-settings.md
+++ b/docs/developer-settings.md
@@ -86,8 +86,15 @@ The "Developer Settings" row only appears when `BuildConfig.IS_DEBUG` is `true`.
 |---|---|
 | `./gradlew :client:composeApp:installDebug` | `true` |
 | `./gradlew :client:composeApp:run` (desktop) | `true` |
+| `./gradlew :client:composeApp:packageDmg` (desktop debug package) | `true` |
 | `./gradlew :client:composeApp:bundleRelease` | `false` |
+| `./gradlew :client:composeApp:packageReleaseDmg` (desktop release package) | `false` |
 | IDE sync (no tasks) | `true` |
+
+> **Desktop packaging caveat:** the plain `packageDmg` / `packageMsi` / `packageDeb` tasks do **not**
+> contain "Release", so they ship with the developer UI visible. The desktop release workflow uses the
+> `packageRelease*` variants (output under `build/compose/binaries/main-release/`) precisely so
+> `IS_DEBUG` is `false`. See [deployment.md](deployment.md).
 
 ## Architecture notes
 


### PR DESCRIPTION
## What

Switch the desktop release workflow from the plain `packageDmg`/`packageMsi`/`packageDeb` tasks to the `packageReleaseDmg`/`packageReleaseMsi`/`packageReleaseDeb` variants, and add a release build type (with R8/ProGuard disabled) to the desktop app.

## Why

`BuildConfig.IS_DEBUG` is derived at configuration time from the requested Gradle task name — any task containing `"Release"` marks the build as release (`client/shared/build.gradle.kts`). The developer-only **Developer Settings** UI is gated behind `IS_DEBUG`.

The desktop release workflow packaged the distributables with `packageDmg` (etc.), whose task name does **not** contain `"Release"`. So the released DMG shipped with `IS_DEBUG=true` and the developer UI visible — which is what a user hit after installing a release DMG. (Android `bundleRelease` and iOS `CONFIGURATION=Release` were already detected correctly, so this only affected desktop.)

## How

- **`client/composeApp/build.gradle.kts`** — add `buildTypes.release.proguard { isEnabled.set(false) }`. Minification is deliberately **off**: the app relies on reflection (Ktor, Supabase, kotlinx.serialization, SQLDelight, Bugsnag, Decompose) and R8 would strip runtime-looked-up classes. The release binary is functionally identical to the old debug package — it just carries the `"Release"` task marker so `IS_DEBUG=false`.
- **`.github/workflows/desktop-release.yml`** — matrix tasks now `packageRelease*`; artifact paths updated from `binaries/main/` to `binaries/main-release/`.
- **Docs** — `deployment.md` and `developer-settings.md` document the release tasks, the `main-release` output dir, and the packaging gating caveat.

## Reviewer notes

- Verified `packageReleaseDmg --dry-run`: the task graph resolves and contains **no** proguard/minify task, confirming R8 is off. A full end-to-end package build wasn't run locally (needs the Supabase/Bugsnag CI secrets and several minutes), so the first tagged release run is the real end-to-end confirmation.
- Next tagged release produces artifacts from `binaries/main-release/` — worth a glance that the GitHub Release attaches all three packages as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)