### PR TITLE
fix(invites): log Resend failures & document the sandbox-sender footgun

### DIFF
--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -149,6 +149,13 @@ The verified sending domain is `plusmobileapps.com` and the default sender is
 `RESEND_FROM` secret). Resend authorizes any address at that exact domain — a subdomain such as
 `chefmate.plusmobileapps.com` would need separate verification.
 
+> **Gotcha:** if `RESEND_FROM` is set to Resend's sandbox sender `onboarding@resend.dev`, every send
+> is restricted to the account owner's own address and all other invites fail with
+> `403 "You can only send testing emails to your own email address"`. Either leave `RESEND_FROM`
+> unset (so `DEFAULT_FROM` wins) or point it at an address on the verified domain — never the
+> sandbox. The Resend failure is now logged (status + `from`) in the function logs to make this
+> obvious.
+
 ## Sync Strategy
 
 The existing offline-first sync is extended for collaboration:

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -108,6 +108,10 @@ Deno.serve(async (req) => {
 
     if (!resendResponse.ok) {
       const detail = await resendResponse.text();
+      // Surface Resend failures in the function logs (they otherwise only land in
+      // net._http_response). Logging `from` makes sender/domain misconfiguration obvious — e.g. a
+      // RESEND_FROM pointing at the `onboarding@resend.dev` sandbox forces a 403 "testing" error.
+      console.error(`Resend failed (${resendResponse.status}) from="${from}": ${detail}`);
       return json({ error: `Resend failed (${resendResponse.status}): ${detail}` }, 502);
     }
 


### PR DESCRIPTION
## What / Why

Collaboration invite emails were failing with a Supabase edge `502`. The trigger (`pg_net` → `send-invite-email`) fired correctly, the function ran, and Resend rejected the send with:

> `403 validation_error: You can only send testing emails to your own email address (<account owner>). To send emails to other recipients, please verify a domain…`

**Root cause was operational, not a code bug.** The `RESEND_FROM` function secret was set to Resend's **sandbox sender `onboarding@resend.dev`**, which forces every send into testing mode — so any invite to an address other than the account owner's 403s — regardless of the (correctly verified) `plusmobileapps.com` domain or a valid API key.

The whole thing was hard to diagnose only because the failing `from` address was invisible: Resend's error landed in `net._http_response` and nothing logged it. This PR fixes that gap.

## Changes

- **`send-invite-email/index.ts`** — on a Resend failure, `console.error` the status, `from`, and body so sender/domain misconfiguration shows up directly in the function logs. No happy-path change.
- **`docs/collaboration.md`** — document the `onboarding@resend.dev` sandbox pitfall, the exact 403 it produces, and the fix.

## The actual operational fix (not in this PR — it's a secret change)

```bash
# clear the sandbox override so DEFAULT_FROM (noreply@plusmobileapps.com) wins
supabase secrets unset RESEND_FROM --project-ref <project-ref>
supabase functions deploy send-invite-email --project-ref <project-ref>
```

## Verification

- Direct Resend `curl` from `noreply@plusmobileapps.com` to a non-owner address → `200` with an email `id` (domain/key confirmed good).
- Diagnostic build exposed the offending `"from":"Chef Mate <onboarding@resend.dev>"` in `net._http_response`, which pinpointed the sandbox override.
- After clearing `RESEND_FROM`, an invite to a non-owner address should return `status_code: 200` in `net._http_response`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)