### PR TITLE
feat(notifications): add Notifications section under the More tab

### DIFF
--- a/client/bottomnav/impl/build.gradle.kts
+++ b/client/bottomnav/impl/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             implementation(libs.arkivanov.decompose.core)
             implementation(libs.arkivanov.decompose.compose.extensions)
             implementation(projects.client.shared)
+            implementation(projects.client.notifications.data.public)
             implementation(libs.kotlinx.serialization.json)
             implementation(compose.components.resources)
             api(projects.client.browser.public)
@@ -21,7 +22,10 @@ kotlin {
             api(projects.client.recipe.list.public)
             api(projects.client.settings.public)
         }
-        commonTest.dependencies { implementation(libs.multiplatform.settings.test) }
+        commonTest.dependencies {
+            implementation(projects.client.notifications.data.testing)
+            implementation(libs.multiplatform.settings.test)
+        }
     }
 }
 

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavBlocImpl.kt
@@ -87,7 +87,11 @@ class BottomNavBlocImpl(
 
     override val state: StateFlow<BottomNavBloc.Model> =
         viewModel.state.mapState {
-            BottomNavBloc.Model(selectedTab = it.selectedTab, tabs = it.tabs.toImmutableList())
+            BottomNavBloc.Model(
+                selectedTab = it.selectedTab,
+                tabs = it.tabs.toImmutableList(),
+                notificationCount = it.notificationCount,
+            )
         }
 
     override val content: Value<ChildStack<*, BottomNavBloc.Child>> = stack
@@ -235,6 +239,7 @@ class BottomNavBlocImpl(
             SettingsBloc.Output.OpenSignIn -> OpenSignIn
             SettingsBloc.Output.OpenSignUp -> OpenSignUp
             SettingsBloc.Output.OpenManageProfile -> OpenManageProfile
+            SettingsBloc.Output.OpenNotifications -> BottomNavBloc.Output.OpenNotifications
             SettingsBloc.Output.OpenAppSettings -> OpenAppSettings
             SettingsBloc.Output.OpenAiChat -> BottomNavBloc.Output.OpenAiChat
             SettingsBloc.Output.OpenDeveloperSettings -> BottomNavBloc.Output.OpenDeveloperSettings

--- a/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavViewModel.kt
+++ b/client/bottomnav/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavViewModel.kt
@@ -2,6 +2,7 @@ package com.plusmobileapps.chefmate.recipe.bottomnav.impl
 
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.notifications.data.NotificationsRepository
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc.Tab.RECIPES
 import com.plusmobileapps.chefmate.recipe.bottomnav.TabOrderPreferences
@@ -11,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 
@@ -18,6 +20,7 @@ import kotlinx.coroutines.flow.update
 class BottomNavViewModel(
     @Main mainContext: CoroutineContext,
     tabOrderPreferences: TabOrderPreferences,
+    notificationsRepository: NotificationsRepository,
 ) : ViewModel(mainContext) {
     private val _state = MutableStateFlow(State(tabs = tabOrderPreferences.tabOrder.value))
     val state: StateFlow<State> = _state.asStateFlow()
@@ -25,6 +28,11 @@ class BottomNavViewModel(
     init {
         tabOrderPreferences.tabOrder
             .onEach { latest -> _state.update { it.copy(tabs = latest) } }
+            .launchIn(scope)
+
+        notificationsRepository.notifications
+            .map { it.size }
+            .onEach { count -> _state.update { it.copy(notificationCount = count) } }
             .launchIn(scope)
     }
 
@@ -35,5 +43,6 @@ class BottomNavViewModel(
     data class State(
         val selectedTab: BottomNavBloc.Tab = RECIPES,
         val tabs: List<BottomNavBloc.Tab>,
+        val notificationCount: Int = 0,
     )
 }

--- a/client/bottomnav/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavViewModelTest.kt
+++ b/client/bottomnav/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/impl/BottomNavViewModelTest.kt
@@ -3,8 +3,11 @@
 
 package com.plusmobileapps.chefmate.recipe.bottomnav.impl
 
+import com.plusmobileapps.chefmate.notifications.data.AppNotification
+import com.plusmobileapps.chefmate.notifications.data.testing.FakeNotificationsRepository
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.DEFAULT_TAB_ORDER
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -13,6 +16,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 class BottomNavViewModelTest {
 
     private val mainContext = UnconfinedTestDispatcher()
+    private val notificationsRepository = FakeNotificationsRepository()
 
     @Test
     fun initial_tabs_are_seeded_from_preferences() {
@@ -25,14 +29,24 @@ class BottomNavViewModelTest {
                 BottomNavBloc.Tab.BROWSER,
             )
         val prefs = FakeTabOrderPreferences(initial = customOrder)
-        val vm = BottomNavViewModel(mainContext = mainContext, tabOrderPreferences = prefs)
+        val vm =
+            BottomNavViewModel(
+                mainContext = mainContext,
+                tabOrderPreferences = prefs,
+                notificationsRepository = notificationsRepository,
+            )
         vm.state.value.tabs shouldBe customOrder
     }
 
     @Test
     fun preferences_updates_propagate_to_state() {
         val prefs = FakeTabOrderPreferences()
-        val vm = BottomNavViewModel(mainContext = mainContext, tabOrderPreferences = prefs)
+        val vm =
+            BottomNavViewModel(
+                mainContext = mainContext,
+                tabOrderPreferences = prefs,
+                notificationsRepository = notificationsRepository,
+            )
         vm.state.value.tabs shouldBe DEFAULT_TAB_ORDER
 
         val newOrder =
@@ -45,5 +59,24 @@ class BottomNavViewModelTest {
             )
         prefs.setTabOrder(newOrder)
         vm.state.value.tabs shouldBe newOrder
+    }
+
+    @Test
+    fun notification_count_reflects_pending_notifications() {
+        val prefs = FakeTabOrderPreferences()
+        val vm =
+            BottomNavViewModel(
+                mainContext = mainContext,
+                tabOrderPreferences = prefs,
+                notificationsRepository = notificationsRepository,
+            )
+        vm.state.value.notificationCount shouldBe 0
+
+        notificationsRepository.notificationsState.value =
+            listOf(
+                AppNotification.RecipeBookInvite("b1", "Desserts", RecipeBookRole.EDITOR),
+                AppNotification.RecipeBookInvite("b2", "Dinners", RecipeBookRole.VIEWER),
+            )
+        vm.state.value.notificationCount shouldBe 2
     }
 }

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavBloc.kt
@@ -43,6 +43,10 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc, ComposeScreen {
     data class Model(
         val selectedTab: Tab = Tab.RECIPES,
         val tabs: ImmutableList<Tab> = Tab.entries.toImmutableList(),
+        /**
+         * Pending in-app notifications; drives the count badge on the More ([Tab.SETTINGS]) tab.
+         */
+        val notificationCount: Int = 0,
     )
 
     enum class Tab {
@@ -84,6 +88,8 @@ interface BottomNavBloc : BackHandlerOwner, BackClickBloc, ComposeScreen {
         data object OpenSignUp : Output()
 
         data object OpenManageProfile : Output()
+
+        data object OpenNotifications : Output()
 
         data object OpenAppSettings : Output()
 

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -175,6 +175,16 @@ private fun PlusBottomBar(state: BottomNavBloc.Model, onClick: (BottomNavBloc.Ta
 }
 
 /**
+ * Renders just the bottom navigation bar for screenshot tests, with [notificationCount] driving the
+ * More-tab badge. Not used in production — the app always renders the bar through
+ * [BottomNavigationScreen].
+ */
+@Composable
+fun BottomNavBarPreview(notificationCount: Int) {
+    PlusBottomBar(state = BottomNavBloc.Model(notificationCount = notificationCount), onClick = {})
+}
+
+/**
  * A tab's icon, wrapped in a count badge on the More ([SETTINGS]) tab when notifications are
  * pending. Shared by the bottom bar and the side nav rail so both surfaces stay in sync.
  */

--- a/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
+++ b/client/bottomnav/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/bottomnav/BottomNavScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBarItem
@@ -93,7 +95,9 @@ private fun SideNavContent(
                 NavRailItem(
                     label = it.getLabel().asTextData(),
                     selected = it == currentState.selectedTab,
-                    icon = { Icon(imageVector = it.getIcon(), contentDescription = null) },
+                    icon = {
+                        TabIcon(tab = it, notificationCount = currentState.notificationCount)
+                    },
                     onClick = { bloc.onTabSelected(it) },
                 )
             }
@@ -164,9 +168,24 @@ private fun PlusBottomBar(state: BottomNavBloc.Model, onClick: (BottomNavBloc.Ta
                         color = ChefMateTheme.colorScheme.onSurface,
                     )
                 },
-                icon = { Icon(imageVector = tab.getIcon(), contentDescription = null) },
+                icon = { TabIcon(tab = tab, notificationCount = state.notificationCount) },
             )
         }
+    }
+}
+
+/**
+ * A tab's icon, wrapped in a count badge on the More ([SETTINGS]) tab when notifications are
+ * pending. Shared by the bottom bar and the side nav rail so both surfaces stay in sync.
+ */
+@Composable
+private fun TabIcon(tab: BottomNavBloc.Tab, notificationCount: Int) {
+    if (tab == SETTINGS && notificationCount > 0) {
+        BadgedBox(badge = { Badge { Text(notificationCount.toString()) } }) {
+            Icon(imageVector = tab.getIcon(), contentDescription = null)
+        }
+    } else {
+        Icon(imageVector = tab.getIcon(), contentDescription = null)
     }
 }
 

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -97,6 +97,8 @@ kotlin {
             api(projects.client.grocery.core.public)
             api(projects.client.meal.data.impl)
             api(projects.client.meal.core.impl)
+            api(projects.client.notifications.data.impl)
+            api(projects.client.notifications.impl)
             api(projects.client.onboarding.impl)
             api(projects.client.onboarding.public)
             implementation(libs.kotlinx.serialization.json)
@@ -166,6 +168,7 @@ kotlin {
             implementation(projects.client.settings.implRobots)
             implementation(projects.client.settings.root.implRobots)
             implementation(projects.client.profile.implRobots)
+            implementation(projects.client.notifications.implRobots)
             implementation(projects.client.onboarding.implRobots)
         }
         val jvmTest by getting {

--- a/client/composeApp/src/androidMain/AndroidManifest.xml
+++ b/client/composeApp/src/androidMain/AndroidManifest.xml
@@ -40,6 +40,20 @@
 
                 <data android:scheme="chefmate" />
             </intent-filter>
+
+            <!-- Verified https App Links for invite emails. Domain ownership is proven by the
+                 hosted https://chefmate.plusmobileapps.com/.well-known/assetlinks.json. -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                        android:scheme="https"
+                        android:host="chefmate.plusmobileapps.com"
+                        android:pathPrefix="/notifications" />
+            </intent-filter>
         </activity>
 
         <!-- Digital Asset Links affiliation for password-manager credential sharing with

--- a/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/MainActivity.kt
+++ b/client/composeApp/src/androidMain/kotlin/com/plusmobileapps/chefmate/MainActivity.kt
@@ -30,6 +30,12 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        setIntent(intent)
+        // A warm app (launchMode=singleTask) receives tapped deep links here rather than through a
+        // fresh onCreate, so route them to the running RootBloc.
+        if (intent.action == Intent.ACTION_VIEW) {
+            intent.data?.toString()?.let { rootBloc.handleDeepLink(it) }
+        }
         handleShareIntent(intent)
     }
 

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/NotificationsNavigationUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/NotificationsNavigationUiTest.kt
@@ -1,0 +1,20 @@
+package com.plusmobileapps.chefmate.tests
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.notifications.robots.notifications
+import com.plusmobileapps.chefmate.recipe.bottomnav.robots.bottomNav
+import com.plusmobileapps.chefmate.settings.robots.more
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class NotificationsNavigationUiTest {
+
+    @Test
+    fun opening_notifications_from_more_tab_shows_the_screen() = runRootBlocTest {
+        bottomNav().clickMoreTab()
+        more().awaitDisplayed().clickNotificationsRow()
+
+        notifications().awaitDisplayed().assertDisplayed()
+    }
+}

--- a/client/grocery/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/testing/FakeGroceryRepository.kt
+++ b/client/grocery/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/testing/FakeGroceryRepository.kt
@@ -153,10 +153,19 @@ class FakeGroceryRepository : GroceryRepository {
 
     override suspend fun removeCollaborator(listId: Long, collaboratorId: Long) {}
 
-    override suspend fun acceptInvitation(memberId: String) {}
+    val pendingInvitations = MutableStateFlow<List<GroceryListInvite>>(emptyList())
+    val acceptedInvitations: MutableList<String> = mutableListOf()
+    val rejectedInvitations: MutableList<String> = mutableListOf()
 
-    override suspend fun rejectInvitation(memberId: String) {}
+    override suspend fun acceptInvitation(memberId: String) {
+        acceptedInvitations += memberId
+        pendingInvitations.update { invites -> invites.filterNot { it.memberId == memberId } }
+    }
 
-    override fun getPendingInvitations(): Flow<List<GroceryListInvite>> =
-        MutableStateFlow(emptyList())
+    override suspend fun rejectInvitation(memberId: String) {
+        rejectedInvitations += memberId
+        pendingInvitations.update { invites -> invites.filterNot { it.memberId == memberId } }
+    }
+
+    override fun getPendingInvitations(): Flow<List<GroceryListInvite>> = pendingInvitations
 }

--- a/client/notifications/data/impl/build.gradle.kts
+++ b/client/notifications/data/impl/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins { alias(libs.plugins.kmpLibrary) }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.notifications.data.public)
+            implementation(projects.client.grocery.data.public)
+            implementation(projects.client.recipebook.data.public)
+            implementation(projects.client.shared)
+        }
+        commonTest.dependencies {
+            implementation(projects.client.grocery.data.testing)
+            implementation(projects.client.recipebook.data.testing)
+        }
+    }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.notifications.data.impl"
+    enableDi = true
+    enableTesting = true
+}

--- a/client/notifications/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/data/impl/NotificationsRepositoryImpl.kt
+++ b/client/notifications/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/data/impl/NotificationsRepositoryImpl.kt
@@ -1,0 +1,86 @@
+package com.plusmobileapps.chefmate.notifications.data.impl
+
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
+import com.plusmobileapps.chefmate.notifications.data.AppNotification
+import com.plusmobileapps.chefmate.notifications.data.NotificationsRepository
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookCollaborationRepository
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.update
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@SingleIn(AppScope::class)
+@Inject
+@ContributesBinding(AppScope::class)
+class NotificationsRepositoryImpl(
+    private val groceryRepository: GroceryRepository,
+    private val recipeBookCollaborationRepository: RecipeBookCollaborationRepository,
+) : NotificationsRepository {
+
+    // Bumped by refresh()/accept()/decline() to force both the grocery flow and the recipe-book
+    // fetch to re-run. flatMapLatest re-subscribes to the grocery flow on each tick — the grocery
+    // pending-invites flow is cold, so re-subscribing re-fetches from the backend. This is what
+    // keeps the list (and the badge) current after a user acts on an invite, since neither source
+    // pushes updates on its own.
+    private val refreshTrigger = MutableStateFlow(0L)
+
+    override val notifications: Flow<List<AppNotification>> = refreshTrigger.flatMapLatest {
+        combine(
+            groceryRepository.getPendingInvitations(),
+            // pendingInvites() is one-shot; wrap it so it re-runs whenever we re-subscribe.
+            flow {
+                emit(
+                    runCatching { recipeBookCollaborationRepository.pendingInvites() }
+                        .getOrDefault(emptyList())
+                )
+            },
+        ) { groceryInvites, recipeBookInvites ->
+            groceryInvites.map {
+                AppNotification.GroceryInvite(
+                    memberId = it.memberId,
+                    listName = it.listName,
+                    role = it.role,
+                )
+            } +
+                recipeBookInvites.map {
+                    AppNotification.RecipeBookInvite(
+                        memberId = it.memberId,
+                        bookName = it.bookName,
+                        role = it.role,
+                    )
+                }
+        }
+    }
+
+    override suspend fun accept(notification: AppNotification) {
+        when (notification) {
+            is AppNotification.GroceryInvite ->
+                groceryRepository.acceptInvitation(notification.memberId)
+            is AppNotification.RecipeBookInvite ->
+                recipeBookCollaborationRepository.acceptInvite(notification.memberId)
+        }
+        refresh()
+    }
+
+    override suspend fun decline(notification: AppNotification) {
+        when (notification) {
+            is AppNotification.GroceryInvite ->
+                groceryRepository.rejectInvitation(notification.memberId)
+            is AppNotification.RecipeBookInvite ->
+                recipeBookCollaborationRepository.declineInvite(notification.memberId)
+        }
+        refresh()
+    }
+
+    override fun refresh() {
+        refreshTrigger.update { it + 1 }
+    }
+}

--- a/client/notifications/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/notifications/data/impl/NotificationsRepositoryImplTest.kt
+++ b/client/notifications/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/notifications/data/impl/NotificationsRepositoryImplTest.kt
@@ -1,0 +1,92 @@
+package com.plusmobileapps.chefmate.notifications.data.impl
+
+import app.cash.turbine.test
+import com.plusmobileapps.chefmate.grocery.data.GroceryListInvite
+import com.plusmobileapps.chefmate.grocery.data.ListRole
+import com.plusmobileapps.chefmate.grocery.data.testing.FakeGroceryRepository
+import com.plusmobileapps.chefmate.notifications.data.AppNotification
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookInvite
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole
+import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookCollaborationRepository
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+class NotificationsRepositoryImplTest {
+
+    private val grocery = FakeGroceryRepository()
+    private val recipeBook = FakeRecipeBookCollaborationRepository()
+
+    private val repository =
+        NotificationsRepositoryImpl(
+            groceryRepository = grocery,
+            recipeBookCollaborationRepository = recipeBook,
+        )
+
+    @Test
+    fun merges_grocery_and_recipe_book_pending_invites() = runTest {
+        grocery.pendingInvitations.value =
+            listOf(
+                GroceryListInvite(memberId = "g1", listName = "Weeknight", role = ListRole.EDITOR)
+            )
+        recipeBook.invites =
+            mutableListOf(
+                RecipeBookInvite(
+                    memberId = "b1",
+                    bookName = "Desserts",
+                    role = RecipeBookRole.EDITOR,
+                )
+            )
+
+        repository.notifications.first() shouldContainExactlyInAnyOrder
+            listOf(
+                AppNotification.GroceryInvite("g1", "Weeknight", ListRole.EDITOR),
+                AppNotification.RecipeBookInvite("b1", "Desserts", RecipeBookRole.EDITOR),
+            )
+    }
+
+    @Test
+    fun emits_empty_when_nothing_pending() = runTest {
+        repository.notifications.first() shouldBe emptyList()
+    }
+
+    @Test
+    fun accept_grocery_invite_routes_to_grocery_repository() = runTest {
+        val invite = AppNotification.GroceryInvite("g1", "Weeknight", ListRole.EDITOR)
+        grocery.pendingInvitations.value =
+            listOf(GroceryListInvite("g1", "Weeknight", ListRole.EDITOR))
+
+        repository.accept(invite)
+
+        grocery.acceptedInvitations shouldBe listOf("g1")
+    }
+
+    @Test
+    fun decline_recipe_book_invite_routes_to_recipe_book_repository() = runTest {
+        val invite = AppNotification.RecipeBookInvite("b1", "Desserts", RecipeBookRole.EDITOR)
+        recipeBook.invites =
+            mutableListOf(RecipeBookInvite("b1", "Desserts", RecipeBookRole.EDITOR))
+
+        repository.decline(invite)
+
+        recipeBook.declined shouldBe listOf("b1")
+    }
+
+    @Test
+    fun refresh_re_fetches_recipe_book_invites() = runTest {
+        repository.notifications.test {
+            awaitItem() shouldBe emptyList()
+
+            // Recipe-book invites are one-shot; a new invite only appears after refresh() re-runs
+            // the fetch.
+            recipeBook.invites =
+                mutableListOf(RecipeBookInvite("b1", "Desserts", RecipeBookRole.EDITOR))
+            repository.refresh()
+
+            awaitItem() shouldContainExactlyInAnyOrder
+                listOf(AppNotification.RecipeBookInvite("b1", "Desserts", RecipeBookRole.EDITOR))
+        }
+    }
+}

--- a/client/notifications/data/public/build.gradle.kts
+++ b/client/notifications/data/public/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins { alias(libs.plugins.kmpLibrary) }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(projects.client.grocery.data.public)
+            api(projects.client.recipebook.data.public)
+            implementation(projects.client.shared)
+        }
+    }
+}
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.notifications.data" }

