### PR TITLE
refactor(client): unify loading spinners on PlusLoadingIndicator

### DIFF
--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatScreen.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -86,6 +85,7 @@ import com.mikepenz.markdown.model.rememberMarkdownState
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.isIosPlatform
 import com.plusmobileapps.chefmate.util.rememberImagePickerLauncher
 import kotlinx.coroutines.delay
@@ -292,7 +292,7 @@ private fun MessageBubble(
                     }
                     if (showProgress) {
                         Spacer(modifier = Modifier.size(6.dp))
-                        CircularProgressIndicator(
+                        PlusLoadingIndicator(
                             modifier = Modifier.size(10.dp),
                             strokeWidth = 1.5.dp,
                             color = contentColor,
@@ -325,7 +325,7 @@ private fun ThinkingBubble(modifier: Modifier = Modifier) {
             shape = RoundedCornerShape(16.dp),
             modifier = Modifier.testTag(AiChatTestTags.THINKING_INDICATOR),
         ) {
-            CircularProgressIndicator(
+            PlusLoadingIndicator(
                 modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp).size(16.dp),
                 strokeWidth = 2.dp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -391,7 +391,7 @@ private fun AddRecipePill(isLoading: Boolean, onClick: () -> Unit, modifier: Mod
             },
             leadingIcon = {
                 if (isLoading) {
-                    CircularProgressIndicator(
+                    PlusLoadingIndicator(
                         modifier = Modifier.size(AssistChipDefaults.IconSize),
                         strokeWidth = 2.dp,
                     )
@@ -473,7 +473,7 @@ private fun AiChatInput(
             modifier = Modifier.testTag(AiChatTestTags.ATTACH_PHOTO_BUTTON),
         ) {
             if (isExtracting) {
-                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                PlusLoadingIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
             } else {
                 Icon(
                     imageVector = Icons.Default.AddPhotoAlternate,

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/ui/CookModeScreen.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/ui/CookModeScreen.kt
@@ -51,7 +51,6 @@ import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.BottomSheetScaffold
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -119,6 +118,7 @@ import com.plusmobileapps.chefmate.ui.KeepScreenOn
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
 import com.plusmobileapps.chefmate.ui.components.PlusTooltipPlacement
 import com.plusmobileapps.chefmate.ui.components.WindowSizeClass
@@ -560,7 +560,7 @@ private fun LoadingState(modifier: Modifier) {
     val padding = ChefMateTheme.dimens.paddingNormal
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            CircularProgressIndicator()
+            PlusLoadingIndicator()
             Spacer(Modifier.height(padding))
             Text(stringResource(Res.string.cook_mode_loading))
         }

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/list/GroceryListScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuDefaults
@@ -83,8 +82,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -153,6 +150,7 @@ import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
@@ -282,7 +280,7 @@ fun GroceryListScreen(
                             )
                         }
                         if (state.isSyncing) {
-                            CircularProgressIndicator(
+                            PlusLoadingIndicator(
                                 modifier = Modifier.size(24.dp).padding(end = 4.dp),
                                 strokeWidth = 2.dp,
                             )
@@ -1036,9 +1034,9 @@ private fun GroceryItemTrailingContent(item: GroceryItem, onDeleteClick: () -> U
                 modifier = Modifier.size(20.dp),
             )
         SyncStatus.SYNCING ->
-            CircularProgressIndicator(
-                modifier =
-                    Modifier.size(16.dp).semantics { contentDescription = syncingDescription },
+            PlusLoadingIndicator(
+                modifier = Modifier.size(16.dp),
+                contentDescription = syncingDescription,
                 strokeWidth = 2.dp,
             )
         SyncStatus.SYNCED ->

--- a/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
+++ b/client/meal/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/MealPlanScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material.icons.outlined.CloudDone
 import androidx.compose.material.icons.outlined.CloudOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
@@ -52,8 +51,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -903,9 +900,9 @@ private fun SyncStatusIcon(syncStatus: SyncStatus, modifier: Modifier = Modifier
                 modifier = modifier.size(20.dp),
             )
         SyncStatus.SYNCING ->
-            CircularProgressIndicator(
-                modifier =
-                    modifier.size(16.dp).semantics { contentDescription = syncingDescription },
+            PlusLoadingIndicator(
+                modifier = modifier.size(16.dp),
+                contentDescription = syncingDescription,
                 strokeWidth = 2.dp,
             )
         SyncStatus.SYNCED ->

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -67,7 +67,6 @@ import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -1773,7 +1772,7 @@ private fun DeletingDialog(modifier: Modifier = Modifier) {
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                CircularProgressIndicator()
+                PlusLoadingIndicator()
                 Text(stringResource(Res.string.recipe_detail_deleting_message))
             }
         },

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/CropPhotoOverlay.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/CropPhotoOverlay.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -42,6 +41,7 @@ import chefmate.client.recipe.core.public.generated.resources.Res
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_crop_cancel
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_crop_confirm
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_crop_title
+import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlin.math.max
 import kotlin.math.min
@@ -175,7 +175,7 @@ fun CropPhotoOverlay(
                     },
                 ) {
                     if (isProcessing) {
-                        CircularProgressIndicator(
+                        PlusLoadingIndicator(
                             modifier = Modifier.size(16.dp),
                             strokeWidth = 2.dp,
                             color = MaterialTheme.colorScheme.onPrimary,

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilterChip
@@ -233,7 +232,7 @@ private fun EditRecipeCoachMark(
 @Composable
 private fun LoadingIndicator(modifier: Modifier = Modifier) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        CircularProgressIndicator()
+        PlusLoadingIndicator()
     }
 }
 

--- a/client/recipe/exporter/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/ExportRecipesScreen.kt
+++ b/client/recipe/exporter/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/exporter/ExportRecipesScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.automirrored.filled.PlaylistAddCheck
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -55,6 +54,7 @@ import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import com.plusmobileapps.chefmate.util.rememberZipSaveLauncher
@@ -132,7 +132,7 @@ private fun ExportFab(selectedCount: Int, isExporting: Boolean, onClick: () -> U
         modifier = Modifier.testTag(ExportRecipesTestTags.EXPORT_BUTTON),
     ) {
         if (isExporting) {
-            CircularProgressIndicator(
+            PlusLoadingIndicator(
                 modifier = Modifier.size(20.dp),
                 color = ChefMateTheme.colorScheme.onPrimaryContainer,
             )
@@ -179,7 +179,7 @@ private fun StatusContent(message: String) {
         modifier = Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingLarge),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        CircularProgressIndicator()
+        PlusLoadingIndicator()
         Spacer(Modifier.height(ChefMateTheme.dimens.paddingNormal))
         Text(message, style = ChefMateTheme.typography.bodyMedium)
     }

--- a/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesScreen.kt
+++ b/client/recipe/importer/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/importer/ImportRecipesScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.icons.automirrored.filled.PlaylistAddCheck
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -55,6 +54,7 @@ import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import com.plusmobileapps.chefmate.util.rememberZipPickerLauncher
 
@@ -147,7 +147,7 @@ private fun StatusContent(message: String) {
         modifier = Modifier.fillMaxWidth().padding(ChefMateTheme.dimens.paddingLarge),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        CircularProgressIndicator()
+        PlusLoadingIndicator()
         Spacer(Modifier.height(ChefMateTheme.dimens.paddingNormal))
         Text(message, style = ChefMateTheme.typography.bodyMedium)
     }
@@ -222,7 +222,7 @@ private fun ReviewContent(
                 .testTag(ImportRecipesTestTags.IMPORT_BUTTON),
     ) {
         if (phase.isImporting) {
-            CircularProgressIndicator(modifier = Modifier.size(20.dp))
+            PlusLoadingIndicator(modifier = Modifier.size(20.dp))
         } else {
             Text(
                 PhraseModel(

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -63,7 +63,6 @@ import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -188,6 +187,7 @@ import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusDialogScaffold
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.components.PlusNavContainer
 import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
@@ -638,7 +638,7 @@ private fun ScanningDialog() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                PlusLoadingIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
                 Text(stringResource(Res.string.recipe_list_scanning_message))
             }
         },
@@ -1640,9 +1640,9 @@ private fun SyncStatusIcon(syncStatus: SyncStatus, modifier: Modifier = Modifier
                 modifier = modifier.size(16.dp),
             )
         SyncStatus.SYNCING ->
-            CircularProgressIndicator(
-                modifier =
-                    modifier.size(14.dp).semantics { contentDescription = syncingDescription },
+            PlusLoadingIndicator(
+                modifier = modifier.size(14.dp),
+                contentDescription = syncingDescription,
                 strokeWidth = 2.dp,
             )
         SyncStatus.SYNCED ->

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusButton.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusButton.kt
@@ -3,7 +3,6 @@ package com.plusmobileapps.chefmate.ui.components
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -52,7 +51,7 @@ fun PlusButton(
             },
     ) {
         if (isLoading) {
-            CircularProgressIndicator(
+            PlusLoadingIndicator(
                 modifier = Modifier.size(18.dp),
                 strokeWidth = 2.dp,
                 color = LocalContentColor.current,

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusLoadingDialog.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusLoadingDialog.kt
@@ -3,7 +3,6 @@ package com.plusmobileapps.chefmate.ui.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,7 +20,7 @@ fun PlusLoadingDialog(message: TextData) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingNormal),
             ) {
-                CircularProgressIndicator()
+                PlusLoadingIndicator()
                 Text(text = message.localized(), style = MaterialTheme.typography.bodyLarge)
             }
         }

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusLoadingIndicator.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusLoadingIndicator.kt
@@ -4,14 +4,45 @@ package com.plusmobileapps.chefmate.ui.components
 
 import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.WavyProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
 
+/**
+ * The app's standard loading spinner: a wavy circular indicator used everywhere in place of the raw
+ * Material [androidx.compose.material3.CircularProgressIndicator], so every loading state reads the
+ * same across screens, dialogs, buttons, and sync badges.
+ *
+ * @param color the indicator color. Override it for spinners drawn on a colored surface (e.g. white
+ *   on a filled button) so they stay legible.
+ * @param strokeWidth the active-indicator stroke width. Leave null for the default; set a smaller
+ *   value for compact inline spinners (buttons, chips, sync badges).
+ */
 @Composable
-fun PlusLoadingIndicator(contentDescription: String? = null, modifier: Modifier = Modifier) {
+fun PlusLoadingIndicator(
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    color: Color = WavyProgressIndicatorDefaults.indicatorColor,
+    strokeWidth: Dp? = null,
+) {
     CircularWavyProgressIndicator(
-        modifier = modifier.semantics { this.contentDescription = contentDescription.orEmpty() }
+        modifier = modifier.semantics { this.contentDescription = contentDescription.orEmpty() },
+        color = color,
+        stroke =
+            if (strokeWidth == null) {
+                WavyProgressIndicatorDefaults.circularIndicatorStroke
+            } else {
+                Stroke(
+                    width = with(LocalDensity.current) { strokeWidth.toPx() },
+                    cap = StrokeCap.Round,
+                )
+            },
     )
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeLoadingScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeLoadingScreenshot_73588fdf_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ac5c36f48038c7948f2a0b29ae646ec5ec3d110eabb76736e9f2543573b44c6
-size 37117
+oid sha256:24f71afa0b06f0b062cb8520a3c6353f879df6225bdbacba84c5a1a6e88a827e
+size 39850

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ExportRecipesScreenshotTestKt/ExportRecipesLoadingScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/ExportRecipesScreenshotTestKt/ExportRecipesLoadingScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d23dc6e5ec9fcbc1274c16f096f3053fe6ace55bcc7e1eb0f66ebd5f81692b0
-size 29102
+oid sha256:3dcbe0f806f6eacc5cef95bf7099a68843ae832051ac39e2554f79dc12ecaf0d
+size 31523

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OtpScreenshotTestKt/OtpLoadingScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/OtpScreenshotTestKt/OtpLoadingScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aaf780ed0d696222243239289b8cc0dadc5d95cdc3f1fa1ece6c065b61299210
-size 77724
+oid sha256:683b35ddc50c69c2ed22df402001b4fd5f19f274b927db6a6dadcc45910ba5ee
+size 80080

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusButtonScreenshotTestKt/PlusButtonLoadingPreview_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PlusButtonScreenshotTestKt/PlusButtonLoadingPreview_748aa731_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3311b1776b134c4a9d299a6eb967fdd759394c4b3b1502438440e994ccf31131
-size 2311
+oid sha256:7e0b34dca9df0533daebc2c2b727452a114affd84d4baef4d9c3390d239ed8d1
+size 2892


### PR DESCRIPTION
## Summary

Sweeps the client so every loading spinner uses the shared wavy `PlusLoadingIndicator` instead of a raw Material `CircularProgressIndicator`, for a consistent loading look across the app.

- **Extends `PlusLoadingIndicator`** with optional `color` and `strokeWidth` params so it can also cover compact inline spinners (buttons, chips, sync-status badges) that previously needed a raw indicator for their color/stroke overrides.
- **Replaces all 20 `CircularProgressIndicator` call sites** across `ui`, `recipe` (list/core/importer/exporter), `grocery`, `meal`, `cook`, and `aichat`. This includes screen/dialog loaders, button/FAB/chip spinners, and the sync-status badges.
- Sync badges now pass `contentDescription` through the component param instead of a hand-rolled `semantics {}` modifier.

## Commits

1. `feat(ui): make PlusLoadingIndicator configurable` — color + strokeWidth params.
2. `refactor(client): use PlusLoadingIndicator for all loading spinners` — the call-site sweep.
3. `test(ui): update loading snapshots for wavy PlusLoadingIndicator` — refreshed references.

## Testing

- `./gradlew :client:composeApp:compileKotlinJvm` — green.
- `./gradlew :client:ui:screenshot-test:updateDebugScreenshotTest` — only 4 references changed (CookMode, ExportRecipes, OTP dialog, PlusButton loading), each visually verified to render the wavy indicator correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)