### PR TITLE
Show declined invites in the collaborator list

### DIFF
--- a/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/edit/ui/EditGroceryListPreviews.kt
+++ b/client/grocery/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/impl/edit/ui/EditGroceryListPreviews.kt
@@ -40,6 +40,13 @@ private val sampleCollaborators =
             role = ListRole.VIEWER,
             status = CollaborationStatus.ACCEPTED,
         ),
+        ListCollaborator(
+            id = 5L,
+            email = "jordan@example.com",
+            displayName = "Jordan Kim",
+            role = ListRole.VIEWER,
+            status = CollaborationStatus.REJECTED,
+        ),
     )
 
 private fun fakeEditBloc(model: EditGroceryListBloc.Model): EditGroceryListBloc =

--- a/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/grocery/core/public/src/commonMain/composeResources/values/strings.xml
@@ -92,6 +92,7 @@
     <string name="grocery_collab_group_editors">Editors</string>
     <string name="grocery_collab_group_viewers">Viewers</string>
     <string name="grocery_collab_pending">Pending</string>
+    <string name="grocery_collab_declined">Declined</string>
     <string name="grocery_remove_collaborator_title">Remove collaborator?</string>
     <string name="grocery_remove_collaborator_message">They’ll lose access to this list. You can invite them again later.</string>
     <string name="grocery_invite_error">Couldn’t send that invite. Check the email — they may already be on the list.</string>

--- a/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/edit/EditGroceryListScreen.kt
+++ b/client/grocery/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/core/edit/EditGroceryListScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import chefmate.client.grocery.core.public.generated.resources.Res
 import chefmate.client.grocery.core.public.generated.resources.grocery_cancel
+import chefmate.client.grocery.core.public.generated.resources.grocery_collab_declined
 import chefmate.client.grocery.core.public.generated.resources.grocery_collab_group_editors
 import chefmate.client.grocery.core.public.generated.resources.grocery_collab_group_owners
 import chefmate.client.grocery.core.public.generated.resources.grocery_collab_group_viewers
@@ -240,20 +241,23 @@ private fun MemberRow(
     canManage: Boolean,
     onRemove: (ListCollaborator) -> Unit,
 ) {
-    // name → email, with pending invites dimmed and tagged. Role is conveyed by the group header
-    // above, so it isn't repeated per row. Pending invites have no account yet, so they fall back
-    // to the email as the primary line.
+    // name → email, with pending/declined invites dimmed and tagged. Role is conveyed by the group
+    // header above, so it isn't repeated per row. Pending invites have no account yet, so they fall
+    // back to the email as the primary line. A declined invite stays visible so the owner can see
+    // the person turned it down (and can then remove or re-invite them).
     val dimens = ChefMateTheme.dimens
     val name = collaborator.displayName?.takeIf { it.isNotBlank() }
     val pending = collaborator.status == CollaborationStatus.PENDING
+    val declined = collaborator.status == CollaborationStatus.REJECTED
     val secondary =
         listOfNotNull(
                 collaborator.email.takeIf { name != null },
                 stringResource(Res.string.grocery_collab_pending).takeIf { pending },
+                stringResource(Res.string.grocery_collab_declined).takeIf { declined },
             )
             .joinToString(" · ")
     Row(
-        modifier = Modifier.fillMaxWidth().alpha(if (pending) 0.5f else 1f),
+        modifier = Modifier.fillMaxWidth().alpha(if (pending || declined) 0.5f else 1f),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(dimens.paddingSmall),
     ) {

--- a/client/recipebook/data/impl/build.gradle.kts
+++ b/client/recipebook/data/impl/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
         commonTest.dependencies {
             implementation(projects.client.auth.data.testing)
             implementation(projects.client.recipebook.data.testing)
+            implementation(projects.client.recipe.data.testing)
             implementation(projects.client.util.testing)
             implementation(libs.multiplatform.settings.test)
         }

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookCollaborationRepository
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookInvite
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMember
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMemberStatus
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRepository
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole
 import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RecipeBookMemberRemoteDataSource
@@ -56,7 +57,12 @@ class RecipeBookCollaborationRepositoryImpl(
                 id = it.memberId,
                 email = it.email,
                 role = RecipeBookRole.fromWire(it.role),
-                accepted = it.status == "accepted",
+                status =
+                    when (it.status) {
+                        "accepted" -> RecipeBookMemberStatus.ACCEPTED
+                        "rejected" -> RecipeBookMemberStatus.REJECTED
+                        else -> RecipeBookMemberStatus.PENDING
+                    },
                 name = if (isCurrentUser) me.userName else it.name,
                 isOwner = it.isOwner,
                 avatarUrl =
@@ -99,6 +105,9 @@ class RecipeBookCollaborationRepositoryImpl(
     }
 
     override suspend fun declineInvite(memberId: String) {
-        remote.deleteMember(memberId)
+        // Mark the invite rejected rather than deleting the row, so the owner can see the recipient
+        // turned it down. The invitee loses book access either way (access requires status =
+        // 'accepted'); the owner can still remove the row later to clear it out.
+        remote.rejectInvite(memberId)
     }
 }

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/RecipeBookMemberRemoteDataSource.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/RecipeBookMemberRemoteDataSource.kt
@@ -21,4 +21,9 @@ interface RecipeBookMemberRemoteDataSource {
 
     /** Accepts invite [memberId]: stamps [userId] and flips status to accepted. */
     suspend fun acceptInvite(memberId: String, userId: String)
+
+    /**
+     * Rejects invite [memberId]: flips status to rejected, keeping the row for the owner to see.
+     */
+    suspend fun rejectInvite(memberId: String)
 }

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/SupabaseRecipeBookMemberRemoteDataSource.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/remote/SupabaseRecipeBookMemberRemoteDataSource.kt
@@ -96,4 +96,12 @@ class SupabaseRecipeBookMemberRemoteDataSource(private val supabaseClient: Supab
             filter { eq("id", memberId) }
         }
     }
+
+    override suspend fun rejectInvite(memberId: String) {
+        supabaseClient.from("recipe_book_members").update(
+            JsonObject(mapOf("status" to JsonPrimitive("rejected")))
+        ) {
+            filter { eq("id", memberId) }
+        }
+    }
 }

