### PR TITLE
Onboarding: sign-up CTA, drop feature flag, image below text

### DIFF
--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/harness/CreateRootBloc.kt
@@ -12,7 +12,6 @@ import com.plusmobileapps.chefmate.App
 import com.plusmobileapps.chefmate.DefaultBlocContext
 import com.plusmobileapps.chefmate.di.TestApplicationComponent
 import com.plusmobileapps.chefmate.di.createTestApplicationComponent
-import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.fixtures.TestRecipes
 import com.plusmobileapps.chefmate.root.DeepLink
 import com.plusmobileapps.chefmate.root.RootBloc
@@ -59,12 +58,9 @@ fun runRootBlocTest(
     // flags leak across tests. Clear it up front for deterministic, isolated runs.
     app.settings.clear()
     app.applyUserState(userState)
-    if (showOnboarding) {
-        // First-run state: enable the gating flag and leave onboarding incomplete so the root
-        // boots into the onboarding flow.
-        app.testFeatureFlags.set(FeatureFlagRegistry.Onboarding, true)
-    } else {
-        // Default to a returning user so tests boot straight into the main app.
+    if (!showOnboarding) {
+        // Default to a returning user so tests boot straight into the main app. Leaving onboarding
+        // incomplete (the showOnboarding = true case) is enough to boot into the onboarding flow.
         app.onboardingRepository.setOnboardingCompleted()
     }
     beforeContent(app)

--- a/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlag.kt
+++ b/client/featureflag/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/featureflag/FeatureFlag.kt
@@ -50,15 +50,5 @@ object FeatureFlagRegistry {
                     "option. When off, the add button opens the blank editor directly.",
         )
 
-    object Onboarding :
-        BooleanFlag(
-            key = "onboarding",
-            defaultValue = false,
-            description =
-                "Show the first-run onboarding flow (and the \"View Onboarding Again\" row in the " +
-                    "More tab). When off, onboarding is never shown.",
-        )
-
-    val all: List<FeatureFlag<*>> =
-        listOf(CookModeV2, HomeBannerText, AiChat, ScanRecipeFromPhoto, Onboarding)
+    val all: List<FeatureFlag<*>> = listOf(CookModeV2, HomeBannerText, AiChat, ScanRecipeFromPhoto)
 }

--- a/client/onboarding/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/robots/OnboardingRobot.kt
+++ b/client/onboarding/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/robots/OnboardingRobot.kt
@@ -55,6 +55,9 @@ class OnboardingRobot(private val test: ComposeUiTest) {
 
     fun clickStartCooking(): OnboardingRobot = click(OnboardingTestTags.START_COOKING_BUTTON)
 
+    fun clickStartCookingSignUp(): OnboardingRobot =
+        click(OnboardingTestTags.START_COOKING_SIGN_UP_BUTTON)
+
     private fun assertDisplayed(tag: String): OnboardingRobot = apply {
         test.waitUntilExactlyOneExists(hasTestTag(tag))
     }

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/OnboardingRootBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/OnboardingRootBlocImpl.kt
@@ -142,6 +142,8 @@ class OnboardingRootBlocImpl(
     private fun handleStartCookingOutput(output: StartCookingBloc.Output) {
         when (output) {
             StartCookingBloc.Output.StartCooking -> finishOnboarding()
+            // The root opens the auth flow; on success it tears down onboarding for us.
+            StartCookingBloc.Output.SignUp -> this.output.onNext(Output.SignUp)
         }
     }
 

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/StartCookingBlocImpl.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/StartCookingBlocImpl.kt
@@ -21,4 +21,8 @@ class StartCookingBlocImpl(
     override fun onStartCookingClicked() {
         output.onNext(StartCookingBloc.Output.StartCooking)
     }
+
+    override fun onSignUpClicked() {
+        output.onNext(StartCookingBloc.Output.SignUp)
+    }
 }

--- a/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/OnboardingPreviews.kt
+++ b/client/onboarding/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/impl/ui/OnboardingPreviews.kt
@@ -50,6 +50,8 @@ val previewMealPlanningBloc: MealPlanningBloc =
 val previewStartCookingBloc: StartCookingBloc =
     object : StartCookingBloc {
         override fun onStartCookingClicked() = Unit
+
+        override fun onSignUpClicked() = Unit
     }
 
 @Preview

--- a/client/onboarding/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/onboarding/impl/OnboardingRootBlocImplTest.kt
+++ b/client/onboarding/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/onboarding/impl/OnboardingRootBlocImplTest.kt
@@ -132,4 +132,19 @@ class OnboardingRootBlocImplTest {
         // Completion is deferred to the root once auth actually succeeds.
         onboardingRepository.hasCompletedOnboarding shouldBe false
     }
+
+    @Test
+    fun When_start_cooking_outputs_sign_up_Then_sign_up_emitted_without_completing() {
+        welcomeOutput.onNext(WelcomeBloc.Output.GetStarted)
+        saveRecipesOutput.onNext(SaveRecipesBloc.Output.Next)
+        cookModeOutput.onNext(CookModeBloc.Output.Next)
+        groceryListOutput.onNext(GroceryListBloc.Output.Next)
+        mealPlanningOutput.onNext(MealPlanningBloc.Output.Next)
+
+        startCookingOutput.onNext(StartCookingBloc.Output.SignUp)
+
+        rootOutput shouldBe OnboardingRootBloc.Output.SignUp
+        // Completion is deferred to the root once auth actually succeeds.
+        onboardingRepository.hasCompletedOnboarding shouldBe false
+    }
 }

--- a/client/onboarding/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/onboarding/public/src/commonMain/composeResources/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="onboarding_start_cooking_title">You’re all set</string>
     <string name="onboarding_start_cooking_message">That’s the whole tour. Save your favorite recipes, plan out your week, and build grocery lists that keep you organized — all from one app. Jump in whenever you’re ready; you can revisit these features any time from the app.</string>
     <string name="onboarding_start_cooking_button">Start cooking</string>
+    <string name="onboarding_start_cooking_sign_up">Sign up for an account</string>
 </resources>

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingInfoLayout.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingInfoLayout.kt
@@ -41,7 +41,6 @@ internal fun OnboardingInfoLayout(
             )
         },
     ) {
-        OnboardingPreviewImage(light = previewLight, dark = previewDark)
         Text(
             text = stringResource(title),
             style = MaterialTheme.typography.headlineMedium,
@@ -53,5 +52,8 @@ internal fun OnboardingInfoLayout(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
+        // Placed after the text (rather than above it) so the screen visibly has more content below
+        // the fold, making it obvious the step scrolls.
+        OnboardingPreviewImage(light = previewLight, dark = previewDark)
     }
 }

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingRootBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingRootBloc.kt
@@ -18,7 +18,8 @@ import com.plusmobileapps.chefmate.ui.ComposeScreen
  * root can load the rest of the app.
  *
  * From the welcome screen the user can also choose to sign in; that is surfaced as [Output.SignIn]
- * so the root can open the authentication flow.
+ * so the root can open the authentication flow. From the final [StartCookingBloc] step, the user
+ * can also choose to sign up for an account, surfaced as [Output.SignUp].
  */
 interface OnboardingRootBloc : BackHandlerOwner, BackClickBloc, ComposeScreen {
     val routerState: Value<ChildStack<*, Child>>
@@ -59,6 +60,9 @@ interface OnboardingRootBloc : BackHandlerOwner, BackClickBloc, ComposeScreen {
 
         /** The user wants to sign in; the root should open the authentication flow. */
         data object SignIn : Output()
+
+        /** The user wants to create an account; the root should open the sign-up flow. */
+        data object SignUp : Output()
     }
 
     fun interface Factory {

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingTestTags.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/OnboardingTestTags.kt
@@ -25,4 +25,5 @@ object OnboardingTestTags {
 
     const val START_COOKING_SCREEN = "onboarding_start_cooking_screen"
     const val START_COOKING_BUTTON = "onboarding_start_cooking_button"
+    const val START_COOKING_SIGN_UP_BUTTON = "onboarding_start_cooking_sign_up_button"
 }

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/StartCookingBloc.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/StartCookingBloc.kt
@@ -10,6 +10,8 @@ import com.plusmobileapps.chefmate.ui.ComposeScreen
 interface StartCookingBloc : ComposeScreen {
     fun onStartCookingClicked()
 
+    fun onSignUpClicked()
+
     @Composable
     override fun Content(modifier: Modifier) {
         StartCookingScreen(bloc = this, modifier = modifier)
@@ -18,6 +20,9 @@ interface StartCookingBloc : ComposeScreen {
     sealed class Output {
         /** The user is done with onboarding and wants to start using the app. */
         data object StartCooking : Output()
+
+        /** The user wants to create an account; the root should open the sign-up flow. */
+        data object SignUp : Output()
     }
 
     fun interface Factory {

--- a/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/StartCookingScreen.kt
+++ b/client/onboarding/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/StartCookingScreen.kt
@@ -15,9 +15,11 @@ import androidx.compose.ui.unit.dp
 import chefmate.client.onboarding.public.generated.resources.Res
 import chefmate.client.onboarding.public.generated.resources.onboarding_start_cooking_button
 import chefmate.client.onboarding.public.generated.resources.onboarding_start_cooking_message
+import chefmate.client.onboarding.public.generated.resources.onboarding_start_cooking_sign_up
 import chefmate.client.onboarding.public.generated.resources.onboarding_start_cooking_title
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusButton
+import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -27,7 +29,15 @@ fun StartCookingScreen(bloc: StartCookingBloc, modifier: Modifier = Modifier) {
         modifier = modifier,
         footer = {
             PlusButton(
+                text = Res.string.onboarding_start_cooking_sign_up.asTextData(),
+                onClick = bloc::onSignUpClicked,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .testTag(OnboardingTestTags.START_COOKING_SIGN_UP_BUTTON),
+            )
+            PlusButton(
                 text = Res.string.onboarding_start_cooking_button.asTextData(),
+                variant = PlusButtonVariant.SECONDARY,
                 onClick = bloc::onStartCookingClicked,
                 modifier = Modifier.fillMaxWidth().testTag(OnboardingTestTags.START_COOKING_BUTTON),
             )

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -20,10 +20,8 @@ import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.di.OnboardingRepository
-import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.featureflag.FeatureFlags
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
-import com.plusmobileapps.chefmate.featureflag.isEnabled
 import com.plusmobileapps.chefmate.grocery.core.edit.EditGroceryListBloc
 import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc
@@ -91,11 +89,9 @@ class RootBlocImpl(
         )
 
     private fun initialStackFor(deepLink: DeepLink): List<Configuration> {
-        // First run: show onboarding before anything else, but only when the feature flag is on.
-        // Deep links are honored once onboarding has been completed on a previous launch (or when
-        // the flag is off).
-        val onboardingEnabled = featureFlags.isEnabled(FeatureFlagRegistry.Onboarding).value
-        if (onboardingEnabled && !onboardingRepository.hasCompletedOnboarding) {
+        // First run: show onboarding before anything else. Deep links are honored once onboarding
+        // has been completed on a previous launch.
+        if (!onboardingRepository.hasCompletedOnboarding) {
             return listOf(Configuration.Onboarding)
         }
         return when (deepLink) {
@@ -300,6 +296,10 @@ class RootBlocImpl(
             OnboardingRootBloc.Output.SignIn ->
                 navigation.bringToFront(
                     Configuration.Authentication(AuthenticationBloc.Props.SignIn)
+                )
+            OnboardingRootBloc.Output.SignUp ->
+                navigation.bringToFront(
+                    Configuration.Authentication(AuthenticationBloc.Props.SignUp)
                 )
         }
     }

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -11,7 +11,6 @@ import com.plusmobileapps.chefmate.auth.ui.otp.OtpBloc
 import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.di.OnboardingRepository
-import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
 import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
@@ -57,7 +56,6 @@ class RootBlocTest {
         deepLink: DeepLink = DeepLink.None,
         context: BlocContext = TestBlocContext.create(),
         onboardingCompleted: Boolean = true,
-        onboardingFlagEnabled: Boolean = true,
     ): RootBlocImpl =
         RootBlocImpl(
             context = context,
@@ -115,8 +113,7 @@ class RootBlocTest {
                 mock()
             },
             cookMode = CookModeBloc.Factory { _, _, _ -> mock() },
-            featureFlags =
-                FakeFeatureFlags(mapOf(FeatureFlagRegistry.Onboarding to onboardingFlagEnabled)),
+            featureFlags = FakeFeatureFlags(),
             featureFlagsBlocFactory = { _, _ -> mock() },
             aiChat = { _, output ->
                 aiChatOutput = output
@@ -149,13 +146,6 @@ class RootBlocTest {
     }
 
     @Test
-    fun When_onboarding_flag_disabled_Then_bottom_nav_is_shown_even_if_not_completed() {
-        val root = createRoot(onboardingCompleted = false, onboardingFlagEnabled = false)
-        root.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
-        root.state.value.backStack.size shouldBe 0
-    }
-
-    @Test
     fun When_onboarding_finishes_Then_bottom_nav_replaces_the_stack() {
         val root = createRoot(onboardingCompleted = false)
         onboardingOutput.onNext(OnboardingRootBloc.Output.Finished)
@@ -177,6 +167,15 @@ class RootBlocTest {
         onboardingOutput.onNext(OnboardingRootBloc.Output.SignIn)
         root.instance() should instanceOf<RootBloc.Child.Authentication>()
         authProps shouldBe AuthenticationBloc.Props.SignIn
+        root.state.value.backStack.size shouldBe 1
+    }
+
+    @Test
+    fun When_onboarding_outputs_sign_up_Then_authentication_is_pushed() {
+        val root = createRoot(onboardingCompleted = false)
+        onboardingOutput.onNext(OnboardingRootBloc.Output.SignUp)
+        root.instance() should instanceOf<RootBloc.Child.Authentication>()
+        authProps shouldBe AuthenticationBloc.Props.SignUp
         root.state.value.backStack.size shouldBe 1
     }
 

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -40,7 +40,6 @@ class SettingsBlocImpl(
                 showSignOutConfirmationDialog = it.showSignOutConfirmationDialog,
                 isDebugBuild = isDebugBuild,
                 isAiChatEnabled = it.isAiChatEnabled,
-                isOnboardingEnabled = it.isOnboardingEnabled,
                 versionName = BuildConfig.VERSION_NAME,
             )
         }

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsViewModel.kt
@@ -31,24 +31,14 @@ class SettingsViewModel(
     private val aiChatEnabled: StateFlow<Boolean> =
         featureFlags.isEnabled(FeatureFlagRegistry.AiChat)
 
-    private val onboardingEnabled: StateFlow<Boolean> =
-        featureFlags.isEnabled(FeatureFlagRegistry.Onboarding)
-
     init {
         observeAuthState()
         observeAiChatFlag()
-        observeOnboardingFlag()
     }
 
     private fun observeAiChatFlag() {
         aiChatEnabled
             .onEach { enabled -> _state.update { it.copy(isAiChatEnabled = enabled) } }
-            .launchIn(scope)
-    }
-
-    private fun observeOnboardingFlag() {
-        onboardingEnabled
-            .onEach { enabled -> _state.update { it.copy(isOnboardingEnabled = enabled) } }
             .launchIn(scope)
     }
 
@@ -120,6 +110,5 @@ class SettingsViewModel(
         val emailAwaitingVerification: String? = null,
         val showSignOutConfirmationDialog: Boolean = false,
         val isAiChatEnabled: Boolean = false,
-        val isOnboardingEnabled: Boolean = false,
     )
 }

--- a/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImplTest.kt
+++ b/client/settings/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImplTest.kt
@@ -130,25 +130,6 @@ class SettingsBlocImplTest {
     }
 
     @Test
-    fun When_onboarding_flag_off_Then_isOnboardingEnabled_is_false() = runTest {
-        // Flag defaults to off — the replay row should be hidden.
-        bloc.state.value.isOnboardingEnabled shouldBe false
-    }
-
-    @Test
-    fun When_onboarding_flag_on_Then_isOnboardingEnabled_is_true() = runTest {
-        featureFlags.set(FeatureFlagRegistry.Onboarding, true)
-
-        bloc.state.test {
-            val initial = awaitItem()
-            if (!initial.isOnboardingEnabled) {
-                awaitItem().isOnboardingEnabled shouldBe true
-            }
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     fun When_authenticated_Then_state_reflects_authenticated() = runTest {
         bloc.state.test {
             awaitItem().isAuthenticated shouldBe false

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -53,8 +53,6 @@ interface SettingsBloc : ComposeScreen {
         val showSignOutConfirmationDialog: Boolean = false,
         val isDebugBuild: Boolean = false,
         val isAiChatEnabled: Boolean = false,
-        /** Gates the "View Onboarding Again" row behind the onboarding feature flag. */
-        val isOnboardingEnabled: Boolean = false,
         val versionName: String = "",
     )
 

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/ui/SettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/ui/SettingsScreen.kt
@@ -150,20 +150,20 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
             HorizontalDivider()
             SettingsRow(
                 name = Res.string.terms_of_use.asTextData(),
-                onClick = { bloc.onUrlClicked("https://chefmate.plusmobileapps.com/terms-of-use/") },
+                onClick = {
+                    bloc.onUrlClicked("https://chefmate.plusmobileapps.com/terms-of-use/")
+                },
             )
             HorizontalDivider()
             SettingsRow(
                 name = Res.string.about.asTextData(),
                 onClick = { bloc.onUrlClicked("https://chefmate.plusmobileapps.com/") },
             )
-            if (viewState.isOnboardingEnabled) {
-                HorizontalDivider()
-                SettingsRow(
-                    name = Res.string.settings_replay_onboarding.asTextData(),
-                    onClick = bloc::onReplayOnboardingClicked,
-                )
-            }
+            HorizontalDivider()
+            SettingsRow(
+                name = Res.string.settings_replay_onboarding.asTextData(),
+                onClick = bloc::onReplayOnboardingClicked,
+            )
             if (viewState.isDebugBuild) {
                 HorizontalDivider()
                 SettingsRow(

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingCookModeDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingCookModeDarkScreenshot_658f3c84_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:268c9d5e66393d8c029cbd0fe1c1691f96daf835dd7a41a3c24022239b4cfdeb
-size 280270
+oid sha256:23721cbac7a67770b42906f0197acc08b811ebe58c19a06faca6293f14502cd1
+size 281124

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingCookModeLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingCookModeLightScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45cf9d00e4506a2da454ec4103d60b12df1bf8e0ce0feceeb947c16649e63415
-size 285438
+oid sha256:b4b2f08c9b80375ee9ce26aff074def73c80b6d73409ec59ab20e522cace560d
+size 285796

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingGroceryListDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingGroceryListDarkScreenshot_658f3c84_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6efbdd1b8d07039f82f12d5c01085c3ec3298292abe42302f28acd8019734021
-size 140456
+oid sha256:9015cfc4709ab04ee070a39f20f6cb315ad52450f022362cb9a41ea92de4ded0
+size 139674

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingGroceryListLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingGroceryListLightScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d027c7c21739f228592e8e28f2f5189c1bcd1264b8969a356aa6f3571904c28c
-size 145918
+oid sha256:dc8b141005ae823ad0ccbbd7070f989ce36ca1a26514393b3e455651ac1632bc
+size 146306

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingMealPlanningDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingMealPlanningDarkScreenshot_658f3c84_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e62b035c559d521cc317c88831bfaa2506626f1b9e30516899e9354389d2c4c
-size 171162
+oid sha256:61fc87f8be459a36fafcecddba2217f5973321e6db4b7680fcf363d0a4035aed
+size 171197

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingMealPlanningLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingMealPlanningLightScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f281d1d3eea7a1a1b80dab6a4fcad93bbfc1c17e2a1d455884141ac8f69b3f3
-size 174980
+oid sha256:bd25c4d44067c50796d44d839663f92f0553255862d55782a75297f5402582de
+size 174974

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingSaveRecipesDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingSaveRecipesDarkScreenshot_658f3c84_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c3c4bb0eb0188753f8605735ba033bc4273cf8657e7f628bab6b687b48e0179e
-size 246271
+oid sha256:3b396e1ac5381289e18c1e407d56c8da9f984d1f4f3f2cf7313339aa4a2b645a
+size 246782

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingSaveRecipesLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingSaveRecipesLightScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c321b34b4c0e1c12eba47677a24102228179f13b1d88d960b1299b8b39b5559e
-size 248653
+oid sha256:849b771cdb5701cb95a5346accbada24dc51c4c8708f8014fc7e639f795cf44f
+size 250035

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingStartCookingDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingStartCookingDarkScreenshot_658f3c84_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e993ec0ceec62bdb42c7bec138fb2af216faefff878c8967366ec0992d00b404
-size 71963
+oid sha256:b58174d64618d20c767c62a6b216f5569de3fc7bd8a0245e8f09a3672ee82799
+size 78765

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingStartCookingLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OnboardingScreenshotTestKt/OnboardingStartCookingLightScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a20d57cb51360fe6567ccfe740bc174485810a0fc5756f43885a515a3db83ad
-size 71432
+oid sha256:e9205e035544c55e9d642baf412df8bf9ee650e000fa45db5932f605b423a2d0
+size 77833


### PR DESCRIPTION
## Summary
- Final onboarding step (`StartCookingScreen`) now shows a "Sign up for an account" button above the existing "Start cooking" button, wired through to the auth flow the same way the Welcome screen's sign-in CTA already is.
- Removed `FeatureFlagRegistry.Onboarding`: onboarding now always shows for first-run users, and the "View Onboarding Again" row in Settings is always visible instead of being flag-gated.
- Moved the preview image below the title/message on the four informational onboarding steps (Save Recipes, Cook Mode, Grocery List, Meal Planning) so it's more obvious the step scrolls.

## Test plan
- [x] `./gradlew compileKotlinJvm` — full project compiles
- [x] `./gradlew :client:root:impl:jvmTest :client:settings:impl:jvmTest` — pass, including new/updated sign-up and flag-removal tests
- [x] `./gradlew :client:composeApp:jvmTest` — full suite passes, including onboarding UI flow tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)