### PR TITLE
fix(auth): iOS credential-autofill field polish (background, sign-up fill, resting hint)

### DIFF
--- a/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
+++ b/client/auth/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/auth/ui/AuthenticationScreen.kt
@@ -211,10 +211,11 @@ private fun AuthenticationBody(
             modifier = Modifier.focusRequester(passwordFocusRequester),
             password = password,
             onPasswordChanged = onPasswordChanged,
-            // Signing in fills the saved password; signing up asks the manager to generate/save a
-            // new one.
-            fieldType =
-                if (isSignIn) AutofillFieldType.PASSWORD else AutofillFieldType.NEW_PASSWORD,
+            // Both modes hint a plain login password so third-party managers offer to fill the
+            // existing credential. (We intentionally don't use a "new password" hint on sign up:
+            // iOS only surfaces that via iCloud Keychain, so with a third-party manager it shows
+            // nothing, whereas a plain password field lets the manager fill an existing login.)
+            fieldType = AutofillFieldType.PASSWORD,
             error = model.passwordError,
             imeAction = if (isSignIn) ImeAction.Done else ImeAction.Next,
             onImeAction = {
@@ -254,7 +255,7 @@ private fun AuthenticationBody(
                     modifier = Modifier.focusRequester(confirmPasswordFocusRequester),
                     password = confirmPassword,
                     onPasswordChanged = onConfirmPasswordChanged,
-                    fieldType = AutofillFieldType.NEW_PASSWORD,
+                    fieldType = AutofillFieldType.PASSWORD,
                     label = stringResource(Res.string.auth_label_confirm_password),
                     error = model.confirmPasswordError,
                     imeAction = ImeAction.Done,

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.kt
@@ -23,10 +23,14 @@ enum class AutofillFieldType {
      * password managers classify it unambiguously as a login field.
      */
     EMAIL,
-    /** An existing password to fill on sign in. */
+    /**
+     * A login password. Hinted so password managers offer to fill the account's saved password.
+     * Used for both sign in and sign up: a plain password hint (rather than a "new password" one)
+     * is what lets third-party managers surface an existing credential on the sign-up form too —
+     * iOS only offers its generate-a-new-password flow through iCloud Keychain, so a new-password
+     * hint shows nothing when a third-party manager is the AutoFill provider.
+     */
     PASSWORD,
-    /** A password being created on sign up, so the manager offers to generate and save it. */
-    NEW_PASSWORD,
 }
 
 /**
@@ -69,20 +73,19 @@ internal val AutofillFieldType.composeContentType: ContentType
         when (this) {
             // This is the account's login identifier, which password managers store as the
             // "username" even though users type their email into it. Hinting plain Username (rather
-            // than also EmailAddress) classifies it unambiguously as a login field, so managers like
+            // than also EmailAddress) classifies it unambiguously as a login field, so managers
+            // like
             // Bitwarden proactively offer the on-focus inline suggestion instead of only filling it
             // on demand.
             AutofillFieldType.EMAIL -> ContentType.Username
             AutofillFieldType.PASSWORD -> ContentType.Password
-            AutofillFieldType.NEW_PASSWORD -> ContentType.NewPassword
         }
 
 internal val AutofillFieldType.keyboardType: KeyboardType
     get() =
         when (this) {
             AutofillFieldType.EMAIL -> KeyboardType.Email
-            AutofillFieldType.PASSWORD,
-            AutofillFieldType.NEW_PASSWORD -> KeyboardType.Password
+            AutofillFieldType.PASSWORD -> KeyboardType.Password
         }
 
 // Masks secure input with bullets. Replacing 1:1 keeps the caret mapping identity, so the cursor

--- a/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.ios.kt
+++ b/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.ios.kt
@@ -13,7 +13,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -74,6 +77,12 @@ actual fun PlusAutofillTextField(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isSecure = fieldType.isSecure(passwordVisible)
+    // The Material resting label sits in the center of the field, but the opaque native field
+    // composites over it (see class doc) so it's invisible until focus floats it up to the outline.
+    // To show a resting hint we set the native field's own placeholder, and clear it while focused
+    // so
+    // it doesn't collide with the Material label that's floating up onto the border.
+    var isFocused by remember { mutableStateOf(false) }
     // The color the field sits on. Painted onto the native field (see class doc) because the
     // interop
     // layer can't render a transparent background, and re-applied in `update` to follow theme
@@ -118,9 +127,10 @@ actual fun PlusAutofillTextField(
                     UIAction.actionWithHandler { _ -> callbacks.onImeAction() },
                     forControlEvents = UIControlEventEditingDidEndOnExit,
                 )
-                // Drive the Material label float from native focus changes.
+                // Drive the Material label float (and the resting placeholder) from native focus.
                 addAction(
                     UIAction.actionWithHandler { _ ->
+                        isFocused = true
                         val focus = FocusInteraction.Focus()
                         callbacks.focus = focus
                         interactionSource.tryEmit(focus)
@@ -129,6 +139,7 @@ actual fun PlusAutofillTextField(
                 )
                 addAction(
                     UIAction.actionWithHandler { _ ->
+                        isFocused = false
                         callbacks.focus?.let {
                             interactionSource.tryEmit(FocusInteraction.Unfocus(it))
                         }
@@ -161,6 +172,10 @@ actual fun PlusAutofillTextField(
                     modifier = Modifier.fillMaxWidth().height(24.dp),
                     update = { field ->
                         field.backgroundColor = fieldBackground.toUIColor()
+                        // Resting hint (unfocused, empty). Cleared on focus so it doesn't double up
+                        // with the Material label floating onto the outline; iOS hides it once the
+                        // user types.
+                        field.placeholder = if (isFocused) null else label
                         if (field.text != value) field.setText(value)
                         if (field.secureTextEntry != isSecure) {
                             field.secureTextEntry = isSecure

--- a/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.ios.kt
+++ b/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.ios.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
@@ -46,13 +48,16 @@ import platform.UIKit.UITextSpellCheckingType
  * passwords key) when genuine `UITextField`s for the login and password are present on screen —
  * Compose's own text input does not satisfy it yet (JetBrains CMP-5802, targeted 1.13.0).
  *
- * The native field is made transparent and placed inside [OutlinedTextFieldDefaults.DecorationBox]
- * so it keeps the Material outline, floating label, error, and trailing icon that the rest of the
- * app uses; Compose draws the decoration, the user types into the native field.
+ * The native field is placed inside [OutlinedTextFieldDefaults.DecorationBox] so it keeps the
+ * Material outline, floating label, error, and trailing icon that the rest of the app uses; Compose
+ * draws the decoration, the user types into the native field.
  *
- * Known caveat: interop views don't yet composite with a truly transparent background in every case
- * (CMP-3154). Our auth fields sit on the surface color, so a clear background reads correctly;
- * revisit if these fields are ever placed over a gradient/image.
+ * Background: interop views don't yet composite with a truly transparent background (CMP-3154), so
+ * a `clearColor` field renders as an opaque system background (solid white/black) that stands out
+ * against the screen. Instead we paint the native field with the resolved Compose [background]
+ * color so it blends into the surface it sits on. The color is re-applied on every recompose so it
+ * tracks light/dark theme changes. Revisit (and switch back to a clear background) once CMP-3154
+ * ships, or if these fields are ever placed over a gradient/image where a solid fill won't match.
  */
 @Composable
 actual fun PlusAutofillTextField(
@@ -70,6 +75,11 @@ actual fun PlusAutofillTextField(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isSecure = fieldType.isSecure(passwordVisible)
+    // The color the field sits on. Painted onto the native field (see class doc) because the
+    // interop
+    // layer can't render a transparent background, and re-applied in `update` to follow theme
+    // changes.
+    val fieldBackground = MaterialTheme.colorScheme.background
 
     // Latest hoisted callbacks, read from inside the once-built native action handlers.
     val callbacks = remember { NativeFieldCallbacks() }
@@ -82,7 +92,8 @@ actual fun PlusAutofillTextField(
         remember(fieldType) {
             UITextField().apply {
                 borderStyle = UITextBorderStyle.UITextBorderStyleNone
-                backgroundColor = UIColor.clearColor
+                // Initial fill; kept in sync with the theme in `update` below.
+                backgroundColor = fieldBackground.toUIColor()
                 setOpaque(false)
                 autocapitalizationType =
                     UITextAutocapitalizationType.UITextAutocapitalizationTypeNone
@@ -151,6 +162,7 @@ actual fun PlusAutofillTextField(
                     factory = { textField },
                     modifier = Modifier.fillMaxWidth().height(24.dp),
                     update = { field ->
+                        field.backgroundColor = fieldBackground.toUIColor()
                         if (field.text != value) field.setText(value)
                         if (field.secureTextEntry != isSecure) {
                             field.secureTextEntry = isSecure
@@ -182,6 +194,15 @@ actual fun PlusAutofillTextField(
         )
     }
 }
+
+/** Bridges a Compose [Color] to the equivalent sRGB [UIColor] for the native field's background. */
+private fun Color.toUIColor(): UIColor =
+    UIColor(
+        red = red.toDouble(),
+        green = green.toDouble(),
+        blue = blue.toDouble(),
+        alpha = alpha.toDouble(),
+    )
 
 /** Holds the latest hoisted callbacks + the in-flight focus interaction for the native field. */
 private class NativeFieldCallbacks {

--- a/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.ios.kt
+++ b/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusAutofillTextField.ios.kt
@@ -36,7 +36,6 @@ import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UITextAutocapitalizationType
 import platform.UIKit.UITextAutocorrectionType
 import platform.UIKit.UITextBorderStyle
-import platform.UIKit.UITextContentTypeNewPassword
 import platform.UIKit.UITextContentTypePassword
 import platform.UIKit.UITextContentTypeUsername
 import platform.UIKit.UITextField
@@ -107,7 +106,6 @@ actual fun PlusAutofillTextField(
                         textContentType = UITextContentTypeUsername
                     }
                     AutofillFieldType.PASSWORD -> textContentType = UITextContentTypePassword
-                    AutofillFieldType.NEW_PASSWORD -> textContentType = UITextContentTypeNewPassword
                 }
 
                 // Native -> Compose: forward every keystroke (and system autofill) to the caller.


### PR DESCRIPTION
Three fixes to the native iOS credential-autofill field (`PlusAutofillTextField`, added in #422). Only the iOS path is affected; Android/desktop delegate to the plain `PlusTextField` and are untouched.

## 1. Blend the field into the surface (`dc053b46`)

The native `UITextField` set a `clearColor` background, but Compose's `UIKitView` interop can't composite a truly transparent background yet (JetBrains **CMP-3154**), so it rendered as an opaque system background — solid white in light mode, black in dark — that stood out against the auth screen.

Now painted with the resolved Compose `colorScheme.background` (the color the auth fields sit on), re-applied in the interop `update` block so it tracks light/dark theme changes. Trivially reverts to a clear background once CMP-3154 ships.

## 2. Sign-up offers to fill an existing login (`2ae2e70c`)

The sign-up password + confirm fields hinted `newPassword`, which drives iOS **Automatic Strong Passwords** — an **iCloud-Keychain-only** flow. On a real device with a third-party manager (Bitwarden/1Password) as the AutoFill provider, `newPassword` fields surface nothing, so sign-up looked like it had no autofill at all while the QuickType bar kept showing only the username suggestion.

Both sign-up fields now hint a plain login password (`AutofillFieldType.PASSWORD`, same as sign in) so the manager offers to **fill an existing credential** on the sign-up form. This trades away iCloud's strong-password generation (which third-party-manager users don't get anyway). The `NEW_PASSWORD` enum value is now unused and was removed along with its content-type/keyboard mappings.

> Note: the associated-domain setup is correct — the hosted AASA advertises `webcredentials` for `Y89258SF5P.com.plusmobileapps.chefmate.ChefMate`, and the entitlement matches. This was an AutoFill-provider behavior difference, not a domain bug.

## 3. Resting hint is now visible (`d6194b9a`)

Because the opaque native field composites **over** the Compose layer, the Material *resting* label (centered when the field is empty + unfocused) was hidden behind it — the hint only appeared once focus floated the label up onto the outline.

The native field now uses its **own placeholder** for the resting hint, cleared on focus so it doesn't collide with the Material label animating onto the border. iOS hides the placeholder automatically once the user types.

## Testing

- `./gradlew :client:ui:public:compileKotlinIosSimulatorArm64 :client:auth:ui:public:compileKotlinIosSimulatorArm64` ✅
- **Needs an on-device check** (can't be exercised in CI):
  - Field matches the surface in light **and** dark mode.
  - Sign-up: password manager offers to fill an existing login; confirm the manager still prompts to **save** a newly created credential.
  - Resting hint is visible before focus and the label transitions onto the outline on focus. (Known minor: the float animation is partly occluded by the opaque native field until the label clears the top edge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)