### PR TITLE
fix(recipe): only number directions when the author typed numbers

### DIFF
--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -1212,6 +1212,7 @@ private fun ColumnScope.RecipeDetailExpandedContent(
                 DirectionLineItem(
                     text = step.text,
                     number = step.number,
+                    isHeader = step.isHeader,
                     highlighted = directionHighlightedIndex == index,
                     onClick = {
                         directionHighlightedIndex =
@@ -1642,19 +1643,21 @@ private fun IngredientLineItem(
 }
 
 /**
- * One rendered directions line. [number] is the step number (1-based, reset per section); a null
- * [number] marks a section header (a line ending in `:`), which renders bold and is not numbered or
- * tappable.
+ * One rendered directions line. When [isHeader] is set (a line ending in `:`) it renders bold and
+ * is not tappable. Otherwise it's a step: [number] is the author's manually-typed enumerator
+ * rendered as a bold prefix when present, or null to render the text plainly — numbers are never
+ * auto-generated.
  */
 @Composable
 private fun DirectionLineItem(
     text: String,
     number: Int?,
+    isHeader: Boolean,
     highlighted: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (number == null) {
+    if (isHeader) {
         Text(
             text = text,
             style = MaterialTheme.typography.titleSmall,
@@ -1674,7 +1677,9 @@ private fun DirectionLineItem(
     val rendered =
         remember(text, number) {
             buildAnnotatedString {
-                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("$number. ") }
+                if (number != null) {
+                    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("$number. ") }
+                }
                 append(text.toInlineMarkdownAnnotatedString())
             }
         }
@@ -1703,26 +1708,33 @@ private fun DirectionLineItem(
 }
 
 /**
- * A directions line with its display info: section headers (lines ending in `:`) carry a null
- * [number]; real steps are numbered 1-based and the counter resets after each header. Any manual
- * leading enumerator the author typed (e.g. "1. ") is stripped so we don't double-number.
+ * A directions line with its display info. Section headers (lines ending in `:`) set [isHeader] and
+ * render bold. Steps are never auto-numbered: [number] is populated only when the author actually
+ * typed a leading enumerator (e.g. "1. " or "2) "), which is stripped from [text] and re-rendered
+ * as a bold prefix. Steps without an enumerator carry a null [number] and render as plain lines —
+ * the same "only show numbers when present" behavior as Cook Mode.
  */
-internal data class DirectionStep(val text: String, val number: Int?)
+internal data class DirectionStep(val text: String, val number: Int?, val isHeader: Boolean)
 
-private val leadingEnumerator = Regex("""^\s*\d+[.)]\s+""")
+private val leadingEnumerator = Regex("""^\s*(\d+)[.)]\s+""")
 
-internal fun directionSteps(directions: String): List<DirectionStep> {
-    var counter = 0
-    return splitLines(directions).map { line ->
+internal fun directionSteps(directions: String): List<DirectionStep> =
+    splitLines(directions).map { line ->
         if (IngredientSection.isHeader(line)) {
-            counter = 0
-            DirectionStep(text = line, number = null)
+            DirectionStep(text = line, number = null, isHeader = true)
         } else {
-            counter += 1
-            DirectionStep(text = line.replaceFirst(leadingEnumerator, ""), number = counter)
+            val match = leadingEnumerator.find(line)
+            if (match != null) {
+                DirectionStep(
+                    text = line.removeRange(match.range),
+                    number = match.groupValues[1].toIntOrNull(),
+                    isHeader = false,
+                )
+            } else {
+                DirectionStep(text = line, number = null, isHeader = false)
+            }
         }
     }
-}
 
 @Composable
 private fun IngredientsContent(
@@ -1763,6 +1775,7 @@ private fun DirectionsContent(
             DirectionLineItem(
                 text = step.text,
                 number = step.number,
+                isHeader = step.isHeader,
                 highlighted = highlightedIndex == index,
                 onClick = {
                     onHighlightedIndexChanged(if (highlightedIndex == index) -1 else index)

--- a/client/recipe/core/public/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/DirectionStepsTest.kt
+++ b/client/recipe/core/public/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/DirectionStepsTest.kt
@@ -6,21 +6,29 @@ import kotlin.test.Test
 class DirectionStepsTest {
 
     @Test
-    fun numbers_each_step_sequentially() {
+    fun plain_steps_are_not_auto_numbered() {
         val steps = directionSteps("Boil water\nAdd pasta\nDrain")
-        steps.map { it.number } shouldBe listOf(1, 2, 3)
+        steps.map { it.number } shouldBe listOf(null, null, null)
+        steps.map { it.isHeader } shouldBe listOf(false, false, false)
         steps.map { it.text } shouldBe listOf("Boil water", "Add pasta", "Drain")
     }
 
     @Test
-    fun strips_manual_leading_enumerators() {
+    fun keeps_manual_leading_enumerators_as_the_displayed_number() {
         val steps = directionSteps("1. Boil water\n2) Add pasta\n3.  Drain")
         steps.map { it.text } shouldBe listOf("Boil water", "Add pasta", "Drain")
         steps.map { it.number } shouldBe listOf(1, 2, 3)
     }
 
     @Test
-    fun headers_are_unnumbered_and_reset_the_counter() {
+    fun preserves_the_authors_own_numbering() {
+        // The author's numbers are shown verbatim — not renumbered sequentially.
+        val steps = directionSteps("1. Preheat oven\n5. Bake\n10. Cool")
+        steps.map { it.number } shouldBe listOf(1, 5, 10)
+    }
+
+    @Test
+    fun headers_are_flagged_and_never_numbered() {
         val steps =
             directionSteps(
                 """
@@ -32,7 +40,8 @@ class DirectionStepsTest {
                 """
                     .trimIndent()
             )
-        steps.map { it.number } shouldBe listOf(null, 1, 2, null, 1)
+        steps.map { it.isHeader } shouldBe listOf(true, false, false, true, false)
+        steps.map { it.number } shouldBe listOf(null, null, null, null, null)
         steps[0].text shouldBe "Make the sauce:"
         steps[3].text shouldBe "Assemble:"
     }
@@ -40,12 +49,13 @@ class DirectionStepsTest {
     @Test
     fun blank_lines_are_dropped() {
         val steps = directionSteps("Boil water\n\n\nAdd pasta")
-        steps.map { it.number } shouldBe listOf(1, 2)
+        steps.map { it.text } shouldBe listOf("Boil water", "Add pasta")
     }
 
     @Test
     fun leaves_inline_markdown_for_the_renderer() {
         val steps = directionSteps("Cook until **golden**")
         steps.single().text shouldBe "Cook until **golden**"
+        steps.single().number shouldBe null
     }
 }


### PR DESCRIPTION
## Summary

Recipe detail was auto-numbering **every** directions line (`1.`, `2.`, `3.` …) regardless of whether the source recipe had numbers. This changes it to behave like Cook Mode: steps render plainly, and a number is shown only when the author actually typed a leading enumerator.

## Behavior

- Plain directions → rendered as plain lines, no numbers (same as Cook Mode).
- Directions that already contain `1.`, `2)`, etc. → those numbers are shown **verbatim** (preserved, not renumbered sequentially).
- Section headers (lines ending in `:`, e.g. `For the sauce:`) → still bold and unnumbered.

## Changes

- `directionSteps()` drops the running counter; it captures a per-line manual enumerator or leaves `number` null.
- `DirectionStep` gains an explicit `isHeader` flag — previously a null `number` *meant* "header," which breaks now that plain numberless steps also carry a null number.
- `DirectionLineItem` branches on `isHeader` for the bold header and only prepends the bold `N. ` prefix when a number is present.
- `DirectionStepsTest` updated to cover the new rules (including preserving the author's own `1/5/10` numbering rather than renumbering).

## Note / trade-off

Recipes previously imported as unnumbered blobs will now display without numbers. If we'd rather keep numbers when the whole block is clearly a sequential step list (just missing enumerators), that heuristic can be added — this PR implements the literal "only show numbers if present."

🤖 Generated with [Claude Code](https://claude.com/claude-code)