### PR TITLE
fix(desktop): bundle jdk.unsupported.desktop so the browser WebView works

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -268,7 +268,12 @@ compose.desktop {
             description = "Chef Mate - Your AI Cooking Assistant"
             vendor = "Plus Mobile Apps"
 
-            modules("java.sql", "java.naming", "jdk.jsobject")
+            // jdk.unsupported.desktop provides jdk.swing.interop.SwingInterOpUtils, which
+            // JavaFX's Swing interop (JFXPanel, used by the desktop browser's WebView) loads at
+            // runtime. Without it the jlink/jpackage runtime image omits the class and the browser
+            // crashes with NoClassDefFoundError the first time the cursor updates over the WebView
+            // (see issue #400). Not needed for `./gradlew run`, which uses the full JDK.
+            modules("java.sql", "java.naming", "jdk.jsobject", "jdk.unsupported.desktop")
 
             // macOS configuration
             macOS {


### PR DESCRIPTION
## What

Adds `jdk.unsupported.desktop` to the packaged desktop app's runtime module list in `client/composeApp/build.gradle.kts`.

## Why

The in-app desktop browser crashed with:

```
java.lang.NoClassDefFoundError: jdk/swing/interop/SwingInterOpUtils
Caused by: java.lang.ClassNotFoundException: jdk.swing.interop.SwingInterOpUtils
```

The browser embeds a JavaFX `WebView` inside a Swing `JFXPanel` (`PlatformWebView.jvm.kt`). JavaFX's Swing interop loads `jdk.swing.interop.SwingInterOpUtils` at runtime, and that class lives in the JDK module `jdk.unsupported.desktop`. The `jpackage`/`jlink` runtime image only includes modules explicitly listed in `nativeDistributions { modules(...) }`, which omitted this one — so the release runtime image stripped the class.

The crash only fires the first time the cursor updates over the WebView (`Scene$MouseHandler.updateCursorFrame` → `JFXPanel.setCursor`), so it was invisible in `./gradlew run` (full JDK) and only reproduced in packaged DMG/MSI/Deb builds. Matches the Bugsnag report in the issue.

## Verification

- Confirmed against the local JDK 21 that `jdk.unsupported.desktop` exports `jdk.swing.interop` (the package containing `SwingInterOpUtils`): `java --describe-module jdk.unsupported.desktop`.
- Not yet reproduced/confirmed via a full packaged build — worth a smoke test of the browser pane in a packaged build before/after release.

Fixes #400