--- a/client/notifications/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/data/AppNotification.kt
+++ b/client/notifications/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/data/AppNotification.kt
@@ -1,0 +1,34 @@
+package com.plusmobileapps.chefmate.notifications.data
+
+import com.plusmobileapps.chefmate.grocery.data.ListRole
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole
+
+/**
+ * An item shown in the in-app Notifications section. Today the only kind is a pending collaboration
+ * invite (to a grocery list or a recipe book) awaiting the current user's Accept/Decline. New kinds
+ * can be added here as the feature grows.
+ *
+ * [key] is a stable, type-qualified identifier safe to use as a list key and to track in-flight
+ * actions — the underlying member ids are unique per table but could otherwise collide across
+ * kinds.
+ */
+sealed interface AppNotification {
+    val key: String
+
+    /** A pending invite to collaborate on the grocery list named [listName]. */
+    data class GroceryInvite(val memberId: String, val listName: String, val role: ListRole) :
+        AppNotification {
+        override val key: String
+            get() = "grocery:$memberId"
+    }
+
+    /** A pending invite to collaborate on the recipe book named [bookName]. */
+    data class RecipeBookInvite(
+        val memberId: String,
+        val bookName: String,
+        val role: RecipeBookRole,
+    ) : AppNotification {
+        override val key: String
+            get() = "recipe_book:$memberId"
+    }
+}