--- a/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImplTest.kt
+++ b/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImplTest.kt
@@ -1,0 +1,129 @@
+@file:Suppress("FunctionName")
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.plusmobileapps.chefmate.recipebook.data.impl
+
+import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
+import com.plusmobileapps.chefmate.database.Database
+import com.plusmobileapps.chefmate.database.testing.createTestDatabase
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMemberStatus
+import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RecipeBookMemberRemoteDataSource
+import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteCollaborator
+import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteRecipeBookInvite
+import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteRecipeBookMember
+import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookRepository
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+class RecipeBookCollaborationRepositoryImplTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val db: Database = createTestDatabase()
+    private val fakeAuth = FakeAuthenticationRepository()
+
+    private fun repository(remote: RecipeBookMemberRemoteDataSource) =
+        RecipeBookCollaborationRepositoryImpl(
+            bookDb = db.recipeBookQueries,
+            ioContext = testDispatcher,
+            remote = remote,
+            authRepository = fakeAuth,
+            recipeBookRepository = FakeRecipeBookRepository(),
+            recipeRepository = FakeRecipeRepository(),
+        )
+
+    /** Creates a synced book (with a remote id) and returns its local id. */
+    private fun createSyncedBook(remoteId: String): Long {
+        db.recipeBookQueries.create(
+            name = "Shared",
+            isDefault = false,
+            createdAt = "2026-07-13 00:00:00",
+            updatedAt = "2026-07-13 00:00:00",
+            clientId = "client-1",
+            ownerId = "test-id",
+        )
+        val id = db.recipeBookQueries.getAll().executeAsList().first { it.name == "Shared" }.id
+        db.recipeBookQueries.updateRemoteId(remoteId = remoteId, id = id)
+        return id
+    }
+
+    @Test
+    fun declining_an_invite_marks_it_rejected_instead_of_deleting_the_row() =
+        runTest(testDispatcher) {
+            fakeAuth.setAuthenticated()
+            val remote = RecordingMemberRemote()
+            val repo = repository(remote)
+
+            repo.declineInvite("member-1")
+
+            // The row is kept (owner still sees it) and stamped rejected — not deleted.
+            remote.rejected shouldContainExactly listOf("member-1")
+            remote.deleted shouldBe emptyList()
+        }
+
+    @Test
+    fun getMembers_maps_each_wire_status_to_the_member_status() =
+        runTest(testDispatcher) {
+            fakeAuth.setAuthenticated()
+            val bookId = createSyncedBook(remoteId = "remote-1")
+            val remote =
+                RecordingMemberRemote(
+                    collaborators =
+                        listOf(
+                            collaborator("owner@example.com", "accepted", isOwner = true),
+                            collaborator("alex@example.com", "accepted"),
+                            collaborator("sam@example.com", "pending"),
+                            collaborator("jordan@example.com", "rejected"),
+                        )
+                )
+            val repo = repository(remote)
+
+            val statusByEmail = repo.getMembers(bookId).associate { it.email to it.status }
+
+            statusByEmail["owner@example.com"] shouldBe RecipeBookMemberStatus.ACCEPTED
+            statusByEmail["alex@example.com"] shouldBe RecipeBookMemberStatus.ACCEPTED
+            statusByEmail["sam@example.com"] shouldBe RecipeBookMemberStatus.PENDING
+            statusByEmail["jordan@example.com"] shouldBe RecipeBookMemberStatus.REJECTED
+        }
+
+    private fun collaborator(email: String, status: String, isOwner: Boolean = false) =
+        RemoteCollaborator(
+            memberId = if (isOwner) null else "m-$email",
+            email = email,
+            role = if (isOwner) "owner" else "editor",
+            status = status,
+            isOwner = isOwner,
+        )
+
+    private class RecordingMemberRemote(
+        private val collaborators: List<RemoteCollaborator> = emptyList()
+    ) : RecipeBookMemberRemoteDataSource {
+        val rejected: MutableList<String> = mutableListOf()
+        val deleted: MutableList<String> = mutableListOf()
+
+        override suspend fun fetchMembers(bookRemoteId: String): List<RemoteRecipeBookMember> =
+            emptyList()
+
+        override suspend fun fetchCollaborators(bookRemoteId: String): List<RemoteCollaborator> =
+            collaborators
+
+        override suspend fun invite(bookRemoteId: String, email: String, role: String) = Unit
+
+        override suspend fun deleteMember(memberId: String) {
+            deleted += memberId
+        }
+
+        override suspend fun fetchPendingInvites(email: String): List<RemoteRecipeBookInvite> =
+            emptyList()
+
+        override suspend fun acceptInvite(memberId: String, userId: String) = Unit
+
+        override suspend fun rejectInvite(memberId: String) {
+            rejected += memberId
+        }
+    }
+}

