### PR TITLE
fix(meal): sync recipes before meals so sign-in sync doesn't drop meals

### DIFF
--- a/client/meal/data/impl/build.gradle.kts
+++ b/client/meal/data/impl/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.client.database.core)
             implementation(projects.client.meal.data.public)
+            implementation(projects.client.recipe.data.public)
             implementation(projects.client.shared)
             implementation(projects.client.auth.data.public)
             api(projects.client.util.public)

--- a/client/meal/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/impl/MealPlanRepositoryImpl.kt
+++ b/client/meal/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/data/impl/MealPlanRepositoryImpl.kt
@@ -14,6 +14,7 @@ import com.plusmobileapps.chefmate.meal.data.MealType
 import com.plusmobileapps.chefmate.meal.data.SyncStatus
 import com.plusmobileapps.chefmate.meal.data.impl.remote.MealPlanRemoteDataSource
 import com.plusmobileapps.chefmate.meal.data.impl.remote.RemoteMealPlan
+import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import com.plusmobileapps.chefmate.util.DateTimeUtil
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
@@ -41,6 +42,7 @@ class MealPlanRepositoryImpl(
     private val dateTimeUtil: DateTimeUtil,
     private val remoteDataSource: MealPlanRemoteDataSource,
     private val authRepository: AuthenticationRepository,
+    private val recipeRepository: RecipeRepository,
 ) : MealPlanRepository {
 
     private val scope = CoroutineScope(ioContext + SupervisorJob())
@@ -153,6 +155,14 @@ class MealPlanRepositoryImpl(
 
     private suspend fun syncWithRemote(userId: String) = syncMutex.withLock {
         try {
+            // Meal plans reference their recipe by the recipe's remote UUID, so the recipes have
+            // to be present locally before we pull meals — otherwise every remote meal is skipped
+            // (its recipe can't be resolved to a local id) and isn't retried until the next sync.
+            // On sign-in the recipe and meal syncs both react to the same auth-state emission and
+            // race, so ensure recipes have synced first. Recipe sync is guarded by its own mutex
+            // and is idempotent, so this coalesces with any in-flight recipe sync.
+            recipeRepository.syncAllUnsynced()
+
             // Push unsynced meal plans (no remoteId yet)
             val unsynced = withContext(ioContext) { queries.getUnsynced().executeAsList() }
             for (meal in unsynced) {


### PR DESCRIPTION
## Problem

Issue #408 — meals still weren't reliably syncing between clients after the UUID fix in #409.

Sign-in **does** already trigger a meal sync (the repo's `init` block collects `AuthState`), so the trigger wasn't the gap. The real cause is a **race**:

- Meal plans reference their recipe by the recipe's **remote UUID**. On pull, the meal sync resolves that UUID to a local recipe id and **skips any meal whose recipe isn't local yet** (`?: continue`), retrying only on the next sync.
- On sign-in the recipe repo and meal repo both react to the *same* `AuthState.Authenticated` emission **concurrently**, each on its own scope. Sign-in wipes local data first, so on a fresh device the meal pull can finish before recipes are inserted — every remote meal gets skipped and doesn't reappear until a manual sync / pull-to-refresh.

## Fix

Await `recipeRepository.syncAllUnsynced()` at the top of `MealPlanRepositoryImpl.syncWithRemote`, so recipes are guaranteed present locally before meals are pulled. Recipe sync has its own mutex and is idempotent, so this coalesces with the concurrent recipe sync rather than doing redundant work. Covers every meal-sync entry point (sign-in collector, sync button, pull-to-refresh).

Adds `recipe.data.public` as a dependency of `meal.data.impl` (no dependency cycle — `recipe.data.public` is interface-only and doesn't depend on meal).

## Verification

- `:client:meal:data:impl` compiles
- `:client:composeApp:compileKotlinJvm` compiles — confirms the Metro DI graph resolves the new `RecipeRepository` dependency
- `:client:meal:core:impl` + `:client:meal:data:impl` JVM tests pass

## Note

There's no repository-level unit test for the meal repo today (unlike grocery's `GroceryRepositoryImplTest`), so this ordering behavior isn't covered by a new test — building the fake remote/SQLDelight harness would be a separate piece of work. Happy to add it if wanted.

Fixes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)