### PR TITLE
fix(invites): send from verified plusmobileapps.com domain

### DIFF
--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -144,6 +144,11 @@ through the Dashboard's SQL Editor, not the CLI. See the header of
 calls, how to verify they landed, and how to rotate `invite_hook_secret` (via `vault.update_secret`
 — `create_secret` errors on a duplicate name).
 
+The verified sending domain is `plusmobileapps.com` and the default sender is
+`noreply@plusmobileapps.com` (see `DEFAULT_FROM` in the edge function; override at runtime with the
+`RESEND_FROM` secret). Resend authorizes any address at that exact domain — a subdomain such as
+`chefmate.plusmobileapps.com` would need separate verification.
+
 ## Sync Strategy
 
 The existing offline-first sync is extended for collaboration:

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -27,8 +27,8 @@ const corsHeaders = {
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 
-const DEFAULT_FROM = "Chef Mate <invites@chefmate.app>";
-const DEFAULT_APP_URL = "https://chefmate.app";
+const DEFAULT_FROM = "Chef Mate <noreply@plusmobileapps.com>";
+const DEFAULT_APP_URL = "https://chefmate.plusmobileapps.com";
 
 interface InvitePayload {
   kind: "grocery" | "recipe_book";


### PR DESCRIPTION
## What

Point the `send-invite-email` edge function's default sender and CTA link at the verified `plusmobileapps.com` domain:

- `DEFAULT_FROM`: `Chef Mate <invites@chefmate.app>` → `Chef Mate <noreply@plusmobileapps.com>`
- `DEFAULT_APP_URL`: `https://chefmate.app` → `https://chefmate.plusmobileapps.com`
- Doc note in `docs/collaboration.md` recording the verified domain / default sender so `chefmate.app` doesn't creep back in.

## Why

The function defaulted to `invites@chefmate.app` / `https://chefmate.app` — a placeholder domain the project **doesn't own** and that appears nowhere else in the repo (every real surface — download page, privacy/terms, Android/iOS autofill + web credentials — uses `chefmate.plusmobileapps.com`). Resend rejected it with `403 … domain is not verified`, forcing the sandbox sender (`onboarding@resend.dev`, deliverable only to the account owner).

`plusmobileapps.com` is now **Verified** in Resend, and it authorizes any From address at that exact domain — so `noreply@plusmobileapps.com` sends successfully. (A subdomain like `chefmate.plusmobileapps.com` would need separate Resend verification, so it's intentionally not used as the sender; it's only the CTA link target.)

Addresses #375 — the sending domain landed as `plusmobileapps.com` rather than the originally-named `chefmate.app`.

## Reviewer notes / follow-up (owner-run, not in this PR)

Code change alone doesn't take effect in prod until:

1. Any stale `RESEND_FROM` / `APP_INVITE_URL` override secret is unset (check `supabase secrets list`) so the new defaults win.
2. `supabase functions deploy send-invite-email`.
3. Send a **fresh external** invite (re-invites are UPDATEs and don't re-fire the trigger), confirm delivery + `noreply@plusmobileapps.com` in Resend logs.

Consideration: `noreply@` can't receive replies. If reply-ability matters, `invites@plusmobileapps.com` routed to a real inbox would be friendlier — deferred to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)