### PR TITLE
fix(collab): resize invite screens for keyboard and send-to-invite

### DIFF
--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/edit/EditGroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/edit/EditGroceryListScreen.kt
@@ -6,8 +6,11 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.FilterChip
@@ -22,7 +25,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import chefmate.client.grocery.core.public.generated.resources.Res
 import chefmate.client.grocery.core.public.generated.resources.grocery_cancel
@@ -71,7 +78,7 @@ fun EditGroceryListScreen(bloc: EditGroceryListBloc, modifier: Modifier = Modifi
     val dimens = ChefMateTheme.dimens
 
     PlusHeaderContainer(
-        modifier = modifier.testTag(EditGroceryListTestTags.SCREEN).fillMaxWidth(),
+        modifier = modifier.testTag(EditGroceryListTestTags.SCREEN).fillMaxWidth().imePadding(),
         data =
             PlusHeaderData.Modal(
                 title = Res.string.grocery_edit_list_title.asTextData(),
@@ -281,6 +288,7 @@ private fun MemberRow(
 @Composable
 private fun InviteRow(state: EditGroceryListBloc.Model, bloc: EditGroceryListBloc) {
     val dimens = ChefMateTheme.dimens
+    val focusManager = LocalFocusManager.current
     Column(
         modifier = Modifier.fillMaxWidth().padding(top = dimens.paddingSmall),
         verticalArrangement = Arrangement.spacedBy(dimens.paddingSmall),
@@ -291,6 +299,19 @@ private fun InviteRow(state: EditGroceryListBloc.Model, bloc: EditGroceryListBlo
             label = { Text(stringResource(Res.string.grocery_invite_hint)) },
             singleLine = true,
             error = state.inviteError,
+            keyboardOptions =
+                KeyboardOptions(
+                    keyboardType = KeyboardType.Email,
+                    capitalization = KeyboardCapitalization.None,
+                    imeAction = ImeAction.Send,
+                ),
+            keyboardActions =
+                KeyboardActions(
+                    onSend = {
+                        bloc.onInviteClicked()
+                        focusManager.clearFocus()
+                    }
+                ),
             modifier = Modifier.fillMaxWidth().testTag(EditGroceryListTestTags.INVITE_FIELD),
         )
         FlowRow(horizontalArrangement = Arrangement.spacedBy(dimens.paddingSmall)) {

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardActions
@@ -27,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -71,7 +73,7 @@ fun EditRecipeBookScreen(bloc: EditRecipeBookBloc, modifier: Modifier = Modifier
     val model by bloc.state.collectAsState()
 
     PlusHeaderContainer(
-        modifier = modifier.testTag(EditRecipeBookTestTags.SCREEN),
+        modifier = modifier.testTag(EditRecipeBookTestTags.SCREEN).imePadding(),
         data = PlusHeaderData.Modal(title = model.title, onCloseClick = bloc::onCloseClicked),
         contentPadding = PaddingValues(horizontal = ChefMateTheme.dimens.paddingNormal),
     ) {
@@ -123,6 +125,7 @@ fun EditRecipeBookScreen(bloc: EditRecipeBookBloc, modifier: Modifier = Modifier
 
 @Composable
 private fun CollaboratorsSection(bloc: EditRecipeBookBloc, model: EditRecipeBookBloc.Model) {
+    val focusManager = LocalFocusManager.current
     Column(
         modifier =
             Modifier.fillMaxWidth()
@@ -175,9 +178,15 @@ private fun CollaboratorsSection(bloc: EditRecipeBookBloc, model: EditRecipeBook
                     KeyboardOptions(
                         keyboardType = KeyboardType.Email,
                         capitalization = KeyboardCapitalization.None,
-                        imeAction = ImeAction.Done,
+                        imeAction = ImeAction.Send,
                     ),
-                keyboardActions = KeyboardActions(onDone = { bloc.onInviteClicked() }),
+                keyboardActions =
+                    KeyboardActions(
+                        onSend = {
+                            bloc.onInviteClicked()
+                            focusManager.clearFocus()
+                        }
+                    ),
             )
 
             FlowRow(


### PR DESCRIPTION
## Summary

The grocery list and recipe book **invite collaborator** screens didn't inset their content for the on-screen keyboard, so the bottom-anchored invite email field sat behind the keyboard on iOS (and Android). This makes both screens keyboard-aware and improves the email input UX.

## Changes

- **Keyboard resize**: added `.imePadding()` to the `PlusHeaderContainer` on both `EditGroceryListScreen` and `EditRecipeBookScreen`. This follows the existing convention in the codebase (`AuthenticationScreen`, `EditRecipeScreen`, `OtpScreen` all do the same) — the scroll viewport shrinks by the keyboard height and auto-scrolls the focused field into view.
- **Email field config**: the invite email field now uses `KeyboardType.Email` + `KeyboardCapitalization.None` with an `ImeAction.Send`. Pressing Send submits the invite and dismisses the keyboard (`focusManager.clearFocus()`).
  - The grocery field previously had **no** keyboard options at all.
  - The recipe book field switched from `Done` to `Send`.

## Notes

- Deliberately scoped to the two screens rather than changing the shared `PlusHeaderContainer` or the iOS `MainViewController` `onFocusBehavior`, to avoid regressing screens that manage keyboard insets themselves (e.g. `AiChatScreen`, browser query bar).
- No snapshot updates: `imePadding()` / `keyboardOptions` have no static visual effect (no keyboard in a screenshot test).
- Verified with `compileKotlinMetadata` on both `public` modules. Not yet exercised on an iOS simulator — worth a quick manual check of the on-device keyboard behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)