--- a/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImplTest.kt
+++ b/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImplTest.kt
@@ -226,5 +226,7 @@ class RecipeBookRepositoryImplTest {
             emptyList()
 
         override suspend fun acceptInvite(memberId: String, userId: String) = Unit
+
+        override suspend fun rejectInvite(memberId: String) = Unit
     }
 }

--- a/client/recipebook/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/RecipeBookMember.kt
+++ b/client/recipebook/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/RecipeBookMember.kt
@@ -1,21 +1,33 @@
 package com.plusmobileapps.chefmate.recipebook.data
 
+/** Invite lifecycle for a [RecipeBookMember]: awaiting a response, accepted, or turned down. */
+enum class RecipeBookMemberStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED,
+}
+
 /**
- * A collaborator on a recipe book. Covers both pending email invites (no [accepted]) and accepted
- * members. [id] is the remote member-row id; null for the synthesized owner entry.
+ * A collaborator on a recipe book. Covers pending email invites, accepted members, and invites the
+ * recipient declined (kept so the owner can see the outcome). [id] is the remote member-row id;
+ * null for the synthesized owner entry.
  */
 data class RecipeBookMember(
     val id: String?,
     val email: String,
     val role: RecipeBookRole,
-    val accepted: Boolean,
+    val status: RecipeBookMemberStatus,
     /** Display name from the user's profile; null for pending invites (no account yet). */
     val name: String? = null,
     /** True for the synthesized entry representing the book owner. */
     val isOwner: Boolean = false,
     /** Profile photo URL when known; null entries fall back to a lettered avatar. */
     val avatarUrl: String? = null,
-)
+) {
+    /** Convenience for the common "membership is live" check. */
+    val accepted: Boolean
+        get() = status == RecipeBookMemberStatus.ACCEPTED
+}
 
 /** A pending invite addressed to the current user, surfaced as the recipe-list banner. */
 data class RecipeBookInvite(val memberId: String, val bookName: String, val role: RecipeBookRole)