--- a/client/notifications/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/data/NotificationsRepository.kt
+++ b/client/notifications/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/data/NotificationsRepository.kt
@@ -1,0 +1,25 @@
+package com.plusmobileapps.chefmate.notifications.data
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Aggregates the current user's in-app notifications from the underlying feature repositories
+ * (grocery + recipe-book collaboration). Emits an empty list when signed out or when nothing is
+ * pending. The same [notifications] stream backs both the Notifications screen and the More-tab
+ * badge count.
+ */
+interface NotificationsRepository {
+    /**
+     * The current notifications, newest sources merged. Re-emits after [refresh] and on sign-in.
+     */
+    val notifications: Flow<List<AppNotification>>
+
+    /** Accepts the invite behind [notification], then refreshes. Throws on failure. */
+    suspend fun accept(notification: AppNotification)
+
+    /** Declines the invite behind [notification], then refreshes. Throws on failure. */
+    suspend fun decline(notification: AppNotification)
+
+    /** Force [notifications] to re-fetch from its sources (e.g. on screen open or app resume). */
+    fun refresh()
+}

--- a/client/notifications/data/testing/build.gradle.kts
+++ b/client/notifications/data/testing/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins { alias(libs.plugins.kmpLibrary) }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(projects.client.notifications.data.public)
+            implementation(projects.client.shared)
+        }
+    }
+}
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.notifications.data.testing" }

--- a/client/notifications/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/data/testing/FakeNotificationsRepository.kt
+++ b/client/notifications/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/data/testing/FakeNotificationsRepository.kt
@@ -1,0 +1,37 @@
+package com.plusmobileapps.chefmate.notifications.data.testing
+
+import com.plusmobileapps.chefmate.notifications.data.AppNotification
+import com.plusmobileapps.chefmate.notifications.data.NotificationsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeNotificationsRepository(
+    initial: List<AppNotification> = emptyList(),
+    /** When set, accept/decline throw it so tests can exercise the error path. */
+    var failWith: Throwable? = null,
+) : NotificationsRepository {
+
+    val notificationsState = MutableStateFlow(initial)
+    override val notifications: Flow<List<AppNotification>> = notificationsState
+
+    val accepted: MutableList<AppNotification> = mutableListOf()
+    val declined: MutableList<AppNotification> = mutableListOf()
+    var refreshCount: Int = 0
+        private set
+
+    override suspend fun accept(notification: AppNotification) {
+        failWith?.let { throw it }
+        accepted += notification
+        notificationsState.value = notificationsState.value.filterNot { it.key == notification.key }
+    }
+
+    override suspend fun decline(notification: AppNotification) {
+        failWith?.let { throw it }
+        declined += notification
+        notificationsState.value = notificationsState.value.filterNot { it.key == notification.key }
+    }
+
+    override fun refresh() {
+        refreshCount++
+    }
+}

--- a/client/notifications/impl-robots/build.gradle.kts
+++ b/client/notifications/impl-robots/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies { implementation(projects.client.notifications.public) }
+    }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.notifications.robots"
+    uiTest = true
+}

--- a/client/notifications/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/robots/NotificationsRobot.kt
+++ b/client/notifications/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/robots/NotificationsRobot.kt
@@ -1,0 +1,49 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package com.plusmobileapps.chefmate.notifications.robots
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import com.plusmobileapps.chefmate.notifications.NotificationsTestTags
+
+/**
+ * Robot for the Notifications screen. Lookups are scoped to a descendant of
+ * [NotificationsTestTags.SCREEN] so controls rendered on other screens don't satisfy matchers.
+ *
+ * Construct via [notifications] from inside a `runComposeUiTest { … }` block.
+ */
+class NotificationsRobot(private val test: ComposeUiTest) {
+
+    private val onScreen = hasAnyAncestor(hasTestTag(NotificationsTestTags.SCREEN))
+
+    fun awaitDisplayed(): NotificationsRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(NotificationsTestTags.SCREEN))
+    }
+
+    fun assertDisplayed(): NotificationsRobot = apply {
+        test.onNode(hasTestTag(NotificationsTestTags.SCREEN)).assertIsDisplayed()
+    }
+
+    fun tapAccept(notificationKey: String): NotificationsRobot = apply {
+        test
+            .onNode(hasTestTag(NotificationsTestTags.ACCEPT_PREFIX + notificationKey) and onScreen)
+            .performClick()
+    }
+
+    fun tapDecline(notificationKey: String): NotificationsRobot = apply {
+        test
+            .onNode(hasTestTag(NotificationsTestTags.DECLINE_PREFIX + notificationKey) and onScreen)
+            .performClick()
+    }
+
+    fun assertEmpty(): NotificationsRobot = apply {
+        test.onNode(hasTestTag(NotificationsTestTags.EMPTY) and onScreen).assertIsDisplayed()
+    }
+}
+
+fun ComposeUiTest.notifications(): NotificationsRobot = NotificationsRobot(this)

--- a/client/notifications/impl/build.gradle.kts
+++ b/client/notifications/impl/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.client.notifications.public)
+            implementation(projects.client.notifications.data.public)
+            implementation(projects.client.text.public)
+            implementation(projects.client.ui.public)
+            implementation(libs.arkivanov.decompose.core)
+            implementation(projects.client.shared)
+            implementation(projects.client.auth.data.public)
+            implementation(projects.client.toast.public)
+            implementation(compose.components.resources)
+        }
+        commonTest.dependencies {
+            implementation(projects.client.notifications.data.testing)
+            implementation(projects.client.auth.data.testing)
+            implementation(projects.client.toast.testing)
+        }
+    }
+}
+
+plusLibrary {
+    namespace = "com.plusmobileapps.chefmate.notifications.impl"
+    enableDi = true
+    enableTesting = true
+}

