### PR TITLE
fix(auth): hint login email field as plain Username for autofill

### DIFF
--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
@@ -381,9 +381,11 @@ fun EmailField(
         keyboardOptions =
             KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
         keyboardActions = KeyboardActions(onNext = { onImeAction() }),
-        // Users sign in with their email, so hint both so password managers match either the
-        // username or email-address field they saved for the account.
-        contentType = ContentType.EmailAddress + ContentType.Username,
+        // Username-primary (with email as a secondary hint): some password managers (e.g.
+        // Bitwarden) anchor their on-focus inline suggestion off the field's primary content type
+        // and only proactively offer to fill fields they classify as "username". Leading with
+        // EmailAddress left the field recognized for manual autofill but not offered automatically.
+        contentType = ContentType.Username + ContentType.EmailAddress,
     )
 }
 

--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
@@ -381,11 +381,11 @@ fun EmailField(
         keyboardOptions =
             KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
         keyboardActions = KeyboardActions(onNext = { onImeAction() }),
-        // Username-primary (with email as a secondary hint): some password managers (e.g.
-        // Bitwarden) anchor their on-focus inline suggestion off the field's primary content type
-        // and only proactively offer to fill fields they classify as "username". Leading with
-        // EmailAddress left the field recognized for manual autofill but not offered automatically.
-        contentType = ContentType.Username + ContentType.EmailAddress,
+        // This is the account's login identifier, which password managers store as the "username"
+        // even though users type their email into it. Hinting plain Username (rather than also
+        // EmailAddress) classifies it unambiguously as a login field, so managers like Bitwarden
+        // proactively offer the on-focus inline suggestion instead of only filling it on demand.
+        contentType = ContentType.Username,
     )
 }
 


### PR DESCRIPTION
## What

Change the login email field's autofill hint to plain **`ContentType.Username`**.

```kotlin
// before
contentType = ContentType.EmailAddress + ContentType.Username
// after
contentType = ContentType.Username
```

(Two commits: first flips to username-primary `Username + EmailAddress`, then drops the `EmailAddress` hint entirely — the final state is `Username`.)

## Why

Reported on-device with **Bitwarden**: focusing the **password** field shows the inline autofill suggestion above the keyboard and fills both fields; focusing the **email** field shows *nothing* — you have to long-press → Autofill to fill it manually. The field is recognized (manual works), but not *proactively offered on focus*.

The field is the account's **login identifier**, which password managers store as the "username" even though users type their email into it. Hinting it as both email + username let managers bucket it as an "email" field rather than the login username field they proactively offer on focus. A plain `Username` hint classifies it unambiguously as a login field.

## Status: experiment — needs on-device confirmation

Manager-specific behavior I can't reproduce in CI. Minimal, zero-risk change; verify by building and watching whether the keyboard suggestion chip now appears when the email field gains focus. Password/confirm fields and other platforms are untouched.

Compiles clean (`:client:auth:ui:public`), ktfmt-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)