### PR TITLE
feat(grocery): deep-link toast + hide autocomplete menu on saved match

### DIFF
--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -213,6 +213,9 @@ class BottomNavBlocImpl(
             is GroceryListBloc.Output.OpenEditList -> {
                 this.output.onNext(BottomNavBloc.Output.OpenEditGroceryList(output.listId))
             }
+            GroceryListBloc.Output.OpenAutocompleteSettings -> {
+                this.output.onNext(BottomNavBloc.Output.OpenGroceryAutocompleteSettings)
+            }
         }
     }
 

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -113,6 +113,9 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc, ComposeScreen {
         data class OpenEditRecipeBook(val bookId: Long?) : Output()
 
         data class OpenEditGroceryList(val listId: Long) : Output()
+
+        /** Deep link into app settings, opened directly on the saved autocomplete items screen. */
+        data object OpenGroceryAutocompleteSettings : Output()
     }
 
     fun interface Factory {

--- a/client/grocery/core/impl/build.gradle.kts
+++ b/client/grocery/core/impl/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(projects.client.grocery.data.testing)
+            implementation(projects.client.toast.testing)
             implementation(libs.multiplatform.settings.test)
         }
     }

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocImpl.kt
@@ -1,5 +1,8 @@
 package com.plusmobileapps.chefmate.grocery.core.impl.list
 
+import chefmate.client.grocery.core.public.generated.resources.Res
+import chefmate.client.grocery.core.public.generated.resources.grocery_autocomplete_manage
+import chefmate.client.grocery.core.public.generated.resources.grocery_autocomplete_saved
 import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.router.slot.SlotNavigation
 import com.arkivanov.decompose.router.slot.activate
@@ -19,6 +22,8 @@ import com.plusmobileapps.chefmate.grocery.data.GroceryItem
 import com.plusmobileapps.chefmate.grocery.data.GroceryListInvite
 import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
 import com.plusmobileapps.chefmate.mapState
+import com.plusmobileapps.chefmate.text.ResourceString
+import com.plusmobileapps.chefmate.toast.ToastService
 import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
