### PR TITLE
feat(auth): enable password-manager autofill on login fields

### DIFF
--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -214,6 +215,9 @@ private fun AuthenticationBody(
             modifier = Modifier.focusRequester(passwordFocusRequester),
             password = password,
             onPasswordChanged = onPasswordChanged,
+            // Signing in fills the saved password; signing up asks the manager to generate/save a
+            // new one.
+            contentType = if (isSignIn) ContentType.Password else ContentType.NewPassword,
             error = model.passwordError,
             imeAction = if (isSignIn) ImeAction.Done else ImeAction.Next,
             onImeAction = {
@@ -253,6 +257,7 @@ private fun AuthenticationBody(
                     modifier = Modifier.focusRequester(confirmPasswordFocusRequester),
                     password = confirmPassword,
                     onPasswordChanged = onConfirmPasswordChanged,
+                    contentType = ContentType.NewPassword,
                     label = stringResource(Res.string.auth_label_confirm_password),
                     error = model.confirmPasswordError,
                     imeAction = ImeAction.Done,
@@ -376,6 +381,9 @@ fun EmailField(
         keyboardOptions =
             KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
         keyboardActions = KeyboardActions(onNext = { onImeAction() }),
+        // Users sign in with their email, so hint both so password managers match either the
+        // username or email-address field they saved for the account.
+        contentType = ContentType.EmailAddress + ContentType.Username,
     )
 }
 
@@ -391,6 +399,7 @@ fun PasswordField(
     modifier: Modifier = Modifier,
     password: String,
     onPasswordChanged: (String) -> Unit,
+    contentType: ContentType,
     label: String = stringResource(Res.string.auth_label_password),
     error: TextData? = null,
     imeAction: ImeAction,
@@ -408,6 +417,7 @@ fun PasswordField(
         keyboardOptions =
             KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = imeAction),
         keyboardActions = KeyboardActions(onNext = { onImeAction() }, onDone = { onImeAction() }),
+        contentType = contentType,
         trailingIcon = {
             val image =
                 if (passwordVisible) Icons.Default.Visibility else Icons.Default.VisibilityOff

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusTextField.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusTextField.kt
@@ -21,8 +21,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.semantics.contentType
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -46,6 +49,7 @@ fun PlusTextField(
     outputTransformation: OutputTransformation? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
+    contentType: ContentType? = null,
 ) {
     val isError = error != null
 
@@ -80,10 +84,20 @@ fun PlusTextField(
         }
     }
 
+    // Capture into a local so the null-check smart-casts inside the semantics lambda. The autofill
+    // hint must land on the text field node itself (not the outer Column) so the platform autofill
+    // service can identify the field and offer to save/fill credentials for it.
+    val autofillContentType = contentType
     val fieldModifier =
-        Modifier.fillMaxWidth().let {
-            if (focusRequester != null) it.focusRequester(focusRequester) else it
-        }
+        Modifier.fillMaxWidth()
+            .let { if (focusRequester != null) it.focusRequester(focusRequester) else it }
+            .let {
+                if (autofillContentType != null) {
+                    it.semantics { this.contentType = autofillContentType }
+                } else {
+                    it
+                }
+            }
 
     val lineLimits =
         if (singleLine) {


### PR DESCRIPTION
## What

Adds Compose Multiplatform autofill hints to the authentication screen's email and password fields so the OS and password managers can identify them and offer to **save and fill** credentials.

- `PlusTextField` gains an optional `contentType: ContentType?` param, applied as a `semantics { contentType = … }` modifier **on the text-field node itself** (not the outer `Column`) — that's where the platform autofill service looks.
- Auth screen hints:
  - Email → `ContentType.EmailAddress + ContentType.Username` (users sign in with email; matches whichever the manager saved)
  - Password → `ContentType.Password` when signing in, `ContentType.NewPassword` when signing up
  - Confirm-password → `ContentType.NewPassword`

## Why

The fields carried no autofill hints, so nothing was ever offered to save or fill on login. These content types are the prerequisite that makes autofill work, and they benefit every platform (Android natively today).

## Notes for reviewers

- Verified: both modules compile (`:client:ui:public` + `:client:auth:ui:public`) and pass ktfmt.
- **Out of scope / follow-up — true `chefmate.plusmobileapps.com` domain association** (sharing credentials saved on the *website* with the app) still needs infra outside this repo:
  - Android: host `/.well-known/assetlinks.json` with a `delegate_permission/common.get_login_creds` entry for the app package + signing SHA-256.
  - iOS: add the Associated Domains entitlement `webcredentials:chefmate.plusmobileapps.com` (no `.entitlements` file exists yet) and serve an `apple-app-site-association` file.
  - These require the website repo and Apple/Play signing config. This PR is the app-side field wiring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)