### PR TITLE
feat(recipe): public recipe sharing via deep link + unified Share button

### DIFF
--- a/client/composeApp/src/androidMain/AndroidManifest.xml
+++ b/client/composeApp/src/androidMain/AndroidManifest.xml
@@ -53,6 +53,10 @@
                         android:scheme="https"
                         android:host="chefmate.plusmobileapps.com"
                         android:pathPrefix="/notifications" />
+                <data
+                        android:scheme="https"
+                        android:host="chefmate.plusmobileapps.com"
+                        android:pathPrefix="/recipe" />
             </intent-filter>
         </activity>
 

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/FakeRecipeRemoteDataSource.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/fakes/FakeRecipeRemoteDataSource.kt
@@ -18,6 +18,8 @@ class FakeRecipeRemoteDataSource : RecipeRemoteDataSource {
 
     override suspend fun fetchAccessibleRecipes(): List<RemoteRecipe> = emptyList()
 
+    override suspend fun fetchPublicRecipe(remoteId: String): RemoteRecipe? = null
+
     override suspend fun setRecipeCategories(
         recipeRemoteId: String,
         categoryRemoteIds: Set<String>,

--- a/client/database/core/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/9.sqm
+++ b/client/database/core/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/9.sqm
@@ -1,0 +1,4 @@
+-- Public recipe sharing: flags a recipe as viewable by anyone with its share link.
+-- Mirrors the server-side `recipes.is_public` column (see the Supabase migration
+-- 20260713_add_recipe_public_sharing.sql). Private (0) is the default.
+ALTER TABLE Recipe ADD COLUMN isPublic INTEGER NOT NULL DEFAULT 0;

--- a/client/database/core/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/Recipe.sq
+++ b/client/database/core/src/commonMain/sqldelight/com/plusmobileapps/chefmate/database/Recipe.sq
@@ -21,7 +21,8 @@ CREATE TABLE Recipe (
     clientId TEXT,
     isDirty INTEGER AS Boolean NOT NULL DEFAULT 0,
     ownerId TEXT,
-    isPendingDelete INTEGER AS Boolean NOT NULL DEFAULT 0
+    isPendingDelete INTEGER AS Boolean NOT NULL DEFAULT 0,
+    isPublic INTEGER AS Boolean NOT NULL DEFAULT 0
 );
 
 getAll:
@@ -41,8 +42,8 @@ INSERT INTO Recipe (title, description, ingredients, directions, imageUrl, sourc
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 createWithRemoteId:
-INSERT INTO Recipe (title, description, ingredients, directions, imageUrl, sourceUrl, servings, prepTime, cookTime, totalTime, calories, starRating, isFavorite, createdAt, updatedAt, remoteId, clientId, ownerId)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO Recipe (title, description, ingredients, directions, imageUrl, sourceUrl, servings, prepTime, cookTime, totalTime, calories, starRating, isFavorite, createdAt, updatedAt, remoteId, clientId, ownerId, isPublic)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(remoteId) DO UPDATE SET
     title = excluded.title,
     description = excluded.description,
@@ -59,7 +60,8 @@ ON CONFLICT(remoteId) DO UPDATE SET
     isFavorite = excluded.isFavorite,
     updatedAt = excluded.updatedAt,
     clientId = excluded.clientId,
-    ownerId = excluded.ownerId;
+    ownerId = excluded.ownerId,
+    isPublic = excluded.isPublic;
 
 lastInsertId:
 SELECT MAX(id) FROM Recipe;
@@ -91,6 +93,9 @@ UPDATE Recipe SET isPendingDelete = 1, isDirty = 0 WHERE id = ?;
 
 getPendingDeletes:
 SELECT * FROM Recipe WHERE isPendingDelete = 1 AND remoteId IS NOT NULL;
+
+setPublic:
+UPDATE Recipe SET isPublic = ?, isDirty = 1, updatedAt = ? WHERE id = ?;
 
 updateRemoteId:
 UPDATE Recipe SET remoteId = ?, isDirty = 0 WHERE id = ?;

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -101,12 +101,15 @@ class RecipeDetailBlocImpl(
         fullImageRouter.subscribe { slot -> fullImageBackCallback.isEnabled = slot.child != null }
     }
 
+    override val shareLink = viewModel.shareLink
+
     override val state: StateFlow<RecipeDetailBloc.Model> =
         viewModel.state.mapState {
             RecipeDetailBloc.Model(
                 isLoading = it.isLoading,
                 isDeleting = it.isDeleting,
                 showDeleteConfirmationDialog = it.showDeleteConfirmationDialog,
+                showShareConfirmation = it.showShareConfirmation,
                 recipe = it.recipe,
                 createdAt = FixedString(dateTimeUtil.formatDateTime(instant = it.recipe.createdAt)),
                 updatedAt = FixedString(dateTimeUtil.formatDateTime(instant = it.recipe.updatedAt)),
@@ -174,6 +177,22 @@ class RecipeDetailBlocImpl(
 
     override fun onSourceUrlClicked(url: String) {
         output.onNext(Output.OpenUrl(url))
+    }
+
+    override fun onShareLinkClicked() {
+        viewModel.onShareLinkClicked()
+    }
+
+    override fun onShareConfirmed() {
+        viewModel.onShareConfirmed()
+    }
+
+    override fun onShareDismissed() {
+        viewModel.onShareDismissed()
+    }
+
+    override fun onStopSharingClicked() {
+        viewModel.onStopSharing()
     }
 
     override fun onDismissSheet() {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -1,5 +1,8 @@
 package com.plusmobileapps.chefmate.recipe.core.impl.detail
 
+import chefmate.client.recipe.core.public.generated.resources.Res
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_sign_in_required
+import com.plusmobileapps.chefmate.ChefMateUrls
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.combineStates
 import com.plusmobileapps.chefmate.di.CoachMarkController
@@ -7,6 +10,8 @@ import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import com.plusmobileapps.chefmate.text.ResourceString
+import com.plusmobileapps.chefmate.toast.ToastService
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
@@ -26,10 +31,14 @@ class RecipeDetailViewModel(
     @Main mainContext: CoroutineContext,
     private val repository: RecipeRepository,
     private val coachMarkController: CoachMarkController,
+    private val toastService: ToastService,
 ) : ViewModel(mainContext) {
 
     private val _output = Channel<Output>(Channel.BUFFERED)
     val output: Flow<Output> = _output.receiveAsFlow()
+
+    private val _shareLink = Channel<String>(Channel.BUFFERED)
+    val shareLink: Flow<String> = _shareLink.receiveAsFlow()
 
     private val _state = MutableStateFlow(State())
 
@@ -75,11 +84,45 @@ class RecipeDetailViewModel(
         }
     }
 
+    fun onShareLinkClicked() {
+        val recipe = _state.value.recipe
+        val remoteId = recipe.remoteId
+        // Already shared: skip the confirmation and share the existing link straight away.
+        if (recipe.isPublic && remoteId != null) {
+            scope.launch { _shareLink.send(ChefMateUrls.recipeShareUrl(remoteId)) }
+        } else {
+            _state.update { it.copy(showShareConfirmation = true) }
+        }
+    }
+
+    fun onShareConfirmed() {
+        _state.update { it.copy(showShareConfirmation = false) }
+        scope.launch {
+            val remoteId = repository.setRecipePublic(recipeId, isPublic = true)
+            if (remoteId != null) {
+                _shareLink.send(ChefMateUrls.recipeShareUrl(remoteId))
+            } else {
+                // setRecipePublic returns null when the recipe can't be synced — the common cause
+                // is being signed out, since a share link needs a remote (global) recipe id.
+                toastService.show(ResourceString(Res.string.recipe_detail_share_sign_in_required))
+            }
+        }
+    }
+
+    fun onShareDismissed() {
+        _state.update { it.copy(showShareConfirmation = false) }
+    }
+
+    fun onStopSharing() {
+        scope.launch { repository.setRecipePublic(recipeId, isPublic = false) }
+    }
+
     override fun onCleared() {
         super.onCleared()
         // Leaving the screen without dismissing frees the queue so other coach marks can show.
         CoachMarkId.recipeDetailSequence.forEach(coachMarkController::release)
         _output.close()
+        _shareLink.close()
     }
 
     /**
@@ -97,6 +140,7 @@ class RecipeDetailViewModel(
         val isLoading: Boolean = true,
         val isDeleting: Boolean = false,
         val showDeleteConfirmationDialog: Boolean = false,
+        val showShareConfirmation: Boolean = false,
         val recipe: Recipe = Recipe.Empty,
         val activeCoachMark: String? = null,
     )

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeBlocImpl.kt
@@ -1,0 +1,52 @@
+package com.plusmobileapps.chefmate.recipe.core.impl.share
+
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.getViewModel
+import com.plusmobileapps.chefmate.recipe.core.share.PublicRecipeBloc
+import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@AssistedInject
+@ContributesAssistedFactory(
+    scope = AppScope::class,
+    assistedFactory = PublicRecipeBloc.Factory::class,
+)
+class PublicRecipeBlocImpl(
+    @Assisted context: BlocContext,
+    @Assisted private val remoteId: String,
+    @Assisted private val output: Consumer<PublicRecipeBloc.Output>,
+    private val viewModelFactory: PublicRecipeViewModel.Factory,
+) : PublicRecipeBloc, BlocContext by context {
+
+    private val scope = createScope()
+
+    private val viewModel: PublicRecipeViewModel = instanceKeeper.getViewModel {
+        viewModelFactory.create(remoteId)
+    }
+
+    init {
+        scope.launch {
+            viewModel.output.collect { viewModelOutput ->
+                when (viewModelOutput) {
+                    is PublicRecipeViewModel.Output.OpenRecipe ->
+                        output.onNext(PublicRecipeBloc.Output.OpenRecipe(viewModelOutput.recipeId))
+                }
+            }
+        }
+    }
+
+    override val state: StateFlow<PublicRecipeBloc.Model> = viewModel.state
+
+    override fun onSaveClicked() = viewModel.onSave()
+
+    override fun onRetryClicked() = viewModel.onRetry()
+
+    override fun onBackClicked() {
+        output.onNext(PublicRecipeBloc.Output.Finished)
+    }
+}

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeViewModel.kt
@@ -1,0 +1,94 @@
+package com.plusmobileapps.chefmate.recipe.core.impl.share
+
+import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.recipe.core.share.PublicRecipeBloc
+import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+@AssistedInject
+class PublicRecipeViewModel(
+    @Assisted private val remoteId: String,
+    @Main mainContext: CoroutineContext,
+    private val repository: RecipeRepository,
+) : ViewModel(mainContext) {
+
+    private val _output = Channel<Output>(Channel.BUFFERED)
+    val output: Flow<Output> = _output.receiveAsFlow()
+
+    private val _state = MutableStateFlow<PublicRecipeBloc.Model>(PublicRecipeBloc.Model.Loading)
+    val state: StateFlow<PublicRecipeBloc.Model> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        _state.value = PublicRecipeBloc.Model.Loading
+        scope.launch {
+            // Owner/collaborator who already has this recipe: skip the read-only preview and open
+            // the real detail screen instead of offering to save a duplicate.
+            repository.getRecipeByRemoteId(remoteId)?.let { local ->
+                _output.send(Output.OpenRecipe(local.id))
+                return@launch
+            }
+            repository
+                .fetchPublicRecipe(remoteId)
+                .onSuccess { recipe ->
+                    _state.value = PublicRecipeBloc.Model.Loaded(recipe = recipe)
+                }
+                .onFailure { error ->
+                    // A missing/private recipe is a definitive "not found"; anything else (network,
+                    // serialization) is treated as a retryable transient failure.
+                    _state.value =
+                        if (error is NoSuchElementException) PublicRecipeBloc.Model.NotFound
+                        else PublicRecipeBloc.Model.Offline
+                }
+        }
+    }
+
+    fun onRetry() = load()
+
+    fun onSave() {
+        val loaded = _state.value as? PublicRecipeBloc.Model.Loaded ?: return
+        if (loaded.isSaving) return
+        _state.value = loaded.copy(isSaving = true)
+        scope.launch {
+            // Reset local/remote identity so createRecipe files a brand-new recipe owned by the
+            // current user (owner is stamped on push) rather than mutating the shared original.
+            val copy =
+                loaded.recipe.copy(
+                    id = -1,
+                    remoteId = null,
+                    isPublic = false,
+                    recipeBookIds = emptySet(),
+                )
+            val saved = repository.createRecipe(copy)
+            _output.send(Output.OpenRecipe(saved.id))
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        _output.close()
+    }
+
+    sealed class Output {
+        data class OpenRecipe(val recipeId: Long) : Output()
+    }
+
+    @AssistedFactory
+    fun interface Factory {
+        fun create(remoteId: String): PublicRecipeViewModel
+    }
+}

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
@@ -3,6 +3,8 @@
 
 package com.plusmobileapps.chefmate.recipe.core.impl.detail
 
+import chefmate.client.recipe.core.public.generated.resources.Res
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_sign_in_required
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.CoachMarkController
@@ -14,6 +16,7 @@ import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
 import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.ResourceString
 import com.plusmobileapps.chefmate.toast.testing.FakeToastService
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
 import com.plusmobileapps.chefmate.util.testing.FakeDateTimeUtil
@@ -27,7 +30,9 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlin.test.Test
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 class RecipeDetailBlocImplTest {
 
@@ -35,6 +40,7 @@ class RecipeDetailBlocImplTest {
     private val output = TestConsumer<RecipeDetailBloc.Output>()
     private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
     private val repository = FakeRecipeRepository(recipes)
+    private val toastService = FakeToastService()
 
     private val sampleRecipe =
         Recipe(
@@ -71,6 +77,7 @@ class RecipeDetailBlocImplTest {
                 mainContext = context.mainContext,
                 repository = repository,
                 coachMarkController = coachMarkController,
+                toastService = toastService,
             )
         }
         val dateTimeUtil = FakeDateTimeUtil()
@@ -178,5 +185,61 @@ class RecipeDetailBlocImplTest {
         bloc.onAddToGroceryListClicked()
         coachMarkController.hasSeen(CoachMarkId.RECIPE_DETAIL_ADD_TO_GROCERY) shouldBe false
         bloc.state.value.activeCoachMark shouldBe CoachMarkId.RECIPE_DETAIL_COOK_MODE
+    }
+
+    @Test
+    fun When_share_link_clicked_on_private_recipe_Then_confirmation_is_shown() {
+        val bloc = createBloc(sampleRecipe.copy(isPublic = false))
+        bloc.onShareLinkClicked()
+        bloc.state.value.showShareConfirmation shouldBe true
+    }
+
+    @Test
+    fun When_share_confirmed_Then_recipe_is_made_public_and_link_is_emitted() {
+        repository.setPublicResult = "abc-remote-id"
+        val bloc = createBloc(sampleRecipe.copy(isPublic = false))
+        val emitted = mutableListOf<String>()
+        val job =
+            CoroutineScope(context.mainContext).launch { bloc.shareLink.collect { emitted += it } }
+
+        bloc.onShareLinkClicked()
+        bloc.onShareConfirmed()
+
+        bloc.state.value.showShareConfirmation shouldBe false
+        repository.lastSetPublic shouldBe (sampleRecipe.id to true)
+        emitted shouldBe listOf("https://chefmate.plusmobileapps.com/recipe/abc-remote-id")
+        job.cancel()
+    }
+
+    @Test
+    fun When_share_confirmed_but_not_signed_in_Then_sign_in_toast_is_shown() {
+        // A null remote id models "couldn't publish" (e.g. signed out).
+        repository.setPublicResult = null
+        val bloc = createBloc(sampleRecipe.copy(isPublic = false))
+        bloc.onShareLinkClicked()
+        bloc.onShareConfirmed()
+        toastService.shown shouldBe
+            listOf(ResourceString(Res.string.recipe_detail_share_sign_in_required))
+    }
+
+    @Test
+    fun When_share_link_clicked_on_already_public_recipe_Then_link_emitted_without_confirmation() {
+        val bloc = createBloc(sampleRecipe.copy(isPublic = true, remoteId = "already-public"))
+        val emitted = mutableListOf<String>()
+        val job =
+            CoroutineScope(context.mainContext).launch { bloc.shareLink.collect { emitted += it } }
+
+        bloc.onShareLinkClicked()
+
+        bloc.state.value.showShareConfirmation shouldBe false
+        emitted shouldBe listOf("https://chefmate.plusmobileapps.com/recipe/already-public")
+        job.cancel()
+    }
+
+    @Test
+    fun When_stop_sharing_clicked_Then_recipe_is_made_private() {
+        val bloc = createBloc(sampleRecipe.copy(isPublic = true, remoteId = "already-public"))
+        bloc.onStopSharingClicked()
+        repository.lastSetPublic shouldBe (sampleRecipe.id to false)
     }
 }

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeBlocImplTest.kt
@@ -1,0 +1,94 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalTime::class)
+
+package com.plusmobileapps.chefmate.recipe.core.impl.share
+
+import com.plusmobileapps.chefmate.recipe.core.share.PublicRecipeBloc
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
+import com.plusmobileapps.chefmate.testing.TestBlocContext
+import com.plusmobileapps.chefmate.testing.TestConsumer
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class PublicRecipeBlocImplTest {
+
+    private val context = TestBlocContext.create()
+    private val output = TestConsumer<PublicRecipeBloc.Output>()
+    private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
+    private val repository = FakeRecipeRepository(recipes)
+
+    private val publicRecipe =
+        Recipe(
+            id = -1,
+            title = "Shared Soup",
+            description = null,
+            ingredients = "water\nsalt",
+            directions = "boil",
+            imageUrl = null,
+            sourceUrl = null,
+            servings = 2,
+            prepTime = null,
+            cookTime = null,
+            totalTime = null,
+            calories = null,
+            starRating = null,
+            remoteId = "remote-1",
+            isPublic = true,
+            createdAt = Instant.DISTANT_PAST,
+            updatedAt = Instant.DISTANT_PAST,
+        )
+
+    private fun createBloc(remoteId: String = "remote-1"): PublicRecipeBlocImpl {
+        val viewModelFactory = PublicRecipeViewModel.Factory { id ->
+            PublicRecipeViewModel(
+                remoteId = id,
+                mainContext = context.mainContext,
+                repository = repository,
+            )
+        }
+        return PublicRecipeBlocImpl(
+            context = context,
+            remoteId = remoteId,
+            output = output,
+            viewModelFactory = viewModelFactory,
+        )
+    }
+
+    @Test
+    fun When_public_recipe_found_Then_state_is_loaded() {
+        repository.publicRecipes["remote-1"] = publicRecipe
+        val bloc = createBloc()
+        val model = bloc.state.value
+        model.shouldBeInstanceOf<PublicRecipeBloc.Model.Loaded>()
+        model.recipe.title shouldBe "Shared Soup"
+    }
+
+    @Test
+    fun When_public_recipe_missing_Then_state_is_not_found() {
+        val bloc = createBloc(remoteId = "does-not-exist")
+        bloc.state.value shouldBe PublicRecipeBloc.Model.NotFound
+    }
+
+    @Test
+    fun When_recipe_already_owned_locally_Then_opens_it_without_preview() {
+        recipes.value = listOf(publicRecipe.copy(id = 5L))
+        val bloc = createBloc()
+        output.lastValue shouldBe PublicRecipeBloc.Output.OpenRecipe(5L)
+    }
+
+    @Test
+    fun When_save_clicked_Then_copy_created_and_opened() {
+        repository.publicRecipes["remote-1"] = publicRecipe
+        val bloc = createBloc()
+        bloc.onSaveClicked()
+        // FakeRecipeRepository.createRecipe returns the recipe unchanged (id -1 here); the point is
+        // that a copy was created and an OpenRecipe output emitted.
+        output.lastValue.shouldBeInstanceOf<PublicRecipeBloc.Output.OpenRecipe>()
+        recipes.value.any { it.title == "Shared Soup" } shouldBe true
+    }
+}

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -45,8 +45,29 @@
     <string name="recipe_detail_share">Share recipe</string>
 <string name="recipe_detail_share_url">Share recipe URL</string>
 <string name="recipe_detail_share_text">Share recipe text</string>
+    <string name="recipe_detail_share_link">Share recipe link</string>
+    <string name="recipe_detail_stop_sharing">Stop sharing link</string>
+    <string name="recipe_detail_public_badge">Shared</string>
+    <string name="recipe_detail_share_confirm_title">Share this recipe?</string>
+    <string name="recipe_detail_share_confirm_body">Anyone with the link will be able to view this recipe. You can stop sharing it at any time.</string>
+    <string name="recipe_detail_share_confirm_button">Share link</string>
+    <string name="recipe_detail_share_cancel">Cancel</string>
+    <string name="recipe_detail_share_sign_in_required">Sign in to share a recipe link.</string>
+    <string name="recipe_detail_share_failed">Couldn’t create a share link. Please try again.</string>
     <string name="recipe_detail_copied_to_clipboard">Copied to clipboard</string>
     <string name="recipe_full_image_close">Close</string>
+
+    <!-- Public recipe preview (opened from a shared link) -->
+    <string name="public_recipe_title">Shared recipe</string>
+    <string name="public_recipe_save">Save to my recipes</string>
+    <string name="public_recipe_saving">Saving…</string>
+    <string name="public_recipe_not_found_title">Recipe unavailable</string>
+    <string name="public_recipe_not_found_body">This recipe isn’t shared, or the link is no longer valid.</string>
+    <string name="public_recipe_offline_title">Couldn’t load recipe</string>
+    <string name="public_recipe_offline_body">Check your connection and try again.</string>
+    <string name="public_recipe_retry">Try again</string>
+    <string name="public_recipe_ingredients">Ingredients</string>
+    <string name="public_recipe_directions">Directions</string>
 
     <!-- Add to Meal Plan -->
     <string name="recipe_detail_add_to_meal_plan">Add to meal plan</string>

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -11,10 +11,18 @@ import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryList
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.ui.ComposeScreen
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 interface RecipeDetailBloc : BackClickBloc, ComposeScreen {
     val state: StateFlow<Model>
+
+    /**
+     * One-shot share-link URLs to hand to the platform share sheet. Emitted after the recipe is
+     * successfully made public (or immediately if it already was). The screen collects this and
+     * passes each URL to `rememberShareLauncher`.
+     */
+    val shareLink: Flow<String>
 
     @Composable
     override fun Content(modifier: Modifier) {
@@ -50,12 +58,28 @@ interface RecipeDetailBloc : BackClickBloc, ComposeScreen {
 
     fun onSourceUrlClicked(url: String)
 
+    /**
+     * Share a Chef Mate link to this recipe. Prompts to make it public first if it isn't already.
+     */
+    fun onShareLinkClicked()
+
+    /** Confirm the "make this recipe public" prompt, then share the link. */
+    fun onShareConfirmed()
+
+    /** Dismiss the "make this recipe public" prompt without sharing. */
+    fun onShareDismissed()
+
+    /** Make a shared recipe private again so its link stops resolving for others. */
+    fun onStopSharingClicked()
+
     fun onDismissSheet()
 
     data class Model(
         val isLoading: Boolean,
         val isDeleting: Boolean,
         val showDeleteConfirmationDialog: Boolean,
+        /** True while the "anyone with the link can view this" confirmation dialog is shown. */
+        val showShareConfirmation: Boolean = false,
         val recipe: Recipe,
         val createdAt: TextData,
         val updatedAt: TextData,

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.MoreVert
@@ -140,9 +141,15 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_prep
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_remove_favorite
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_servings
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_cancel
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_confirm_body
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_confirm_button
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_confirm_title
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_link
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_text
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_url
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_source
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_stop_sharing
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_timestamps
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_total_time
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_updated
@@ -167,6 +174,7 @@ import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.LocalAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.LocalSecondaryAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
+import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
@@ -182,6 +190,7 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
@@ -191,9 +200,33 @@ fun RecipeDetailScreen(bloc: RecipeDetailBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val shareLauncher = rememberShareLauncher()
+    val toastService = LocalToastService.current
 
     // The "added to grocery list" toast (with its View action) is fired from the BLoC through the
     // app-wide ToastService; the "copied to clipboard" toast below goes through the same service.
+
+    // Hand each share-link URL emitted by the BLoC to the platform share sheet. On desktop the
+    // launcher copies to the clipboard and returns true, so we show the same "copied" toast used by
+    // the other share options.
+    LaunchedEffect(bloc) {
+        bloc.shareLink.collect { url ->
+            if (shareLauncher(url)) {
+                toastService.show(ResourceString(Res.string.recipe_detail_copied_to_clipboard))
+            }
+        }
+    }
+
+    // "Anyone with the link can view this" confirmation before a recipe is first made public.
+    if (state.showShareConfirmation) {
+        PlusDialog(
+            title = ResourceString(Res.string.recipe_detail_share_confirm_title),
+            message = ResourceString(Res.string.recipe_detail_share_confirm_body),
+            confirmButtonText = ResourceString(Res.string.recipe_detail_share_confirm_button),
+            dismissButtonText = ResourceString(Res.string.recipe_detail_share_cancel),
+            onConfirmClick = bloc::onShareConfirmed,
+            onDismissRequest = bloc::onShareDismissed,
+        )
+    }
 
     // Delete confirmation dialog
     if (state.showDeleteConfirmationDialog) {
@@ -288,8 +321,9 @@ private fun RecipeDetailBody(
                             PlusHeaderData.TrailingAccessory.Custom {
                                 RecipeDetailActions(
                                     recipe = state.recipe,
-                                    // Compact collapses into the three-dot overflow; wider windows
-                                    // have the app-bar room to surface the actions directly.
+                                    // Compact collapses Edit/Delete into the three-dot overflow;
+                                    // wider windows surface them directly. The Share button is
+                                    // always its own dedicated control in both layouts.
                                     inlineActions = !isCompact,
                                     showOverflowMenu = showOverflowMenu,
                                     onShowOverflowMenuChange = onShowOverflowMenuChange,
@@ -300,6 +334,8 @@ private fun RecipeDetailBody(
                                             toastService.show(copiedMessage)
                                         }
                                     },
+                                    onShareLink = bloc::onShareLinkClicked,
+                                    onStopSharing = bloc::onStopSharingClicked,
                                 )
                             },
                     ),
@@ -479,52 +515,57 @@ private fun RecipeDetailActions(
     onEdit: () -> Unit,
     onDelete: () -> Unit,
     onShare: (String) -> Unit,
+    onShareLink: () -> Unit,
+    onStopSharing: () -> Unit,
 ) {
+    // A single Share button owns every share option in both layouts. Edit/Delete are surfaced
+    // inline on wide windows and collapsed into a three-dot overflow on compact ones.
     if (inlineActions) {
-        InlineRecipeActions(
+        IconButton(onClick = onEdit) {
+            Icon(
+                imageVector = Icons.Default.Edit,
+                contentDescription = stringResource(Res.string.recipe_detail_edit),
+            )
+        }
+        ShareActionButton(
             recipe = recipe,
-            onEdit = onEdit,
-            onDelete = onDelete,
             onShare = onShare,
+            onShareLink = onShareLink,
+            onStopSharing = onStopSharing,
         )
+        IconButton(onClick = onDelete) {
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = stringResource(Res.string.recipe_detail_delete),
+            )
+        }
     } else {
-        OverflowRecipeActions(
+        ShareActionButton(
             recipe = recipe,
+            onShare = onShare,
+            onShareLink = onShareLink,
+            onStopSharing = onStopSharing,
+        )
+        EditDeleteOverflow(
             expanded = showOverflowMenu,
             onExpandedChange = onShowOverflowMenuChange,
             onEdit = onEdit,
             onDelete = onDelete,
-            onShare = onShare,
         )
     }
 }
 
-/** Tablet/wide layout: Edit, Share, and Delete laid out directly in the app bar. */
+/**
+ * The single Share affordance: an icon button whose dropdown offers every share option — a Chef
+ * Mate link, the source URL (when present), the full recipe text, and, once shared, stop-sharing.
+ */
 @Composable
-private fun InlineRecipeActions(
+private fun ShareActionButton(
     recipe: Recipe,
-    onEdit: () -> Unit,
-    onDelete: () -> Unit,
     onShare: (String) -> Unit,
+    onShareLink: () -> Unit,
+    onStopSharing: () -> Unit,
 ) {
-    IconButton(onClick = onEdit) {
-        Icon(
-            imageVector = Icons.Default.Edit,
-            contentDescription = stringResource(Res.string.recipe_detail_edit),
-        )
-    }
-    ShareActionButton(recipe = recipe, onShare = onShare)
-    IconButton(onClick = onDelete) {
-        Icon(
-            imageVector = Icons.Default.Delete,
-            contentDescription = stringResource(Res.string.recipe_detail_delete),
-        )
-    }
-}
-
-/** Share icon button that owns its own dropdown for picking the source URL or the recipe text. */
-@Composable
-private fun ShareActionButton(recipe: Recipe, onShare: (String) -> Unit) {
     Box {
         var showShareMenu by remember { mutableStateOf(false) }
         IconButton(onClick = { showShareMenu = true }) {
@@ -538,20 +579,20 @@ private fun ShareActionButton(recipe: Recipe, onShare: (String) -> Unit) {
                 recipe = recipe,
                 onClose = { showShareMenu = false },
                 onShare = onShare,
+                onShareLink = onShareLink,
+                onStopSharing = onStopSharing,
             )
         }
     }
 }
 
-/** Compact layout: every action collapsed behind a single three-dot overflow menu. */
+/** Compact layout: Edit and Delete collapsed behind a single three-dot overflow menu. */
 @Composable
-private fun OverflowRecipeActions(
-    recipe: Recipe,
+private fun EditDeleteOverflow(
     expanded: Boolean,
     onExpandedChange: (Boolean) -> Unit,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
-    onShare: (String) -> Unit,
 ) {
     Box {
         IconButton(onClick = { onExpandedChange(true) }) {
@@ -569,11 +610,6 @@ private fun OverflowRecipeActions(
                     onEdit()
                 },
             )
-            RecipeShareMenuItems(
-                recipe = recipe,
-                onClose = { onExpandedChange(false) },
-                onShare = onShare,
-            )
             DropdownMenuItem(
                 text = { Text(stringResource(Res.string.recipe_detail_delete)) },
                 leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
@@ -587,15 +623,27 @@ private fun OverflowRecipeActions(
 }
 
 /**
- * The two share entries — the source URL (only when present) and the full recipe text — shared by
- * both the compact overflow menu and the tablet Share button's own dropdown.
+ * The share entries in the Share button's dropdown: a Chef Mate recipe link (always), the source
+ * URL (only when present), the full recipe text, and — once the recipe is public — a stop-sharing
+ * entry. The link and stop-sharing actions route through the BLoC (they toggle public visibility);
+ * the URL and text actions share content directly via [onShare].
  */
 @Composable
 private fun RecipeShareMenuItems(
     recipe: Recipe,
     onClose: () -> Unit,
     onShare: (String) -> Unit,
+    onShareLink: () -> Unit,
+    onStopSharing: () -> Unit,
 ) {
+    DropdownMenuItem(
+        text = { Text(stringResource(Res.string.recipe_detail_share_link)) },
+        leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
+        onClick = {
+            onClose()
+            onShareLink()
+        },
+    )
     recipe.sourceUrl?.let { url ->
         DropdownMenuItem(
             text = { Text(stringResource(Res.string.recipe_detail_share_url)) },
@@ -614,6 +662,16 @@ private fun RecipeShareMenuItems(
             onShare(formatRecipeAsText(recipe))
         },
     )
+    if (recipe.isPublic) {
+        DropdownMenuItem(
+            text = { Text(stringResource(Res.string.recipe_detail_stop_sharing)) },
+            leadingIcon = { Icon(Icons.Default.LinkOff, contentDescription = null) },
+            onClick = {
+                onClose()
+                onStopSharing()
+            },
+        )
+    }
 }
 
 /**
@@ -1839,6 +1897,8 @@ val previewRecipeDetailBloc: RecipeDetailBloc =
                     showDeleteConfirmationDialog = false,
                 )
             )
+        override val shareLink = emptyFlow<String>()
+
         override val childSlot: Value<ChildSlot<*, RecipeDetailBloc.Sheet>> =
             MutableValue(ChildSlot<Any, RecipeDetailBloc.Sheet>(null))
 
@@ -1891,6 +1951,22 @@ val previewRecipeDetailBloc: RecipeDetailBloc =
 
         override fun onSourceUrlClicked(url: String) {
             TODO("Not yet implemented")
+        }
+
+        override fun onShareLinkClicked() {
+            // Preview no-op
+        }
+
+        override fun onShareConfirmed() {
+            // Preview no-op
+        }
+
+        override fun onShareDismissed() {
+            // Preview no-op
+        }
+
+        override fun onStopSharingClicked() {
+            // Preview no-op
         }
 
         override fun onDismissSheet() {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/share/PublicRecipeBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/share/PublicRecipeBloc.kt
@@ -1,0 +1,61 @@
+package com.plusmobileapps.chefmate.recipe.core.share
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.plusmobileapps.chefmate.BackClickBloc
+import com.plusmobileapps.chefmate.BlocContext
+import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.ui.ComposeScreen
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Read-only preview of a recipe opened from a shared link (`https://…/recipe/<remoteId>`) by a
+ * recipient who doesn't own or collaborate on it. It fetches the public recipe by its remote id and
+ * offers to save an owned copy. Recipients who already have the recipe locally are routed straight
+ * to the normal [com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc] instead.
+ */
+interface PublicRecipeBloc : BackClickBloc, ComposeScreen {
+    val state: StateFlow<Model>
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        PublicRecipePreviewScreen(bloc = this, modifier = modifier)
+    }
+
+    /** Saves an owned copy of the previewed recipe into the user's own recipes. */
+    fun onSaveClicked()
+
+    /** Retries the fetch after a load failure. */
+    fun onRetryClicked()
+
+    sealed interface Model {
+        data object Loading : Model
+
+        data class Loaded(val recipe: Recipe, val isSaving: Boolean = false) : Model
+
+        /** The recipe isn't public, was deleted, or the id is invalid. */
+        data object NotFound : Model
+
+        /** The fetch failed for a transient reason (e.g. no connectivity). */
+        data object Offline : Model
+    }
+
+    sealed class Output {
+        data object Finished : Output()
+
+        /**
+         * Open the recipe in the normal detail screen, carrying its local id. Emitted both when the
+         * recipient already had the recipe locally (resolved by remote id) and after saving a copy.
+         */
+        data class OpenRecipe(val recipeId: Long) : Output()
+    }
+
+    fun interface Factory {
+        fun create(
+            context: BlocContext,
+            remoteId: String,
+            output: Consumer<Output>,
+        ): PublicRecipeBloc
+    }
+}

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/share/PublicRecipePreviewScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/share/PublicRecipePreviewScreen.kt
@@ -1,0 +1,188 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.plusmobileapps.chefmate.recipe.core.share
+
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import chefmate.client.recipe.core.public.generated.resources.Res
+import chefmate.client.recipe.core.public.generated.resources.public_recipe_directions
+import chefmate.client.recipe.core.public.generated.resources.public_recipe_ingredients
+import chefmate.client.recipe.core.public.generated.resources.public_recipe_not_found_body
+import chefmate.client.recipe.core.public.generated.resources.public_recipe_not_found_title
+import chefmate.client.recipe.core.public.generated.resources.public_recipe_offline_body
+import chefmate.client.recipe.core.public.generated.resources.public_recipe_offline_title
+import chefmate.client.recipe.core.public.generated.resources.public_recipe_retry
+import chefmate.client.recipe.core.public.generated.resources.public_recipe_save
+import chefmate.client.recipe.core.public.generated.resources.public_recipe_title
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.components.PlusButton
+import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
+import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
+import com.plusmobileapps.chefmate.ui.components.RecipeImage
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlin.time.ExperimentalTime
+import org.jetbrains.compose.resources.stringResource
+
+/** Stable test tags for the public recipe preview screen, shared with its UI-test robot. */
+object PublicRecipeTestTags {
+    const val SCREEN: String = "public_recipe_screen"
+    const val SAVE_BUTTON: String = "public_recipe_save_button"
+}
+
+@Composable
+fun PublicRecipePreviewScreen(bloc: PublicRecipeBloc, modifier: Modifier = Modifier) {
+    val state by bloc.state.collectAsState()
+    Box(modifier = modifier.fillMaxSize().testTag(PublicRecipeTestTags.SCREEN)) {
+        PlusHeaderContainer(
+            modifier = Modifier.fillMaxSize(),
+            data =
+                PlusHeaderData.Child(
+                    title = Res.string.public_recipe_title.asTextData(),
+                    onBackClick = bloc::onBackClicked,
+                ),
+            scrollEnabled = false,
+        ) {
+            when (val model = state) {
+                PublicRecipeBloc.Model.Loading ->
+                    CenteredMessage { PlusLoadingIndicator(modifier = Modifier.size(48.dp)) }
+                PublicRecipeBloc.Model.NotFound ->
+                    CenteredMessage {
+                        MessageBlock(
+                            title = stringResource(Res.string.public_recipe_not_found_title),
+                            body = stringResource(Res.string.public_recipe_not_found_body),
+                        )
+                    }
+                PublicRecipeBloc.Model.Offline ->
+                    CenteredMessage {
+                        MessageBlock(
+                            title = stringResource(Res.string.public_recipe_offline_title),
+                            body = stringResource(Res.string.public_recipe_offline_body),
+                        )
+                        PlusButton(
+                            text = Res.string.public_recipe_retry.asTextData(),
+                            variant = PlusButtonVariant.SECONDARY,
+                            onClick = bloc::onRetryClicked,
+                        )
+                    }
+                is PublicRecipeBloc.Model.Loaded -> LoadedContent(model, bloc::onSaveClicked)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadedContent(model: PublicRecipeBloc.Model.Loaded, onSave: () -> Unit) {
+    val recipe = model.recipe
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(ChefMateTheme.dimens.paddingNormal),
+        verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingNormal),
+    ) {
+        if (recipe.imageUrl != null) {
+            RecipeImage(
+                imageUrl = recipe.imageUrl,
+                contentDescription = recipe.title,
+                modifier = Modifier.fillMaxWidth().height(220.dp).clip(RoundedCornerShape(16.dp)),
+            )
+        }
+        Text(text = recipe.title, style = MaterialTheme.typography.headlineSmall)
+        recipe.description
+            ?.takeIf { it.isNotBlank() }
+            ?.let { description ->
+                Text(text = description, style = MaterialTheme.typography.bodyMedium)
+            }
+        RecipeSection(
+            title = stringResource(Res.string.public_recipe_ingredients),
+            body = recipe.ingredients,
+        )
+        RecipeSection(
+            title = stringResource(Res.string.public_recipe_directions),
+            body = recipe.directions,
+        )
+        PlusButton(
+            text = Res.string.public_recipe_save.asTextData(),
+            isLoading = model.isSaving,
+            modifier = Modifier.fillMaxWidth().testTag(PublicRecipeTestTags.SAVE_BUTTON),
+            onClick = onSave,
+        )
+    }
+}
+
+@Composable
+private fun RecipeSection(title: String, body: String) {
+    if (body.isBlank()) return
+    Column(verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingExtraSmall)) {
+        Text(text = title, style = MaterialTheme.typography.titleMedium)
+        Text(text = body, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun CenteredMessage(content: @Composable () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(ChefMateTheme.dimens.paddingLarge),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            spacedBy(ChefMateTheme.dimens.paddingNormal, Alignment.CenterVertically),
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun MessageBlock(title: String, body: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleLarge,
+        textAlign = TextAlign.Center,
+    )
+    Text(
+        text = body,
+        style = MaterialTheme.typography.bodyMedium,
+        textAlign = TextAlign.Center,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+/** Fake bloc in a fixed [model] for @Preview and screenshot tests. */
+fun previewPublicRecipeBloc(model: PublicRecipeBloc.Model): PublicRecipeBloc =
+    object : PublicRecipeBloc {
+        override val state = kotlinx.coroutines.flow.MutableStateFlow(model)
+
+        override fun onSaveClicked() = Unit
+
+        override fun onRetryClicked() = Unit
+
+        override fun onBackClicked() = Unit
+    }
+
+val previewPublicRecipeLoadedBloc: PublicRecipeBloc =
+    previewPublicRecipeBloc(PublicRecipeBloc.Model.Loaded(recipe = Recipe.Sample))
+
+val previewPublicRecipeNotFoundBloc: PublicRecipeBloc =
+    previewPublicRecipeBloc(PublicRecipeBloc.Model.NotFound)

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
@@ -178,6 +178,35 @@ class RecipeRepositoryImpl(
             .map { row -> row?.takeUnless { it.isPendingDelete }?.toRecipe() }
             .flowOn(ioContext)
 
+    override suspend fun getRecipeByRemoteId(remoteId: String): Recipe? =
+        withContext(ioContext) {
+            db.getByRemoteId(remoteId)
+                .executeAsOneOrNull()
+                ?.takeUnless { it.isPendingDelete }
+                ?.toRecipe()
+        }
+
+    override suspend fun fetchPublicRecipe(remoteId: String): Result<Recipe> = runCatching {
+        val remote =
+            remoteDataSource.fetchPublicRecipe(remoteId)
+                ?: throw NoSuchElementException("No public recipe with id $remoteId")
+        remote.toPublicPreview()
+    }
+
+    override suspend fun setRecipePublic(id: Long, isPublic: Boolean): String? {
+        // Publishing requires a remote row (the share link embeds the remote id), which requires
+        // auth. Bail early so the caller can prompt the user to sign in.
+        if (authRepository.state.value !is AuthState.Authenticated) return null
+        withContext(ioContext) {
+            db.setPublic(isPublic = isPublic, updatedAt = dateTimeUtil.now.toString(), id = id)
+        }
+        val existingRemoteId =
+            withContext(ioContext) { db.getById(id).executeAsOneOrNull()?.remoteId }
+        // Create the remote row on first publish, otherwise push the flag change.
+        if (existingRemoteId == null) pushAddToRemote(id) else pushUpdateToRemote(id)
+        return withContext(ioContext) { db.getById(id).executeAsOneOrNull()?.remoteId }
+    }
+
     override suspend fun deleteRecipe(id: Long) {
         val entity = withContext(ioContext) { db.getById(id).executeAsOneOrNull() } ?: return
         val remoteId = entity.remoteId
@@ -244,6 +273,7 @@ class RecipeRepositoryImpl(
                             calories = entity.calories?.toInt(),
                             starRating = entity.starRating?.toInt(),
                             isFavorite = entity.isFavorite,
+                            isPublic = entity.isPublic,
                             createdAt = entity.createdAt,
                             updatedAt = entity.updatedAt,
                             clientId = clientId,
@@ -293,6 +323,7 @@ class RecipeRepositoryImpl(
                         calories = entity.calories?.toInt(),
                         starRating = entity.starRating?.toInt(),
                         isFavorite = entity.isFavorite,
+                        isPublic = entity.isPublic,
                         updatedAt = entity.updatedAt,
                         clientId = entity.clientId,
                     )
@@ -349,6 +380,7 @@ class RecipeRepositoryImpl(
                                 calories = recipe.calories?.toInt(),
                                 starRating = recipe.starRating?.toInt(),
                                 isFavorite = recipe.isFavorite,
+                                isPublic = recipe.isPublic,
                                 createdAt = recipe.createdAt,
                                 updatedAt = recipe.updatedAt,
                                 clientId = clientId,
@@ -392,6 +424,7 @@ class RecipeRepositoryImpl(
                             calories = recipe.calories?.toInt(),
                             starRating = recipe.starRating?.toInt(),
                             isFavorite = recipe.isFavorite,
+                            isPublic = recipe.isPublic,
                             updatedAt = recipe.updatedAt,
                             clientId = recipe.clientId,
                         )
@@ -441,6 +474,7 @@ class RecipeRepositoryImpl(
                             // Preserve the real owner so shared recipes aren't mistaken for the
                             // current user's own; defensively fall back to the syncing user.
                             ownerId = remote.ownerId.ifBlank { userId },
+                            isPublic = remote.isPublic,
                         )
                     }
                 }
@@ -619,10 +653,38 @@ class RecipeRepositoryImpl(
             categories = attachedCategories.toSet(),
             recipeBookIds = bookJoinDb.getBookIdsForRecipe(id).executeAsList().toSet(),
             syncStatus = syncStatus,
+            remoteId = remoteId,
+            isPublic = isPublic,
             createdAt = Instant.parse(createdAt),
             updatedAt = Instant.parse(updatedAt),
         )
     }
+
+    /** Maps a remotely-fetched public recipe into a transient (unsaved) domain [Recipe]. */
+    private fun RemoteRecipe.toPublicPreview(): Recipe =
+        Recipe(
+            id = -1,
+            title = title,
+            description = description,
+            ingredients = ingredients.orEmpty(),
+            directions = directions.orEmpty(),
+            imageUrl = imageUrl,
+            sourceUrl = sourceUrl,
+            servings = servings,
+            prepTime = prepTime,
+            cookTime = cookTime,
+            totalTime = totalTime,
+            calories = calories,
+            starRating = starRating,
+            isFavorite = false,
+            categories = emptySet(),
+            recipeBookIds = emptySet(),
+            syncStatus = SyncStatus.SYNCED,
+            remoteId = id,
+            isPublic = isPublic,
+            createdAt = createdAt?.let { Instant.parse(it) } ?: Instant.DISTANT_PAST,
+            updatedAt = updatedAt?.let { Instant.parse(it) } ?: Instant.DISTANT_PAST,
+        )
 
     private companion object {
         const val TAG = "RecipeRepositoryImpl"

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RecipeRemoteDataSource.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RecipeRemoteDataSource.kt
@@ -12,6 +12,13 @@ interface RecipeRemoteDataSource {
     suspend fun fetchAccessibleRecipes(): List<RemoteRecipe>
 
     /**
+     * Fetches a single recipe by its remote id, but only if it has been marked public. Returns null
+     * when no public recipe with that id exists (missing, or private and outside RLS access). Used
+     * to render a shared recipe link for a recipient who doesn't own or collaborate on it.
+     */
+    suspend fun fetchPublicRecipe(remoteId: String): RemoteRecipe?
+
+    /**
      * Replaces the recipe's attached-category set in the `recipe_categories` join table: deletes
      * any rows for [recipeRemoteId] whose `category_id` isn't in [categoryRemoteIds], then inserts
      * the missing rows. Idempotent — safe to call repeatedly with the same set.

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RemoteRecipe.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RemoteRecipe.kt
@@ -20,6 +20,7 @@ data class RemoteRecipe(
     val calories: Int? = null,
     @SerialName("star_rating") val starRating: Int? = null,
     @SerialName("is_favorite") val isFavorite: Boolean = false,
+    @SerialName("is_public") val isPublic: Boolean = false,
     @SerialName("created_at") val createdAt: String? = null,
     @SerialName("updated_at") val updatedAt: String? = null,
     @SerialName("client_id") val clientId: String? = null,

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipeRemoteDataSource.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipeRemoteDataSource.kt
@@ -32,6 +32,17 @@ class SupabaseRecipeRemoteDataSource(private val supabaseClient: SupabaseClient)
     override suspend fun fetchAccessibleRecipes(): List<RemoteRecipe> =
         supabaseClient.from("recipes").select().decodeList<RemoteRecipe>()
 
+    override suspend fun fetchPublicRecipe(remoteId: String): RemoteRecipe? =
+        supabaseClient
+            .from("recipes")
+            .select {
+                filter {
+                    eq("id", remoteId)
+                    eq("is_public", true)
+                }
+            }
+            .decodeSingleOrNull<RemoteRecipe>()
+
     override suspend fun setRecipeCategories(
         recipeRemoteId: String,
         categoryRemoteIds: Set<String>,

--- a/client/recipe/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImplTest.kt
+++ b/client/recipe/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImplTest.kt
@@ -26,6 +26,7 @@ import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 
@@ -404,6 +405,63 @@ class RecipeRepositoryImplTest {
         return db.recipeBookQueries.lastInsertId().executeAsOne().MAX!!
     }
 
+    @Test
+    fun setRecipePublic_when_authenticated_flags_public_and_returns_remote_id() =
+        runTest(testDispatcher) {
+            fakeAuth.setAuthenticated()
+            val created = recipeRepository.createRecipe(blankRecipe("Shared Stew"))
+
+            val remoteId = recipeRepository.setRecipePublic(created.id, isPublic = true)
+
+            remoteId shouldBe recipeRepository.getRecipe(created.id).first()?.remoteId
+            (remoteId != null) shouldBe true
+            recipeRepository.getRecipe(created.id).first()?.isPublic shouldBe true
+        }
+
+    @Test
+    fun setRecipePublic_when_unauthenticated_returns_null() =
+        runTest(testDispatcher) {
+            val created = recipeRepository.createRecipe(blankRecipe("Private Pie"))
+            recipeRepository.setRecipePublic(created.id, isPublic = true) shouldBe null
+        }
+
+    @Test
+    fun fetchPublicRecipe_maps_a_public_remote_recipe() =
+        runTest(testDispatcher) {
+            recipeRemote.publicRecipe =
+                RemoteRecipe(
+                    id = "pub-1",
+                    ownerId = "another-user",
+                    title = "Public Pancakes",
+                    ingredients = "flour",
+                    directions = "mix",
+                    isPublic = true,
+                )
+
+            val result = recipeRepository.fetchPublicRecipe("pub-1")
+
+            result.isSuccess shouldBe true
+            result.getOrNull()?.title shouldBe "Public Pancakes"
+            result.getOrNull()?.remoteId shouldBe "pub-1"
+            result.getOrNull()?.isPublic shouldBe true
+        }
+
+    @Test
+    fun fetchPublicRecipe_fails_when_recipe_is_not_public() =
+        runTest(testDispatcher) {
+            recipeRepository.fetchPublicRecipe("missing").isFailure shouldBe true
+        }
+
+    @Test
+    fun getRecipeByRemoteId_returns_the_local_recipe() =
+        runTest(testDispatcher) {
+            fakeAuth.setAuthenticated()
+            val created = recipeRepository.createRecipe(blankRecipe("Findable"))
+            val remoteId = recipeRepository.getRecipe(created.id).first()?.remoteId
+
+            recipeRepository.getRecipeByRemoteId(remoteId!!)?.title shouldBe "Findable"
+        }
+
     private fun blankRecipe(title: String, categories: Set<Category> = emptySet()) =
         Recipe(
             id = -1,
@@ -446,6 +504,13 @@ class RecipeRepositoryImplTest {
         }
 
         override suspend fun fetchAccessibleRecipes(): List<RemoteRecipe> = fetchResult
+
+        var publicRecipe: RemoteRecipe? = null
+
+        override suspend fun fetchPublicRecipe(remoteId: String): RemoteRecipe? =
+            publicRecipe?.takeIf {
+                it.id == remoteId
+            }
 
         override suspend fun setRecipeCategories(
             recipeRemoteId: String,

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/Recipe.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/Recipe.kt
@@ -27,6 +27,10 @@ data class Recipe(
      */
     val recipeBookIds: Set<Long> = emptySet(),
     val syncStatus: SyncStatus = SyncStatus.NOT_SYNCED,
+    /** The recipe's global Supabase id, present once synced; the identifier used in share links. */
+    val remoteId: String? = null,
+    /** True when the owner has published this recipe so anyone with its share link can view it. */
+    val isPublic: Boolean = false,
     val createdAt: Instant,
     val updatedAt: Instant,
 ) {

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeRepository.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeRepository.kt
@@ -24,6 +24,28 @@ interface RecipeRepository {
 
     suspend fun getRecipe(id: Long): Flow<Recipe?>
 
+    /**
+     * Looks up a locally-stored recipe by its global [remoteId], or null if none is stored. Used to
+     * resolve a shared recipe link to a recipe the current user already owns or collaborates on so
+     * it opens in the normal detail screen instead of the read-only public preview.
+     */
+    suspend fun getRecipeByRemoteId(remoteId: String): Recipe?
+
+    /**
+     * Fetches a public recipe by its global [remoteId] from the remote source, for a recipient
+     * opening a share link to a recipe they don't have locally. The returned [Recipe] is transient
+     * (not persisted; local [Recipe.id] is -1) — call [createRecipe] to save an owned copy. Fails
+     * when the recipe isn't public/accessible or the fetch errors (e.g. offline).
+     */
+    suspend fun fetchPublicRecipe(remoteId: String): Result<Recipe>
+
+    /**
+     * Marks the recipe [id] public or private, ensuring it is pushed to the remote first (so it has
+     * a [Recipe.remoteId]). Returns the recipe's remote id — the identifier a share link embeds —
+     * or null if it couldn't be synced (e.g. signed out, or the push failed).
+     */
+    suspend fun setRecipePublic(id: Long, isPublic: Boolean): String?
+
     suspend fun deleteRecipe(id: Long)
 
     suspend fun clearLocalData()

--- a/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeRepository.kt
+++ b/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeRepository.kt
@@ -11,6 +11,18 @@ import kotlinx.coroutines.flow.map
 class FakeRecipeRepository(
     private val recipes: MutableStateFlow<List<Recipe>> = MutableStateFlow(emptyList())
 ) : RecipeRepository {
+
+    /** Public recipes reachable by remote id via [fetchPublicRecipe], keyed by remote id. */
+    val publicRecipes: MutableMap<String, Recipe> = mutableMapOf()
+
+    /**
+     * Remote id returned by [setRecipePublic]; null simulates an unauthenticated/failed publish.
+     */
+    var setPublicResult: String? = "remote-id"
+
+    /** Records the last [setRecipePublic] invocation for assertions. */
+    var lastSetPublic: Pair<Long, Boolean>? = null
+
     override fun getRecipes(): Flow<List<Recipe>> = recipes.asStateFlow()
 
     override fun getRecipes(presets: Set<BuiltinCategory>?): Flow<List<Recipe>> =
@@ -36,6 +48,19 @@ class FakeRecipeRepository(
     override suspend fun getRecipe(id: Long): Flow<Recipe?> =
         recipes.value.firstOrNull { it.id == id }?.let { MutableStateFlow(it) }
             ?: MutableStateFlow(null)
+
+    override suspend fun getRecipeByRemoteId(remoteId: String): Recipe? =
+        recipes.value.firstOrNull { it.remoteId == remoteId }
+
+    override suspend fun fetchPublicRecipe(remoteId: String): Result<Recipe> =
+        publicRecipes[remoteId]?.let { Result.success(it) }
+            ?: Result.failure(NoSuchElementException("No public recipe with id $remoteId"))
+
+    override suspend fun setRecipePublic(id: Long, isPublic: Boolean): String? {
+        lastSetPublic = id to isPublic
+        recipes.value = recipes.value.map { if (it.id == id) it.copy(isPublic = isPublic) else it }
+        return setPublicResult
+    }
 
     override suspend fun deleteRecipe(id: Long) {
         recipes.value = recipes.value.filterNot { it.id == id }

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -9,6 +9,7 @@ import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.router.stack.replaceAll
+import com.arkivanov.decompose.router.stack.replaceCurrent
 import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.aichat.AiChatRootBloc
@@ -32,6 +33,7 @@ import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc.Props.Detail
+import com.plusmobileapps.chefmate.recipe.core.share.PublicRecipeBloc
 import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
 import com.plusmobileapps.chefmate.recipebook.edit.EditRecipeBookBloc
 import com.plusmobileapps.chefmate.root.RootBloc.Child.BottomNavigation
@@ -54,6 +56,7 @@ class RootBlocImpl(
     private val bottomNav: BottomNavBloc.Factory,
     private val browserRootBlocFactory: BrowserRootBloc.Factory,
     private val recipeRoot: RecipeRootBloc.Factory,
+    private val publicRecipe: PublicRecipeBloc.Factory,
     private val mealPlannerRoot: MealPlannerRootBloc.Factory,
     private val authentication: AuthenticationBloc.Factory,
     private val otpBloc: OtpBloc.Factory,
@@ -105,6 +108,11 @@ class RootBlocImpl(
             DeepLink.MealPlanner -> listOf(Configuration.BottomNavigation)
             is DeepLink.RecipeDetail ->
                 listOf(Configuration.BottomNavigation, RecipeRoot(Detail(deepLink.recipeId)))
+            is DeepLink.PublicRecipe ->
+                listOf(
+                    Configuration.BottomNavigation,
+                    Configuration.PublicRecipe(deepLink.remoteId),
+                )
             DeepLink.AppSettings ->
                 listOf(Configuration.BottomNavigation, Configuration.SettingsRoot())
             DeepLink.Notifications ->
@@ -143,6 +151,8 @@ class RootBlocImpl(
             DeepLink.AppSettings -> navigation.bringToFront(Configuration.SettingsRoot())
             is DeepLink.RecipeDetail ->
                 navigation.bringToFront(RecipeRoot(Detail(deepLink.recipeId)))
+            is DeepLink.PublicRecipe ->
+                navigation.bringToFront(Configuration.PublicRecipe(deepLink.remoteId))
             DeepLink.Groceries -> {
                 selectBottomNavTab(BottomNavBloc.Tab.GROCERIES)
                 navigation.bringToFront(Configuration.BottomNavigation)
@@ -206,6 +216,16 @@ class RootBlocImpl(
                             context = context,
                             props = config.props,
                             output = ::handleRecipeRootOutput,
+                        )
+                )
+
+            is Configuration.PublicRecipe ->
+                RootBloc.Child.PublicRecipe(
+                    bloc =
+                        publicRecipe.create(
+                            context = context,
+                            remoteId = config.remoteId,
+                            output = ::handlePublicRecipeOutput,
                         )
                 )
 
@@ -587,6 +607,17 @@ class RootBlocImpl(
         }
     }
 
+    private fun handlePublicRecipeOutput(output: PublicRecipeBloc.Output) {
+        when (output) {
+            PublicRecipeBloc.Output.Finished -> navigation.pop()
+            // Replace the preview with the real detail screen — the recipe is now in the user's
+            // library (either already owned, or just saved as a copy), so back shouldn't return to
+            // the read-only preview.
+            is PublicRecipeBloc.Output.OpenRecipe ->
+                navigation.replaceCurrent(RecipeRoot(Detail(output.recipeId)))
+        }
+    }
+
     private fun handleAuthenticationOutput(output: AuthenticationBloc.Output) {
         when (output) {
             AuthenticationBloc.Output.Finished -> navigation.pop()
@@ -639,6 +670,8 @@ class RootBlocImpl(
         @Serializable data object BottomNavigation : Configuration()
 
         @Serializable data class RecipeRoot(val props: RecipeRootBloc.Props) : Configuration()
+
+        @Serializable data class PublicRecipe(val remoteId: String) : Configuration()
 
         @Serializable
         data class Authentication(val props: AuthenticationBloc.Props) : Configuration()

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/DeepLinkTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/DeepLinkTest.kt
@@ -2,6 +2,7 @@
 
 package com.plusmobileapps.chefmate.root
 
+import com.plusmobileapps.chefmate.ChefMateUrls
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
@@ -29,10 +30,24 @@ class DeepLinkTest {
     }
 
     @Test
-    fun parse_recipe_detail_returns_none_when_id_is_missing_or_invalid() {
+    fun parse_recipe_detail_returns_none_when_id_segment_is_missing() {
         DeepLink.parse("chefmate://recipe") shouldBe DeepLink.None
         DeepLink.parse("chefmate://recipe/") shouldBe DeepLink.None
-        DeepLink.parse("chefmate://recipe/abc") shouldBe DeepLink.None
+    }
+
+    @Test
+    fun parse_non_numeric_recipe_segment_is_a_public_share_link() {
+        // A non-numeric id is a global remote UUID from a cross-user share link, not a local id.
+        DeepLink.parse("chefmate://recipe/abc") shouldBe DeepLink.PublicRecipe("abc")
+        val uuid = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+        DeepLink.parse("https://chefmate.plusmobileapps.com/recipe/$uuid") shouldBe
+            DeepLink.PublicRecipe(uuid)
+    }
+
+    @Test
+    fun recipe_share_url_round_trips_through_parse() {
+        val uuid = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+        DeepLink.parse(ChefMateUrls.recipeShareUrl(uuid)) shouldBe DeepLink.PublicRecipe(uuid)
     }
 
     @Test

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -18,6 +18,7 @@ import com.plusmobileapps.chefmate.onboarding.OnboardingRootBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
+import com.plusmobileapps.chefmate.recipe.core.share.PublicRecipeBloc
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
 import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
 import com.plusmobileapps.chefmate.settings.root.SettingsRootBloc
@@ -35,6 +36,8 @@ class RootBlocTest {
     var bottomNavOutput: Consumer<BottomNavBloc.Output> = Consumer {}
     var recipeOutput: Consumer<RecipeRootBloc.Output> = Consumer {}
     var recipeProps: RecipeRootBloc.Props? = null
+    var publicRecipeOutput: Consumer<PublicRecipeBloc.Output> = Consumer {}
+    var publicRecipeRemoteId: String? = null
     var settingsRootOutput: Consumer<SettingsRootBloc.Output> = Consumer {}
     var settingsRootProps: SettingsRootBloc.Props? = null
     var manageProfileOutput:
@@ -95,6 +98,11 @@ class RootBlocTest {
             recipeRoot = { _, props, output ->
                 recipeOutput = output
                 recipeProps = props
+                mock()
+            },
+            publicRecipe = { _, remoteId, output ->
+                publicRecipeRemoteId = remoteId
+                publicRecipeOutput = output
                 mock()
             },
             mealPlannerRoot = MealPlannerRootBloc.Factory { _, _, _ -> mock() },
@@ -434,6 +442,23 @@ class RootBlocTest {
         root.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
         root.state.value.backStack.size shouldBe 1
         recipeProps shouldBe RecipeRootBloc.Props.Detail(recipeId = 42L)
+    }
+
+    @Test
+    fun Given_public_recipe_deeplink_When_initialized_Then_public_recipe_is_on_top() {
+        val uuid = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+        val root = createRoot(DeepLink.PublicRecipe(remoteId = uuid))
+        root.instance() should instanceOf<RootBloc.Child.PublicRecipe>()
+        root.state.value.backStack.size shouldBe 1
+        publicRecipeRemoteId shouldBe uuid
+    }
+
+    @Test
+    fun Given_running_app_When_public_recipe_deeplink_handled_Then_public_recipe_is_shown() {
+        val uuid = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+        rootBloc.handleDeepLink("https://chefmate.plusmobileapps.com/recipe/$uuid")
+        rootBloc.instance() should instanceOf<RootBloc.Child.PublicRecipe>()
+        publicRecipeRemoteId shouldBe uuid
     }
 
     @Test

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/DeepLink.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/DeepLink.kt
@@ -1,9 +1,18 @@
 package com.plusmobileapps.chefmate.root
 
+import com.plusmobileapps.chefmate.ChefMateUrls
+
 sealed class DeepLink {
     data object None : DeepLink()
 
     data class RecipeDetail(val recipeId: Long) : DeepLink()
+
+    /**
+     * A shared recipe link keyed by the recipe's global [remoteId] (a Supabase UUID). Distinct from
+     * [RecipeDetail], whose id is a device-local `Long` only meaningful to the current user; this
+     * is the cross-user share form (`https://chefmate.plusmobileapps.com/recipe/<uuid>`).
+     */
+    data class PublicRecipe(val remoteId: String) : DeepLink()
 
     data object Groceries : DeepLink()
 
@@ -18,13 +27,13 @@ sealed class DeepLink {
     data object SignUp : DeepLink()
 
     companion object {
-        const val SCHEME: String = "chefmate"
+        const val SCHEME: String = ChefMateUrls.SCHEME
 
         /**
          * Host of the Universal Link / App Link web domain, e.g.
          * https://chefmate.plusmobileapps.com.
          */
-        const val WEB_HOST: String = "chefmate.plusmobileapps.com"
+        const val WEB_HOST: String = ChefMateUrls.WEB_HOST
 
         fun parse(uri: String?): DeepLink {
             if (uri.isNullOrBlank()) return None
@@ -32,8 +41,10 @@ sealed class DeepLink {
             val host = segments.firstOrNull() ?: return None
             return when (host) {
                 "recipe" -> {
-                    val id = segments.getOrNull(1)?.toLongOrNull() ?: return None
-                    RecipeDetail(id)
+                    val segment = segments.getOrNull(1) ?: return None
+                    // A numeric id is the device-local RecipeDetail (dev/internal navigation); a
+                    // non-numeric segment is a global remote UUID from a cross-user share link.
+                    segment.toLongOrNull()?.let { RecipeDetail(it) } ?: PublicRecipe(segment)
                 }
                 "groceries" -> Groceries
                 "meal-planner" -> MealPlanner

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -19,6 +19,7 @@ import com.plusmobileapps.chefmate.profile.ManageProfileBloc
 import com.plusmobileapps.chefmate.recipe.bottomnav.BottomNavBloc
 import com.plusmobileapps.chefmate.recipe.core.addmeal.MealPlannerRootBloc
 import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
+import com.plusmobileapps.chefmate.recipe.core.share.PublicRecipeBloc
 import com.plusmobileapps.chefmate.recipe.exporter.ExportRecipesBloc
 import com.plusmobileapps.chefmate.recipebook.edit.EditRecipeBookBloc
 import com.plusmobileapps.chefmate.settings.root.SettingsRootBloc
@@ -45,6 +46,8 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class BottomNavigation(override val bloc: BottomNavBloc) : Child()
 
         data class RecipeRoot(override val bloc: RecipeRootBloc) : Child()
+
+        data class PublicRecipe(override val bloc: PublicRecipeBloc) : Child()
 
         data class Authentication(override val bloc: AuthenticationBloc) : Child()
 

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/ChefMateUrls.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/ChefMateUrls.kt
@@ -1,0 +1,23 @@
+package com.plusmobileapps.chefmate
+
+/**
+ * Canonical Chef Mate deep-link scheme/host and the builders for share links. Lives in
+ * `client:shared` so both `root:public` (which parses links) and feature modules (which build them)
+ * can depend on it without a cycle — `recipe:core:public` can't depend on `root:public` because
+ * `root:public` already depends on it.
+ */
+object ChefMateUrls {
+    const val SCHEME: String = "chefmate"
+
+    /**
+     * Host of the Universal Link / App Link web domain, e.g. https://chefmate.plusmobileapps.com.
+     */
+    const val WEB_HOST: String = "chefmate.plusmobileapps.com"
+
+    /**
+     * The shareable web link to a recipe, keyed by its global [remoteId] (a Supabase UUID). Opens
+     * the recipe in the app via App Links / Universal Links. The remote id — not the local recipe
+     * id — is used so the link resolves to the same recipe for every user.
+     */
+    fun recipeShareUrl(remoteId: String): String = "https://$WEB_HOST/recipe/$remoteId"
+}

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTest.kt
@@ -1,0 +1,33 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.recipe.core.share.PublicRecipePreviewScreen
+import com.plusmobileapps.chefmate.recipe.core.share.previewPublicRecipeLoadedBloc
+import com.plusmobileapps.chefmate.recipe.core.share.previewPublicRecipeNotFoundBloc
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun PublicRecipeLoadedScreenshot() {
+    ChefMateTheme { PublicRecipePreviewScreen(bloc = previewPublicRecipeLoadedBloc) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PublicRecipeLoadedDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) {
+        PublicRecipePreviewScreen(bloc = previewPublicRecipeLoadedBloc)
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 600)
+@Composable
+fun PublicRecipeNotFoundScreenshot() {
+    ChefMateTheme { PublicRecipePreviewScreen(bloc = previewPublicRecipeNotFoundBloc) }
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTestKt/PublicRecipeLoadedDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTestKt/PublicRecipeLoadedDarkScreenshot_658f3c84_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b60f20844349a532733cbf051c5427b0e948f89ad032d18ffaa813fca45b429f
+size 131065

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTestKt/PublicRecipeLoadedScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTestKt/PublicRecipeLoadedScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b04388d7529bbf208a6f75231a45d2f1aef7d187b2e68673916d3e235a1118ea
+size 130621

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTestKt/PublicRecipeNotFoundScreenshot_d1e6916b_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTestKt/PublicRecipeNotFoundScreenshot_d1e6916b_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c5e6db1282bca2f4183acc8b457a790fffb071262b8329ac582dc41072703bc
+size 32594

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailCompactScreenshot_39ac46f6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailCompactScreenshot_39ac46f6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d8051c5ccf74982d4bb60b3c4eaa466e7a18cdfaf2dd8f91d331f545bf53f00
-size 130584
+oid sha256:843bddb1af3da642a2679a2187d1e48f064ade319e76852a92d56b74f1431f96
+size 131699

--- a/docs/navigation-deeplinks.md
+++ b/docs/navigation-deeplinks.md
@@ -10,14 +10,21 @@ For the unrelated Supabase email-verification flow (`chefmate://auth/...`), see 
 
 | URI | Lands on |
 |---|---|
-| `chefmate://recipe/{id}` | Recipe detail for the given recipe id (`Long`) |
+| `chefmate://recipe/{id}` | Recipe detail for the given **local** recipe id (`Long`) — dev/internal navigation only; a local id is meaningless to another user |
+| `chefmate://recipe/{remoteId}` / `https://chefmate.plusmobileapps.com/recipe/{remoteId}` | **Public recipe share link.** A non-numeric segment is treated as the recipe's global Supabase id (UUID). If the recipe is already in the user's library it opens the normal detail screen; otherwise it opens the read-only public preview with a "Save to my recipes" action. See [Public recipe sharing](#public-recipe-sharing). |
 | `chefmate://groceries` | Bottom-nav `Groceries` tab |
 | `chefmate://meal-planner` | Bottom-nav `Meals` tab |
 | `chefmate://settings` | App settings root screen (the destination reached via Settings tab → "App Settings") |
 | `chefmate://signin` | Authentication screen in sign-in mode |
 | `chefmate://signup` | Authentication screen in sign-up mode |
 
-Unknown URIs, missing/invalid path segments (`chefmate://recipe`, `chefmate://recipe/abc`), and non-`chefmate://` URIs all fall back to `DeepLink.None` and the app launches normally on the recipes tab.
+Unknown URIs, a missing recipe segment (`chefmate://recipe`, `chefmate://recipe/`), and non-`chefmate://` / non-web-host URIs all fall back to `DeepLink.None` and the app launches normally on the recipes tab. Note `chefmate://recipe/abc` is **not** `None` — a non-numeric segment is parsed as a public-recipe share link (see below).
+
+## Public recipe sharing
+
+Recipes are private by default (RLS-scoped to the owner and accepted recipe-book collaborators). The **Share → "Share recipe link"** action on the recipe detail screen makes a recipe public (after a confirmation dialog) and shares `https://chefmate.plusmobileapps.com/recipe/{remoteId}`, where `remoteId` is the recipe's global Supabase UUID. "Stop sharing link" makes it private again. Backing pieces: `recipes.is_public` + an additive `SELECT` RLS policy (`supabase/migrations/20260713_add_recipe_public_sharing.sql`), and `RecipeRepository.setRecipePublic` / `fetchPublicRecipe`.
+
+A recipient opening the link routes to `DeepLink.PublicRecipe(remoteId)` → `RootBloc.Child.PublicRecipe` (`PublicRecipeBloc`): if they already have the recipe locally it opens the normal detail screen; otherwise it fetches the public row and shows a read-only preview with **"Save to my recipes"** (which files an owned copy via `createRecipe`).
 
 ## Android
 
@@ -78,4 +85,11 @@ The `chefmate://import?url=...` share flow still goes through the existing `onOp
 3. If the target lives behind the bottom nav, also update the `initialBottomNavTab` mapping.
 4. Add coverage in `DeepLinkTest` (parser) and `RootBlocTest` (initial stack).
 
-Platform entry points already forward any parsed deeplink, so no changes are required on Android/JVM/iOS for additional URIs.
+Platform entry points already forward any parsed deeplink, so no changes are required on Android/JVM/iOS for additional `chefmate://` URIs.
+
+### `https://` App Links / Universal Links
+
+Opening an `https://chefmate.plusmobileapps.com/...` link from a browser or email (rather than the `chefmate://` scheme) additionally requires the path to be registered for verified deep linking:
+
+- **Android:** add the path prefix to the `autoVerify` `<intent-filter>` in `AndroidManifest.xml` (e.g. `/recipe`, `/notifications`). Domain ownership is proven by the hosted `.well-known/assetlinks.json`, which is domain-level and needs no per-path change.
+- **iOS:** the `applinks:chefmate.plusmobileapps.com` entitlement is not path-scoped, but the **externally hosted** `apple-app-site-association` file (in the `chefmate-site` repo, not this one) must list the path (e.g. add `/recipe/*`) for Universal Links to open the app. This is a separate deploy from the app.

--- a/supabase/migrations/20260713_add_recipe_public_sharing.sql
+++ b/supabase/migrations/20260713_add_recipe_public_sharing.sql
@@ -1,0 +1,28 @@
+-- Adds public recipe sharing: an `is_public` flag on `recipes` plus an additive RLS
+-- SELECT policy so anyone signed in can read a recipe once its owner marks it public.
+--
+-- Sharing model: a recipe's global identity is its `id` (UUID). A share link embeds that
+-- UUID (https://chefmate.plusmobileapps.com/recipe/<uuid>). Because UUIDs are unguessable,
+-- "anyone with the link" is effectively "anyone who knows the UUID" — a capability URL. The
+-- read policy is scoped to the `authenticated` role for now: the apps require sign-in and
+-- there is no public web recipe renderer yet. Widen to `anon` later if a logged-out web
+-- fallback page is built.
+--
+-- This policy is ADDITIVE to the existing owner and shared-book-member SELECT policies
+-- (Postgres ORs permissive policies together), so it only ever grants extra read access to
+-- rows explicitly flagged public. It references no other table, so it cannot reintroduce the
+-- RLS recursion fixed in 20260610_fix_recipe_rls_recursion.sql.
+--
+-- The `recipes` table itself was created out-of-band (its base DDL is not in this migrations
+-- folder), so this uses `ADD COLUMN IF NOT EXISTS` defensively and must be verified against the
+-- local Supabase stack before being applied to prod.
+
+ALTER TABLE recipes ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT false;
+
+-- Only public rows are exposed; private recipes remain owner/collaborator scoped.
+DROP POLICY IF EXISTS "Anyone can view public recipes" ON recipes;
+CREATE POLICY "Anyone can view public recipes" ON recipes
+    FOR SELECT TO authenticated USING (is_public = true);
+
+-- Partial index to keep the public-by-id lookup cheap.
+CREATE INDEX IF NOT EXISTS idx_recipes_public ON recipes(id) WHERE is_public;


### PR DESCRIPTION
## What & why

Adds **public recipe sharing** so a recipe can be shared by link. This started as "add a deeplink + share button for the recipe detail screen," but recipes are private (RLS-scoped to owner + book collaborators) and recipe ids are **device-local `Long`s** — so a naive `/recipe/{id}` link would silently open the *recipient's* own recipe #N. The real change is the deferred "public recipes" phase: a shareable link that others can actually open.

**Flow:** Recipe detail → Share → **Share recipe link** → confirm "anyone with the link can view this" → the recipe is made public and `https://chefmate.plusmobileapps.com/recipe/{remoteId}` is shared. A recipient opening it either lands on the recipe (if already in their library) or a **read-only preview** with **Save to my recipes** (files an owned copy). **Stop sharing link** makes it private again.

## Key decisions

- **Links key off the global `remoteId` (Supabase UUID), not the local `Long`.** `DeepLink.parse` branches a numeric segment to the internal `RecipeDetail(Long)` and a non-numeric segment to `DeepLink.PublicRecipe(remoteId)`.
- **Capability-URL model:** `recipes.is_public` + an additive `SELECT` RLS policy scoped to `authenticated`. UUIDs are unguessable, so "anyone with the link" ≈ "anyone who knows the UUID."
- **One Share button:** the action bar was refactored to a single Share dropdown (link / source URL / recipe text / stop sharing) in both compact and wide layouts.
- `PublicRecipeBloc` lives in `recipe/core` (not a new module) since `root:public` already depends on `recipe.core.public`. `ChefMateUrls` (the URL builder) lives in `client:shared` to avoid a `recipe:core:public → root:public` cycle.

## Commits (per concern)

1. `feat(recipe)` — `is_public` column + RLS migration (+ local SQLDelight schema)
2. `feat(recipe)` — data layer: `remoteId`/`isPublic` on the model, `getRecipeByRemoteId` / `fetchPublicRecipe` / `setRecipePublic` (+ repo tests)
3. `feat(recipe)` — public recipe preview BLoC + screen (+ unit tests)
4. `feat(root)` — deep-link routing + `/recipe` Android App Links path (+ DeepLink/RootBloc tests)
5. `feat(recipe)` — share-link action + unified Share button (+ BLoC tests)
6. `test(recipe)` — snapshots (public preview + re-recorded compact detail)
7. `docs` — navigation-deeplinks

## Testing

- Unit tests (data, root, recipe core) and screenshot `validateDebugScreenshotTest` pass locally; desktop app compiles (DI graph assembles).

## Reviewer notes / follow-ups

- ⚠️ **Backend not exercised end-to-end.** Verify the migration on the **local Supabase Docker stack** before prod — the base `recipes` table DDL isn't in the migrations folder (migration drift), so the migration is defensive (`ADD COLUMN IF NOT EXISTS`).
- **iOS Universal Links** need `/recipe/*` added to the externally-hosted `apple-app-site-association` (in the `chefmate-site` repo) — a separate deploy. Android's `assetlinks.json` is domain-level and needs no change.
- **No `impl-robots` UI test** yet for the preview/save flow (repo convention wants one) — logic is covered by BLoC/unit tests; flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