--- a/client/recipebook/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/testing/FakeRecipeBookCollaborationRepository.kt
+++ b/client/recipebook/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/testing/FakeRecipeBookCollaborationRepository.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.recipebook.data.testing
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookCollaborationRepository
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookInvite
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMember
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMemberStatus
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole
 
 class FakeRecipeBookCollaborationRepository(
@@ -23,7 +24,12 @@ class FakeRecipeBookCollaborationRepository(
     override suspend fun invite(bookId: Long, email: String, role: RecipeBookRole) {
         invited += Triple(bookId, email, role)
         members +=
-            RecipeBookMember(id = "m-${members.size}", email = email, role = role, accepted = false)
+            RecipeBookMember(
+                id = "m-${members.size}",
+                email = email,
+                role = role,
+                status = RecipeBookMemberStatus.PENDING,
+            )
     }
 
     override suspend fun removeMember(memberId: String) {

--- a/client/recipebook/edit/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModelTest.kt
+++ b/client/recipebook/edit/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModelTest.kt
@@ -78,7 +78,8 @@ class EditRecipeBookViewModelTest {
                     id = "m1",
                     email = "alex@example.com",
                     role = com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole.EDITOR,
-                    accepted = true,
+                    status =
+                        com.plusmobileapps.chefmate.recipebook.data.RecipeBookMemberStatus.ACCEPTED,
                 )
             )
             val vm =
@@ -107,7 +108,8 @@ class EditRecipeBookViewModelTest {
                     id = "m1",
                     email = "alex@example.com",
                     role = com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole.EDITOR,
-                    accepted = true,
+                    status =
+                        com.plusmobileapps.chefmate.recipebook.data.RecipeBookMemberStatus.ACCEPTED,
                 )
             )
             val vm =

--- a/client/recipebook/edit/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipebook/edit/public/src/commonMain/composeResources/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="edit_recipe_book_role_editor">Editor</string>
     <string name="edit_recipe_book_role_viewer">Viewer</string>
     <string name="edit_recipe_book_member_pending">Pending</string>
+    <string name="edit_recipe_book_member_declined">Declined</string>
     <string name="edit_recipe_book_group_owner">Owner</string>
     <string name="edit_recipe_book_group_editors">Editors</string>
     <string name="edit_recipe_book_group_viewers">Viewers</string>

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookPreviews.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookPreviews.kt
@@ -7,6 +7,7 @@ import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_bo
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_edit_title
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_name_error
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMember
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMemberStatus
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole
 import com.plusmobileapps.chefmate.recipebook.edit.EditRecipeBookBloc.Model
 import com.plusmobileapps.chefmate.text.asTextData
@@ -81,7 +82,7 @@ val previewEditRecipeBookCollaboratorsBloc: EditRecipeBookBloc =
                         id = null,
                         email = "you@example.com",
                         role = RecipeBookRole.OWNER,
-                        accepted = true,
+                        status = RecipeBookMemberStatus.ACCEPTED,
                         name = "Jordan Lee",
                         isOwner = true,
                     ),
@@ -89,14 +90,21 @@ val previewEditRecipeBookCollaboratorsBloc: EditRecipeBookBloc =
                         id = "1",
                         email = "alex@example.com",
                         role = RecipeBookRole.EDITOR,
-                        accepted = true,
+                        status = RecipeBookMemberStatus.ACCEPTED,
                         name = "Alex Rivera",
                     ),
                     RecipeBookMember(
                         id = "2",
                         email = "sam@example.com",
                         role = RecipeBookRole.VIEWER,
-                        accepted = false,
+                        status = RecipeBookMemberStatus.PENDING,
+                    ),
+                    RecipeBookMember(
+                        id = "3",
+                        email = "jordan@example.com",
+                        role = RecipeBookRole.EDITOR,
+                        status = RecipeBookMemberStatus.REJECTED,
+                        name = "Jordan Kim",
                     ),
                 ),
         )
@@ -116,7 +124,7 @@ val previewEditRecipeBookMemberViewBloc: EditRecipeBookBloc =
                         id = null,
                         email = "casey@example.com",
                         role = RecipeBookRole.OWNER,
-                        accepted = true,
+                        status = RecipeBookMemberStatus.ACCEPTED,
                         name = "Casey Morgan",
                         isOwner = true,
                     ),
@@ -124,14 +132,14 @@ val previewEditRecipeBookMemberViewBloc: EditRecipeBookBloc =
                         id = "1",
                         email = "you@example.com",
                         role = RecipeBookRole.EDITOR,
