### PR TITLE
feat(collaboration): email invitees when added to a shared list (#355)

### DIFF
--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -120,6 +120,28 @@ For users who don't have an account yet, the `invited_email` is stored with `use
 database trigger on `auth.users` INSERT automatically migrates pending invitations when the user
 signs up.
 
+### Email notification on invite
+
+An invitee is emailed out-of-band when they're invited, so they don't have to already be in the
+app to discover a pending invite. Because every client inserts the invite directly into the member
+table, this is done entirely on the backend and requires no app-side code:
+
+- An `AFTER INSERT` trigger on `grocery_list_members` (and `recipe_book_members`) calls
+  `notify_invite_email()`, which fires `pg_net` at the `send-invite-email` edge function for each
+  new `status='pending'` row. `net.http_post` is async, so a slow or failing email never blocks or
+  rolls back the invite insert.
+- The edge function resolves the list/book name and the inviter's display name with the
+  service-role client and sends the mail via Resend.
+- **Re-invites don't re-email**: the `UNIQUE(list_id, invited_email)` constraint makes a repeat
+  invite an UPDATE, not an INSERT, so the trigger doesn't fire.
+
+**Setup:** deploy the function (`supabase functions deploy send-invite-email`), set its secrets
+(`RESEND_API_KEY`, `INVITE_HOOK_SECRET`; `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are
+auto-injected), verify the Resend sending domain, and store two Vault secrets the trigger reads —
+`project_url` and `invite_hook_secret` (the latter matching `INVITE_HOOK_SECRET`). See the header
+of `supabase/migrations/20260707_invite_email_notification.sql` for the exact `vault.create_secret`
+calls.
+
 ## Sync Strategy
 
 The existing offline-first sync is extended for collaboration:
@@ -159,6 +181,8 @@ The existing offline-first sync is extended for collaboration:
 | Concern | Path |
 |---------|------|
 | Supabase migration | `supabase/migrations/20260425_add_collaboration.sql` |
+| Invite-email migration | `supabase/migrations/20260707_invite_email_notification.sql` |
+| Invite-email edge function | `supabase/functions/send-invite-email/index.ts` |
 | SQLDelight migration | `client/database/core/src/commonMain/sqldelight/.../database/6.sqm` |
 | Member queries | `client/database/core/src/commonMain/sqldelight/.../GroceryListMember.sq` |
 | Collaboration models | `client/grocery/data/public/.../CollaborationModels.kt` |

--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -138,9 +138,11 @@ table, this is done entirely on the backend and requires no app-side code:
 **Setup:** deploy the function (`supabase functions deploy send-invite-email`), set its secrets
 (`RESEND_API_KEY`, `INVITE_HOOK_SECRET`; `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are
 auto-injected), verify the Resend sending domain, and store two Vault secrets the trigger reads —
-`project_url` and `invite_hook_secret` (the latter matching `INVITE_HOOK_SECRET`). See the header
-of `supabase/migrations/20260707_invite_email_notification.sql` for the exact `vault.create_secret`
-calls.
+`project_url` and `invite_hook_secret` (the latter matching `INVITE_HOOK_SECRET`). Vault secrets go
+through the Dashboard's SQL Editor, not the CLI. See the header of
+`supabase/migrations/20260707_invite_email_notification.sql` for the exact `vault.create_secret`
+calls, how to verify they landed, and how to rotate `invite_hook_secret` (via `vault.update_secret`
+— `create_secret` errors on a duplicate name).
 
 ## Sync Strategy
 

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -1,0 +1,175 @@
+// Supabase Edge Function: send-invite-email
+//
+// Emails a collaboration invitee when they're invited to a shared grocery list or recipe book.
+// Invites are plain INSERTs into `grocery_list_members` / `recipe_book_members` with
+// status='pending', done directly by every client (iOS/Android/Desktop/Web). A database trigger
+// (see supabase/migrations/20260707_invite_email_notification.sql) fires `pg_net` at this function
+// on each new pending invite, so the notification is client-agnostic and needs no app-side code.
+//
+// Auth: callers must present `Authorization: Bearer <INVITE_HOOK_SECRET>`. Only the DB trigger
+// should reach this — it must NOT be invokable with an ordinary user JWT. Set INVITE_HOOK_SECRET
+// to a long random value and store the same value in Vault for the trigger (see the migration).
+//
+// Body (sent by the trigger):
+//   { kind: "grocery" | "recipe_book", memberId, parentId, invitedEmail, invitedBy, role }
+// `invitedBy` is only present for grocery invites; recipe-book invites fall back to the book owner.
+//
+// Deploy:  supabase functions deploy send-invite-email
+// Secrets: supabase secrets set RESEND_API_KEY=<key> INVITE_HOOK_SECRET=<random>
+//          (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are injected automatically by Supabase.)
+//          RESEND_FROM and APP_INVITE_URL are optional overrides for the sender / call-to-action.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const DEFAULT_FROM = "Chef Mate <invites@chefmate.app>";
+const DEFAULT_APP_URL = "https://chefmate.app";
+
+interface InvitePayload {
+  kind: "grocery" | "recipe_book";
+  memberId: string;
+  parentId: string;
+  invitedEmail: string;
+  invitedBy?: string | null;
+  role?: string | null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const hookSecret = Deno.env.get("INVITE_HOOK_SECRET");
+    if (!hookSecret) {
+      return json({ error: "INVITE_HOOK_SECRET is not configured" }, 500);
+    }
+    const authHeader = req.headers.get("Authorization");
+    if (authHeader !== `Bearer ${hookSecret}`) {
+      return json({ error: "Unauthorized" }, 401);
+    }
+
+    const resendApiKey = Deno.env.get("RESEND_API_KEY");
+    if (!resendApiKey) {
+      return json({ error: "RESEND_API_KEY is not configured" }, 500);
+    }
+
+    const payload = (await req.json()) as InvitePayload;
+    if (!payload?.kind || !payload?.parentId || !payload?.invitedEmail) {
+      return json({ error: "Missing kind, parentId, or invitedEmail" }, 400);
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const admin = createClient(supabaseUrl, serviceRoleKey);
+
+    // Resolve the parent list/book: its display name and owner (the inviter fallback).
+    const table = payload.kind === "grocery" ? "grocery_lists" : "recipe_books";
+    const { data: parent, error: parentError } = await admin
+      .from(table)
+      .select("name, owner_id")
+      .eq("id", payload.parentId)
+      .single();
+
+    if (parentError || !parent) {
+      return json({ error: `Could not load ${table}: ${parentError?.message ?? "not found"}` }, 404);
+    }
+
+    const listName = (parent.name as string) || (payload.kind === "grocery" ? "a grocery list" : "a recipe book");
+    const kindLabel = payload.kind === "grocery" ? "grocery list" : "recipe book";
+
+    // Inviter: `invited_by` when present (grocery), else the parent owner (recipe books).
+    const inviterId = payload.invitedBy ?? (parent.owner_id as string | null);
+    const inviterName = await resolveInviterName(admin, inviterId);
+
+    const appUrl = Deno.env.get("APP_INVITE_URL") ?? DEFAULT_APP_URL;
+    const from = Deno.env.get("RESEND_FROM") ?? DEFAULT_FROM;
+    const subject = `${inviterName} invited you to “${listName}” on Chef Mate`;
+
+    const resendResponse = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${resendApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from,
+        to: payload.invitedEmail,
+        subject,
+        html: htmlBody(inviterName, listName, kindLabel, appUrl),
+        text: textBody(inviterName, listName, kindLabel, appUrl),
+      }),
+    });
+
+    if (!resendResponse.ok) {
+      const detail = await resendResponse.text();
+      return json({ error: `Resend failed (${resendResponse.status}): ${detail}` }, 502);
+    }
+
+    return new Response(null, { status: 204, headers: corsHeaders });
+  } catch (e) {
+    return json({ error: String(e) }, 500);
+  }
+});
+
+// Inviter's display name from auth.users metadata, falling back to their email, then "Someone".
+async function resolveInviterName(
+  admin: ReturnType<typeof createClient>,
+  inviterId: string | null,
+): Promise<string> {
+  if (!inviterId) return "Someone";
+  try {
+    const { data, error } = await admin.auth.admin.getUserById(inviterId);
+    if (error || !data?.user) return "Someone";
+    const name = data.user.user_metadata?.name;
+    if (typeof name === "string" && name.trim().length > 0) return name.trim();
+    return data.user.email ?? "Someone";
+  } catch (_) {
+    return "Someone";
+  }
+}
+
+function htmlBody(inviter: string, listName: string, kindLabel: string, appUrl: string): string {
+  return `
+    <div style="font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 480px; margin: 0 auto; color: #1a1a1a;">
+      <h2 style="margin-bottom: 8px;">You’ve been invited to collaborate</h2>
+      <p><strong>${escapeHtml(inviter)}</strong> invited you to the ${kindLabel}
+        <strong>“${escapeHtml(listName)}”</strong> on Chef Mate.</p>
+      <p>Open Chef Mate with this email address to accept the invite.</p>
+      <p style="margin: 24px 0;">
+        <a href="${appUrl}" style="background: #2e7d32; color: #fff; padding: 12px 20px; border-radius: 8px; text-decoration: none; display: inline-block;">Open Chef Mate</a>
+      </p>
+      <p style="color: #777; font-size: 13px;">If you weren’t expecting this, you can safely ignore this email.</p>
+    </div>`;
+}
+
+function textBody(inviter: string, listName: string, kindLabel: string, appUrl: string): string {
+  return [
+    `${inviter} invited you to the ${kindLabel} “${listName}” on Chef Mate.`,
+    ``,
+    `Open Chef Mate with this email address to accept the invite: ${appUrl}`,
+    ``,
+    `If you weren’t expecting this, you can safely ignore this email.`,
+  ].join("\n");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/20260707_invite_email_notification.sql
+++ b/supabase/migrations/20260707_invite_email_notification.sql
@@ -10,13 +10,24 @@
 -- Safe to re-run (idempotent). Run in the Supabase SQL editor / via `supabase db push`.
 --
 -- OPERATOR SETUP — before this does anything, store two Vault secrets the trigger reads (the
--- edge function itself reads RESEND_API_KEY / INVITE_HOOK_SECRET from function secrets separately):
+-- edge function itself reads RESEND_API_KEY / INVITE_HOOK_SECRET from function secrets separately).
+-- Run these in the Supabase Dashboard's SQL Editor (they use the `vault` schema, not exposed via
+-- the CLI):
 --
 --   select vault.create_secret('https://<project-ref>.supabase.co', 'project_url');
 --   select vault.create_secret('<same value as INVITE_HOOK_SECRET>', 'invite_hook_secret');
 --
