### PR TITLE
fix(admin): rollout 100% silently fails to save

### DIFF
--- a/admin/src/commonMain/kotlin/com/plusmobileapps/chefmate/admin/SupabaseFactory.kt
+++ b/admin/src/commonMain/kotlin/com/plusmobileapps/chefmate/admin/SupabaseFactory.kt
@@ -5,6 +5,8 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.serializer.KotlinXSerializer
+import kotlinx.serialization.json.Json
 
 /**
  * Builds the Supabase client for the admin app from the build-time anon key. The anon key is safe
@@ -15,6 +17,18 @@ fun createAdminSupabaseClient(): SupabaseClient =
         supabaseUrl = BuildConfig.SUPABASE_URL,
         supabaseKey = BuildConfig.SUPABASE_KEY,
     ) {
+        // The library default (encodeDefaults = false) drops any field whose value matches its
+        // Kotlin default from the JSON body — e.g. AdminFeatureFlag.rolloutPercent defaults to
+        // 100, so setting rollout to exactly 100% silently omitted rollout_percent from
+        // insert/upsert requests, leaving the old value in place on update. Always encode
+        // defaults so every field is sent explicitly.
+        defaultSerializer =
+            KotlinXSerializer(
+                Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                }
+            )
         install(Auth)
         install(Postgrest)
     }


### PR DESCRIPTION
## Summary
- Setting a feature flag's rollout to exactly 100% in the admin app would save without error but the value would revert to the old percentage on reload.
- Root cause: `supabase-kt`'s default JSON serializer has `encodeDefaults = false`, which drops any field whose value equals its Kotlin default from the request body. `AdminFeatureFlag.rolloutPercent` defaults to `100`, so setting rollout to exactly 100% omitted `rollout_percent` from the insert/upsert JSON entirely. For `update()` (a Postgrest upsert), Postgrest's generated `ON CONFLICT DO UPDATE SET` clause only includes columns present in the payload, so the column was skipped and the old value silently persisted.
- Fix: explicitly configure the admin Supabase client's serializer with `encodeDefaults = true` so every field is always sent, regardless of whether it matches a Kotlin default.
- Bonus: this also fixes a latent bug where creating a *new* flag left at the default 100% rollout would insert using the table's actual column default (`0`), silently launching the flag dark.

## Test plan
- [x] `./gradlew :admin:compileKotlinJvm`
- [x] `./gradlew :admin:jvmTest`
- [ ] Manually verify in the admin app: edit an existing flag, set rollout to 100%, save, reload, confirm it persists at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)