-                        accepted = true,
+                        status = RecipeBookMemberStatus.ACCEPTED,
                         name = "Jordan Lee",
                     ),
                     RecipeBookMember(
                         id = "2",
                         email = "sam@example.com",
                         role = RecipeBookRole.VIEWER,
-                        accepted = false,
+                        status = RecipeBookMemberStatus.PENDING,
                     ),
                 ),
         )
@@ -151,7 +159,7 @@ val previewEditRecipeBookRemoveConfirmBloc: EditRecipeBookBloc =
                         id = null,
                         email = "you@example.com",
                         role = RecipeBookRole.OWNER,
-                        accepted = true,
+                        status = RecipeBookMemberStatus.ACCEPTED,
                         name = "Jordan Lee",
                         isOwner = true,
                     ),
@@ -159,7 +167,7 @@ val previewEditRecipeBookRemoveConfirmBloc: EditRecipeBookBloc =
                         id = "1",
                         email = "alex@example.com",
                         role = RecipeBookRole.EDITOR,
-                        accepted = true,
+                        status = RecipeBookMemberStatus.ACCEPTED,
                         name = "Alex Rivera",
                     ),
                 ),
@@ -168,7 +176,7 @@ val previewEditRecipeBookRemoveConfirmBloc: EditRecipeBookBloc =
                     id = "1",
                     email = "alex@example.com",
                     role = RecipeBookRole.EDITOR,
