### PR TITLE
fix(onboarding): sync demo bloc with OnboardingRootBloc API

### DIFF
--- a/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoBlocImpl.kt
+++ b/client/onboarding/demo/src/commonMain/kotlin/com/plusmobileapps/chefmate/onboarding/demo/OnboardingDemoBlocImpl.kt
@@ -53,6 +53,7 @@ class OnboardingDemoBlocImpl(
                     bloc =
                         onboardingRootFactory.create(
                             context = context,
+                            props = OnboardingRootBloc.Props(),
                             output = ::handleOnboardingOutput,
                         )
                 )
@@ -60,10 +61,12 @@ class OnboardingDemoBlocImpl(
 
     private fun handleOnboardingOutput(output: OnboardingRootBloc.Output) {
         when (output) {
-            // Both terminal outcomes return to the debug landing screen so the flow can be
+            // Every terminal outcome returns to the debug landing screen so the flow can be
             // relaunched; the demo has no real app or auth flow to hand off to.
             OnboardingRootBloc.Output.Finished,
-            OnboardingRootBloc.Output.SignIn -> navigation.bringToFront(Configuration.Landing)
+            OnboardingRootBloc.Output.Dismissed,
+            OnboardingRootBloc.Output.SignIn,
+            OnboardingRootBloc.Output.SignUp -> navigation.bringToFront(Configuration.Landing)
         }
     }
 


### PR DESCRIPTION
## What changed

Updates the standalone onboarding demo app (`:client:onboarding:demo`) to match the current `OnboardingRootBloc` public API:

- Passes the now-required `props` argument to `Factory.create`, using first-run defaults (`OnboardingRootBloc.Props()` — not dismissible, not signed in).
- Handles the new `Output.Dismissed` and `Output.SignUp` branches so the `when` is exhaustive. Both route back to the demo landing screen, matching the existing `Finished` / `SignIn` behavior (the demo has no real app or auth flow to hand off to).

## Why

The **JVM + Android tests** CI job was failing (e.g. [run 29312018579](https://github.com/Plus-Mobile-Apps/chef-mate/actions/runs/29312018579)) with a compile error, not a test failure:

```
> Task :client:onboarding:demo:compileKotlinJvm FAILED
e: OnboardingDemoBlocImpl.kt:56 No value passed for parameter 'props'.
e: OnboardingDemoBlocImpl.kt:62 'when' expression must be exhaustive. Add the 'Dismissed', 'SignUp' branches or an 'else' branch.
```

The demo app was added in #305, and the re-entrant onboarding work later added the `props` parameter and the `Dismissed`/`SignUp` outputs to the public API without updating the demo module.

## Testing

- `./gradlew :client:onboarding:demo:compileKotlinJvm` → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)