### PR TITLE
feat(ios): add Associated Domains entitlement for login autofill

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,7 +63,8 @@ platform :ios do
 
   desc "Generate/refresh signing certificates and provisioning profiles (read-write match)"
   desc "Run this once after adding an app id (e.g. the watch app) so its profile is registered."
-  lane :certificates do
+  desc "Pass force:true to regenerate profiles after enabling a new capability on an App ID."
+  lane :certificates do |options|
     # Sets the App Store Connect API token globally (used by `produce` and `match` below).
     api_key = asc_api_key
 
@@ -78,9 +79,13 @@ platform :ios do
       team_id: ENV["TEAM_ID"] || "Y89258SF5P",
     )
 
+    # `force:` regenerates existing profiles instead of reusing them. Needed when an App ID gains a
+    # capability (e.g. Associated Domains) — the old profile is still valid but lacks the new
+    # entitlement, so match would otherwise keep serving the stale one.
     match(
       type: "appstore",
       readonly: false,
+      force: options.fetch(:force, false),
       api_key: api_key,
     )
   end

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -454,6 +454,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -617,6 +618,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = Y89258SF5P;

--- a/iosApp/iosApp/iosApp.entitlements
+++ b/iosApp/iosApp/iosApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:chefmate.plusmobileapps.com</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
> **Draft — do not merge until the provisioning steps below are done.** Merging first will break iOS Release/CI signing (Manual signing + Match rejects entitlements not present in the profile).

## What

The iOS counterpart to the website's `apple-app-site-association` file ([chefmate-site#8](https://github.com/Plus-Mobile-Apps/chefmate-site/pull/8), now live) and the Compose autofill hints from #385. Adds a `webcredentials` Associated Domain so iOS Password AutoFill offers credentials saved for `chefmate.plusmobileapps.com` on the app's login screen.

- New `iosApp/iosApp/iosApp.entitlements`:
  `com.apple.developer.associated-domains = webcredentials:chefmate.plusmobileapps.com`
- `CODE_SIGN_ENTITLEMENTS` wired into the **iosApp target's Debug and Release configs only** — deliberately *not* in `Config.xcconfig`, which is attached to the project-level configs and would leak the entitlement onto the watch app and share extension.
- `ci(ios)`: the `certificates` lane now accepts `force:` and passes it to `match`, so the App Store profile can be regenerated after the capability is enabled (a stale-but-valid profile is otherwise reused).

## ⚠️ Required before merge (needs your Apple account — I can't do these)

1. **Enable the capability on the App ID.** Developer Portal → Certificates, IDs & Profiles → Identifiers → `com.plusmobileapps.chefmate.ChefMate` → check **Associated Domains** → Save. (Match/`sigh` reflects App ID capabilities; it does not enable them.)
2. **Regenerate the App Store provisioning profile** with force, via the ios-platform lane:
   ```bash
   bundle exec fastlane ios certificates force:true
   ```
   Notes: the lane must be `ios certificates` (the shell's default platform is `android`), and `fastlane match appstore --force` standalone does **not** work here — it fails with `'api_key' value must be a Hash!` because match on its own can't build the ASC key. The lane routes through `asc_api_key` for that reason.
3. Only then merge — CI's `release` lane fetches the updated profile read-only.

## Verify after a signed build ships

On device (iOS 14+): tap the email/password field on the login screen → the QuickType bar should offer credentials saved for the website. The site AASA is already live and validated by Apple's CDN:
```bash
curl -i https://app-site-association.cdn-apple.com/a/v1/chefmate.plusmobileapps.com
```

## Notes

- Debug config uses Automatic signing, so local dev builds pick up the capability without the Match step (as long as your Apple ID can manage the App ID).
- No Kotlin/Compose changes — the field-level autofill hints already merged in #385 cover all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)