### PR TITLE
feat(profile): require typing email to confirm account deletion

### DIFF
--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/ManageProfileNavigationUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/ManageProfileNavigationUiTest.kt
@@ -28,4 +28,20 @@ class ManageProfileNavigationUiTest {
         // Saving pops back to the More tab.
         more().awaitDisplayed()
     }
+
+    @Test
+    fun delete_confirm_is_gated_until_the_account_email_is_typed() = runRootBlocTest {
+        bottomNav().clickMoreTab()
+        more().awaitDisplayed().clickManageProfileRow()
+
+        // The default authenticated test user's email (see FakeAuthenticationRepository.fakeUser).
+        manageProfile()
+            .awaitDisplayed()
+            .tapDeleteAccount()
+            .assertConfirmDeleteDisabled()
+            .typeDeleteConfirmation("nope@example.com")
+            .assertConfirmDeleteDisabled()
+            .typeDeleteConfirmation("test@example.com")
+            .assertConfirmDeleteEnabled()
+    }
 }

--- a/client/profile/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/robots/ManageProfileRobot.kt
+++ b/client/profile/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/robots/ManageProfileRobot.kt
@@ -5,6 +5,8 @@ package com.plusmobileapps.chefmate.profile.robots
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasTestTag
@@ -44,6 +46,29 @@ class ManageProfileRobot(private val test: ComposeUiTest) {
 
     fun tapDeleteAccount(): ManageProfileRobot = apply {
         test.onNode(hasTestTag(ManageProfileTestTags.DELETE_ACCOUNT) and onScreen).performClick()
+    }
+
+    fun typeDeleteConfirmation(email: String): ManageProfileRobot = apply {
+        // The test tag sits on the PlusTextField wrapper; the editable node is the descendant that
+        // owns the set-text action.
+        test
+            .onNode(
+                hasSetTextAction() and
+                    hasAnyAncestor(hasTestTag(ManageProfileTestTags.DELETE_CONFIRMATION))
+            )
+            .performTextReplacement(email)
+    }
+
+    fun tapConfirmDelete(): ManageProfileRobot = apply {
+        test.onNode(hasTestTag(ManageProfileTestTags.DELETE_CONFIRM)).performClick()
+    }
+
+    fun assertConfirmDeleteEnabled(): ManageProfileRobot = apply {
+        test.onNode(hasTestTag(ManageProfileTestTags.DELETE_CONFIRM)).assertIsEnabled()
+    }
+
+    fun assertConfirmDeleteDisabled(): ManageProfileRobot = apply {
+        test.onNode(hasTestTag(ManageProfileTestTags.DELETE_CONFIRM)).assertIsNotEnabled()
     }
 
     fun assertDisplayed(): ManageProfileRobot = apply {

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImpl.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImpl.kt
@@ -63,6 +63,10 @@ class ManageProfileBlocImpl(
         viewModel.showDeleteDialog()
     }
 
+    override fun onDeleteConfirmationChanged(confirmation: String) {
+        viewModel.setDeleteConfirmation(confirmation)
+    }
+
     override fun onDeleteConfirmed() {
         viewModel.deleteAccount()
     }

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileViewModel.kt
@@ -108,15 +108,31 @@ class ManageProfileViewModel(
     }
 
     fun showDeleteDialog() {
-        _state.update { it.copy(showDeleteDialog = true, deleteError = null) }
+        _state.update {
+            it.copy(showDeleteDialog = true, deleteConfirmation = "", deleteError = null)
+        }
+    }
+
+    fun setDeleteConfirmation(confirmation: String) {
+        _state.update { it.copy(deleteConfirmation = confirmation) }
     }
 
     fun dismissDeleteDialog() {
-        _state.update { it.copy(showDeleteDialog = false) }
+        _state.update { it.copy(showDeleteDialog = false, deleteConfirmation = "") }
     }
 
     fun deleteAccount() {
-        _state.update { it.copy(showDeleteDialog = false, isDeleting = true, deleteError = null) }
+        // Guard against deletion unless the typed email matches — mirrors the disabled confirm
+        // button so a stray call (e.g. an IME action) can't bypass the confirmation gate.
+        if (!_state.value.canConfirmDelete) return
+        _state.update {
+            it.copy(
+                showDeleteDialog = false,
+                deleteConfirmation = "",
+                isDeleting = true,
+                deleteError = null,
+            )
+        }
         scope.launch {
             deleteAccountUseCase()
                 .onSuccess { _outputs.send(Output.Deleted) }

--- a/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfilePreviews.kt
+++ b/client/profile/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/impl/ui/ManageProfilePreviews.kt
@@ -24,6 +24,8 @@ private fun manageProfileBloc(model: Model): ManageProfileBloc =
 
         override fun onDeleteAccountClicked() = Unit
 
+        override fun onDeleteConfirmationChanged(confirmation: String) = Unit
+
         override fun onDeleteConfirmed() = Unit
 
         override fun onDeleteDismissed() = Unit
@@ -42,6 +44,16 @@ val previewManageProfileSavingBloc: ManageProfileBloc =
 val previewManageProfileDeleteDialogBloc: ManageProfileBloc =
     manageProfileBloc(
         Model(displayName = "Julia Child", email = "julia@example.com", showDeleteDialog = true)
+    )
+
+val previewManageProfileDeleteDialogConfirmableBloc: ManageProfileBloc =
+    manageProfileBloc(
+        Model(
+            displayName = "Julia Child",
+            email = "julia@example.com",
+            showDeleteDialog = true,
+            deleteConfirmation = "julia@example.com",
+        )
     )
 
 val previewManageProfileErrorBloc: ManageProfileBloc =

--- a/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
+++ b/client/profile/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/profile/impl/ManageProfileBlocImplTest.kt
@@ -165,11 +165,48 @@ class ManageProfileBlocImplTest {
     }
 
     @Test
-    fun When_delete_confirmed_Then_account_deleted_and_output_emitted() = runTest {
+    fun When_delete_confirmed_with_matching_email_Then_account_deleted_and_output_emitted() =
+        runTest {
+            bloc.onDeleteAccountClicked()
+            bloc.onDeleteConfirmationChanged("chef@example.com")
+            bloc.onDeleteConfirmed()
+
+            deleteCalled shouldBe true
+            output.lastValue shouldBe ManageProfileBloc.Output.AccountDeleted
+        }
+
+    @Test
+    fun When_confirmation_matches_email_ignoring_case_and_whitespace_Then_delete_is_enabled() =
+        runTest {
+            bloc.onDeleteAccountClicked()
+            bloc.onDeleteConfirmationChanged("  CHEF@example.com  ")
+
+            bloc.state.value.canConfirmDelete shouldBe true
+        }
+
+    @Test
+    fun When_confirmation_does_not_match_email_Then_delete_is_blocked() = runTest {
         bloc.onDeleteAccountClicked()
+        bloc.onDeleteConfirmationChanged("wrong@example.com")
+        bloc.state.value.canConfirmDelete shouldBe false
+
         bloc.onDeleteConfirmed()
 
-        deleteCalled shouldBe true
-        output.lastValue shouldBe ManageProfileBloc.Output.AccountDeleted
+        deleteCalled shouldBe false
+        output.values.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun When_delete_dismissed_Then_confirmation_is_cleared() = runTest {
+        bloc.state.test {
+            awaitItem()
+            bloc.onDeleteAccountClicked()
+            awaitItem().showDeleteDialog shouldBe true
+            bloc.onDeleteConfirmationChanged("chef@example.com")
+            awaitItem().deleteConfirmation shouldBe "chef@example.com"
+            bloc.onDeleteDismissed()
+            awaitItem().deleteConfirmation shouldBe ""
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/client/profile/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/profile/public/src/commonMain/composeResources/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="manage_profile_delete_account">Delete Account</string>
     <string name="manage_profile_delete_dialog_title">Delete account?</string>
     <string name="manage_profile_delete_dialog_message">This permanently deletes your account and all of your recipes, groceries, and meal plans. This can’t be undone.</string>
+    <string name="manage_profile_delete_dialog_confirmation_prompt">To confirm, type your email {email} below.</string>
+    <string name="manage_profile_delete_dialog_confirmation_hint">Email</string>
     <string name="manage_profile_delete_dialog_confirm">Delete</string>
     <string name="manage_profile_delete_dialog_cancel">Cancel</string>
     <string name="manage_profile_delete_error">Couldn’t delete your account. Please try again.</string>

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileBloc.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileBloc.kt
@@ -27,6 +27,8 @@ interface ManageProfileBloc : ComposeScreen {
 
     fun onDeleteAccountClicked()
 
+    fun onDeleteConfirmationChanged(confirmation: String)
+
     fun onDeleteConfirmed()
 
     fun onDeleteDismissed()
@@ -41,12 +43,21 @@ interface ManageProfileBloc : ComposeScreen {
         val isSaving: Boolean = false,
         val saveError: TextData? = null,
         val showDeleteDialog: Boolean = false,
+        /** What the user has typed into the delete-confirmation field; must match [email]. */
+        val deleteConfirmation: String = "",
         val isDeleting: Boolean = false,
         val deleteError: TextData? = null,
     ) {
         /** Save is enabled once a non-blank name exists and no save/delete is in flight. */
         val canSave: Boolean
             get() = displayName.isNotBlank() && !isSaving && !isDeleting
+
+        /**
+         * Deletion is only allowed once the typed confirmation matches the account email
+         * (case-insensitive, trimmed) — the guard against accidental account deletion.
+         */
+        val canConfirmDelete: Boolean
+            get() = email.isNotBlank() && deleteConfirmation.trim().equals(email, ignoreCase = true)
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -58,6 +69,7 @@ interface ManageProfileBloc : ComposeScreen {
             if (isSaving != other.isSaving) return false
             if (saveError != other.saveError) return false
             if (showDeleteDialog != other.showDeleteDialog) return false
+            if (deleteConfirmation != other.deleteConfirmation) return false
             if (isDeleting != other.isDeleting) return false
             if (deleteError != other.deleteError) return false
             return true
@@ -71,6 +83,7 @@ interface ManageProfileBloc : ComposeScreen {
             result = 31 * result + isSaving.hashCode()
             result = 31 * result + (saveError?.hashCode() ?: 0)
             result = 31 * result + showDeleteDialog.hashCode()
+            result = 31 * result + deleteConfirmation.hashCode()
             result = 31 * result + isDeleting.hashCode()
             result = 31 * result + (deleteError?.hashCode() ?: 0)
             return result

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileScreen.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileScreen.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Icon
@@ -22,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import chefmate.client.profile.public.generated.resources.Res
@@ -30,6 +33,8 @@ import chefmate.client.profile.public.generated.resources.manage_profile_change_
 import chefmate.client.profile.public.generated.resources.manage_profile_delete_account
 import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_cancel
 import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_confirm
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_confirmation_hint
+import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_confirmation_prompt
 import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_message
 import chefmate.client.profile.public.generated.resources.manage_profile_delete_dialog_title
 import chefmate.client.profile.public.generated.resources.manage_profile_display_name_hint
@@ -38,10 +43,12 @@ import chefmate.client.profile.public.generated.resources.manage_profile_email_l
 import chefmate.client.profile.public.generated.resources.manage_profile_save
 import chefmate.client.profile.public.generated.resources.manage_profile_title
 import coil3.compose.AsyncImage
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusButton
 import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
-import com.plusmobileapps.chefmate.ui.components.PlusDialog
+import com.plusmobileapps.chefmate.ui.components.PlusDialogScaffold
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusTextField
@@ -55,11 +62,11 @@ fun ManageProfileScreen(bloc: ManageProfileBloc, modifier: Modifier = Modifier) 
     val pickPhoto = rememberImagePickerLauncher { picked -> picked?.let(bloc::onPhotoPicked) }
 
     if (state.showDeleteDialog) {
-        PlusDialog(
-            title = Res.string.manage_profile_delete_dialog_title.asTextData(),
-            message = Res.string.manage_profile_delete_dialog_message.asTextData(),
-            confirmButtonText = Res.string.manage_profile_delete_dialog_confirm.asTextData(),
-            dismissButtonText = Res.string.manage_profile_delete_dialog_cancel.asTextData(),
+        DeleteAccountDialog(
+            email = state.email,
+            confirmation = state.deleteConfirmation,
+            canConfirm = state.canConfirmDelete,
+            onConfirmationChange = bloc::onDeleteConfirmationChanged,
             onConfirmClick = bloc::onDeleteConfirmed,
             onDismissRequest = bloc::onDeleteDismissed,
         )
@@ -142,6 +149,64 @@ fun ManageProfileScreen(bloc: ManageProfileBloc, modifier: Modifier = Modifier) 
                     enabled = !state.isSaving && !state.isDeleting,
                     isLoading = state.isDeleting,
                     onClick = bloc::onDeleteAccountClicked,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun DeleteAccountDialog(
+    email: String,
+    confirmation: String,
+    canConfirm: Boolean,
+    onConfirmationChange: (String) -> Unit,
+    onConfirmClick: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    PlusDialogScaffold(
+        onDismissRequest = onDismissRequest,
+        header = { Text(Res.string.manage_profile_delete_dialog_title.asTextData().localized()) },
+        content = {
+            Column(verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal)) {
+                Text(Res.string.manage_profile_delete_dialog_message.asTextData().localized())
+                Text(
+                    PhraseModel(
+                            Res.string.manage_profile_delete_dialog_confirmation_prompt,
+                            "email" to FixedString(email),
+                        )
+                        .localized()
+                )
+                PlusTextField(
+                    value = confirmation,
+                    onValueChange = onConfirmationChange,
+                    modifier =
+                        Modifier.fillMaxWidth().testTag(ManageProfileTestTags.DELETE_CONFIRMATION),
+                    placeholder = {
+                        Text(
+                            Res.string.manage_profile_delete_dialog_confirmation_hint
+                                .asTextData()
+                                .localized()
+                        )
+                    },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                )
+            }
+        },
+        footer = {
+            Row(horizontalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal)) {
+                PlusButton(
+                    text = Res.string.manage_profile_delete_dialog_cancel.asTextData(),
+                    variant = PlusButtonVariant.SECONDARY,
+                    onClick = onDismissRequest,
+                )
+                PlusButton(
+                    text = Res.string.manage_profile_delete_dialog_confirm.asTextData(),
+                    variant = PlusButtonVariant.DESTRUCTIVE,
+                    enabled = canConfirm,
+                    modifier = Modifier.testTag(ManageProfileTestTags.DELETE_CONFIRM),
+                    onClick = onConfirmClick,
                 )
             }
         },

--- a/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileTestTags.kt
+++ b/client/profile/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/profile/ManageProfileTestTags.kt
@@ -6,4 +6,6 @@ object ManageProfileTestTags {
     const val DISPLAY_NAME = "manage_profile_display_name"
     const val SAVE = "manage_profile_save"
     const val DELETE_ACCOUNT = "manage_profile_delete_account"
+    const val DELETE_CONFIRMATION = "manage_profile_delete_confirmation"
+    const val DELETE_CONFIRM = "manage_profile_delete_confirm"
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.android.tools.screenshot.PreviewTest
 import com.plusmobileapps.chefmate.profile.impl.ui.previewManageProfileBloc
 import com.plusmobileapps.chefmate.profile.impl.ui.previewManageProfileDeleteDialogBloc
+import com.plusmobileapps.chefmate.profile.impl.ui.previewManageProfileDeleteDialogConfirmableBloc
 import com.plusmobileapps.chefmate.profile.impl.ui.previewManageProfileSavingBloc
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -36,4 +37,11 @@ fun ManageProfileSavingScreenshot() {
 @Composable
 fun ManageProfileDeleteDialogScreenshot() {
     ChefMateTheme { previewManageProfileDeleteDialogBloc.Content() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun ManageProfileDeleteDialogConfirmableScreenshot() {
+    ChefMateTheme { previewManageProfileDeleteDialogConfirmableBloc.Content() }
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDeleteDialogConfirmableScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDeleteDialogConfirmableScreenshot_e0e29121_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84765e375530fbd99268418f1ba64e0e001421b2bd04d1a501ed73f11bf39ade
+size 104016

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDeleteDialogScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ManageProfileScreenshotTestKt/ManageProfileDeleteDialogScreenshot_e0e29121_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:901a89720ccb77fadad986e1ea3ff4af669adecce3797f57a88af97fc4c0240d
-size 89102
+oid sha256:899a2a07dfa604927ce476ce0d9856822314f32ca4bf248e08656165541da1b9
+size 99931


### PR DESCRIPTION
## Summary

Makes account deletion harder to trigger accidentally by requiring the user to type their email address to confirm, closing #334.

The delete-account dialog now:
- shows the account email and the destructive warning
- includes a text field where the user must retype their email
- keeps the **Delete** button disabled until the typed value matches the account email (case-insensitive, whitespace-trimmed)

The `ManageProfileViewModel` also guards `deleteAccount()` on the same `canConfirmDelete` check so a stray confirm (e.g. an IME action) can't bypass the gate, and it clears the typed value whenever the dialog opens or is dismissed.

## Before / After

The confirm button is disabled with an empty/mismatched field and only enables once the email matches:

| Empty field (Delete disabled) | Matching email (Delete enabled) |
|---|---|
| grey Delete button | red Delete button |

## Testing

- `:client:profile:impl:jvmTest` — added unit tests for the match (case/whitespace-insensitive), the blocked mismatch path, and confirmation reset on dismiss.
- `:client:composeApp:jvmTest` — added a root UI test (`ManageProfileNavigationUiTest`) proving Delete stays disabled until the account email is typed.
- `:client:ui:screenshot-test:updateDebugScreenshotTest` — refreshed the delete-dialog reference and added a confirmable variant; PNGs inspected.
- New robot actions on `ManageProfileRobot` for typing the confirmation, tapping confirm, and asserting its enabled state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)