--- a/client/notifications/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/impl/NotificationsBlocImpl.kt
+++ b/client/notifications/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/impl/NotificationsBlocImpl.kt
@@ -1,0 +1,43 @@
+package com.plusmobileapps.chefmate.notifications.impl
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.getViewModel
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc.Model
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc.Output
+import com.plusmobileapps.chefmate.notifications.data.AppNotification
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.Provider
+import kotlinx.coroutines.flow.StateFlow
+
+@AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = NotificationsBloc.Factory::class,
+)
+class NotificationsBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val output: Consumer<Output>,
+    viewModelFactory: Provider<NotificationsViewModel>,
+) : NotificationsBloc, BlocContext by context {
+
+    private val viewModel = instanceKeeper.getViewModel { viewModelFactory() }
+
+    override val state: StateFlow<Model> = viewModel.state
+
+    override fun onBack() {
+        output.onNext(Output.Back)
+    }
+
+    override fun onAccept(notification: AppNotification) {
+        viewModel.accept(notification)
+    }
+
+    override fun onDecline(notification: AppNotification) {
+        viewModel.decline(notification)
+    }
+}

--- a/client/notifications/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/impl/NotificationsViewModel.kt
+++ b/client/notifications/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/impl/NotificationsViewModel.kt
@@ -1,0 +1,83 @@
+package com.plusmobileapps.chefmate.notifications.impl
+
+import chefmate.client.notifications.public.generated.resources.Res
+import chefmate.client.notifications.public.generated.resources.notifications_accept_error
+import chefmate.client.notifications.public.generated.resources.notifications_decline_error
+import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
+import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc.Model
+import com.plusmobileapps.chefmate.notifications.data.AppNotification
+import com.plusmobileapps.chefmate.notifications.data.NotificationsRepository
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.toast.ToastService
+import dev.zacsweers.metro.Inject
+import kotlin.coroutines.CoroutineContext
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@Inject
+class NotificationsViewModel(
+    @Main mainContext: CoroutineContext,
+    private val repository: NotificationsRepository,
+    authenticationRepository: AuthenticationRepository,
+    private val toastService: ToastService,
+) : ViewModel(mainContext) {
+
+    private val processing = MutableStateFlow(persistentSetOf<String>())
+
+    val state: StateFlow<Model> =
+        combine(repository.notifications, authenticationRepository.state, processing) {
+                notifications,
+                authState,
+                inFlight ->
+                Model(
+                    notifications = notifications.toImmutableList(),
+                    isLoading = false,
+                    isSignedIn =
+                        (authState as? AuthState.Authenticated)?.user?.isAnonymous == false,
+                    processing = inFlight,
+                )
+            }
+            .stateIn(scope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), Model())
+
+    init {
+        // Recipe-book invites are one-shot; kick a fetch each time the screen is entered so the
+        // list is current even if it went stale since the badge last refreshed.
+        repository.refresh()
+    }
+
+    fun accept(notification: AppNotification) {
+        act(notification, Res.string.notifications_accept_error) { repository.accept(it) }
+    }
+
+    fun decline(notification: AppNotification) {
+        act(notification, Res.string.notifications_decline_error) { repository.decline(it) }
+    }
+
+    private fun act(
+        notification: AppNotification,
+        errorMessage: org.jetbrains.compose.resources.StringResource,
+        action: suspend (AppNotification) -> Unit,
+    ) {
+        if (notification.key in processing.value) return
+        processing.update { it.add(notification.key) }
+        scope.launch {
+            runCatching { action(notification) }
+                .onFailure { toastService.show(errorMessage.asTextData()) }
+            processing.update { it.remove(notification.key) }
+        }
+    }
+
+    private companion object {
+        const val STOP_TIMEOUT_MS = 5000L
+    }
+}

--- a/client/notifications/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/impl/ui/NotificationsPreviews.kt
+++ b/client/notifications/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/impl/ui/NotificationsPreviews.kt
@@ -1,0 +1,77 @@
+package com.plusmobileapps.chefmate.notifications.impl.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.plusmobileapps.chefmate.grocery.data.ListRole
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc.Model
+import com.plusmobileapps.chefmate.notifications.data.AppNotification
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.MutableStateFlow
+
+private fun notificationsBloc(model: Model): NotificationsBloc =
+    object : NotificationsBloc {
+        override val state = MutableStateFlow(model)
+
+        override fun onBack() = Unit
+
+        override fun onAccept(notification: AppNotification) = Unit
+
+        override fun onDecline(notification: AppNotification) = Unit
+    }
+
+val previewNotificationsBloc: NotificationsBloc =
+    notificationsBloc(
+        Model(
+            notifications =
+                persistentListOf(
+                    AppNotification.GroceryInvite(
+                        memberId = "g1",
+                        listName = "Weeknight Dinners",
+                        role = ListRole.EDITOR,
+                    ),
+                    AppNotification.RecipeBookInvite(
+                        memberId = "b1",
+                        bookName = "Holiday Baking",
+                        role = RecipeBookRole.EDITOR,
+                    ),
+                ),
+            isLoading = false,
+        )
+    )
+
+val previewNotificationsProcessingBloc: NotificationsBloc =
+    notificationsBloc(
+        Model(
+            notifications =
+                persistentListOf(
+                    AppNotification.GroceryInvite(
+                        memberId = "g1",
+                        listName = "Weeknight Dinners",
+                        role = ListRole.EDITOR,
+                    )
+                ),
+            isLoading = false,
+            processing = kotlinx.collections.immutable.persistentSetOf("grocery:g1"),
+        )
+    )
+
+val previewNotificationsEmptyBloc: NotificationsBloc = notificationsBloc(Model(isLoading = false))
+
+val previewNotificationsSignedOutBloc: NotificationsBloc =
+    notificationsBloc(Model(isLoading = false, isSignedIn = false))
+
+@Preview
+@Composable
+internal fun NotificationsPreview() {
+    ChefMateTheme { previewNotificationsBloc.Content(Modifier) }
+}
+
+@Preview
+@Composable
+internal fun NotificationsEmptyPreview() {
+    ChefMateTheme { previewNotificationsEmptyBloc.Content(Modifier) }
+}