--- To rotate, delete and recreate the named secret. `project_url` is the base URL; the trigger
--- appends `/functions/v1/send-invite-email`.
+-- `project_url` is the base URL; the trigger appends `/functions/v1/send-invite-email`.
+--
+-- Verify the secrets landed (prints only the names, not the plaintext):
+--   select name from vault.decrypted_secrets;
+--
+-- To rotate: `vault.create_secret` errors on a duplicate name, so update in place instead —
+--   select vault.update_secret(
+--     (select id from vault.secrets where name = 'invite_hook_secret'),
+--     '<new-secret>'
+--   );
+-- and set the matching new value with `supabase secrets set INVITE_HOOK_SECRET=<new-secret>`.
 -- ============================================================
 
 CREATE EXTENSION IF NOT EXISTS pg_net;

--- a/supabase/migrations/20260707_invite_email_notification.sql
+++ b/supabase/migrations/20260707_invite_email_notification.sql
@@ -1,0 +1,95 @@
+-- ============================================================
+-- Email notification on collaboration invite (#355)
+--
+-- Grocery-list and recipe-book invites are plain INSERTs into `grocery_list_members` /
+-- `recipe_book_members` (status='pending'), performed directly by every client. This migration
+-- notifies the invitee by email: an AFTER INSERT trigger fires `pg_net` at the `send-invite-email`
+-- edge function, which sends the mail via Resend. Being a DB trigger, it's client-agnostic
+-- (iOS/Android/Desktop/Web) and needs no app-side change.
+--
+-- Safe to re-run (idempotent). Run in the Supabase SQL editor / via `supabase db push`.
+--
+-- OPERATOR SETUP — before this does anything, store two Vault secrets the trigger reads (the
+-- edge function itself reads RESEND_API_KEY / INVITE_HOOK_SECRET from function secrets separately):
+--
+--   select vault.create_secret('https://<project-ref>.supabase.co', 'project_url');
+--   select vault.create_secret('<same value as INVITE_HOOK_SECRET>', 'invite_hook_secret');
+--
+-- To rotate, delete and recreate the named secret. `project_url` is the base URL; the trigger
+-- appends `/functions/v1/send-invite-email`.
+-- ============================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- Reads a Vault secret by name, or NULL if unset. SECURITY DEFINER: only the definer (superuser
+-- during migration) can read vault.decrypted_secrets, not the authenticated role.
+CREATE OR REPLACE FUNCTION invite_email_config(p_name text)
+RETURNS text LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public, vault AS $$
+  SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = p_name LIMIT 1;
+$$;
+
+-- Trigger fn: on a new pending invite, POST the invite details to the send-invite-email function.
+-- TG_ARGV[0] is the kind ('grocery' | 'recipe_book'); the parent id column differs per table, so
+-- read it dynamically from the NEW row. grocery_list_members carries invited_by; recipe_book_members
+-- does not, so we default it to NULL (the function falls back to the parent owner).
+CREATE OR REPLACE FUNCTION notify_invite_email()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_kind text := TG_ARGV[0];
+  v_base_url text := invite_email_config('project_url');
+  v_secret text := invite_email_config('invite_hook_secret');
+  v_parent_id uuid;
+  v_invited_by uuid;
+BEGIN
+  -- Only a genuine new invite: pending, not yet linked to a user (skips the accepted owner
+  -- auto-row and any pre-linked self-add).
+  IF NEW.status <> 'pending' OR NEW.user_id IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Missing config: don't fail the invite insert — just skip the email. (Comment in the header
+  -- explains the required vault.create_secret calls.)
+  IF v_base_url IS NULL OR v_secret IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF v_kind = 'grocery' THEN
+    v_parent_id := NEW.list_id;
+    v_invited_by := NEW.invited_by;
+  ELSE
+    v_parent_id := NEW.recipe_book_id;
+    v_invited_by := NULL;
+  END IF;
+
+  -- Async: net.http_post queues into net.http_request_queue and returns immediately, so a slow or
+  -- failing email never blocks or rolls back the invite insert. Delivery/errors land in
+  -- net._http_response.
+  PERFORM net.http_post(
+    url := rtrim(v_base_url, '/') || '/functions/v1/send-invite-email',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || v_secret
+    ),
+    body := jsonb_build_object(
+      'kind', v_kind,
+      'memberId', NEW.id,
+      'parentId', v_parent_id,
+      'invitedEmail', NEW.invited_email,
+      'invitedBy', v_invited_by,
+      'role', NEW.role
+    )
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_notify_grocery_invite_email ON grocery_list_members;
+CREATE TRIGGER trg_notify_grocery_invite_email
+  AFTER INSERT ON grocery_list_members
+  FOR EACH ROW EXECUTE FUNCTION notify_invite_email('grocery');
+
+DROP TRIGGER IF EXISTS trg_notify_recipe_book_invite_email ON recipe_book_members;
+CREATE TRIGGER trg_notify_recipe_book_invite_email
+  AFTER INSERT ON recipe_book_members
+  FOR EACH ROW EXECUTE FUNCTION notify_invite_email('recipe_book');


