### PR TITLE
feat(aichat): move Gemini API key to a Supabase edge function

### DIFF
--- a/client/aichat/impl/build.gradle.kts
+++ b/client/aichat/impl/build.gradle.kts
@@ -16,6 +16,8 @@ kotlin {
             implementation(projects.client.util.public)
             implementation(libs.arkivanov.decompose.core)
             implementation(libs.arkivanov.decompose.compose.extensions)
+            implementation(libs.supabase.client)
+            implementation(libs.supabase.auth)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.serialization.json)

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/GeminiClient.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/GeminiClient.kt
@@ -1,19 +1,21 @@
 package com.plusmobileapps.chefmate.aichat.impl
 
 import com.plusmobileapps.chefmate.aichat.ChatMessage
-import com.plusmobileapps.chefmate.aichat.impl.di.GeminiApiKey
+import com.plusmobileapps.chefmate.aichat.impl.di.AiChatFunctionConfig
 import com.plusmobileapps.chefmate.aichat.impl.di.GeminiHttpClient
 import com.plusmobileapps.chefmate.di.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.sse.SSEClientException
 import io.ktor.client.plugins.sse.sse
 import io.ktor.client.request.headers
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -30,12 +32,18 @@ interface GeminiClient {
     fun streamReply(history: List<ChatMessage>): Flow<String>
 }
 