--- a/client/notifications/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/notifications/impl/NotificationsBlocImplTest.kt
+++ b/client/notifications/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/notifications/impl/NotificationsBlocImplTest.kt
@@ -1,0 +1,133 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.notifications.impl
+
+import app.cash.turbine.test
+import chefmate.client.notifications.public.generated.resources.Res
+import chefmate.client.notifications.public.generated.resources.notifications_accept_error
+import com.plusmobileapps.chefmate.auth.data.AuthState
+import com.plusmobileapps.chefmate.auth.data.ChefMateUser
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.grocery.data.ListRole
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc
+import com.plusmobileapps.chefmate.notifications.data.AppNotification
+import com.plusmobileapps.chefmate.notifications.data.testing.FakeNotificationsRepository
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole
+import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.plusmobileapps.chefmate.testing.TestConsumer
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.toast.testing.FakeToastService
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class NotificationsBlocImplTest {
+
+    private val context = TestBlocContext.create()
+    private val output = TestConsumer<NotificationsBloc.Output>()
+    private val groceryInvite =
+        AppNotification.GroceryInvite("g1", "Weeknight Dinners", ListRole.EDITOR)
+    private val recipeBookInvite =
+        AppNotification.RecipeBookInvite("b1", "Holiday Baking", RecipeBookRole.EDITOR)
+
+    private val notificationsRepository =
+        FakeNotificationsRepository(initial = listOf(groceryInvite, recipeBookInvite))
+    private val authRepository =
+        FakeAuthenticationRepository().apply {
+            setState(
+                AuthState.Authenticated(
+                    ChefMateUser(
+                        userId = "id-1",
+                        userName = "Chef",
+                        userEmail = "chef@example.com",
+                        userProfileImageUrl = null,
+                    )
+                )
+            )
+        }
+    private val toastService = FakeToastService()
+
+    private val bloc by lazy {
+        NotificationsBlocImpl(
+            context = context,
+            output = output,
+            viewModelFactory = {
+                NotificationsViewModel(
+                    mainContext = context.mainContext,
+                    repository = notificationsRepository,
+                    authenticationRepository = authRepository,
+                    toastService = toastService,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun When_opened_Then_state_lists_pending_notifications_for_signed_in_user() = runTest {
+        bloc.state.test {
+            var item = awaitItem()
+            while (item.isLoading) item = awaitItem()
+            item.notifications shouldBe listOf(groceryInvite, recipeBookInvite)
+            item.isSignedIn shouldBe true
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun When_opened_Then_repository_is_refreshed() {
+        bloc // instantiate
+        notificationsRepository.refreshCount shouldBe 1
+    }
+
+    @Test
+    fun When_accept_Then_routed_to_repository() = runTest {
+        bloc.onAccept(groceryInvite)
+
+        notificationsRepository.accepted shouldBe listOf(groceryInvite)
+    }
+
+    @Test
+    fun When_decline_Then_routed_to_repository() = runTest {
+        bloc.onDecline(recipeBookInvite)
+
+        notificationsRepository.declined shouldBe listOf(recipeBookInvite)
+    }
+
+    @Test
+    fun When_accept_fails_Then_error_toast_is_shown() = runTest {
+        notificationsRepository.failWith = RuntimeException("boom")
+
+        bloc.onAccept(groceryInvite)
+
+        toastService.shown shouldBe listOf(Res.string.notifications_accept_error.asTextData())
+    }
+
+    @Test
+    fun When_back_Then_output_emitted() {
+        bloc.onBack()
+
+        output.lastValue shouldBe NotificationsBloc.Output.Back
+    }
+
+    @Test
+    fun When_anonymous_Then_state_is_signed_out() = runTest {
+        authRepository.setState(
+            AuthState.Authenticated(
+                ChefMateUser(
+                    userId = "anon",
+                    userName = "",
+                    userEmail = "",
+                    userProfileImageUrl = null,
+                    isAnonymous = true,
+                )
+            )
+        )
+
+        bloc.state.test {
+            var item = awaitItem()
+            while (item.isLoading) item = awaitItem()
+            item.isSignedIn shouldBe false
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/client/notifications/public/build.gradle.kts
+++ b/client/notifications/public/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    alias(libs.plugins.kmpLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.arkivanov.decompose.core)
+            implementation(projects.client.shared)
+            api(projects.client.notifications.data.public)
+            api(projects.client.text.public)
+            implementation(projects.client.ui.public)
+            implementation(projects.client.util.public)
+            implementation(compose.components.resources)
+        }
+    }
+}
+
+compose { resources { publicResClass = true } }
+
+plusLibrary { namespace = "com.plusmobileapps.chefmate.notifications" }

--- a/client/notifications/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/notifications/public/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,12 @@
+<resources>
+    <string name="notifications_title">Notifications</string>
+    <string name="notifications_grocery_invite_message">You’ve been invited to collaborate on the grocery list “{list}”.</string>
+    <string name="notifications_recipe_book_invite_message">You’ve been invited to collaborate on the recipe book “{book}”.</string>
+    <string name="notifications_accept">Accept</string>
+    <string name="notifications_decline">Decline</string>
+    <string name="notifications_empty_title">You’re all caught up</string>
+    <string name="notifications_empty_message">Invitations to shared grocery lists and recipe books will show up here.</string>
+    <string name="notifications_signed_out">Sign in to see invitations addressed to your account.</string>
+    <string name="notifications_accept_error">Couldn’t accept the invitation. Please try again.</string>
+    <string name="notifications_decline_error">Couldn’t decline the invitation. Please try again.</string>
+</resources>

--- a/client/notifications/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/NotificationsBloc.kt
+++ b/client/notifications/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/NotificationsBloc.kt
@@ -1,0 +1,53 @@
+package com.plusmobileapps.chefmate.notifications
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.notifications.data.AppNotification
+import com.plusmobileapps.chefmate.notifications.ui.NotificationsScreen
+import com.plusmobileapps.chefmate.ui.ComposeScreen
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.flow.StateFlow
+
+interface NotificationsBloc : ComposeScreen {
+    val state: StateFlow<Model>
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        NotificationsScreen(bloc = this, modifier = modifier)
+    }
+
+    fun onBack()
+
+    fun onAccept(notification: AppNotification)
+
+    fun onDecline(notification: AppNotification)
+
+    data class Model(
+        val notifications: ImmutableList<AppNotification> = persistentListOf(),
+        val isLoading: Boolean = true,
+        /**
+         * False when there's no real (non-anonymous) session. Invites are addressed to an account
+         * email, so a signed-out/anonymous user has none to act on — the screen shows a sign-in
+         * hint instead of an empty state.
+         */
+        val isSignedIn: Boolean = true,
+        /**
+         * [AppNotification.key]s with an accept/decline in flight, used to disable their buttons.
+         */
+        val processing: ImmutableSet<String> = persistentSetOf(),
+    )
+
+    sealed class Output {
+        /** Pop back to the More tab. */
+        data object Back : Output()
+    }
+
+    fun interface Factory {
+        fun create(context: BlocContext, output: Consumer<Output>): NotificationsBloc
+    }
+}

--- a/client/notifications/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/NotificationsTestTags.kt
+++ b/client/notifications/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/NotificationsTestTags.kt
@@ -1,0 +1,10 @@
+package com.plusmobileapps.chefmate.notifications
+
+object NotificationsTestTags {
+    const val SCREEN = "notifications_screen"
+    const val EMPTY = "notifications_empty"
+
+    /** Per-row tags are suffixed with the notification's [AppNotification.key]. */
+    const val ACCEPT_PREFIX = "notifications_accept_"
+    const val DECLINE_PREFIX = "notifications_decline_"
+}

--- a/client/notifications/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/ui/NotificationsScreen.kt
+++ b/client/notifications/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/notifications/ui/NotificationsScreen.kt
@@ -1,0 +1,176 @@
+package com.plusmobileapps.chefmate.notifications.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import chefmate.client.notifications.public.generated.resources.Res
+import chefmate.client.notifications.public.generated.resources.notifications_accept
+import chefmate.client.notifications.public.generated.resources.notifications_decline
+import chefmate.client.notifications.public.generated.resources.notifications_empty_message
+import chefmate.client.notifications.public.generated.resources.notifications_empty_title
+import chefmate.client.notifications.public.generated.resources.notifications_grocery_invite_message
+import chefmate.client.notifications.public.generated.resources.notifications_recipe_book_invite_message
+import chefmate.client.notifications.public.generated.resources.notifications_signed_out
+import chefmate.client.notifications.public.generated.resources.notifications_title
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc
+import com.plusmobileapps.chefmate.notifications.NotificationsTestTags
+import com.plusmobileapps.chefmate.notifications.data.AppNotification
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.PhraseModel
+import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusButton
+import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@Composable
+fun NotificationsScreen(bloc: NotificationsBloc, modifier: Modifier = Modifier) {
+    val state by bloc.state.collectAsState()
+
+    PlusHeaderContainer(
+        modifier = modifier.testTag(NotificationsTestTags.SCREEN),
+        data =
+            PlusHeaderData.Child(
+                title = Res.string.notifications_title.asTextData(),
+                onBackClick = bloc::onBack,
+            ),
+        contentPadding = PaddingValues(ChefMateTheme.dimens.paddingNormal),
+    ) {
+        when {
+            state.isLoading -> Unit
+            !state.isSignedIn ->
+                EmptyState(message = Res.string.notifications_signed_out.asTextData())
+            state.notifications.isEmpty() ->
+                EmptyState(
+                    title = Res.string.notifications_empty_title.asTextData(),
+                    message = Res.string.notifications_empty_message.asTextData(),
+                )
+            else ->
+                state.notifications.forEach { notification ->
+                    NotificationCard(
+                        notification = notification,
+                        isProcessing = notification.key in state.processing,
+                        onAccept = { bloc.onAccept(notification) },
+                        onDecline = { bloc.onDecline(notification) },
+                    )
+                }
+        }
+    }
+}
+
+@Composable
+private fun NotificationCard(
+    notification: AppNotification,
+    isProcessing: Boolean,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(bottom = ChefMateTheme.dimens.paddingNormal),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            ),
+    ) {
+        Column(modifier = Modifier.padding(ChefMateTheme.dimens.paddingNormal)) {
+            Text(
+                text = notification.message().localized(),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (isProcessing) {
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth().padding(top = ChefMateTheme.dimens.paddingNormal),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    PlusLoadingIndicator(modifier = Modifier.width(24.dp))
+                }
+            } else {
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth().padding(top = ChefMateTheme.dimens.paddingNormal),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    PlusButton(
+                        text = Res.string.notifications_decline.asTextData(),
+                        variant = PlusButtonVariant.SECONDARY,
+                        modifier =
+                            Modifier.testTag(
+                                NotificationsTestTags.DECLINE_PREFIX + notification.key
+                            ),
+                        onClick = onDecline,
+                    )
+                    Spacer(modifier = Modifier.width(ChefMateTheme.dimens.paddingNormal))
+                    PlusButton(
+                        text = Res.string.notifications_accept.asTextData(),
+                        modifier =
+                            Modifier.testTag(
+                                NotificationsTestTags.ACCEPT_PREFIX + notification.key
+                            ),
+                        onClick = onAccept,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyState(message: TextData, title: TextData? = null) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(top = ChefMateTheme.dimens.paddingLarge),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall),
+    ) {
+        title?.let {
+            Text(
+                text = it.localized(),
+                style = ChefMateTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+            )
+        }
+        Text(
+            text = message.localized(),
+            style = ChefMateTheme.typography.bodyMedium,
+            color = ChefMateTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.testTag(NotificationsTestTags.EMPTY),
+        )
+    }
+}
+
+private fun AppNotification.message(): TextData =
+    when (this) {
+        is AppNotification.GroceryInvite ->
+            PhraseModel(
+                resource = Res.string.notifications_grocery_invite_message,
+                "list" to FixedString(listName),
+            )
+        is AppNotification.RecipeBookInvite ->
+            PhraseModel(
+                resource = Res.string.notifications_recipe_book_invite_message,
+                "book" to FixedString(bookName),
+            )
+    }

--- a/client/root/impl/build.gradle.kts
+++ b/client/root/impl/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             implementation(projects.client.cook.public)
             implementation(projects.client.featureflag.public)
             implementation(projects.client.grocery.core.public)
+            implementation(projects.client.notifications.public)
             implementation(projects.client.onboarding.public)
             implementation(projects.client.profile.public)
             implementation(projects.client.recipe.core.public)

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -25,6 +25,7 @@ import com.plusmobileapps.chefmate.di.OnboardingRepository
 import com.plusmobileapps.chefmate.featureflag.FeatureFlags
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
 import com.plusmobileapps.chefmate.grocery.core.edit.EditGroceryListBloc
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc
 import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
@@ -58,6 +59,7 @@ class RootBlocImpl(
     private val otpBloc: OtpBloc.Factory,
     private val settingsRoot: SettingsRootBloc.Factory,
     private val manageProfile: ManageProfileBloc.Factory,
+    private val notifications: NotificationsBloc.Factory,
     private val developerSettings: DeveloperSettingsBloc.Factory,
     private val cookMode: CookModeBloc.Factory,
     private val featureFlags: FeatureFlags,
@@ -105,6 +107,8 @@ class RootBlocImpl(
                 listOf(Configuration.BottomNavigation, RecipeRoot(Detail(deepLink.recipeId)))
             DeepLink.AppSettings ->
                 listOf(Configuration.BottomNavigation, Configuration.SettingsRoot())
+            DeepLink.Notifications ->
+                listOf(Configuration.BottomNavigation, Configuration.Notifications)
             DeepLink.SignIn ->
                 listOf(
                     Configuration.BottomNavigation,
@@ -129,6 +133,43 @@ class RootBlocImpl(
             stack.value.items.map { it.instance }.filterIsInstance<BottomNavigation>().firstOrNull()
         bottomNavChild?.bloc?.handleSharedUrl(url)
         navigation.bringToFront(Configuration.BottomNavigation)
+    }
+
+    override fun handleDeepLink(url: String) {
+        // Only routed once past onboarding — a first-run user has no populated stack to return to.
+        if (!onboardingRepository.hasCompletedOnboarding) return
+        when (val deepLink = DeepLink.parse(url)) {
+            DeepLink.Notifications -> navigation.bringToFront(Configuration.Notifications)
+            DeepLink.AppSettings -> navigation.bringToFront(Configuration.SettingsRoot())
+            is DeepLink.RecipeDetail ->
+                navigation.bringToFront(RecipeRoot(Detail(deepLink.recipeId)))
+            DeepLink.Groceries -> {
+                selectBottomNavTab(BottomNavBloc.Tab.GROCERIES)
+                navigation.bringToFront(Configuration.BottomNavigation)
+            }
+            DeepLink.MealPlanner -> {
+                selectBottomNavTab(BottomNavBloc.Tab.MEALS)
+                navigation.bringToFront(Configuration.BottomNavigation)
+            }
+            DeepLink.SignIn ->
+                navigation.bringToFront(
+                    Configuration.Authentication(AuthenticationBloc.Props.SignIn)
+                )
+            DeepLink.SignUp ->
+                navigation.bringToFront(
+                    Configuration.Authentication(AuthenticationBloc.Props.SignUp)
+                )
+            DeepLink.None -> Unit
+        }
+    }
+
+    private fun selectBottomNavTab(tab: BottomNavBloc.Tab) {
+        stack.value.items
+            .map { it.instance }
+            .filterIsInstance<BottomNavigation>()
+            .firstOrNull()
+            ?.bloc
+            ?.onTabSelected(tab)
     }
 
     private fun createChild(config: Configuration, context: BlocContext): RootBloc.Child =
@@ -227,6 +268,15 @@ class RootBlocImpl(
                         manageProfile.create(
                             context = context,
                             output = ::handleManageProfileOutput,
+                        )
+                )
+
+            Configuration.Notifications ->
+                RootBloc.Child.Notifications(
+                    bloc =
+                        notifications.create(
+                            context = context,
+                            output = ::handleNotificationsOutput,
                         )
                 )
 
@@ -369,6 +419,10 @@ class RootBlocImpl(
                 navigation.bringToFront(Configuration.ManageProfile)
             }
 
+            BottomNavBloc.Output.OpenNotifications -> {
+                navigation.bringToFront(Configuration.Notifications)
+            }
+
             BottomNavBloc.Output.OpenAppSettings -> {
                 navigation.bringToFront(Configuration.SettingsRoot())
             }
@@ -457,6 +511,12 @@ class RootBlocImpl(
             // on its own once the auth state flips.
             ManageProfileBloc.Output.Back,
             ManageProfileBloc.Output.AccountDeleted -> navigation.pop()
+        }
+    }
+
+    private fun handleNotificationsOutput(output: NotificationsBloc.Output) {
+        when (output) {
+            NotificationsBloc.Output.Back -> navigation.pop()
         }
     }
 
@@ -596,6 +656,8 @@ class RootBlocImpl(
         ) : Configuration()
 
         @Serializable data object ManageProfile : Configuration()
+
+        @Serializable data object Notifications : Configuration()
 
         @Serializable data object DeveloperSettings : Configuration()
 

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/DeepLinkTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/DeepLinkTest.kt
@@ -40,6 +40,7 @@ class DeepLinkTest {
         DeepLink.parse("chefmate://groceries") shouldBe DeepLink.Groceries
         DeepLink.parse("chefmate://meal-planner") shouldBe DeepLink.MealPlanner
         DeepLink.parse("chefmate://settings") shouldBe DeepLink.AppSettings
+        DeepLink.parse("chefmate://notifications") shouldBe DeepLink.Notifications
         DeepLink.parse("chefmate://signin") shouldBe DeepLink.SignIn
         DeepLink.parse("chefmate://signup") shouldBe DeepLink.SignUp
     }
@@ -48,5 +49,30 @@ class DeepLinkTest {
     fun parse_tolerates_trailing_slash() {
         DeepLink.parse("chefmate://groceries/") shouldBe DeepLink.Groceries
         DeepLink.parse("chefmate://recipe/42/") shouldBe DeepLink.RecipeDetail(42L)
+    }
+
+    @Test
+    fun parse_https_app_links_for_our_web_host() {
+        DeepLink.parse("https://chefmate.plusmobileapps.com/notifications") shouldBe
+            DeepLink.Notifications
+        DeepLink.parse("https://chefmate.plusmobileapps.com/notifications/") shouldBe
+            DeepLink.Notifications
+        DeepLink.parse("https://chefmate.plusmobileapps.com/recipe/42") shouldBe
+            DeepLink.RecipeDetail(42L)
+        DeepLink.parse("https://chefmate.plusmobileapps.com/groceries") shouldBe DeepLink.Groceries
+    }
+
+    @Test
+    fun parse_ignores_query_and_fragment() {
+        DeepLink.parse("https://chefmate.plusmobileapps.com/notifications?ref=email") shouldBe
+            DeepLink.Notifications
+        DeepLink.parse("chefmate://notifications#top") shouldBe DeepLink.Notifications
+    }
+
+    @Test
+    fun parse_returns_none_for_other_https_hosts() {
+        DeepLink.parse("https://example.com/notifications") shouldBe DeepLink.None
+        DeepLink.parse("https://chefmate.plusmobileapps.com.evil.com/notifications") shouldBe
+            DeepLink.None
     }
 }

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -13,6 +13,7 @@ import com.plusmobileapps.chefmate.browser.BrowserRootBloc
 import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.di.OnboardingRepository
 import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc
 import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
@@ -38,6 +39,9 @@ class RootBlocTest {
     var settingsRootProps: SettingsRootBloc.Props? = null
     var manageProfileOutput:
         Consumer<com.plusmobileapps.chefmate.profile.ManageProfileBloc.Output> =
+        Consumer {}
+    var notificationsOutput:
+        Consumer<com.plusmobileapps.chefmate.notifications.NotificationsBloc.Output> =
         Consumer {}
     var developerSettingsOutput:
         Consumer<com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc.Output> =
@@ -111,6 +115,10 @@ class RootBlocTest {
             },
             manageProfile = { _, output ->
                 manageProfileOutput = output
+                mock()
+            },
+            notifications = { _, output ->
+                notificationsOutput = output
                 mock()
             },
             developerSettings = { _, output ->
@@ -282,6 +290,21 @@ class RootBlocTest {
     }
 
     @Test
+    fun When_bottom_nav_outputs_open_notifications_Then_notifications_is_shown() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenNotifications)
+        rootBloc.instance() should instanceOf<RootBloc.Child.Notifications>()
+        rootBloc.state.value.backStack.size shouldBe 1
+    }
+
+    @Test
+    fun Given_notifications_When_back_outputted_Then_bottom_nav_is_shown() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenNotifications)
+        rootBloc.instance() should instanceOf<RootBloc.Child.Notifications>()
+        notificationsOutput.onNext(NotificationsBloc.Output.Back)
+        rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+    }
+
+    @Test
     fun When_bottom_nav_opens_grocery_autocomplete_settings_Then_settings_root_deep_links() {
         bottomNavOutput.onNext(BottomNavBloc.Output.OpenGroceryAutocompleteSettings)
         rootBloc.instance() should instanceOf<RootBloc.Child.SettingsRoot>()
@@ -434,6 +457,19 @@ class RootBlocTest {
         val root = createRoot(DeepLink.AppSettings)
         root.instance() should instanceOf<RootBloc.Child.SettingsRoot>()
         root.state.value.backStack.size shouldBe 1
+    }
+
+    @Test
+    fun Given_notifications_deeplink_When_initialized_Then_notifications_is_on_top() {
+        val root = createRoot(DeepLink.Notifications)
+        root.instance() should instanceOf<RootBloc.Child.Notifications>()
+        root.state.value.backStack.size shouldBe 1
+    }
+
+    @Test
+    fun Given_running_app_When_notifications_deeplink_handled_Then_notifications_is_shown() {
+        rootBloc.handleDeepLink("https://chefmate.plusmobileapps.com/notifications")
+        rootBloc.instance() should instanceOf<RootBloc.Child.Notifications>()
     }
 
     @Test

--- a/client/root/public/build.gradle.kts
+++ b/client/root/public/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             api(projects.client.developerSettings.public)
             api(projects.client.featureflag.public)
             api(projects.client.grocery.core.public)
+            api(projects.client.notifications.public)
             api(projects.client.onboarding.public)
             api(projects.client.profile.public)
             api(projects.client.recipe.core.public)

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/DeepLink.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/DeepLink.kt
@@ -11,6 +11,8 @@ sealed class DeepLink {
 
     data object AppSettings : DeepLink()
 
+    data object Notifications : DeepLink()
+
     data object SignIn : DeepLink()
 
     data object SignUp : DeepLink()
@@ -18,12 +20,15 @@ sealed class DeepLink {
     companion object {
         const val SCHEME: String = "chefmate"
 
+        /**
+         * Host of the Universal Link / App Link web domain, e.g.
+         * https://chefmate.plusmobileapps.com.
+         */
+        const val WEB_HOST: String = "chefmate.plusmobileapps.com"
+
         fun parse(uri: String?): DeepLink {
             if (uri.isNullOrBlank()) return None
-            val prefix = "$SCHEME://"
-            if (!uri.startsWith(prefix)) return None
-            val rest = uri.substring(prefix.length).trimEnd('/')
-            val segments = rest.split('/').filter { it.isNotEmpty() }
+            val segments = pathSegments(uri) ?: return None
             val host = segments.firstOrNull() ?: return None
             return when (host) {
                 "recipe" -> {
@@ -33,10 +38,41 @@ sealed class DeepLink {
                 "groceries" -> Groceries
                 "meal-planner" -> MealPlanner
                 "settings" -> AppSettings
+                "notifications" -> Notifications
                 "signin" -> SignIn
                 "signup" -> SignUp
                 else -> None
             }
+        }
+
+        /**
+         * The path segments of a supported deep link, or null if [uri] isn't one. Accepts both the
+         * custom scheme (`chefmate://<host>/...`, used for dev + in-app share) and the
+         * Universal/App Link web form (`https://chefmate.plusmobileapps.com/<path>`, used by the
+         * invite emails). For the web form the leading domain is dropped so both map to the same
+         * `host`/segment routing.
+         */
+        private fun pathSegments(uri: String): List<String>? {
+            val schemePrefix = "$SCHEME://"
+            val rest =
+                when {
+                    uri.startsWith(schemePrefix) -> uri.substring(schemePrefix.length)
+                    else -> {
+                        val afterScheme =
+                            uri.substringAfter("://", missingDelimiterValue = "").ifEmpty {
+                                return null
+                            }
+                        // Only our own web host maps to an in-app destination. Compare the whole
+                        // host authority (up to the path) so lookalikes like
+                        // "chefmate.plusmobileapps.com.evil.com" don't match by prefix.
+                        val host = afterScheme.substringBefore('/').substringBefore('?')
+                        if (!host.equals(WEB_HOST, ignoreCase = true)) return null
+                        afterScheme.substring(host.length)
+                    }
+                }
+            // Drop any query/fragment before splitting into path segments.
+            val path = rest.substringBefore('?').substringBefore('#').trim('/')
+            return path.split('/').filter { it.isNotEmpty() }
         }
     }
 }

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -13,6 +13,7 @@ import com.plusmobileapps.chefmate.cook.CookModeBloc
 import com.plusmobileapps.chefmate.devsettings.DeveloperSettingsBloc
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagsBloc
 import com.plusmobileapps.chefmate.grocery.core.edit.EditGroceryListBloc
+import com.plusmobileapps.chefmate.notifications.NotificationsBloc
 import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
@@ -27,6 +28,13 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
     val state: Value<ChildStack<*, Child>>
 
     fun handleSharedUrl(url: String)
+
+    /**
+     * Route an incoming deep link while the app is already running (Android `onNewIntent`, iOS
+     * `continueUserActivity`/`onOpenURL`). Cold-launch links are handled by the initial stack; this
+     * covers the warm-start case where that stack was already built.
+     */
+    fun handleDeepLink(url: String)
 
     sealed class Child {
 
@@ -49,6 +57,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class SettingsRoot(override val bloc: SettingsRootBloc) : Child()
 
         data class ManageProfile(override val bloc: ManageProfileBloc) : Child()
+
+        data class Notifications(override val bloc: NotificationsBloc) : Child()
 
         data class DeveloperSettings(override val bloc: DeveloperSettingsBloc) : Child()
 

--- a/client/settings/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/robots/MoreRobot.kt
+++ b/client/settings/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/robots/MoreRobot.kt
@@ -30,6 +30,8 @@ class MoreRobot(private val test: ComposeUiTest) {
 
     fun clickManageProfileRow(): MoreRobot = clickRow("Manage Profile")
 
+    fun clickNotificationsRow(): MoreRobot = clickRow("Notifications")
+
     private fun clickRow(label: String): MoreRobot = apply {
         test.waitUntilExactlyOneExists(hasText(label) and onScreen)
         test.onNode(hasText(label) and onScreen).performClick()

--- a/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
+++ b/client/settings/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/impl/SettingsBlocImpl.kt
@@ -68,6 +68,10 @@ class SettingsBlocImpl(
         output.onNext(Output.OpenManageProfile)
     }
 
+    override fun onNotificationsClicked() {
+        output.onNext(Output.OpenNotifications)
+    }
+
     override fun onUrlClicked(url: String) {
         output.onNext(Output.OpenUrl(url))
     }

--- a/client/settings/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/settings/public/src/commonMain/composeResources/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="sign_out">Sign Out</string>
     <string name="sign_up">Sign Up</string>
     <string name="manage_profile">Manage Profile</string>
+    <string name="settings_notifications">Notifications</string>
     <string name="greeting_authenticated">Hello {name}!</string>
     <string name="email_verification_required">Please check your email ({email}) to verify your account before signing in.</string>
     <string name="settings_guest_banner">You’re using ChefMate as a guest. Sign up to back up your recipes across devices.</string>

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/SettingsBloc.kt
@@ -29,6 +29,8 @@ interface SettingsBloc : ComposeScreen {
 
     fun onManageProfileClicked()
 
+    fun onNotificationsClicked()
+
     fun onUrlClicked(url: String)
 
     fun onAppSettingsClicked()
@@ -62,6 +64,8 @@ interface SettingsBloc : ComposeScreen {
         data object OpenSignIn : Output()
 
         data object OpenManageProfile : Output()
+
+        data object OpenNotifications : Output()
 
         data object OpenAppSettings : Output()
 

--- a/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/ui/SettingsScreen.kt
+++ b/client/settings/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/settings/ui/SettingsScreen.kt
@@ -40,6 +40,7 @@ import chefmate.client.settings.public.generated.resources.privacy_policy
 import chefmate.client.settings.public.generated.resources.settings
 import chefmate.client.settings.public.generated.resources.settings_ai_chat
 import chefmate.client.settings.public.generated.resources.settings_guest_banner
+import chefmate.client.settings.public.generated.resources.settings_notifications
 import chefmate.client.settings.public.generated.resources.settings_replay_onboarding
 import chefmate.client.settings.public.generated.resources.sign_in
 import chefmate.client.settings.public.generated.resources.sign_out
@@ -133,6 +134,15 @@ fun SettingsScreen(bloc: SettingsBloc, modifier: Modifier = Modifier) {
                         onClick = bloc::onSignUpClicked,
                     )
                 }
+            }
+            // Notifications aggregate collaboration invites, which are addressed to a real account
+            // — so the row is only meaningful for a signed-in, non-anonymous user.
+            if (viewState.isAuthenticated && !viewState.isAnonymous) {
+                HorizontalDivider()
+                SettingsRow(
+                    name = Res.string.settings_notifications.asTextData(),
+                    onClick = bloc::onNotificationsClicked,
+                )
             }
             HorizontalDivider()
             SettingsRow(
@@ -301,6 +311,8 @@ private val previewBlocUnauthenticated =
 
         override fun onManageProfileClicked() = Unit
 
+        override fun onNotificationsClicked() = Unit
+
         override fun onUrlClicked(url: String) = Unit
 
         override fun onAppSettingsClicked() = Unit
@@ -339,6 +351,8 @@ private val previewBlocAuthenticated =
 
         override fun onManageProfileClicked() = Unit
 
+        override fun onNotificationsClicked() = Unit
+
         override fun onUrlClicked(url: String) = Unit
 
         override fun onAppSettingsClicked() = Unit
@@ -372,6 +386,8 @@ private val previewBlocAnonymous =
         override fun onSignOutDismissed() = Unit
 
         override fun onManageProfileClicked() = Unit
+
+        override fun onNotificationsClicked() = Unit
 
         override fun onUrlClicked(url: String) = Unit
 

--- a/client/ui/screenshot-test/build.gradle.kts
+++ b/client/ui/screenshot-test/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
     implementation(project(":client:meal:core:public"))
     implementation(project(":client:meal:core:impl"))
     implementation(project(":client:meal:data:public"))
+    implementation(project(":client:notifications:public"))
+    implementation(project(":client:notifications:impl"))
     implementation(project(":client:onboarding:public"))
     implementation(project(":client:onboarding:impl"))
     implementation(project(":client:recipe:categories:public"))

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/BottomNavBarScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/BottomNavBarScreenshotTest.kt
@@ -1,0 +1,30 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBarPreview
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun BottomNavBarNoBadgeScreenshot() {
+    ChefMateTheme { Surface { BottomNavBarPreview(notificationCount = 0) } }
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun BottomNavBarWithBadgeScreenshot() {
+    ChefMateTheme { Surface { BottomNavBarPreview(notificationCount = 3) } }
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun BottomNavBarWithBadgeDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) { Surface { BottomNavBarPreview(notificationCount = 3) } }
+}

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTest.kt
@@ -1,0 +1,47 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.notifications.impl.ui.previewNotificationsBloc
+import com.plusmobileapps.chefmate.notifications.impl.ui.previewNotificationsEmptyBloc
+import com.plusmobileapps.chefmate.notifications.impl.ui.previewNotificationsProcessingBloc
+import com.plusmobileapps.chefmate.notifications.impl.ui.previewNotificationsSignedOutBloc
+import com.plusmobileapps.chefmate.ui.Content
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun NotificationsLightScreenshot() {
+    ChefMateTheme { previewNotificationsBloc.Content() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun NotificationsDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) { previewNotificationsBloc.Content() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun NotificationsProcessingScreenshot() {
+    ChefMateTheme { previewNotificationsProcessingBloc.Content() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun NotificationsEmptyScreenshot() {
+    ChefMateTheme { previewNotificationsEmptyBloc.Content() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+fun NotificationsSignedOutScreenshot() {
+    ChefMateTheme { previewNotificationsSignedOutBloc.Content() }
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavBarScreenshotTestKt/BottomNavBarNoBadgeScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavBarScreenshotTestKt/BottomNavBarNoBadgeScreenshot_748aa731_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b33f28a0b28d6d960550124f9c2cc748a5ca150c9d569942a14336c44004adf
+size 12928

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavBarScreenshotTestKt/BottomNavBarWithBadgeDarkScreenshot_4d30ee2f_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavBarScreenshotTestKt/BottomNavBarWithBadgeDarkScreenshot_4d30ee2f_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38e83decb3d3ed50272fb725b89b5c6c31f670af082569cc5afd967267da30cb
+size 14748

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavBarScreenshotTestKt/BottomNavBarWithBadgeScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BottomNavBarScreenshotTestKt/BottomNavBarWithBadgeScreenshot_748aa731_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89545a98ee1a87876c40263bb53d7df611db0764b5cdd9d3cfdd50f303b7ff6e
+size 14220

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTestKt/NotificationsDarkScreenshot_907cdd58_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTestKt/NotificationsDarkScreenshot_907cdd58_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37b5f2daea651704274a9cb4f9a4d31ae2bffb73b692b8e23c7766d5dc6329e4
+size 64524

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTestKt/NotificationsEmptyScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTestKt/NotificationsEmptyScreenshot_e0e29121_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bef5d8aa28d126c004d9ab239a69f1d74f942eb4a72eef2ed14c58b539e2d322
+size 38430

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTestKt/NotificationsLightScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTestKt/NotificationsLightScreenshot_e0e29121_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bf830b0f11065d97f9750f462e8549ad9f48dd01f4f8f7b11d05352b3811a67
+size 62314

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTestKt/NotificationsProcessingScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTestKt/NotificationsProcessingScreenshot_e0e29121_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3664ad2ca7ef063405210512f526a20b735d24b8156123869193685d2c3e56d
+size 36428

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTestKt/NotificationsSignedOutScreenshot_e0e29121_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/NotificationsScreenshotTestKt/NotificationsSignedOutScreenshot_e0e29121_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb8448d0e0dd5651dd69a66a59d87e72c7f0b4e34ee9a5cbb12a587a4337d0be
+size 28601

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -26,11 +26,24 @@ struct ContentView: View {
         .ignoresSafeArea(.all)
         .ignoresSafeArea(.keyboard)
         .onOpenURL { url in
-            guard url.scheme == "chefmate", url.host == "import",
-                  let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-                  let sharedUrl = components.queryItems?.first(where: { $0.name == "url" })?.value
-            else { return }
-            appDelegate.root.handleSharedUrl(url: sharedUrl)
+            // The share extension re-enters via chefmate://import?url=… — hand that to the browser.
+            if url.scheme == "chefmate", url.host == "import",
+               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+               let sharedUrl = components.queryItems?.first(where: { $0.name == "url" })?.value {
+                appDelegate.root.handleSharedUrl(url: sharedUrl)
+                return
+            }
+            // Any other custom-scheme deep link (e.g. chefmate://notifications) while running.
+            if url.scheme == "chefmate" {
+                appDelegate.root.handleDeepLink(url: url.absoluteString)
+            }
+        }
+        // Universal Links (https://chefmate.plusmobileapps.com/…) arrive as a browsing user
+        // activity, for both cold launch and while the app is already running.
+        .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+            if let url = activity.webpageURL {
+                appDelegate.root.handleDeepLink(url: url.absoluteString)
+            }
         }
     }
 }

--- a/iosApp/iosApp/iosApp.entitlements
+++ b/iosApp/iosApp/iosApp.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:chefmate.plusmobileapps.com</string>
+		<string>applinks:chefmate.plusmobileapps.com</string>
 	</array>
 </dict>
 </plist>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -118,6 +118,18 @@ include(":client:meal:data:public")
 
 include(":client:meal:data:testing")
 
+include(":client:notifications:data:impl")
+
+include(":client:notifications:data:public")
+
+include(":client:notifications:data:testing")
+
+include(":client:notifications:impl")
+
+include(":client:notifications:impl-robots")
+
+include(":client:notifications:public")
+
 include(":client:recipe:categories:impl")
 
 include(":client:recipe:categories:impl-robots")

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -87,7 +87,11 @@ Deno.serve(async (req) => {
     const inviterId = payload.invitedBy ?? (parent.owner_id as string | null);
     const inviterName = await resolveInviterName(admin, inviterId);
 
-    const appUrl = Deno.env.get("APP_INVITE_URL") ?? DEFAULT_APP_URL;
+    const baseUrl = Deno.env.get("APP_INVITE_URL") ?? DEFAULT_APP_URL;
+    // Deep link straight to the in-app Notifications screen via Universal Link / App Link. The app
+    // verifies chefmate.plusmobileapps.com, so this opens the app when installed and falls back to
+    // the web page otherwise. Trailing slash trimmed so we don't emit a double slash.
+    const appUrl = `${baseUrl.replace(/\/+$/, "")}/notifications`;
     const from = Deno.env.get("RESEND_FROM") ?? DEFAULT_FROM;
     const subject = `${inviterName} invited you to “${listName}” on Chef Mate`;
 


### PR DESCRIPTION
## What & why

Adds an in-app **Notifications** section under the **More** tab that aggregates pending collaboration invites (grocery lists + recipe books) with **Accept/Decline** actions, shows a **count badge** on the More tab, and supports **Universal/App Link deep linking** so invite emails open straight to the screen.

The invite domain already existed end-to-end (models, Supabase RPCs, grocery + recipe-book repositories with accept/decline). Invites previously surfaced *only* as inline banners on the grocery/recipe list screens — there was no single place to see everything awaiting a response, and the invite email linked to a plain web URL with no route. This PR adds an aggregation + presentation + navigation layer over the existing domain and **leaves the inline banners in place**.

## What's included

- **New `client/notifications` modules** (`data` public/impl/testing, UI public/impl, impl-robots), following the repo's module/BLoC conventions (Metro `@ContributesAssistedFactory`, no manual DI wiring).
  - `NotificationsRepository` merges `GroceryRepository.getPendingInvitations()` with `RecipeBookCollaborationRepository.pendingInvites()` into one `Flow<List<AppNotification>>`. A refresh trigger re-fetches **both** sources after accept/decline — the grocery pending-invites flow only re-maps on auth-state change and recipe-book invites are one-shot, so neither pushes updates on its own.
- **More-tab row → Notifications**: `OpenNotifications` threaded through Settings → BottomNav → Root into a new `Configuration.Notifications` destination. The row shows for signed-in, non-anonymous users (invites are addressed to an account email).
- **Count badge** on the More-tab icon (bottom bar **and** nav rail) via Material `Badge`, driven by `NotificationsRepository` through `BottomNavViewModel`.
- **Deep linking**: `DeepLink.parse` now accepts `chefmate://notifications` and `https://chefmate.plusmobileapps.com/notifications` (host-exact check to reject lookalikes). Cold-launch via `initialStackFor`; warm-launch via new `RootBloc.handleDeepLink` wired into Android `onNewIntent` and iOS `onOpenURL` + `onContinueUserActivity`.
- **Platform App Links**: Android manifest `autoVerify` https intent filter; iOS `applinks:` associated domain. `send-invite-email` now links to `…/notifications`.

## Tests

- Repository aggregation + routing (`NotificationsRepositoryImplTest`)
- BLoC behavior incl. error toast + signed-out state (`NotificationsBlocImplTest`)
- Badge count propagation (`BottomNavViewModelTest`)
- Expanded `DeepLinkTest` (custom scheme, https, query/fragment, lookalike host) + Root nav/deep-link tests
- More → Notifications robot flow (`NotificationsNavigationUiTest`)
- 5 recorded screenshot references (light/dark/populated/empty/signed-out)

Verified: `compileDebugKotlinAndroid` passes (Metro graph resolves the new bindings), the above unit + UI tests pass, and the rendered screen was visually confirmed.

## Reviewer notes

- **App Links depend on the already-hosted well-known files.** Confirm `apple-app-site-association` `paths`/`components` include `/notifications` and `assetlinks.json` carries the current signing cert; an end-to-end device tap test (`adb shell pm get-app-links com.plusmobileapps.chefmate` → `verified`) is worth doing.
- **No bottom-bar badge snapshot** — there's no existing screenshot harness for the nav bar itself, so the badge is covered by the `notificationCount` unit test and the trivial `TabIcon` conditional rather than a new snapshot harness.
- Recipe-book invites are one-shot (no realtime), so that source's badge/list freshness relies on `refresh()` triggers (screen open, post-action). Acceptable for v1; noted as a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)