### PR TITLE
fix(grocery): reconcile remote item edits during realtime sync

### DIFF
--- a/client/database/core/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/Grocery.sq
+++ b/client/database/core/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/Grocery.sq
@@ -76,6 +76,9 @@ UPDATE Grocery SET clientId = ? WHERE id = ?;
 update:
 UPDATE Grocery SET name = ?, isChecked = ?, aisle = ?, updatedAt = ?, isDirty = 1 WHERE id = ?;
 
+updateFromRemote:
+UPDATE Grocery SET name = ?, isChecked = ?, updatedAt = ?, listRemoteId = ?, listId = ?, recipeName = ?, aisle = ? WHERE id = ?;
+
 getDirty:
 SELECT * FROM Grocery WHERE isDirty = 1 AND remoteId IS NOT NULL;
 

--- a/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
+++ b/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
@@ -697,7 +697,26 @@ class GroceryRepositoryImpl(
                     for (remoteItem in remoteItems) {
                         val remoteId = remoteItem.id ?: continue
                         val existing = queries.getByRemoteId(remoteId).executeAsOneOrNull()
-                        if (existing != null) continue
+                        if (existing != null) {
+                            // Item already known locally — reconcile remote edits (e.g. a
+                            // "purchased" toggle made on another device) into the local row.
+                            // Skip rows with unpushed local changes: their dirty edit is pushed
+                            // earlier in this reconcile, and overwriting here would drop a change
+                            // made concurrently while we were fetching.
+                            if (!existing.isDirty) {
+                                queries.updateFromRemote(
+                                    name = remoteItem.name,
+                                    isChecked = remoteItem.isChecked,
+                                    updatedAt = remoteItem.updatedAt ?: existing.updatedAt,
+                                    listRemoteId = listRemoteId,
+                                    listId = list.id,
+                                    recipeName = remoteItem.recipeName,
+                                    aisle = remoteItem.aisle,
+                                    id = existing.id,
+                                )
+                            }
+                            continue
+                        }
 
                         val matchedByClientId =
                             remoteItem.clientId?.let { clientId ->

--- a/client/grocery/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImplTest.kt
+++ b/client/grocery/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImplTest.kt
@@ -753,6 +753,79 @@ class GroceryRepositoryImplTest {
         }
 
     @Test
+    fun realtime_change_pulls_an_updated_checked_state_for_an_existing_item() =
+        runTest(testDispatcher) {
+            // Local list already linked to a remote list with one synced, unchecked item —
+            // simulates Device B that previously synced the item.
+            val localListId = repository.ensureDefaultList()
+            val remoteListId = "remote-list-checked-sync"
+            val now = "2026-01-01T00:00:00"
+            db.groceryListQueries.updateRemoteId(remoteId = remoteListId, id = localListId)
+            db.groceryQueries.createWithRemoteId(
+                name = "Milk",
+                isChecked = false,
+                createdAt = now,
+                updatedAt = now,
+                remoteId = "remote-milk",
+                listRemoteId = remoteListId,
+                clientId = "client-milk",
+                listId = localListId,
+                recipeName = null,
+                aisle = null,
+            )
+            fakeRemote.remoteLists["user-1"] =
+                mutableListOf(
+                    RemoteGroceryList(
+                        id = remoteListId,
+                        name = "My Grocery List",
+                        ownerId = "user-1",
+                    )
+                )
+            fakeRemote.remoteItems[remoteListId] =
+                mutableListOf(
+                    RemoteGroceryItem(
+                        id = "remote-milk",
+                        listId = remoteListId,
+                        name = "Milk",
+                        isChecked = false,
+                        clientId = "client-milk",
+                    )
+                )
+            fakeAuth.setState(
+                AuthState.Authenticated(
+                    ChefMateUser(
+                        userId = "user-1",
+                        userName = "Test",
+                        userEmail = "test@test.com",
+                        userProfileImageUrl = null,
+                    )
+                )
+            )
+            advanceUntilIdle()
+            repository.getGroceries(localListId).first().first().isChecked shouldBe false
+
+            // Device A marks the item as purchased, then a realtime change arrives.
+            fakeRemote.remoteItems[remoteListId] =
+                mutableListOf(
+                    RemoteGroceryItem(
+                        id = "remote-milk",
+                        listId = remoteListId,
+                        name = "Milk",
+                        isChecked = true,
+                        updatedAt = "2026-01-02T00:00:00",
+                        clientId = "client-milk",
+                    )
+                )
+            fakeRemote.changes.tryEmit(Unit)
+            advanceUntilIdle()
+
+            // The heartbeat re-reconciled and the local item now reflects the purchased state.
+            repository.getGroceries(localListId).test {
+                awaitItem().first().isChecked shouldBe true
+            }
+        }
+
+    @Test
     fun updateChecked_pushes_the_new_checked_state_to_the_backend() =
         runTest(testDispatcher) {
             fakeAuth.setState(


### PR DESCRIPTION
## Problem

With realtime cross-device grocery sync (#404), Device A toggling an item's **purchased** (`isChecked`) state did not update on Device B. Device B *received* the realtime heartbeat and ran a full `syncWithRemote` reconcile — but the item never changed.

## Root cause

The pull loop in `syncWithRemote` only handled *inserting new* items. For an item already known locally (matched by `remoteId`), it bailed out:

```kotlin
val existing = queries.getByRemoteId(remoteId).executeAsOneOrNull()
if (existing != null) continue   // ← dropped the remote edit
```

So any edit to an already-synced item (purchased toggle, rename, aisle/recipe change) coming from another device was silently discarded.

## Fix

- Add a `updateFromRemote` query that applies remote fields to an existing local row **without** touching `isDirty`.
- The pull loop now reconciles existing items instead of skipping them.
- The update is guarded on `!existing.isDirty`: rows with unpushed local edits are already pushed earlier in the same reconcile, so skipping them here prevents a stale remote read from clobbering a change made concurrently while the fetch was in flight. Once pushed and dirty-cleared, the next pull re-applies the identical value idempotently.

## Testing

- New test `realtime_change_pulls_an_updated_checked_state_for_an_existing_item` reproduces the scenario (synced unchecked item → realtime emission with `isChecked = true` → local item flips to checked). Fails on the old `continue`, passes now.
- All 21 tests in `:client:grocery:data:impl` pass.

## Known related gap (not addressed here)

The list-sync path has the same shape — an existing list updates ownership but not its `name`, so a **list renamed on another device** won't propagate via realtime either. Left out to keep this change scoped to the reported purchased-toggle bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)