### PR TITLE
feat(settings): add Contact Us tile to More tab

### DIFF
--- a/client/settings/public/build.gradle.kts
+++ b/client/settings/public/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
             api(projects.client.text.public)
             api(projects.client.browser.public)
             implementation(projects.client.ui.public)
+            implementation(projects.client.util.public)
             implementation(compose.components.resources)
         }
     }

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="privacy_policy">Privacy Policy</string>
     <string name="terms_of_use">Terms of Use</string>
     <string name="about">About</string>
+    <string name="contact_us">Contact Us</string>
     <string name="sign_in">Sign In</string>
     <string name="sign_out">Sign Out</string>
     <string name="sign_up">Sign Up</string>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/ui/SettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/ui/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import chefmate.client.settings.public.generated.resources.Res
 import chefmate.client.settings.public.generated.resources.about
+import chefmate.client.settings.public.generated.resources.contact_us
 import chefmate.client.settings.public.generated.resources.developer_settings
 import chefmate.client.settings.public.generated.resources.greeting_authenticated
 import chefmate.client.settings.public.generated.resources.manage_profile
@@ -59,10 +60,15 @@ import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import com.plusmobileapps.chefmate.util.rememberEmailLauncher
+
+/** Support inbox surfaced by the "Contact Us" row in the More tab. */
+private const val SUPPORT_EMAIL = "support@plusmobileapps.com"
 
 @Composable
 fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
     val viewState by bloc.state.collectAsState()
+    val launchEmail = rememberEmailLauncher()
 
     if (viewState.showSignOutConfirmationDialog) {
         PlusDialog(
@@ -158,6 +164,11 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
             SettingsRow(
                 name = Res.string.about.asTextData(),
                 onClick = { bloc.onUrlClicked("https://chefmate.plusmobileapps.com/") },
+            )
+            HorizontalDivider()
+            SettingsRow(
+                name = Res.string.contact_us.asTextData(),
+                onClick = { launchEmail(SUPPORT_EMAIL) },
             )
             HorizontalDivider()
             SettingsRow(

--- a/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/EmailLauncher.android.kt
+++ b/client/util/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/util/EmailLauncher.android.kt
@@ -1,0 +1,27 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+actual fun rememberEmailLauncher(): (email: String) -> Unit {
+    val context = LocalContext.current
+    return remember(context) {
+        { email ->
+            val intent = Intent(Intent.ACTION_SENDTO).apply { data = Uri.parse("mailto:$email") }
+            // ACTION_SENDTO with a mailto: URI resolves only to email apps. Guard against devices
+            // with no mail client so the tap can't crash the app.
+            try {
+                context.startActivity(intent)
+            } catch (_: ActivityNotFoundException) {
+                // No email client installed — nothing to do.
+            }
+        }
+    }
+}

--- a/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/EmailLauncher.kt
+++ b/client/util/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/util/EmailLauncher.kt
@@ -1,0 +1,10 @@
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Returns an email launcher function. The returned function accepts an email address and opens the
+ * platform's default email client with that address pre-filled in the "to" field via a `mailto:`
+ * link. Unlike opening a URL in the in-app browser, this hands off to the OS mail app.
+ */
+@Composable expect fun rememberEmailLauncher(): (email: String) -> Unit

--- a/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/EmailLauncher.ios.kt
+++ b/client/util/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/util/EmailLauncher.ios.kt
@@ -1,0 +1,17 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+
+@Composable
+actual fun rememberEmailLauncher(): (email: String) -> Unit = { email ->
+    val url = NSURL(string = "mailto:$email")
+    UIApplication.sharedApplication.openURL(
+        url,
+        options = mapOf<Any?, Any>(),
+        completionHandler = null,
+    )
+}

--- a/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/EmailLauncher.jvm.kt
+++ b/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/EmailLauncher.jvm.kt
@@ -1,0 +1,18 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import java.awt.Desktop
+import java.net.URI
+
+@Composable
+actual fun rememberEmailLauncher(): (email: String) -> Unit = remember {
+    { email ->
+        val desktop = if (Desktop.isDesktopSupported()) Desktop.getDesktop() else null
+        if (desktop != null && desktop.isSupported(Desktop.Action.MAIL)) {
+            desktop.mail(URI("mailto:$email"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Contact Us** tile to the More tab. Tapping it opens the device's default email client with `support@plusmobileapps.com` pre-filled in the To field.

The existing `OpenUrl` path opens the *in-app browser*, which can't handle `mailto:`. Following the codebase's established `rememberShareLauncher` expect/actual pattern, this adds a platform email launcher that hands off to the OS mail app.

## Changes

**`feat(util): add cross-platform email launcher`**
- New `rememberEmailLauncher()` Compose expect/actual in `client/util/public`:
  - **Android** — `ACTION_SENDTO` intent with a `mailto:` URI (resolves only to mail apps), guarded against devices with no mail client.
  - **iOS** — `UIApplication.openURL` with the `mailto:` URL.
  - **Desktop/JVM** — `Desktop.mail(URI("mailto:…"))`.

**`feat(settings): add Contact Us tile to More tab`**
- New "Contact Us" `SettingsRow` between *About* and *View Onboarding Again*.
- `contact_us` string resource and a `projects.client.util.public` dependency on `settings/public`.

## Testing

- Compiles clean on JVM, iOS (simulatorArm64), and Android targets.
- `ktfmt --kotlinlang-style` passes.
- Not yet exercised on a device/simulator — the actual mail-client handoff has not been manually verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)