### PR TITLE
fix(update): macOS in-app update fails with "disk image is corrupted"

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -179,7 +179,15 @@ jobs:
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           BASE="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}"
+          # Compose names the macOS artifact "Chef Mate-<ver>.dmg" (packageName has a space).
+          # GitHub rewrites spaces to periods on asset upload, so a feed URL built from the raw
+          # local name 404s at download time. Rename the space out *before* both feed generation
+          # and the release upload (files: artifacts/*) so the served name matches the feed exactly.
           DMG=$(cd artifacts && ls *.dmg)
+          if [ "$DMG" != "${DMG// /.}" ]; then
+            (cd artifacts && mv "$DMG" "${DMG// /.}")
+            DMG="${DMG// /.}"
+          fi
           DEB=$(cd artifacts && ls *.deb)
           cat > artifacts/latest.json <<EOF
           {

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/update/DesktopUpdater.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/update/DesktopUpdater.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readRemaining
 import java.awt.Desktop
@@ -98,6 +99,12 @@ class DesktopUpdater(
         val fileName = target.downloadUrl.substringAfterLast('/')
         val dest = File(System.getProperty("java.io.tmpdir"), fileName)
         http.prepareGet(target.downloadUrl).execute { response ->
+            // A stale/misbuilt feed can point at a URL that 404s. Without this guard we'd stream
+            // the error page into the .dmg and hand macOS a "disk image is corrupted" dialog.
+            // Fail loudly so startDownload() reverts to the retryable Available banner instead.
+            if (!response.status.isSuccess()) {
+                error("Download failed: HTTP ${response.status.value} for ${target.downloadUrl}")
+            }
             val total = response.headers["Content-Length"]?.toLongOrNull() ?: -1L
             val channel: ByteReadChannel = response.bodyAsChannel()
             var read = 0L


### PR DESCRIPTION
## Problem

The macOS in-app updater fails on install with **"The disk image couldn't be opened — The disk image is corrupted."** The DMG isn't actually corrupt: the updater is downloading a **404 page** and saving it as the `.dmg`.

### Root cause

Compose names the macOS artifact after `packageName = "Chef Mate"`, i.e. `Chef Mate-1.9.12.dmg` (with a **space**). **GitHub rewrites spaces to periods on asset upload**, so the served asset is `Chef.Mate-1.9.12.dmg`. But the update feed is generated from the raw local filename (`ls *.dmg`), so `latest.json` advertises the space variant that GitHub never serves.

Verified against the live 1.9.12 release:

| URL | Result |
|---|---|
| feed URL `.../Chef Mate-1.9.12.dmg` (space) | **HTTP 404**, 9-byte `Not Found` body |
| actual asset `.../Chef.Mate-1.9.12.dmg` (dot) | **HTTP 200**, ~199 MB DMG |

The updater streamed those 9 bytes into the installer file and asked macOS to mount it → corruption dialog. This has been broken for every macOS release since the self-updater shipped (#229).

## Fix

1. **`desktop-release.yml`** — rename the space to a period in the DMG artifact *before* both feed generation and the release upload (`files: artifacts/*`), so the served asset name matches the feed exactly and there's nothing for GitHub to rewrite.
2. **`DesktopUpdater`** — reject non-2xx responses before writing the installer, so a stale/misbuilt feed surfaces as a clean "update failed, retry" (reverts to the Available banner) instead of a scary macOS corruption dialog.

## Follow-up (not in this PR)

The **already-published 1.9.12 `latest.json`** still points at the 404 URL, so users on the current build can't self-update even after this merges. That release's `latest.json` needs to be regenerated/replaced (or a new version cut) for existing installs to recover.

## Testing

- `./gradlew :client:composeApp:compileKotlinJvm` passes.
- Confirmed the 404-vs-200 behavior against the live release URLs (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)