### PR TITLE
feat(auth): native iOS UITextField for credential autofill save prompts

### DIFF
--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
@@ -12,9 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -38,12 +35,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import chefmate.client.auth.ui.public.generated.resources.Res
 import chefmate.client.auth.ui.public.generated.resources.auth_button_email_me_a_code
@@ -72,10 +67,11 @@ import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.ResourceString
 import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.ui.components.AutofillFieldType
+import com.plusmobileapps.chefmate.ui.components.PlusAutofillTextField
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingDialog
-import com.plusmobileapps.chefmate.ui.components.PlusTextField
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import org.jetbrains.compose.resources.stringResource
 
@@ -217,7 +213,8 @@ private fun AuthenticationBody(
             onPasswordChanged = onPasswordChanged,
             // Signing in fills the saved password; signing up asks the manager to generate/save a
             // new one.
-            contentType = if (isSignIn) ContentType.Password else ContentType.NewPassword,
+            fieldType =
+                if (isSignIn) AutofillFieldType.PASSWORD else AutofillFieldType.NEW_PASSWORD,
             error = model.passwordError,
             imeAction = if (isSignIn) ImeAction.Done else ImeAction.Next,
             onImeAction = {
@@ -257,7 +254,7 @@ private fun AuthenticationBody(
                     modifier = Modifier.focusRequester(confirmPasswordFocusRequester),
                     password = confirmPassword,
                     onPasswordChanged = onConfirmPasswordChanged,
-                    contentType = ContentType.NewPassword,
+                    fieldType = AutofillFieldType.NEW_PASSWORD,
                     label = stringResource(Res.string.auth_label_confirm_password),
                     error = model.confirmPasswordError,
                     imeAction = ImeAction.Done,
@@ -371,29 +368,16 @@ fun EmailField(
     onEmailChanged: (String) -> Unit,
     onImeAction: () -> Unit,
 ) {
-    PlusTextField(
+    PlusAutofillTextField(
         modifier = modifier.fillMaxWidth(),
         value = email,
         onValueChange = onEmailChanged,
-        label = { Text(stringResource(Res.string.auth_label_email)) },
+        fieldType = AutofillFieldType.EMAIL,
+        label = stringResource(Res.string.auth_label_email),
         error = error,
-        singleLine = true,
-        keyboardOptions =
-            KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
-        keyboardActions = KeyboardActions(onNext = { onImeAction() }),
-        // This is the account's login identifier, which password managers store as the "username"
-        // even though users type their email into it. Hinting plain Username (rather than also
-        // EmailAddress) classifies it unambiguously as a login field, so managers like Bitwarden
-        // proactively offer the on-focus inline suggestion instead of only filling it on demand.
-        contentType = ContentType.Username,
+        imeAction = ImeAction.Next,
+        onImeAction = onImeAction,
     )
-}
-
-// Masks the field's contents with bullets for the state-based text field. Replacing 1:1 keeps the
-// caret mapping identity, so the cursor stays put. Mirrors PasswordVisualTransformation from the
-// legacy value/onValueChange API.
-private val PasswordOutputTransformation = OutputTransformation {
-    replace(0, length, "•".repeat(length))
 }
 
 @Composable
@@ -401,25 +385,23 @@ fun PasswordField(
     modifier: Modifier = Modifier,
     password: String,
     onPasswordChanged: (String) -> Unit,
-    contentType: ContentType,
+    fieldType: AutofillFieldType,
     label: String = stringResource(Res.string.auth_label_password),
     error: TextData? = null,
     imeAction: ImeAction,
     onImeAction: () -> Unit,
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
-    PlusTextField(
+    PlusAutofillTextField(
         modifier = modifier.fillMaxWidth(),
         value = password,
         onValueChange = onPasswordChanged,
-        label = { Text(label) },
+        fieldType = fieldType,
+        label = label,
         error = error,
-        singleLine = true,
-        outputTransformation = if (passwordVisible) null else PasswordOutputTransformation,
-        keyboardOptions =
-            KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = imeAction),
-        keyboardActions = KeyboardActions(onNext = { onImeAction() }, onDone = { onImeAction() }),
-        contentType = contentType,
+        passwordVisible = passwordVisible,
+        imeAction = imeAction,
+        onImeAction = onImeAction,
         trailingIcon = {
             val image =
                 if (passwordVisible) Icons.Default.Visibility else Icons.Default.VisibilityOff

--- a/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.android.kt
+++ b/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.android.kt
@@ -1,0 +1,39 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.text.input.ImeAction
+import com.plusmobileapps.chefmate.text.TextData
+
+// Android's Compose autofill fills and saves credentials from the standard field, so delegate to
+// the shared fallback (the plain PlusTextField with credential hints).
+@Composable
+actual fun PlusAutofillTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    fieldType: AutofillFieldType,
+    label: String,
+    modifier: Modifier,
+    error: TextData?,
+    passwordVisible: Boolean,
+    imeAction: ImeAction,
+    onImeAction: () -> Unit,
+    focusRequester: FocusRequester?,
+    trailingIcon: @Composable (() -> Unit)?,
+) =
+    FallbackAutofillTextField(
+        value = value,
+        onValueChange = onValueChange,
+        fieldType = fieldType,
+        label = label,
+        modifier = modifier,
+        error = error,
+        passwordVisible = passwordVisible,
+        imeAction = imeAction,
+        onImeAction = onImeAction,
+        focusRequester = focusRequester,
+        trailingIcon = trailingIcon,
+    )

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.kt
@@ -1,0 +1,129 @@
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import com.plusmobileapps.chefmate.text.TextData
+
+/**
+ * Which credential a [PlusAutofillTextField] represents. Each platform maps this to the right
+ * autofill semantics (iOS `textContentType`, Android autofill hints) and keyboard so the system
+ * offers to fill/save the account login.
+ */
+enum class AutofillFieldType {
+    /**
+     * The account identifier. Users type their email, but it is hinted as the login "username" so
+     * password managers classify it unambiguously as a login field.
+     */
+    EMAIL,
+    /** An existing password to fill on sign in. */
+    PASSWORD,
+    /** A password being created on sign up, so the manager offers to generate and save it. */
+    NEW_PASSWORD,
+}
+
+/**
+ * A credential text field for login/signup forms.
+ *
+ * This exists as a separate component from [PlusTextField] because the iOS Keychain save/update
+ * prompt requires *real* `UITextField`s on screen (see JetBrains CMP-5802). The iOS actual
+ * therefore renders a native `UITextField` via interop, which carries tradeoffs (native<->Compose
+ * text sync, the CMP-3154 transparent-background caveat) that we deliberately keep out of the
+ * general-purpose [PlusTextField]. Every non-iOS platform delegates straight back to
+ * [PlusTextField] via [FallbackAutofillTextField], so only iOS auth screens take the native path.
+ *
+ * The caller owns [passwordVisible] and supplies the visibility [trailingIcon]; the component only
+ * consumes [passwordVisible] to decide whether the value is masked (or, on iOS, secure entry).
+ *
+ * Remove this component and its iOS actual once CMP-5802 ships (targeted Compose Multiplatform
+ * 1.13.0) and fold the callers back onto [PlusTextField].
+ */
+@Composable
+expect fun PlusAutofillTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    fieldType: AutofillFieldType,
+    label: String,
+    modifier: Modifier = Modifier,
+    error: TextData? = null,
+    passwordVisible: Boolean = false,
+    imeAction: ImeAction = ImeAction.Default,
+    onImeAction: () -> Unit = {},
+    focusRequester: FocusRequester? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+)
+
+/** Whether the field's contents should be obscured (any password field that isn't revealed). */
+internal fun AutofillFieldType.isSecure(passwordVisible: Boolean): Boolean =
+    this != AutofillFieldType.EMAIL && !passwordVisible
+
+internal val AutofillFieldType.composeContentType: ContentType
+    get() =
+        when (this) {
+            // This is the account's login identifier, which password managers store as the
+            // "username" even though users type their email into it. Hinting plain Username (rather
+            // than also EmailAddress) classifies it unambiguously as a login field, so managers like
+            // Bitwarden proactively offer the on-focus inline suggestion instead of only filling it
+            // on demand.
+            AutofillFieldType.EMAIL -> ContentType.Username
+            AutofillFieldType.PASSWORD -> ContentType.Password
+            AutofillFieldType.NEW_PASSWORD -> ContentType.NewPassword
+        }
+
+internal val AutofillFieldType.keyboardType: KeyboardType
+    get() =
+        when (this) {
+            AutofillFieldType.EMAIL -> KeyboardType.Email
+            AutofillFieldType.PASSWORD,
+            AutofillFieldType.NEW_PASSWORD -> KeyboardType.Password
+        }
+
+// Masks secure input with bullets. Replacing 1:1 keeps the caret mapping identity, so the cursor
+// stays put. Mirrors the masking PlusTextField callers previously applied inline.
+private val PasswordMaskTransformation = OutputTransformation {
+    replace(0, length, "•".repeat(length))
+}
+
+/**
+ * Shared non-iOS implementation: the existing [PlusTextField] with the credential autofill hints
+ * applied. Android's Compose autofill already fills/saves logins here, and desktop is unaffected,
+ * so these platforms need nothing more than the hint. Android and JVM `actual`s both delegate here.
+ */
+@Composable
+internal fun FallbackAutofillTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    fieldType: AutofillFieldType,
+    label: String,
+    modifier: Modifier,
+    error: TextData?,
+    passwordVisible: Boolean,
+    imeAction: ImeAction,
+    onImeAction: () -> Unit,
+    focusRequester: FocusRequester?,
+    trailingIcon: @Composable (() -> Unit)?,
+) {
+    PlusTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        label = { Text(label) },
+        error = error,
+        singleLine = true,
+        focusRequester = focusRequester,
+        outputTransformation =
+            if (fieldType.isSecure(passwordVisible)) PasswordMaskTransformation else null,
+        keyboardOptions =
+            KeyboardOptions(keyboardType = fieldType.keyboardType, imeAction = imeAction),
+        keyboardActions = KeyboardActions(onNext = { onImeAction() }, onDone = { onImeAction() }),
+        contentType = fieldType.composeContentType,
+        trailingIcon = trailingIcon,
+    )
+}

--- a/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.ios.kt
+++ b/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.ios.kt
@@ -1,0 +1,191 @@
+@file:Suppress("ktlint:standard:filename")
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.UIKitView
+import com.plusmobileapps.chefmate.text.TextData
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.UIKit.UIAction
+import platform.UIKit.UIColor
+import platform.UIKit.UIControlEventEditingChanged
+import platform.UIKit.UIControlEventEditingDidBegin
+import platform.UIKit.UIControlEventEditingDidEnd
+import platform.UIKit.UIControlEventEditingDidEndOnExit
+import platform.UIKit.UIKeyboardTypeEmailAddress
+import platform.UIKit.UIReturnKeyType
+import platform.UIKit.UITextAutocapitalizationType
+import platform.UIKit.UITextAutocorrectionType
+import platform.UIKit.UITextBorderStyle
+import platform.UIKit.UITextContentTypeNewPassword
+import platform.UIKit.UITextContentTypePassword
+import platform.UIKit.UITextContentTypeUsername
+import platform.UIKit.UITextField
+import platform.UIKit.UITextSpellCheckingType
+
+/**
+ * iOS renders a real, transparent `UITextField` via interop instead of a Compose text field.
+ * Apple's Keychain heuristic only offers the save/update-password prompt (and the QuickType
+ * passwords key) when genuine `UITextField`s for the login and password are present on screen —
+ * Compose's own text input does not satisfy it yet (JetBrains CMP-5802, targeted 1.13.0).
+ *
+ * The native field is made transparent and placed inside [OutlinedTextFieldDefaults.DecorationBox]
+ * so it keeps the Material outline, floating label, error, and trailing icon that the rest of the
+ * app uses; Compose draws the decoration, the user types into the native field.
+ *
+ * Known caveat: interop views don't yet composite with a truly transparent background in every case
+ * (CMP-3154). Our auth fields sit on the surface color, so a clear background reads correctly;
+ * revisit if these fields are ever placed over a gradient/image.
+ */
+@Composable
+actual fun PlusAutofillTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    fieldType: AutofillFieldType,
+    label: String,
+    modifier: Modifier,
+    error: TextData?,
+    passwordVisible: Boolean,
+    imeAction: ImeAction,
+    onImeAction: () -> Unit,
+    focusRequester: FocusRequester?,
+    trailingIcon: @Composable (() -> Unit)?,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isSecure = fieldType.isSecure(passwordVisible)
+
+    // Latest hoisted callbacks, read from inside the once-built native action handlers.
+    val callbacks = remember { NativeFieldCallbacks() }
+    callbacks.onValueChange = onValueChange
+    callbacks.onImeAction = onImeAction
+
+    // The native field is built once; `update` below re-syncs the mutable bits (text, secure entry,
+    // return key) whenever Compose recomposes.
+    val textField =
+        remember(fieldType) {
+            UITextField().apply {
+                borderStyle = UITextBorderStyle.UITextBorderStyleNone
+                backgroundColor = UIColor.clearColor
+                setOpaque(false)
+                autocapitalizationType =
+                    UITextAutocapitalizationType.UITextAutocapitalizationTypeNone
+                autocorrectionType = UITextAutocorrectionType.UITextAutocorrectionTypeNo
+                spellCheckingType = UITextSpellCheckingType.UITextSpellCheckingTypeNo
+
+                // The autofill semantics Apple's login-form heuristic keys on.
+                when (fieldType) {
+                    AutofillFieldType.EMAIL -> {
+                        keyboardType = UIKeyboardTypeEmailAddress
+                        textContentType = UITextContentTypeUsername
+                    }
+                    AutofillFieldType.PASSWORD -> textContentType = UITextContentTypePassword
+                    AutofillFieldType.NEW_PASSWORD -> textContentType = UITextContentTypeNewPassword
+                }
+
+                // Native -> Compose: forward every keystroke (and system autofill) to the caller.
+                addAction(
+                    UIAction.actionWithHandler { _ -> callbacks.onValueChange(text ?: "") },
+                    forControlEvents = UIControlEventEditingChanged,
+                )
+                // Return key -> submit / advance focus.
+                addAction(
+                    UIAction.actionWithHandler { _ -> callbacks.onImeAction() },
+                    forControlEvents = UIControlEventEditingDidEndOnExit,
+                )
+                // Drive the Material label float from native focus changes.
+                addAction(
+                    UIAction.actionWithHandler { _ ->
+                        val focus = FocusInteraction.Focus()
+                        callbacks.focus = focus
+                        interactionSource.tryEmit(focus)
+                    },
+                    forControlEvents = UIControlEventEditingDidBegin,
+                )
+                addAction(
+                    UIAction.actionWithHandler { _ ->
+                        callbacks.focus?.let {
+                            interactionSource.tryEmit(FocusInteraction.Unfocus(it))
+                        }
+                        callbacks.focus = null
+                    },
+                    forControlEvents = UIControlEventEditingDidEnd,
+                )
+            }
+        }
+
+    // DecorationBox draws only the Material chrome and takes no modifier, so apply the caller's
+    // modifier here and bridge a Compose focus request (IME "Next" on the previous field) onto the
+    // native responder.
+    val focusModifier =
+        modifier
+            .let { base ->
+                if (focusRequester != null) base.focusRequester(focusRequester) else base
+            }
+            .onFocusChanged { if (it.isFocused) textField.becomeFirstResponder() }
+            .focusable()
+
+    Box(modifier = focusModifier) {
+        OutlinedTextFieldDefaults.DecorationBox(
+            value = value,
+            // Masking is handled natively by secureTextEntry, so no Compose transformation applies.
+            visualTransformation = VisualTransformation.None,
+            innerTextField = {
+                UIKitView(
+                    factory = { textField },
+                    modifier = Modifier.fillMaxWidth().height(24.dp),
+                    update = { field ->
+                        if (field.text != value) field.setText(value)
+                        if (field.secureTextEntry != isSecure) {
+                            field.secureTextEntry = isSecure
+                            // Toggling secureTextEntry can drop the font metrics; re-set to
+                            // restore.
+                            val currentFont = field.font
+                            field.font = null
+                            field.font = currentFont
+                        }
+                        field.returnKeyType =
+                            when (imeAction) {
+                                ImeAction.Next -> UIReturnKeyType.UIReturnKeyNext
+                                ImeAction.Done -> UIReturnKeyType.UIReturnKeyDone
+                                ImeAction.Go -> UIReturnKeyType.UIReturnKeyGo
+                                ImeAction.Search -> UIReturnKeyType.UIReturnKeySearch
+                                ImeAction.Send -> UIReturnKeyType.UIReturnKeySend
+                                else -> UIReturnKeyType.UIReturnKeyDefault
+                            }
+                    },
+                )
+            },
+            enabled = true,
+            singleLine = true,
+            interactionSource = interactionSource,
+            isError = error != null,
+            label = { Text(label) },
+            trailingIcon = trailingIcon,
+            supportingText = error?.let { errorText -> { Text(errorText.localized()) } },
+        )
+    }
+}
+
+/** Holds the latest hoisted callbacks + the in-flight focus interaction for the native field. */
+private class NativeFieldCallbacks {
+    var onValueChange: (String) -> Unit = {}
+    var onImeAction: () -> Unit = {}
+    var focus: FocusInteraction.Focus? = null
+}

--- a/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.jvm.kt
+++ b/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.jvm.kt
@@ -1,0 +1,39 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.text.input.ImeAction
+import com.plusmobileapps.chefmate.text.TextData
+
+// Desktop has no OS credential-autofill integration to satisfy, so delegate to the shared fallback
+// and behave exactly like the standard PlusTextField.
+@Composable
+actual fun PlusAutofillTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    fieldType: AutofillFieldType,
+    label: String,
+    modifier: Modifier,
+    error: TextData?,
+    passwordVisible: Boolean,
+    imeAction: ImeAction,
+    onImeAction: () -> Unit,
+    focusRequester: FocusRequester?,
+    trailingIcon: @Composable (() -> Unit)?,
+) =
+    FallbackAutofillTextField(
+        value = value,
+        onValueChange = onValueChange,
+        fieldType = fieldType,
+        label = label,
+        modifier = modifier,
+        error = error,
+        passwordVisible = passwordVisible,
+        imeAction = imeAction,
+        onImeAction = onImeAction,
+        focusRequester = focusRequester,
+        trailingIcon = trailingIcon,
+    )


### PR DESCRIPTION
## Why

On iOS, the login/signup fields never trigger the **Keychain save/update-password prompt** (and often don't surface the QuickType passwords key). Apple's login-form heuristic only fires when *real* `UITextField`s for the username and password are present on screen — Compose Multiplatform's own text input doesn't satisfy it yet. This is tracked upstream in [JetBrains **CMP-5802**](https://youtrack.jetbrains.com/issue/CMP-5802), currently *In Progress* and targeted for **Compose Multiplatform 1.13.0**.

This PR implements the community workaround from that issue thread: render a genuine native `UITextField` for the credential fields on iOS.

## What

New component **`PlusAutofillTextField`** (`client/ui/public`), an `expect`/`actual` credential field used only by the auth screens:

- **iOS** → a transparent native `UITextField` via `UIKitView` interop, with `textContentType` = username/password/newPassword and `secureTextEntry`, wrapped in `OutlinedTextFieldDefaults.DecorationBox` so it keeps the Material outline, floating label, error text, and password-visibility trailing icon. Text syncs both ways; the return key and Material label-float are wired through native control events.
- **Android / desktop** → delegate straight back to the existing `PlusTextField` with the same Compose autofill hints. Android's Compose autofill already fills/saves logins, so behavior there is unchanged.

`AuthenticationScreen`'s `EmailField`/`PasswordField` now use it. The general-purpose `PlusTextField` is deliberately **left untouched** — the native-interop tradeoffs (two-way text sync, the CMP-3154 transparent-background caveat) stay scoped to the two auth screens on iOS only.

This is a temporary workaround: once **CMP-5802** ships, delete the iOS `actual` and fold the callers back onto `PlusTextField` (noted in the KDoc).

## Verification

- ✅ Compiles: `commonMain`, `iosSimulatorArm64`, `androidMain`, and `jvm` for both `:client:ui:public` and `:client:auth:ui:public`.
- ⚠️ **Runtime iOS behavior not yet verified on device/simulator** (no iOS runtime in the authoring environment). Needs a on-device check for: the Keychain save/update prompt actually firing, field rendering/height inside the Material outline, the transparent background over the surface color (CMP-3154), password show/hide, and `Next` focus-chaining email → password → confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)