### PR TITLE
feat(android): declare Digital Asset Links affiliation for autofill

### DIFF
--- a/client/composeApp/src/androidMain/AndroidManifest.xml
+++ b/client/composeApp/src/androidMain/AndroidManifest.xml
@@ -41,6 +41,12 @@
                 <data android:scheme="chefmate" />
             </intent-filter>
         </activity>
+
+        <!-- Digital Asset Links affiliation for password-manager credential sharing with
+             chefmate.plusmobileapps.com (login autofill). Must be an <application> child. -->
+        <meta-data
+                android:name="asset_statements"
+                android:resource="@string/asset_statements" />
     </application>
 
 </manifest>

--- a/client/composeApp/src/androidMain/res/values/strings.xml
+++ b/client/composeApp/src/androidMain/res/values/strings.xml
@@ -1,3 +1,12 @@
 <resources>
     <string name="app_name">Chef Mate</string>
+    <!--
+      Declares the app's affiliation with chefmate.plusmobileapps.com so password managers share
+      login credentials between the website and this app (autofill). This is the reverse half of the
+      Digital Asset Links pairing; the site hosts the matching /.well-known/assetlinks.json with the
+      delegate_permission/common.get_login_creds relation for this package + signing cert.
+    -->
+    <string name="asset_statements" translatable="false">
+        [{ \"include\": \"https://chefmate.plusmobileapps.com/.well-known/assetlinks.json\" }]
+    </string>
 </resources>


### PR DESCRIPTION
## What

Adds the **app → site** half of the Digital Asset Links pairing so password managers share login credentials between `chefmate.plusmobileapps.com` and the app. This is the Android counterpart to the iOS `webcredentials` entitlement (#388).

- New `asset_statements` string resource → `[{ "include": "https://chefmate.plusmobileapps.com/.well-known/assetlinks.json" }]`
- `asset_statements` `<meta-data>` under `<application>` referencing it

## Why

- **#385** added the Compose autofill hints → in-app save/fill already works, keyed to the package.
- The site (chefmate-site #11) hosts `assetlinks.json` with `delegate_permission/common.get_login_creds` → the **site → app** direction.
- This PR is the missing **app → site** declaration. Without it, password managers won't treat website-saved credentials and app credentials as affiliated, so the `chefmate.plusmobileapps.com` domain sharing wouldn't kick in.

## Verification done

- `strings.xml` / `AndroidManifest.xml` well-formed.
- `./gradlew :client:composeApp:processDebugManifest :client:composeApp:mergeDebugResources` succeeds.
- Confirmed in build output: the `<meta-data>` merges into the final manifest and the escaped JSON resolves to the correct URL.

## Depends on

The affiliation only resolves once the site's `assetlinks.json` carries the real signing SHA-256 (chefmate-site #11) and is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)