-                    accepted = true,
+                    status = RecipeBookMemberStatus.ACCEPTED,
                     name = "Alex Rivera",
                 ),
         )

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
@@ -41,6 +41,7 @@ import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_bo
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_group_viewers
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_invite_button
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_invite_email_label
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_member_declined
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_member_pending
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_name_label
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_remove_cancel
@@ -53,6 +54,7 @@ import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_bo
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_role_viewer
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_save
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMember
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMemberStatus
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRole
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
@@ -237,20 +239,23 @@ private fun MemberGroup(
 
 @Composable
 private fun MemberRow(member: RecipeBookMember, canManage: Boolean, onRemove: (String) -> Unit) {
-    // name → email, with pending invites dimmed and tagged. Role is conveyed by the group header
-    // above, so it isn't repeated per row. Pending invites have no account, so they fall back to
-    // the email as the primary line.
+    // name → email, with pending/declined invites dimmed and tagged. Role is conveyed by the group
+    // header above, so it isn't repeated per row. Pending invites have no account, so they fall
+    // back
+    // to the email as the primary line. A declined invite stays visible so the owner can see the
+    // recipient turned it down (and can then remove or re-invite them).
     val name = member.name?.takeIf { it.isNotBlank() }
+    val pending = member.status == RecipeBookMemberStatus.PENDING
+    val declined = member.status == RecipeBookMemberStatus.REJECTED
     val secondary =
         listOfNotNull(
                 member.email.takeIf { name != null },
-                stringResource(Res.string.edit_recipe_book_member_pending).takeIf {
-                    !member.accepted
-                },
+                stringResource(Res.string.edit_recipe_book_member_pending).takeIf { pending },
+                stringResource(Res.string.edit_recipe_book_member_declined).takeIf { declined },
             )
             .joinToString(" · ")
     Row(
-        modifier = Modifier.fillMaxWidth().alpha(if (member.accepted) 1f else 0.5f),
+        modifier = Modifier.fillMaxWidth().alpha(if (pending || declined) 0.5f else 1f),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall),
     ) {

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditGroceryListScreenshotTestKt/EditGroceryListAuthenticatedDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditGroceryListScreenshotTestKt/EditGroceryListAuthenticatedDarkScreenshot_658f3c84_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:90b8bfe76c4b00c08bc7a20e6b8890dac96a0fb70867249d1955fe72977ce874
-size 99959
+oid sha256:84b4053ec0e8a1dde9fa3b14b5b195b11a25ff72d5df4d3c65ae33ecb6af2f46
+size 109521

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditGroceryListScreenshotTestKt/EditGroceryListAuthenticatedLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditGroceryListScreenshotTestKt/EditGroceryListAuthenticatedLightScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:244b8e29fe411d14eed2130d5fc1062f2ce9e63fdfb5f3487ed25b8e26188a08
-size 97605
+oid sha256:8679b6e1fa62eac1c66dca5f535e9e8faaf18f3a8a0a6a9958aeab2602443fb9
+size 106812

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditGroceryListScreenshotTestKt/EditGroceryListDeleteConfirmScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditGroceryListScreenshotTestKt/EditGroceryListDeleteConfirmScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42e6d3655ef54270c3192311cea91b6f200adfa19d226bb3e6a55f2bc5656eab
-size 116178
+oid sha256:7682fb8131e81ce7742db23a51cf5bf56853bf06d9cc78a5d7757fbbca8edf7b
+size 124361

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookCollaboratorsScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookCollaboratorsScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d68c5ad07ab84fa2c509e9faf7b40e7155bd30a9e3d7995a6136c663220e20a7
-size 87304
+oid sha256:69ecf30b3b7b796ad6e17ddbfe45914bbb1ec8eb59c1b9626f4c1b1a6a5fbd51
+size 97285

--- a/supabase/migrations/20260713_recipe_book_reject_invite.sql
+++ b/supabase/migrations/20260713_recipe_book_reject_invite.sql
@@ -1,0 +1,16 @@
+-- Let a recipe-book invitee reject an invite instead of the invite silently disappearing.
+--
+-- Previously declining an invite DELETEd the member row, so the book owner had no way to tell the
+-- difference between "never responded" and "declined". The client now stamps status = 'rejected'
+-- (mirroring grocery-list collaboration), so the owner sees the declined invite in the collaborator
+-- list. The row stays readable to the owner via recipe_book_collaborators (which already returns
+-- every status), and the invitee loses content access because can_access_recipe_book requires
+-- status = 'accepted'.
+--
+-- The original status CHECK only allowed ('pending', 'accepted'); widen it to include 'rejected'.
+ALTER TABLE recipe_book_members
+    DROP CONSTRAINT IF EXISTS recipe_book_members_status_check;
+
+ALTER TABLE recipe_book_members
+    ADD CONSTRAINT recipe_book_members_status_check
+    CHECK (status IN ('pending', 'accepted', 'rejected'));


### PR DESCRIPTION
## What

When someone **rejects** an invitation to a grocery list or recipe book, the person who sent the invite now sees that they actually declined — the collaborator row stays visible, dimmed, and tagged **"Declined"** (next to the existing "Pending" tag).

Previously:
- **Grocery list** already stored a `rejected` status server-side, but the owner's UI rendered a declined member identically to an accepted one (full opacity, no tag).
- **Recipe book** *deleted* the member row on decline, so the owner couldn't tell "never responded" from "declined" — the invite just vanished.

## Changes

**UI (both features)**
- `EditGroceryListScreen` / `EditRecipeBookScreen`: a `REJECTED` member is dimmed and tagged "Declined". The owner can still remove or re-invite them.
- New strings `grocery_collab_declined` / `edit_recipe_book_member_declined`.

**Recipe-book data layer (to match the grocery model)**
- `declineInvite` now stamps `status = 'rejected'` via a new `RecipeBookMemberRemoteDataSource.rejectInvite`, instead of deleting the row. The invitee still loses content access because `can_access_recipe_book` requires `status = 'accepted'`.
- `RecipeBookMember.accepted: Boolean` → `status: RecipeBookMemberStatus` enum (`PENDING`/`ACCEPTED`/`REJECTED`), with an `accepted` convenience getter.
- **Migration** `20260713_recipe_book_reject_invite.sql` widens the `recipe_book_members` status CHECK to allow `'rejected'` (grocery's constraint already allowed it). The `recipe_book_collaborators` RPC already returns every status, so no RPC change was needed.

**Tests**
- New `RecipeBookCollaborationRepositoryImplTest`: decline marks rejected (row kept, not deleted) and `getMembers` maps each wire status.
- Added a `REJECTED` collaborator to the grocery + recipe-book edit previews and re-recorded the reference screenshots.

## ⚠️ Deploy note
The migration must be applied to Supabase **before/with** this client change — the current prod `recipe_book_members` status CHECK rejects `'rejected'`, so declining a recipe-book invite would otherwise fail. (Grocery-list rejects already work in prod.)

## Testing
- `:client:recipebook:data:impl:jvmTest`, `:client:recipebook:edit:impl:jvmTest`, `:client:grocery:core:impl:jvmTest` — green.
- `:client:ui:screenshot-test:updateDebugScreenshotTest` — references re-recorded and visually verified (both light/dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)