### PR DESCRIPTION
## What

Sends a backend email to an invitee when they're invited to a shared **grocery list** or **recipe book**, closing #355.

Today, invites are plain client-side `INSERT`s into `grocery_list_members` / `recipe_book_members` (status `pending`). Nothing notifies the invitee — they only discover a pending invite in-app, which requires already having an account and opening the app. This adds an out-of-band email.

## How

Entirely backend, **no Kotlin/client changes** — since every client (iOS/Android/Desktop/Web) inserts the invite directly, a DB trigger covers them all at once.

- **`supabase/functions/send-invite-email/index.ts`** — Deno edge function (mirrors the existing `cleanup-avatars`/`delete-account` shape). Resolves the list/book name and inviter display name with the service-role client, then sends HTML + text mail via **Resend**. Gated behind a shared `INVITE_HOOK_SECRET` so only the trigger can invoke it.
- **`supabase/migrations/20260707_invite_email_notification.sql`** — enables `pg_net` and adds an `AFTER INSERT` trigger on both member tables that fires `pg_net` at the function for each new `status='pending'` row. The trigger reads the function URL + hook secret from **Supabase Vault**.
- **`docs/collaboration.md`** — documents the path + setup.

### Reviewer notes

- **Async by design:** `net.http_post` queues and returns immediately, so a slow or failing email never blocks or rolls back the invite insert. Missing Vault config skips the email rather than erroring.
- **Trigger guard** (`status='pending' AND user_id IS NULL`) skips the accepted owner auto-row and accepts.
- **Shared trigger fn across two tables:** `recipe_book_members` has no `invited_by`/`list_id` columns — safe because plpgsql resolves `NEW.<col>` lazily and each column is only referenced inside its matching `kind` branch.
- **Re-invites don't re-email:** the `UNIQUE(list_id, invited_email)` constraint makes a repeat invite an UPDATE, not an INSERT.
- The email links to a constant app URL (`APP_INVITE_URL`, default `https://chefmate.app`) rather than a deep link into the specific list — open to wiring a deep link if preferred.

### Deploy / setup required

- `supabase functions deploy send-invite-email`
- `supabase secrets set RESEND_API_KEY=<key> INVITE_HOOK_SECRET=<random>` (verify a Resend sending domain)
- Store two Vault secrets the trigger reads — `project_url` and `invite_hook_secret` (matching `INVITE_HOOK_SECRET`); exact `vault.create_secret` calls are in the migration header.

## Testing

Not yet run end-to-end (standalone `deno` unavailable + local Supabase stack not up in this worktree). Suggested verification: deploy/serve the function with a Resend test key, `INSERT` a pending row into each member table, and confirm entries land in `net.http_request_queue` / `net._http_response` and the mail renders. Owner auto-rows and accepts must not trigger a send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)