+/**
+ * Talks to the `ai-chat` Supabase Edge Function (which holds the Gemini API key) rather than Gemini
+ * directly. The function pipes Gemini's SSE stream straight back, so each event's `data:` is still
+ * a Gemini `GenerateContentResponse` and the parsing below is unchanged from the direct-to-Gemini
+ * days.
+ */
 @Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealGeminiClient(
     @GeminiHttpClient private val httpClient: HttpClient,
-    @GeminiApiKey private val apiKey: String,
+    private val functionConfig: AiChatFunctionConfig,
 ) : GeminiClient {
 
     private val json = Json {
@@ -44,41 +52,53 @@ class RealGeminiClient(
     }
 
     override fun streamReply(history: List<ChatMessage>): Flow<String> = flow {
-        if (apiKey.isBlank()) {
-            throw GeminiException("MISSING_API_KEY")
-        }
         val contents = history.map { message ->
             GeminiContent(
                 role = if (message.role == ChatMessage.Role.USER) "user" else "model",
                 parts = listOf(GeminiPart(text = message.content)),
             )
         }
-        val request = GeminiRequest(contents = contents)
+        val request = ChatRequest(stream = true, contents = contents)
+        val token = functionConfig.accessToken()
 
-        httpClient.sse(
-            urlString =
-                "https://generativelanguage.googleapis.com/v1beta/models/" +
-                    "$MODEL_ID:streamGenerateContent?alt=sse&key=$apiKey",
-            request = {
-                method = HttpMethod.Post
-                contentType(ContentType.Application.Json)
-                headers { append(HttpHeaders.Accept, "text/event-stream") }
-                setBody(request)
-            },
-        ) {
-            incoming.collect { event ->
-                val data = event.data ?: return@collect
-                if (data.isBlank() || data == "[DONE]") return@collect
-                val parsed =
-                    runCatching { json.decodeFromString(GeminiStreamResponse.serializer(), data) }
-                        .getOrNull() ?: return@collect
-                val text = parsed.candidates?.firstOrNull()?.content?.parts?.firstOrNull()?.text
-                if (!text.isNullOrEmpty()) emit(text)
+        try {
+            httpClient.sse(
+                urlString = functionConfig.functionUrl,
+                request = {
+                    method = HttpMethod.Post
+                    contentType(ContentType.Application.Json)
+                    headers {
+                        append("apikey", functionConfig.anonKey)
+                        append(HttpHeaders.Authorization, "Bearer $token")
+                        append(HttpHeaders.Accept, "text/event-stream")
+                    }
+                    setBody(request)
+                },
+            ) {
+                incoming.collect { event ->
+                    val data = event.data ?: return@collect
+                    if (data.isBlank() || data == "[DONE]") return@collect
+                    val parsed =
+                        runCatching {
+                            json.decodeFromString(GeminiStreamResponse.serializer(), data)
+                        }
+                            .getOrNull() ?: return@collect
+                    val text = parsed.candidates?.firstOrNull()?.content?.parts?.firstOrNull()?.text
+                    if (!text.isNullOrEmpty()) emit(text)
+                }
             }
+        } catch (e: SSEClientException) {
+            // 503 means the server-side Gemini key isn't configured. Surface it as the same
+            // "no API key" state the UI showed when the key was a client build variable.
+            if (e.response?.status == HttpStatusCode.ServiceUnavailable) {
+                throw GeminiException("MISSING_API_KEY", e)
+            }
+            throw GeminiException("REQUEST_FAILED", e)
         }
     }
 
-    @Serializable private data class GeminiRequest(val contents: List<GeminiContent>)
+    @Serializable
+    private data class ChatRequest(val stream: Boolean, val contents: List<GeminiContent>)
 
     @Serializable private data class GeminiContent(val role: String, val parts: List<GeminiPart>)
 
@@ -88,8 +108,4 @@ class RealGeminiClient(
     private data class GeminiStreamResponse(val candidates: List<GeminiCandidate>? = null)
 
     @Serializable private data class GeminiCandidate(val content: GeminiContent? = null)
-
-    companion object {
-        private const val MODEL_ID = "gemini-2.5-flash"
-    }
 }

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/GeminiRecipeExtractor.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/GeminiRecipeExtractor.kt
@@ -1,7 +1,7 @@
 package com.plusmobileapps.chefmate.aichat.impl
 
 import com.plusmobileapps.chefmate.aichat.ChatMessage
-import com.plusmobileapps.chefmate.aichat.impl.di.GeminiApiKey
+import com.plusmobileapps.chefmate.aichat.impl.di.AiChatFunctionConfig
 import com.plusmobileapps.chefmate.aichat.impl.di.GeminiHttpClient
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
@@ -14,10 +14,14 @@ import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metro.binding
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import io.ktor.http.isSuccess
 import io.ktor.util.encodeBase64
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -41,6 +45,10 @@ interface GeminiRecipeExtractor {
  * a single image ([RecipeImageExtractor.extractFromImage], used by the chat photo-attach button and
  * the standalone "Scan from photo" flow). Both share the same structured-output request and
  * parsing; only the request `contents` differ.
+ *
+ * Requests go through the `ai-chat` Supabase Edge Function (which holds the Gemini API key) rather
+ * than Gemini directly. The function returns Gemini's `:generateContent` JSON verbatim, so the
+ * `candidates` parsing below is unchanged from the direct-to-Gemini days.
  */
 @Inject
 @SingleIn(AppScope::class)
@@ -48,7 +56,7 @@ interface GeminiRecipeExtractor {
 @ContributesBinding(AppScope::class, binding = binding<RecipeImageExtractor>())
 class RealGeminiRecipeExtractor(
     @GeminiHttpClient private val httpClient: HttpClient,
-    @GeminiApiKey private val apiKey: String,
+    private val functionConfig: AiChatFunctionConfig,
 ) : GeminiRecipeExtractor, RecipeImageExtractor {
 
     private val json = Json {
@@ -93,21 +101,37 @@ class RealGeminiRecipeExtractor(
      * [RecipeExtractionException] carrying a typed [RecipeExtractionError].
      */
     private suspend fun generate(contents: List<GeminiContent>): ExtractedRecipeData {
-        if (apiKey.isBlank()) throw RecipeExtractionException(RecipeExtractionError.MISSING_API_KEY)
-
-        val request = GeminiRequest(contents = contents, generationConfig = recipeGenerationConfig)
+        val request =
+            ChatRequest(
+                stream = false,
+                contents = contents,
+                generationConfig = recipeGenerationConfig,
+            )
+        val token = functionConfig.accessToken()
 
         val response: GeminiResponse =
             try {
-                httpClient
-                    .post(
-                        "https://generativelanguage.googleapis.com/v1beta/models/" +
-                            "$MODEL_ID:generateContent?key=$apiKey"
-                    ) {
+                val httpResponse =
+                    httpClient.post(functionConfig.functionUrl) {
                         contentType(ContentType.Application.Json)
+                        headers {
+                            append("apikey", functionConfig.anonKey)
+                            append(HttpHeaders.Authorization, "Bearer $token")
+                        }
                         setBody(request)
                     }
-                    .body<GeminiResponse>()
+                // The edge function returns 503 when the server-side Gemini key isn't configured;
+                // surface that as the same "no API key" state the UI showed when the key was a
+                // build variable. Any other non-2xx is a generic request failure.
+                if (httpResponse.status == HttpStatusCode.ServiceUnavailable) {
+                    throw RecipeExtractionException(RecipeExtractionError.MISSING_API_KEY)
+                }
+                if (!httpResponse.status.isSuccess()) {
+                    throw RecipeExtractionException(RecipeExtractionError.REQUEST_FAILED)
+                }
+                httpResponse.body<GeminiResponse>()
+            } catch (e: RecipeExtractionException) {
+                throw e
             } catch (e: Throwable) {
                 throw RecipeExtractionException(RecipeExtractionError.REQUEST_FAILED, e)
             }
@@ -116,11 +140,12 @@ class RealGeminiRecipeExtractor(
             response.candidates?.firstOrNull()?.content?.parts?.firstOrNull()?.text
                 ?: throw RecipeExtractionException(RecipeExtractionError.EMPTY_RESPONSE)
 
-        val recipe =
-            runCatching { json.decodeFromString(RecipeJson.serializer(), payload) }
-                .getOrElse {
-                    throw RecipeExtractionException(RecipeExtractionError.MALFORMED_JSON, it)
-                }
+        val recipe = runCatching {
+            json.decodeFromString(RecipeJson.serializer(), payload)
+        }
+            .getOrElse {
+                throw RecipeExtractionException(RecipeExtractionError.MALFORMED_JSON, it)
+            }
 
         if (recipe.title.isBlank() || recipe.ingredients.isEmpty() || recipe.directions.isEmpty()) {
             throw RecipeExtractionException(RecipeExtractionError.INCOMPLETE_RECIPE)
@@ -153,7 +178,8 @@ class RealGeminiRecipeExtractor(
         )
 
     @Serializable
-    private data class GeminiRequest(
+    private data class ChatRequest(
+        val stream: Boolean,
         val contents: List<GeminiContent>,
         val generationConfig: JsonObject,
     )
@@ -190,8 +216,6 @@ class RealGeminiRecipeExtractor(
     )
 
     companion object {
-        private const val MODEL_ID = "gemini-2.5-flash"
-
         private const val IMAGE_EXTRACTION_INSTRUCTION =
             "Extract the recipe shown in this image as JSON matching the response schema. The " +
                 "image may be a cookbook page, food label, screenshot, or handwritten card. Use " +

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/di/GeminiHttpClient.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/di/GeminiHttpClient.kt
@@ -1,11 +1,14 @@
 package com.plusmobileapps.chefmate.aichat.impl.di
 
-import com.plusmobileapps.chefmate.buildconfig.BuildConfig
 import com.plusmobileapps.chefmate.di.AppScope
+import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.Qualifier
 import dev.zacsweers.metro.SingleIn
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.auth.auth
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.sse.SSE
@@ -30,18 +33,50 @@ import kotlinx.serialization.json.Json
 annotation class GeminiHttpClient
 
 /**
- * Qualifier for the Gemini API key. Provided from [BuildConfig] but injected (rather than read
- * directly) so the Gemini clients can be unit-tested with a fixed key instead of depending on the
- * build-time value.
+ * Connection details for the `ai-chat` Supabase Edge Function that proxies to Gemini.
+ *
+ * The Gemini API key used to live in the client build
+ * ([com.plusmobileapps.chefmate.buildconfig.BuildConfig]), which leaked it to anyone who cracked
+ * the binary. It now lives only in the edge function; the client just needs the function URL and
+ * Supabase auth headers, which this abstraction supplies. Injected (rather than reading
+ * [SupabaseClient] directly in the Gemini clients) so those clients stay unit-testable against a
+ * plain fake.
  */
-@Qualifier
-@Target(
-    AnnotationTarget.PROPERTY_GETTER,
-    AnnotationTarget.FUNCTION,
-    AnnotationTarget.VALUE_PARAMETER,
-    AnnotationTarget.TYPE,
-)
-annotation class GeminiApiKey
+interface AiChatFunctionConfig {
+    /**
+     * Absolute URL of the `ai-chat` edge function, e.g.
+     * `https://xyz.supabase.co/functions/v1/ai-chat`.
+     */
+    val functionUrl: String
+
+    /** Supabase anon/public key, sent as the `apikey` header. */
+    val anonKey: String
+
+    /**
+     * Bearer token for the `Authorization` header: the current user's access token (the app is
+     * always signed in, anonymously at minimum), falling back to the anon key.
+     */
+    fun accessToken(): String
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class SupabaseAiChatFunctionConfig(private val supabaseClient: SupabaseClient) :
+    AiChatFunctionConfig {
+
+    override val functionUrl: String =
+        "${supabaseClient.supabaseHttpUrl}/functions/v1/$FUNCTION_NAME"
+
+    override val anonKey: String = supabaseClient.supabaseKey
+
+    override fun accessToken(): String =
+        supabaseClient.auth.currentAccessTokenOrNull() ?: supabaseClient.supabaseKey
+
+    companion object {
+        private const val FUNCTION_NAME = "ai-chat"
+    }
+}
 
 @ContributesTo(AppScope::class)
 interface GeminiHttpClientComponent {
@@ -60,6 +95,4 @@ interface GeminiHttpClientComponent {
             )
         }
     }
-
-    @Provides @GeminiApiKey fun providesGeminiApiKey(): String = BuildConfig.GEMINI_API_KEY
 }

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatPreviews.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatPreviews.kt
@@ -116,7 +116,7 @@ val previewAiChatBlocError: AiChatBloc =
         AiChatBloc.Model(
             messages = sampleConversation,
             canAddRecipe = true,
-            error = FixedString("Gemini API key missing. Set gemini.key in gradle properties."),
+            error = FixedString("AI features aren’t available right now. Please try again later."),
         )
     )
 

--- a/client/aichat/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/aichat/impl/GeminiRecipeExtractorImageTest.kt
+++ b/client/aichat/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/aichat/impl/GeminiRecipeExtractorImageTest.kt
@@ -1,5 +1,6 @@
 package com.plusmobileapps.chefmate.aichat.impl
 
+import com.plusmobileapps.chefmate.aichat.impl.di.AiChatFunctionConfig
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import io.kotest.assertions.throwables.shouldThrow
@@ -55,8 +56,13 @@ class GeminiRecipeExtractorImageTest {
     }
 
     @Test
-    fun extractFromImage_blank_api_key_throws_missing_api_key() = runTest {
-        val extractor = extractorReturning(geminiResponse("{}"), apiKey = "")
+    fun extractFromImage_server_missing_key_503_throws_missing_api_key() = runTest {
+        // The edge function returns 503 when GEMINI_API_KEY isn't configured server-side.
+        val extractor =
+            extractorReturning(
+                """{"error":"MISSING_API_KEY"}""",
+                status = HttpStatusCode.ServiceUnavailable,
+            )
 
         val error =
             shouldThrow<RecipeExtractionException> {
@@ -113,23 +119,21 @@ class GeminiRecipeExtractorImageTest {
     }
 
     /** Wraps [recipeJson] (the structured-output payload) in Gemini's candidate envelope. */
-    private fun geminiResponse(recipeJson: String): String =
-        buildJsonObject {
-                putJsonArray("candidates") {
-                    addJsonObject {
-                        putJsonObject("content") {
-                            put("role", "model")
-                            putJsonArray("parts") { addJsonObject { put("text", recipeJson) } }
-                        }
-                    }
+    private fun geminiResponse(recipeJson: String): String = buildJsonObject {
+        putJsonArray("candidates") {
+            addJsonObject {
+                putJsonObject("content") {
+                    put("role", "model")
+                    putJsonArray("parts") { addJsonObject { put("text", recipeJson) } }
                 }
             }
-            .toString()
+        }
+    }
+        .toString()
 
     private fun extractorReturning(
         responseBody: String,
         status: HttpStatusCode = HttpStatusCode.OK,
-        apiKey: String = "test-key",
     ): RealGeminiRecipeExtractor {
         val engine = MockEngine { request ->
             lastRequestBody = (request.body as TextContent).text
@@ -150,6 +154,13 @@ class GeminiRecipeExtractorImageTest {
                     )
                 }
             }
-        return RealGeminiRecipeExtractor(client, apiKey)
+        return RealGeminiRecipeExtractor(client, FakeAiChatFunctionConfig)
+    }
+
+    private object FakeAiChatFunctionConfig : AiChatFunctionConfig {
+        override val functionUrl = "https://test.supabase.co/functions/v1/ai-chat"
+        override val anonKey = "test-anon-key"
+
+        override fun accessToken() = "test-access-token"
     }
 }

--- a/client/aichat/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/aichat/public/src/commonMain/composeResources/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="aichat_done">Done</string>
     <string name="aichat_empty_title">Start a conversation</string>
     <string name="aichat_empty_description">Ask Gemini about recipes, ingredients, or anything else.</string>
-    <string name="aichat_error_no_api_key">Gemini API key missing. Set gemini.key in your gradle properties.</string>
+    <string name="aichat_error_no_api_key">AI features aren’t available right now. Please try again later.</string>
     <string name="aichat_error_generic">Something went wrong. Try again.</string>
     <string name="aichat_role_you">You</string>
     <string name="aichat_role_gemini">Gemini</string>

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -63,8 +63,6 @@ val supabaseTestingKey =
 val bugsnagApiKey =
     (findProperty("bugsnag.apiKey") as? String) ?: System.getenv("BUGSNAG_API_KEY") ?: ""
 
-val geminiKey = (findProperty("gemini.key") as? String) ?: System.getenv("GEMINI_API_KEY") ?: ""
-
 // Collect test users by incrementing n until a pair is missing. Looked up in order:
 // 1. local.properties at the project root (chefmate.user.<n> / chefmate.user.password.<n>)
 // 2. ~/.gradle/gradle.properties or any other Gradle property source (same keys)
@@ -126,7 +124,6 @@ buildkonfig {
         buildConfigField(STRING, "SUPABASE_TESTING_URL", supabaseTestingUrl)
         buildConfigField(STRING, "SUPABASE_TESTING_KEY", supabaseTestingKey)
         buildConfigField(STRING, "BUGSNAG_API_KEY", bugsnagApiKey)
-        buildConfigField(STRING, "GEMINI_API_KEY", geminiKey)
         buildConfigField(STRING, "TEST_USERS", testUsersSerialized)
         buildConfigField(BOOLEAN, "IS_DEBUG", isDebugBuildFlag.toString())
         buildConfigField(STRING, "VERSION_NAME", appVersionName)

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatErrorLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatErrorLightScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91ee24477f6a1c614f6fbef1de93c0ac820d49b6a54eafc4db3db76447608d1e
-size 130553
+oid sha256:71a1dc258211b33cc8a28907896f1fba04e29c422c250b3eeb362037f8176c2c
+size 130248

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -1,0 +1,126 @@
+// Supabase Edge Function: ai-chat
+//
+// Server-side proxy for the in-app AI chat (Google Gemini). The Gemini API key used to ship in the
+// client build (BuildConfig.GEMINI_API_KEY), which meant anyone could pull it out of the binary.
+// Moving the key into this function keeps it server-only: the client sends the chat history, this
+// function forwards it to Gemini with the secret key and streams the reply back.
+//
+// The app talks to this function for two things, distinguished by the `stream` flag in the body:
+//   - stream = true  → streaming chat reply (Gemini `:streamGenerateContent?alt=sse`). The upstream
+//                      SSE body is piped straight back so the client's existing SSE parsing is
+//                      unchanged (each event's `data:` is a Gemini `GenerateContentResponse`).
+//   - stream = false → one-shot structured-output extraction (Gemini `:generateContent`). Used by
+//                      the "Add recipe" pill and the photo-scan flow. `generationConfig` carries the
+//                      responseSchema. The Gemini JSON is returned verbatim (same `candidates` shape).
+//
+// Only `contents` and `generationConfig` are forwarded — the model id and API key are fixed here so
+// a client can't override them.
+//
+// Auth: callers must present a Supabase JWT (the app is always signed in, anonymously at minimum).
+// Edge Functions verify the JWT at the gateway by default; we additionally reject a missing header.
+//
+// Deploy:  supabase functions deploy ai-chat
+// Secrets: supabase secrets set GEMINI_API_KEY=<key>
+//          (SUPABASE_URL / SUPABASE_ANON_KEY are injected automatically by Supabase.)
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const MODEL_ID = "gemini-2.5-flash";
+const GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta/models";
+
+interface ChatRequest {
+  stream?: boolean;
+  contents?: unknown;
+  generationConfig?: unknown;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return json({ error: "Method not allowed" }, 405);
+  }
+
+  // Gate access to signed-in callers. Supabase verifies the JWT at the gateway; this is a
+  // defence-in-depth check so the function never runs unauthenticated even if that changes.
+  if (!req.headers.get("Authorization")) {
+    return json({ error: "Missing Authorization header" }, 401);
+  }
+
+  const apiKey = Deno.env.get("GEMINI_API_KEY");
+  if (!apiKey) {
+    // Surfaced by the client as the "AI features not configured" state.
+    return json({ error: "MISSING_API_KEY" }, 503);
+  }
+
+  let payload: ChatRequest;
+  try {
+    payload = (await req.json()) as ChatRequest;
+  } catch (_) {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (!Array.isArray(payload.contents) || payload.contents.length === 0) {
+    return json({ error: "Missing contents" }, 400);
+  }
+
+  // Only forward the two fields we control; the model id and key are fixed above.
+  const geminiBody: Record<string, unknown> = { contents: payload.contents };
+  if (payload.generationConfig != null) {
+    geminiBody.generationConfig = payload.generationConfig;
+  }
+
+  const stream = payload.stream === true;
+  const upstreamUrl = stream
+    ? `${GEMINI_BASE}/${MODEL_ID}:streamGenerateContent?alt=sse&key=${apiKey}`
+    : `${GEMINI_BASE}/${MODEL_ID}:generateContent?key=${apiKey}`;
+
+  let geminiResponse: Response;
+  try {
+    geminiResponse = await fetch(upstreamUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(geminiBody),
+    });
+  } catch (e) {
+    return json({ error: `Gemini request failed: ${String(e)}` }, 502);
+  }
+
+  if (!geminiResponse.ok) {
+    const detail = await geminiResponse.text();
+    return json({ error: `Gemini error (${geminiResponse.status}): ${detail}` }, 502);
+  }
+
+  if (stream) {
+    // Pipe Gemini's Server-Sent Events straight back to the client, unbuffered.
+    return new Response(geminiResponse.body, {
+      status: 200,
+      headers: {
+        ...corsHeaders,
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  }
+
+  // One-shot: return Gemini's JSON verbatim so the client parses the same `candidates` shape.
+  const body = await geminiResponse.text();
+  return new Response(body, {
+    status: 200,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
Closes #290.

## Why

The Gemini API key powering AI chat shipped in the client build
(`BuildConfig.GEMINI_API_KEY`), so anyone could extract it from the binary. This
moves the key server-side into a Supabase Edge Function, matching how the app
already handles other privileged operations (`delete-account`, `send-invite-email`).

## What

**New `ai-chat` edge function** (`supabase/functions/ai-chat/index.ts`)
- Holds `GEMINI_API_KEY` as a secret and proxies both AI-chat entry points,
  distinguished by a `stream` flag in the request body:
  - `stream: true` → SSE passthrough of Gemini `:streamGenerateContent` (the app's
    progressive streaming reply).
  - `stream: false` → one-shot `:generateContent` for structured-output recipe
    extraction (the "Add recipe" pill + photo-scan flow).
- Forwards only `contents` and `generationConfig`; the model id and key are fixed
  server-side so a client can't override them.
- Requires a Supabase JWT (the app is always signed in, anonymously at minimum);
  returns `503 {"error":"MISSING_API_KEY"}` when the key isn't configured.

**Client rewire** (`client/aichat/impl`)
- New injectable `AiChatFunctionConfig` (backed by `SupabaseClient`) supplies the
  function URL, anon key, and current access token — keeps the Gemini clients
  unit-testable against a plain fake instead of the full SDK.
- `RealGeminiClient` (streaming) and `RealGeminiRecipeExtractor` (one-shot) now
  call the edge function with Supabase auth headers. Gemini's response shapes are
  piped through verbatim, so the existing SSE / `candidates` parsing is unchanged.
- The function's 503 maps to the existing `MISSING_API_KEY` → "AI unavailable"
  error state.

**Cleanup**
- Removed `GEMINI_API_KEY` / `gemini.key` from `BuildConfig` (`client/shared`).
- Reworded the "no API key" copy — it no longer tells end users to set a gradle
  property.

## Deployment note

After merge, deploy the function and set its secret:

```
supabase functions deploy ai-chat
supabase secrets set GEMINI_API_KEY=<key>
```

## Testing

- `./gradlew :client:aichat:impl:jvmTest` — green (extractor tests updated;
  MISSING_API_KEY now driven by a 503 response).
- `./gradlew :client:composeApp:compileKotlinJvm` — full DI graph resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)