### PR TITLE
fix(recipe): sort unrated recipes to bottom in Top Rated

### DIFF
--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
@@ -512,5 +512,10 @@ private fun applySort(recipes: List<Recipe>, sort: RecipeSortOption): List<Recip
         RecipeSortOption.ALPHABETICAL_ASC -> recipes.sortedBy { it.title.lowercase() }
         RecipeSortOption.ALPHABETICAL_DESC -> recipes.sortedByDescending { it.title.lowercase() }
         RecipeSortOption.TOP_RATED ->
-            recipes.sortedWith(compareByDescending<Recipe, Int?>(nullsLast()) { it.starRating })
+            // Highest rating first, descending by stars, then unrated recipes at the bottom.
+            // Alphabetical title breaks ties, so unrated recipes are ordered alphabetically.
+            recipes.sortedWith(
+                compareByDescending<Recipe> { it.starRating ?: Int.MIN_VALUE }
+                    .thenBy { it.title.lowercase() }
+            )
     }

--- a/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
+++ b/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
@@ -316,15 +316,15 @@ class RecipeListViewModelTest {
     }
 
     @Test
-    fun When_sort_top_rated_Then_rated_recipes_sorted_descending() {
-        val unrated = recipe(1, starRating = null)
-        val threeStars = recipe(2, starRating = 3)
-        val fiveStars = recipe(3, starRating = 5)
-        recipes.value = listOf(unrated, threeStars, fiveStars)
+    fun When_sort_top_rated_Then_rated_first_descending_then_unrated_alphabetical() {
+        val unratedZ = recipe(1, title = "Zucchini", starRating = null)
+        val threeStars = recipe(2, title = "Bread", starRating = 3)
+        val fiveStars = recipe(3, title = "Cake", starRating = 5)
+        val unratedA = recipe(4, title = "Apple", starRating = null)
+        recipes.value = listOf(unratedZ, threeStars, fiveStars, unratedA)
         viewModel.updateSort(RecipeSortOption.TOP_RATED)
-        val rated =
-            viewModel.state.value.displayRecipes.filter { it.starRating != null }.map { it.id }
-        rated shouldBe listOf(3L, 2L)
+        // Highest rating first, descending by stars, then unrated at the bottom alphabetically.
+        viewModel.state.value.displayRecipes.map { it.id } shouldBe listOf(3L, 2L, 4L, 1L)
     }
 
     @Test


### PR DESCRIPTION
## Problem

When sorting the recipe list by **Top Rated**, unrated recipes appeared *first*, before the highest-rated ones.

The sort used `compareByDescending(nullsLast()) { it.starRating }`. `compareByDescending` reverses the underlying comparator, which also reverses the `nullsLast()` null placement — so nulls (unrated recipes) ended up on top.

## Fix

Sort highest rating first, descending by stars, with unrated recipes pushed to the bottom and ordered alphabetically by title:

```kotlin
recipes.sortedWith(
    compareByDescending<Recipe> { it.starRating ?: Int.MIN_VALUE }
        .thenBy { it.title.lowercase() }
)
```

The alphabetical `thenBy` also gives unrated recipes the requested alphabetical ordering (and a deterministic tiebreaker among equally-rated ones).

## Tests

Strengthened the existing `TOP_RATED` test — it previously filtered out unrated recipes, so it never caught this bug. It now asserts the full ordering: rated recipes descending, then unrated at the bottom alphabetically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)