@@ -37,6 +42,7 @@ class GroceryListBlocImpl(
     @Assisted private val output: Consumer<GroceryListBloc.Output>,
     viewModelFactory: Provider<GroceryListViewModel>,
     private val groceryDetailFactory: GroceryDetailBloc.Factory,
+    private val toastService: ToastService,
 ) : GroceryListBloc, BlocContext by context {
 
     private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
@@ -69,6 +75,7 @@ class GroceryListBlocImpl(
                 recipeFilter = it.recipeFilter,
                 availableRecipes = it.availableRecipes.toImmutableList(),
                 autocompleteSuggestions = it.autocompleteSuggestions.toImmutableList(),
+                queryMatchesSavedAutocomplete = it.queryMatchesSavedAutocomplete,
                 hasNoRecipeItems = it.hasNoRecipeItems,
                 isSyncing = it.isSyncing,
                 lists = it.lists.toImmutableList(),
@@ -105,7 +112,16 @@ class GroceryListBlocImpl(
     }
 
     override fun onSaveAutocompleteItem(name: String) {
+        if (name.isBlank()) return
         viewModel.saveAutocompleteItem(name)
+        // Confirm the save and offer a jump to the settings screen that lists every saved item. The
+        // action routes through the app-scoped output rather than capturing this screen, since the
+        // toast callback outlives the composition.
+        toastService.show(
+            message = ResourceString(Res.string.grocery_autocomplete_saved),
+            actionLabel = ResourceString(Res.string.grocery_autocomplete_manage),
+            onAction = { output.onNext(GroceryListBloc.Output.OpenAutocompleteSettings) },
+        )
     }
 
     override fun onGroceryItemClicked(item: GroceryItem) {

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListViewModel.kt
@@ -2,8 +2,6 @@
 
 package com.plusmobileapps.chefmate.grocery.core.impl.list
 
-import chefmate.client.grocery.core.public.generated.resources.Res
-import chefmate.client.grocery.core.public.generated.resources.grocery_autocomplete_saved
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.combineStates
 import com.plusmobileapps.chefmate.di.CoachMarkController
@@ -20,8 +18,6 @@ import com.plusmobileapps.chefmate.grocery.data.GroceryListModel
 import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
 import com.plusmobileapps.chefmate.grocery.data.IngredientParser
 import com.plusmobileapps.chefmate.grocery.data.ListRole
-import com.plusmobileapps.chefmate.text.ResourceString
-import com.plusmobileapps.chefmate.toast.ToastService
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.string
 import dev.zacsweers.metro.Inject
@@ -43,7 +39,6 @@ class GroceryListViewModel(
     @Main mainContext: CoroutineContext,
     private val repository: GroceryRepository,
     private val autocompleteRepository: GroceryAutocompleteRepository,
-    private val toastService: ToastService,
     settings: Settings,
     private val coachMarkController: CoachMarkController,
 ) : ViewModel(mainContext) {
@@ -132,6 +127,11 @@ class GroceryListViewModel(
                             items = items,
                             customItems = customNames,
                         )
+                    val queryMatchesSavedAutocomplete =
+                        queryMatchesSavedAutocomplete(
+                            query = newGroceryItemName,
+                            customItems = customNames,
+                        )
                     val filtered =
                         when (filter) {
                             GroceryFilter.ALL -> items
@@ -178,6 +178,7 @@ class GroceryListViewModel(
                         groupedItems = grouped,
                         availableRecipes = availableRecipes,
                         autocompleteSuggestions = autocompleteSuggestions,
+                        queryMatchesSavedAutocomplete = queryMatchesSavedAutocomplete,
                         hasNoRecipeItems = hasNoRecipeItems,
                     )
                 }
@@ -187,6 +188,7 @@ class GroceryListViewModel(
                             groupedItems = content.groupedItems,
                             availableRecipes = content.availableRecipes,
                             autocompleteSuggestions = content.autocompleteSuggestions,
+                            queryMatchesSavedAutocomplete = content.queryMatchesSavedAutocomplete,
                             hasNoRecipeItems = content.hasNoRecipeItems,
                         )
                     }
@@ -220,14 +222,14 @@ class GroceryListViewModel(
         _newGroceryItemName.value = ""
     }
 
-    /** Saves the current query text as a reusable autocomplete entry, confirming with a toast. */
+    /**
+     * Saves the current query text as a reusable autocomplete entry. Confirmation (and the deep
+     * link to the autocomplete settings) is surfaced by the BLoC, which owns the navigation output.
+     */
     fun saveAutocompleteItem(name: String) {
         val trimmed = name.trim()
         if (trimmed.isBlank()) return
-        scope.launch {
-            autocompleteRepository.addItem(trimmed)
-            toastService.show(ResourceString(Res.string.grocery_autocomplete_saved))
-        }
+        scope.launch { autocompleteRepository.addItem(trimmed) }
     }
 
     fun onSyncClicked() {
@@ -377,6 +379,7 @@ class GroceryListViewModel(
         val recipeFilter: String? = null,
         val availableRecipes: List<String> = emptyList(),
         val autocompleteSuggestions: List<String> = emptyList(),
+        val queryMatchesSavedAutocomplete: Boolean = false,
         val hasNoRecipeItems: Boolean = false,
         val isSyncing: Boolean = false,
         val lists: List<GroceryListModel> = emptyList(),
@@ -393,6 +396,7 @@ class GroceryListViewModel(
         val groupedItems: List<GroceryGroup>,
         val availableRecipes: List<String>,
         val autocompleteSuggestions: List<String>,
+        val queryMatchesSavedAutocomplete: Boolean,
         val hasNoRecipeItems: Boolean,
     )
 
@@ -433,6 +437,20 @@ class GroceryListViewModel(
                 .filter { it.lowercase() != normalizedQuery }
                 .take(MAX_AUTOCOMPLETE_SUGGESTIONS)
                 .toList()
+        }
+
+        /**
+         * True when [query] resolves to an item already saved in the user's autocomplete library.
+         * Used to hide the suggestion dropdown entirely — there is nothing to add and the exact
+         * match would otherwise dangle as a redundant "Save …" row.
+         */
+        private fun queryMatchesSavedAutocomplete(
+            query: String,
+            customItems: List<String>,
+        ): Boolean {
+            val normalizedQuery = IngredientParser.parse(query).name.trim().lowercase()
+            if (normalizedQuery.isBlank()) return false
+            return customItems.any { it.trim().lowercase() == normalizedQuery }
         }
     }
 }

--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListPreviews.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/ui/GroceryListPreviews.kt
@@ -177,6 +177,24 @@ val previewGroceryListBlocAutocomplete: GroceryListBloc =
         pendingInput = "stra",
     )
 
+/**
+ * The typed text exactly matches an item already saved in the autocomplete library
+ * (`queryMatchesSavedAutocomplete = true`), so the suggestion dropdown must stay hidden even though
+ * suggestions are present and the field is "focused". Regression coverage for #371.
+ */
+val previewGroceryListBlocAutocompleteSaved: GroceryListBloc =
+    groceryListBloc(
+        model =
+            GroceryListBloc.Model(
+                groupedItems = sampleGroups,
+                autocompleteSuggestions = persistentListOf("Strawberry jam", "Strawberry yogurt"),
+                queryMatchesSavedAutocomplete = true,
+                lists = persistentListOf(sampleList),
+                selectedList = sampleList,
+            ),
+        pendingInput = "Strawberries",
+    )
+
 @Preview(showBackground = true, heightDp = 1100)
 @Composable
 internal fun GroceryListPreview() {
@@ -201,6 +219,17 @@ internal fun GroceryListAutocompletePreview() {
     ChefMateTheme {
         GroceryListScreen(
             bloc = previewGroceryListBlocAutocomplete,
+            forceShowAutocompleteSuggestions = true,
+        )
+    }
+}
+
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+internal fun GroceryListAutocompleteSavedPreview() {
+    ChefMateTheme {
+        GroceryListScreen(
+            bloc = previewGroceryListBlocAutocompleteSaved,
             forceShowAutocompleteSuggestions = true,
         )
     }

--- a/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
+++ b/client/grocery/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/list/GroceryListBlocTest.kt
@@ -4,6 +4,9 @@
 package com.plusmobileapps.chefmate.grocery.core.impl.list
 
 import app.cash.turbine.test
+import chefmate.client.grocery.core.public.generated.resources.Res
+import chefmate.client.grocery.core.public.generated.resources.grocery_autocomplete_manage
+import chefmate.client.grocery.core.public.generated.resources.grocery_autocomplete_saved
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.CoachMarkController
 import com.plusmobileapps.chefmate.di.CoachMarkId
@@ -17,7 +20,8 @@ import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
 import com.plusmobileapps.chefmate.grocery.data.testing.FakeGroceryAutocompleteRepository
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
-import com.plusmobileapps.chefmate.toast.ToastService
+import com.plusmobileapps.chefmate.text.ResourceString
+import com.plusmobileapps.chefmate.toast.testing.FakeToastService
 import com.russhwolf.settings.MapSettings
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
@@ -52,7 +56,7 @@ class GroceryListBlocTest {
         everySuspend { ensureDefaultList() } returns 1L
     }
     val autocompleteRepository = FakeGroceryAutocompleteRepository()
-    val toastService: ToastService = mock(MockMode.autoUnit)
+    val toastService = FakeToastService()
 
     var detailItemId: Long? = null
     var detailOutput: Consumer<GroceryDetailBloc.Output> = Consumer {}
@@ -76,12 +80,12 @@ class GroceryListBlocTest {
                     mainContext = context.mainContext,
                     repository = repository,
                     autocompleteRepository = autocompleteRepository,
-                    toastService = toastService,
                     settings = settings,
                     coachMarkController = coachMarkController,
                 )
             },
             groceryDetailFactory = groceryDetailFactory,
+            toastService = toastService,
         )
 
     @Test
@@ -415,6 +419,54 @@ class GroceryListBlocTest {
     }
 
     @Test
+    fun When_onSaveAutocompleteItem_Then_toast_shown_with_manage_action() = runTest {
+        bloc.onSaveAutocompleteItem("Cold brew concentrate")
+
+        toastService.shown shouldContain ResourceString(Res.string.grocery_autocomplete_saved)
+        toastService.shownActionLabels shouldContain
+            ResourceString(Res.string.grocery_autocomplete_manage)
+
+        // Tapping the toast action deep links to the autocomplete settings screen.
+        toastService.lastOnAction?.invoke()
+        output.lastValue shouldBe GroceryListBloc.Output.OpenAutocompleteSettings
+    }
+
+    @Test
+    fun When_blank_autocomplete_item_saved_Then_no_toast_and_nothing_persisted() = runTest {
+        bloc.onSaveAutocompleteItem("   ")
+
+        toastService.shown shouldBe emptyList()
+        autocompleteRepository.observeItems().first() shouldBe emptyList()
+    }
+
+    @Test
+    fun When_query_matches_saved_autocomplete_item_Then_flag_is_set() = runTest {
+        bloc.state.test {
+            awaitItem() shouldBe GroceryListBloc.Model()
+            groceries.emit(
+                listOf(
+                    GroceryItem(
+                        id = 1,
+                        name = "Eggs",
+                        displayName = "Eggs",
+                        category = GroceryCategory.DAIRY,
+                    )
+                )
+            )
+            awaitItem()
+
+            autocompleteRepository.addItem("Zeppole")
+            // A partial query keeps the dropdown open (flag stays false)…
+            bloc.onNewGroceryItemNameChange("zep")
+            awaitItem().queryMatchesSavedAutocomplete shouldBe false
+
+            // …but once the text exactly matches the saved library item, the menu is suppressed.
+            bloc.onNewGroceryItemNameChange("Zeppole")
+            awaitItem().queryMatchesSavedAutocomplete shouldBe true
+        }
+    }
+
+    @Test
     fun When_clear_filters_applied_Then_recipe_filter_is_also_cleared() = runTest {
         val items =
             listOf(
@@ -540,12 +592,12 @@ class GroceryListBlocTest {
                         mainContext = freshContext.mainContext,
                         repository = repository,
                         autocompleteRepository = autocompleteRepository,
-                        toastService = toastService,
                         settings = MapSettings(),
                         coachMarkController = controller,
                     )
                 },
                 groceryDetailFactory = groceryDetailFactory,
+                toastService = toastService,
             )
 
         tooltipBloc.state.value.showSyncTooltip shouldBe true

--- a/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
@@ -97,4 +97,5 @@
     <string name="grocery_invite_error">Couldn’t send that invite. Check the email — they may already be on the list.</string>
     <string name="grocery_save_autocomplete">Save “{item}” for autocomplete</string>
     <string name="grocery_autocomplete_saved">Saved to autocomplete</string>
+    <string name="grocery_autocomplete_manage">Manage</string>
 </resources>

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListBloc.kt
@@ -104,6 +104,12 @@ interface GroceryListBloc : ComposeScreen {
         val recipeFilter: String? = null,
         val availableRecipes: ImmutableList<String> = persistentListOf(),
         val autocompleteSuggestions: ImmutableList<String> = persistentListOf(),
+        /**
+         * True when the current input text exactly matches an item already in the user's saved
+         * autocomplete library. The suggestion dropdown is hidden in this case — there is nothing
+         * new to add and the exact match is redundant.
+         */
+        val queryMatchesSavedAutocomplete: Boolean = false,
         val hasNoRecipeItems: Boolean = false,
         val isSyncing: Boolean = false,
         val lists: ImmutableList<GroceryListModel> = persistentListOf(),
@@ -120,6 +126,9 @@ interface GroceryListBloc : ComposeScreen {
         data object OpenRecipes : Output()
 
         data class OpenEditList(val listId: Long) : Output()
+
+        /** Deep link to the settings screen listing all saved autocomplete items. */
+        data object OpenAutocompleteSettings : Output()
     }
 
     sealed class Sheet {

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -388,6 +388,7 @@ fun GroceryListScreen(
                     GroceryListInput(
                         name = bloc.newGroceryItemName,
                         suggestions = state.autocompleteSuggestions,
+                        queryMatchesSavedAutocomplete = state.queryMatchesSavedAutocomplete,
                         onNameChange = bloc::onNewGroceryItemNameChange,
                         onAddClick = {
                             awaitingAddedItem = true
@@ -850,6 +851,7 @@ private fun DeleteItemsDialog(
 private fun GroceryListInput(
     name: StateFlow<String>,
     suggestions: List<String>,
+    queryMatchesSavedAutocomplete: Boolean,
     onNameChange: (String) -> Unit,
     onAddClick: () -> Unit,
     onSaveAutocompleteItem: (String) -> Unit,
@@ -862,12 +864,19 @@ private fun GroceryListInput(
     var isFocused by remember { mutableStateOf(false) }
     val trimmedQuery = state.value.trim()
     // Offer to save the typed text only when it isn't already one of the suggestions (a saved
-    // custom item or a built-in already suggests it, so re-saving would be redundant).
+    // custom item or a built-in already suggests it, so re-saving would be redundant) and it isn't
+    // already in the saved autocomplete library.
     val saveQuery = trimmedQuery.takeIf { q ->
-        q.isNotEmpty() && suggestions.none { it.equals(q, ignoreCase = true) }
+        q.isNotEmpty() &&
+            !queryMatchesSavedAutocomplete &&
+            suggestions.none { it.equals(q, ignoreCase = true) }
     }
+    // Hide the whole dropdown once the entered text matches a saved library item — there is nothing
+    // left to suggest or save. This is also what collapses the menu right after the user saves.
     val expanded =
-        (isFocused || forceShowSuggestions) && (suggestions.isNotEmpty() || saveQuery != null)
+        (isFocused || forceShowSuggestions) &&
+            !queryMatchesSavedAutocomplete &&
+            (suggestions.isNotEmpty() || saveQuery != null)
     val dismissKeyboard: () -> Unit = {
         focusManager.clearFocus()
         keyboardController?.hide()

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -105,7 +105,7 @@ class RootBlocImpl(
             is DeepLink.RecipeDetail ->
                 listOf(Configuration.BottomNavigation, RecipeRoot(Detail(deepLink.recipeId)))
             DeepLink.AppSettings ->
-                listOf(Configuration.BottomNavigation, Configuration.SettingsRoot)
+                listOf(Configuration.BottomNavigation, Configuration.SettingsRoot())
             DeepLink.SignIn ->
                 listOf(
                     Configuration.BottomNavigation,
@@ -202,10 +202,14 @@ class RootBlocImpl(
                         )
                 )
 
-            Configuration.SettingsRoot ->
+            is Configuration.SettingsRoot ->
                 RootBloc.Child.SettingsRoot(
                     bloc =
-                        settingsRoot.create(context = context, output = ::handleSettingsRootOutput)
+                        settingsRoot.create(
+                            context = context,
+                            props = config.props,
+                            output = ::handleSettingsRootOutput,
+                        )
                 )
 
             Configuration.ManageProfile ->
@@ -346,7 +350,13 @@ class RootBlocImpl(
             }
 
             BottomNavBloc.Output.OpenAppSettings -> {
-                navigation.bringToFront(Configuration.SettingsRoot)
+                navigation.bringToFront(Configuration.SettingsRoot())
+            }
+
+            BottomNavBloc.Output.OpenGroceryAutocompleteSettings -> {
+                navigation.bringToFront(
+                    Configuration.SettingsRoot(SettingsRootBloc.Props.GroceryAutocomplete)
+                )
             }
 
             BottomNavBloc.Output.OpenAiChat -> {
@@ -557,7 +567,10 @@ class RootBlocImpl(
 
         @Serializable data class MealPlanner(val props: MealPlannerRootBloc.Props) : Configuration()
 
-        @Serializable data object SettingsRoot : Configuration()
+        @Serializable
+        data class SettingsRoot(
+            val props: SettingsRootBloc.Props = SettingsRootBloc.Props.Default
+        ) : Configuration()
 
         @Serializable data object ManageProfile : Configuration()
 

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -35,6 +35,7 @@ class RootBlocTest {
     var recipeOutput: Consumer<RecipeRootBloc.Output> = Consumer {}
     var recipeProps: RecipeRootBloc.Props? = null
     var settingsRootOutput: Consumer<SettingsRootBloc.Output> = Consumer {}
+    var settingsRootProps: SettingsRootBloc.Props? = null
     var manageProfileOutput:
         Consumer<com.plusmobileapps.chefmate.profile.ManageProfileBloc.Output> =
         Consumer {}
@@ -100,7 +101,8 @@ class RootBlocTest {
                 otpOutput = output
                 mock()
             },
-            settingsRoot = { _, output ->
+            settingsRoot = { _, props, output ->
+                settingsRootProps = props
                 settingsRootOutput = output
                 mock()
             },
@@ -234,6 +236,15 @@ class RootBlocTest {
         bottomNavOutput.onNext(BottomNavBloc.Output.OpenAppSettings)
         rootBloc.instance() should instanceOf<RootBloc.Child.SettingsRoot>()
         rootBloc.state.value.backStack.size shouldBe 1
+        settingsRootProps shouldBe SettingsRootBloc.Props.Default
+    }
+
+    @Test
+    fun When_bottom_nav_opens_grocery_autocomplete_settings_Then_settings_root_deep_links() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenGroceryAutocompleteSettings)
+        rootBloc.instance() should instanceOf<RootBloc.Child.SettingsRoot>()
+        rootBloc.state.value.backStack.size shouldBe 1
+        settingsRootProps shouldBe SettingsRootBloc.Props.GroceryAutocomplete
     }
 
     @Test

--- a/client/settings/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/impl/SettingsRootBlocImpl.kt
+++ b/client/settings/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/impl/SettingsRootBlocImpl.kt
@@ -32,6 +32,7 @@ import kotlinx.serialization.Serializable
 )
 class SettingsRootBlocImpl(
     @Assisted context: BlocContext,
+    @Assisted private val props: SettingsRootBloc.Props,
     @Assisted private val output: Consumer<Output>,
     private val appSettings: AppSettingsBloc.Factory,
     private val bottomNavOrder: BottomNavOrderBloc.Factory,
@@ -47,11 +48,20 @@ class SettingsRootBlocImpl(
         childStack(
             source = navigation,
             serializer = Configuration.serializer(),
-            initialStack = { listOf(Configuration.AppSettings) },
+            initialStack = { initialStackFor(props) },
             handleBackButton = true,
             key = "SettingsRootRouter",
             childFactory = ::createChild,
         )
+
+    // Deep links keep AppSettings underneath the requested screen so Back returns there rather than
+    // straight out of settings.
+    private fun initialStackFor(props: SettingsRootBloc.Props): List<Configuration> =
+        when (props) {
+            SettingsRootBloc.Props.Default -> listOf(Configuration.AppSettings)
+            SettingsRootBloc.Props.GroceryAutocomplete ->
+                listOf(Configuration.AppSettings, Configuration.GroceryAutocomplete)
+        }
 
     override val routerState: Value<ChildStack<*, SettingsRootBloc.Child>> = stack
 

--- a/client/settings/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/root/impl/SettingsRootBlocImplTest.kt
+++ b/client/settings/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/root/impl/SettingsRootBlocImplTest.kt
@@ -2,6 +2,7 @@
 
 package com.plusmobileapps.chefmate.settings.root.impl
 
+import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.grocery.autocomplete.GroceryAutocompleteBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavOrderBloc
@@ -29,9 +30,17 @@ class SettingsRootBlocImplTest {
 
     var rootOutput: SettingsRootBloc.Output? = null
 
-    val bloc =
+    val bloc = createBloc()
+
+    // Each bloc needs its own context — Decompose registers the child stack under a fixed key, so
+    // two blocs sharing one context would clash.
+    private fun createBloc(
+        props: SettingsRootBloc.Props = SettingsRootBloc.Props.Default,
+        context: BlocContext = this.context,
+    ) =
         SettingsRootBlocImpl(
             context = context,
+            props = props,
             output = { rootOutput = it },
             appSettings = { _, output ->
                 appSettingsOutput = output
@@ -135,6 +144,15 @@ class SettingsRootBlocImplTest {
         appSettingsOutput.onNext(AppSettingsBloc.Output.OpenGroceryAutocomplete)
         groceryAutocompleteOutput.onNext(GroceryAutocompleteBloc.Output.Back)
         bloc.instance() should instanceOf<SettingsRootBloc.Child.AppSettings>()
+    }
+
+    @Test
+    fun When_started_with_grocery_autocomplete_props_Then_it_opens_over_app_settings() {
+        val deepLinked =
+            createBloc(SettingsRootBloc.Props.GroceryAutocomplete, TestBlocContext.create())
+        deepLinked.instance() should instanceOf<SettingsRootBloc.Child.GroceryAutocomplete>()
+        // App settings sits underneath so Back returns there rather than out of settings.
+        deepLinked.routerState.value.backStack.size shouldBe 1
     }
 
     @Test

--- a/client/settings/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/SettingsRootBloc.kt
+++ b/client/settings/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/root/SettingsRootBloc.kt
@@ -15,6 +15,7 @@ import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
 import com.plusmobileapps.chefmate.recipe.importer.ImportRecipesBloc
 import com.plusmobileapps.chefmate.settings.AppSettingsBloc
 import com.plusmobileapps.chefmate.ui.ComposeScreen
+import kotlinx.serialization.Serializable
 
 interface SettingsRootBloc : BackHandlerOwner, BackClickBloc, ComposeScreen {
     val routerState: Value<ChildStack<*, Child>>
@@ -45,7 +46,21 @@ interface SettingsRootBloc : BackHandlerOwner, BackClickBloc, ComposeScreen {
         data object Back : Output()
     }
 
+    /** Which screen the settings stack opens on. */
+    @Serializable
+    sealed class Props {
+        /** Land on the top-level app settings list (the normal entry point). */
+        @Serializable data object Default : Props()
+
+        /** Deep link straight to the saved autocomplete items, with app settings underneath. */
+        @Serializable data object GroceryAutocomplete : Props()
+    }
+
     fun interface Factory {
-        fun create(context: BlocContext, output: Consumer<Output>): SettingsRootBloc
+        fun create(
+            context: BlocContext,
+            props: Props,
+            output: Consumer<Output>,
+        ): SettingsRootBloc
     }
 }

--- a/client/toast/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/testing/FakeToastService.kt
+++ b/client/toast/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/toast/testing/FakeToastService.kt
@@ -25,6 +25,16 @@ class FakeToastService : ToastService {
 
     private val _shown = mutableListOf<TextData>()
 
+    /** Every action label passed to [show], in order (null when a message had no action). */
+    val shownActionLabels: List<TextData?>
+        get() = _shownActionLabels
+
+    private val _shownActionLabels = mutableListOf<TextData?>()
+
+    /** The action callback from the most recent [show], so tests can invoke a toast's action. */
+    var lastOnAction: (() -> Unit)? = null
+        private set
+
     override fun show(
         message: TextData,
         actionLabel: TextData?,
@@ -32,6 +42,8 @@ class FakeToastService : ToastService {
         onAction: (() -> Unit)?,
     ) {
         _shown += message
+        _shownActionLabels += actionLabel
+        lastOnAction = onAction
         _queue.update { it.enqueue(message, actionLabel, duration, onAction) }
     }
 

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTest.kt
@@ -8,12 +8,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.android.tools.screenshot.PreviewTest
-import com.plusmobileapps.chefmate.grocery.core.list.GroceryListScreen
 import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBloc
 import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBlocAutocomplete
+import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBlocAutocompleteSaved
 import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBlocEmpty
 import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBlocFilteredEmpty
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryListBloc
+import com.plusmobileapps.chefmate.grocery.core.list.GroceryListScreen
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
@@ -34,6 +35,20 @@ private fun GroceryListAutocompleteScreenshot(darkTheme: Boolean = false) {
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
             GroceryListScreen(
                 bloc = previewGroceryListBlocAutocomplete,
+                forceShowAutocompleteSuggestions = true,
+            )
+        }
+    }
+}
+
+// The typed text already matches a saved autocomplete item, so the dropdown is suppressed even with
+// suggestions present and forceShowAutocompleteSuggestions = true — regression coverage for #371.
+@Composable
+private fun GroceryListAutocompleteSavedScreenshot(darkTheme: Boolean = false) {
+    ChefMateTheme(darkTheme = darkTheme) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            GroceryListScreen(
+                bloc = previewGroceryListBlocAutocompleteSaved,
                 forceShowAutocompleteSuggestions = true,
             )
         }
@@ -61,6 +76,13 @@ fun GroceryListPhonePortraitDarkScreenshot() {
 @Composable
 fun GroceryListAutocompletePhonePortraitLightScreenshot() {
     GroceryListAutocompleteScreenshot()
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun GroceryListAutocompleteSavedPhonePortraitLightScreenshot() {
+    GroceryListAutocompleteSavedScreenshot()
 }
 
 // ── Empty state — regression coverage for the "Browse my recipes" CTA ──────

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListAutocompleteSavedPhonePortraitLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/GroceryListScreenshotTestKt/GroceryListAutocompleteSavedPhonePortraitLightScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63641ac068dedfe3aad892f2bcb189d8a7cd2d2bd1aab81f97d4782701edbe70
+size 61687


### PR DESCRIPTION
Closes #371

## What & why

When adding an item to a grocery list, the input offers a **“Save … for autocomplete”** row in the suggestion dropdown. Two problems the issue calls out:

1. Saving gave a plain toast with no way to get to the list of saved items, and the dropdown stayed open showing a now-redundant “Save …” row.
2. Typing an item that’s already in your autocomplete library still showed the dropdown (the exact match was only filtered out of the suggestion list, leaving a dangling save row).

## Changes

- **Snackbar with a deep link.** Saving now shows a snackbar confirming the save with a **“Manage”** action that deep links to the settings screen listing all saved autocomplete items. The action routes through app-scoped BLoC output (`GroceryListBloc.Output.OpenAutocompleteSettings`) rather than capturing the short-lived screen, per the repo’s toast-action convention.
- **Hide the menu on an exact match.** The suggestion dropdown is now hidden entirely once the entered text exactly matches an item already saved in the autocomplete library (`Model.queryMatchesSavedAutocomplete`). This also collapses the menu right after a save (the just-saved item is now in the library), satisfying the “then the menu should be hidden” part of the issue.
- **Cross-tab navigation.** New output flows Grocery → BottomNav → Root into a new `SettingsRootBloc.Props.GroceryAutocomplete` start destination that opens the autocomplete screen with App Settings underneath, so Back returns to settings rather than straight out.

## Testing

- Unit tests: toast + deep-link action emission, blank-input guard, and the `queryMatchesSavedAutocomplete` flag (`GroceryListBlocTest`); the new `SettingsRootBloc.Props.GroceryAutocomplete` start destination (`SettingsRootBlocImplTest`); the new BottomNav→Root deep link (`RootBlocTest`).
- Snapshot: new `@PreviewTest` proving the dropdown stays hidden when the typed text matches a saved item, even with `forceShowAutocompleteSuggestions = true`.
- `./gradlew :client:grocery:core:impl:jvmTest :client:root:impl:jvmTest :client:bottomnav:impl:jvmTest :client:settings:root:impl:jvmTest :client:ui:screenshot-test:validateDebugScreenshotTest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)