### PR TITLE
feat(recipe): link to other recipes within ingredients & directions (#377)

### DIFF
--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -58,6 +58,8 @@ class RecipeDetailBlocImpl(
             viewModel.output.collect { viewModelOutput ->
                 when (viewModelOutput) {
                     RecipeDetailViewModel.Output.RecipeDeleted -> output.onNext(Output.Finished)
+                    is RecipeDetailViewModel.Output.OpenRecipe ->
+                        output.onNext(Output.OpenRecipe(viewModelOutput.recipeId))
                 }
             }
         }
@@ -177,6 +179,10 @@ class RecipeDetailBlocImpl(
 
     override fun onSourceUrlClicked(url: String) {
         output.onNext(Output.OpenUrl(url))
+    }
+
+    override fun onRecipeLinkClicked(clientId: String) {
+        viewModel.onRecipeLinkClicked(clientId)
     }
 
     override fun onShareLinkClicked() {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.recipe.core.impl.detail
 
 import chefmate.client.recipe.core.public.generated.resources.Res
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_linked_recipe_not_found
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_sign_in_required
 import com.plusmobileapps.chefmate.ChefMateUrls
 import com.plusmobileapps.chefmate.ViewModel
@@ -117,6 +118,21 @@ class RecipeDetailViewModel(
         scope.launch { repository.setRecipePublic(recipeId, isPublic = false) }
     }
 
+    /**
+     * Resolve a tapped recipe-to-recipe link's [clientId] to a locally-stored recipe and open it. A
+     * miss (the target isn't in this device's collection) surfaces a toast instead of navigating.
+     */
+    fun onRecipeLinkClicked(clientId: String) {
+        scope.launch {
+            val target = repository.getRecipeByClientId(clientId)
+            if (target != null) {
+                _output.send(Output.OpenRecipe(target.id))
+            } else {
+                toastService.show(ResourceString(Res.string.recipe_detail_linked_recipe_not_found))
+            }
+        }
+    }
+
     override fun onCleared() {
         super.onCleared()
         // Leaving the screen without dismissing frees the queue so other coach marks can show.
@@ -147,6 +163,9 @@ class RecipeDetailViewModel(
 
     sealed class Output {
         data object RecipeDeleted : Output()
+
+        /** A tapped recipe link resolved to the local recipe with this id. */
+        data class OpenRecipe(val recipeId: Long) : Output()
     }
 
     @AssistedFactory

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeBlocImpl.kt
@@ -4,13 +4,22 @@ import chefmate.client.recipe.core.impl.generated.resources.Res
 import chefmate.client.recipe.core.impl.generated.resources.create_recipe
 import chefmate.client.recipe.core.impl.generated.resources.edit_recipe
 import chefmate.client.recipe.core.impl.generated.resources.edit_recipe_upload_failed
+import com.arkivanov.decompose.router.slot.ChildSlot
+import com.arkivanov.decompose.router.slot.SlotNavigation
+import com.arkivanov.decompose.router.slot.activate
+import com.arkivanov.decompose.router.slot.childSlot
+import com.arkivanov.decompose.router.slot.dismiss
+import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.getViewModel
 import com.plusmobileapps.chefmate.mapState
+import com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc
 import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc
+import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc.LinkField
+import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc.LinkInsertion
 import com.plusmobileapps.chefmate.recipe.core.edit.EditRecipeBloc.Output
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.Category
@@ -20,8 +29,12 @@ import com.plusmobileapps.chefmate.text.ResourceString
 import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 
 @AssistedInject
 @ContributesAssistedFactory(
@@ -36,12 +49,32 @@ class EditRecipeBlocImpl(
     @Assisted consumePendingPhoto: Boolean,
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: EditRecipeViewModel.Factory,
+    private val recipePickerFactory: RecipePickerBloc.Factory,
 ) : EditRecipeBloc, BlocContext by context {
     private val scope = createScope()
 
     private val viewModel: EditRecipeViewModel = instanceKeeper.getViewModel {
         viewModelFactory.create(recipeId, extractedRecipe, fromAi, consumePendingPhoto)
     }
+
+    // The field awaiting a picked link; paired with the resolved link when the picker returns.
+    private var pendingLinkField: LinkField? = null
+
+    private val pickerNavigation = SlotNavigation<PickerConfig>()
+    private val pickerRouter =
+        childSlot(
+            source = pickerNavigation,
+            serializer = PickerConfig.serializer(),
+            key = "EditRecipeBloc_LinkPicker",
+            childFactory = { _, childContext ->
+                recipePickerFactory.create(context = childContext, output = ::handlePickerOutput)
+            },
+        )
+
+    override val recipePickerSlot: Value<ChildSlot<*, RecipePickerBloc>> = pickerRouter
+
+    private val _linkInsertions = Channel<LinkInsertion>(Channel.BUFFERED)
+    override val linkInsertions: Flow<LinkInsertion> = _linkInsertions.receiveAsFlow()
 
     override val state: StateFlow<EditRecipeBloc.Model> =
         viewModel.state.mapState {
@@ -93,6 +126,23 @@ class EditRecipeBlocImpl(
                     }
                 }
             }
+        }
+        scope.launch {
+            viewModel.recipeLinkPicked.collect { selection ->
+                val field = pendingLinkField ?: return@collect
+                pendingLinkField = null
+                pickerNavigation.dismiss()
+                _linkInsertions.send(
+                    LinkInsertion(field = field, label = selection.label, url = selection.url)
+                )
+            }
+        }
+    }
+
+    private fun handlePickerOutput(pickerOutput: RecipePickerBloc.Output) {
+        when (pickerOutput) {
+            is RecipePickerBloc.Output.RecipeSelected ->
+                viewModel.onRecipeLinkPicked(pickerOutput.recipeId)
         }
     }
 
@@ -207,7 +257,19 @@ class EditRecipeBlocImpl(
         viewModel.dismissCoachMark(id)
     }
 
+    override fun onLinkRecipeClicked(field: LinkField) {
+        pendingLinkField = field
+        pickerNavigation.activate(PickerConfig)
+    }
+
+    override fun onLinkPickerDismissed() {
+        pendingLinkField = null
+        pickerNavigation.dismiss()
+    }
+
     override fun onBackClicked() {
         viewModel.tryToClose()
     }
+
+    @Serializable private data object PickerConfig
 }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModel.kt
@@ -3,6 +3,7 @@
 package com.plusmobileapps.chefmate.recipe.core.impl.edit
 
 import co.touchlab.kermit.Logger
+import com.plusmobileapps.chefmate.ChefMateUrls
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.combineStates
 import com.plusmobileapps.chefmate.di.CoachMarkController
@@ -54,6 +55,12 @@ class EditRecipeViewModel(
 ) : ViewModel(mainContext) {
     private val _output = Channel<Output>(Channel.BUFFERED)
     val output: Flow<Output> = _output.receiveAsFlow()
+
+    // One-shot recipe links resolved from the picker, handed to the screen to splice into the field
+    // that requested them (caret-aware insertion lives in the editor, not here).
+    private val _recipeLinkPicked = Channel<RecipeLinkSelection>(Channel.BUFFERED)
+    val recipeLinkPicked: Flow<RecipeLinkSelection> = _recipeLinkPicked.receiveAsFlow()
+
     private val _state = MutableStateFlow(State())
 
     // Fold the shared controller's active mark into state so the screen shows at most one coach
@@ -183,6 +190,21 @@ class EditRecipeViewModel(
 
     fun updateDirections(value: String) {
         _directions.value = value
+    }
+
+    /**
+     * Resolve a recipe chosen in the link picker to a `[Title](chefmate://recipe/<clientId>)` link
+     * and emit it for the screen to splice into the targeted field. A recipe with no [clientId] yet
+     * (an older row awaiting sync backfill) can't be linked stably, so it is skipped.
+     */
+    fun onRecipeLinkPicked(recipeId: Long) {
+        scope.launch {
+            val recipe = repository.getRecipe(recipeId).first() ?: return@launch
+            val clientId = recipe.clientId ?: return@launch
+            _recipeLinkPicked.send(
+                RecipeLinkSelection(label = recipe.title, url = ChefMateUrls.recipeLink(clientId))
+            )
+        }
     }
 
     fun updateImageUrl(value: String) {
@@ -374,6 +396,7 @@ class EditRecipeViewModel(
         // Leaving the screen without dismissing frees the queue so other coach marks can show.
         CoachMarkId.editRecipeSequence.forEach(coachMarkController::release)
         _output.close()
+        _recipeLinkPicked.close()
     }
 
     private suspend fun loadRecipe(id: Long) {
@@ -475,6 +498,9 @@ class EditRecipeViewModel(
 
         data class Finished(val recipeId: Long) : Output()
     }
+
+    /** A resolved recipe link (`label` = recipe title, `url` = `chefmate://recipe/<clientId>`). */
+    data class RecipeLinkSelection(val label: String, val url: String)
 
     @AssistedFactory
     fun interface Factory {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
@@ -116,6 +116,12 @@ class RecipeRootBlocImpl(
             is RecipeDetailBloc.Output.EditRecipe -> {
                 navigation.bringToFront(Configuration.Edit(output.recipeId, extracted = null))
             }
+            is RecipeDetailBloc.Output.OpenRecipe -> {
+                // Bring the linked recipe's detail to the front — reusing an existing entry when
+                // the
+                // recipe is already in the stack (e.g. A → B → A) so links can't grow it unbounded.
+                navigation.bringToFront(Configuration.Detail(output.recipeId))
+            }
             is RecipeDetailBloc.Output.OpenUrl -> {
                 this.output.onNext(RecipeRootBloc.Output.OpenUrl(output.url))
             }

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
@@ -4,6 +4,7 @@
 package com.plusmobileapps.chefmate.recipe.core.impl.detail
 
 import chefmate.client.recipe.core.public.generated.resources.Res
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_linked_recipe_not_found
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_sign_in_required
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
@@ -241,5 +242,27 @@ class RecipeDetailBlocImplTest {
         val bloc = createBloc(sampleRecipe.copy(isPublic = true, remoteId = "already-public"))
         bloc.onStopSharingClicked()
         repository.lastSetPublic shouldBe (sampleRecipe.id to false)
+    }
+
+    @Test
+    fun When_recipe_link_clicked_and_target_exists_Then_open_recipe_output_emitted() {
+        val bloc = createBloc()
+        val target = sampleRecipe.copy(id = 42L, clientId = "target-client-id")
+        recipes.value = recipes.value + target
+
+        bloc.onRecipeLinkClicked("target-client-id")
+
+        output.lastValue shouldBe RecipeDetailBloc.Output.OpenRecipe(42L)
+    }
+
+    @Test
+    fun When_recipe_link_clicked_and_target_missing_Then_not_found_toast_shown() {
+        val bloc = createBloc()
+
+        bloc.onRecipeLinkClicked("unknown-client-id")
+
+        output.values shouldBe emptyList()
+        toastService.shown shouldBe
+            listOf(ResourceString(Res.string.recipe_detail_linked_recipe_not_found))
     }
 }

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModelTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/edit/EditRecipeViewModelTest.kt
@@ -463,6 +463,42 @@ class EditRecipeViewModelTest {
         vm.state.value.showDiscardChangesDialog shouldBe false
     }
 
+    @Test
+    fun When_recipe_link_picked_Then_client_id_link_is_emitted() = runTest {
+        recipes.value =
+            listOf(seedRecipe(id = 5, title = "Green Sauce", clientId = "sauce-client-id"))
+        val vm = createViewModel()
+
+        vm.onRecipeLinkPicked(recipeId = 5)
+
+        vm.recipeLinkPicked.first() shouldBe
+            EditRecipeViewModel.RecipeLinkSelection(
+                label = "Green Sauce",
+                url = "chefmate://recipe/sauce-client-id",
+            )
+    }
+
+    private fun seedRecipe(id: Long, title: String, clientId: String?) =
+        Recipe(
+            id = id,
+            title = title,
+            description = null,
+            ingredients = "",
+            directions = "",
+            imageUrl = null,
+            sourceUrl = null,
+            servings = null,
+            prepTime = null,
+            cookTime = null,
+            totalTime = null,
+            calories = null,
+            starRating = null,
+            isFavorite = false,
+            clientId = clientId,
+            createdAt = Instant.DISTANT_PAST,
+            updatedAt = Instant.DISTANT_PAST,
+        )
+
     private fun seedExistingRecipe(categories: Set<Category>) {
         recipes.value =
             listOf(

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImplTest.kt
@@ -95,6 +95,13 @@ class RecipeRootBlocImplTest {
     }
 
     @Test
+    fun When_detail_outputs_open_recipe_Then_linked_recipe_detail_is_shown() {
+        val bloc = createBloc(RecipeRootBloc.Props.Detail(1L))
+        detailOutput.onNext(RecipeDetailBloc.Output.OpenRecipe(99L))
+        bloc.routerState.value.active.instance.shouldBeInstanceOf<RecipeRootBloc.Child.Detail>()
+    }
+
+    @Test
     fun When_edit_outputs_cancelled_from_create_Then_root_outputs_finished() {
         createBloc(RecipeRootBloc.Props.Create)
         editOutput.onNext(EditRecipeBloc.Output.Cancelled)

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="recipe_detail_share_sign_in_required">Sign in to share a recipe link.</string>
     <string name="recipe_detail_share_failed">Couldn’t create a share link. Please try again.</string>
     <string name="recipe_detail_copied_to_clipboard">Copied to clipboard</string>
+    <string name="recipe_detail_linked_recipe_not_found">That linked recipe isn’t in your collection.</string>
     <string name="recipe_full_image_close">Close</string>
 
     <!-- Public recipe preview (opened from a shared link) -->

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -59,6 +59,14 @@ interface RecipeDetailBloc : BackClickBloc, ComposeScreen {
     fun onSourceUrlClicked(url: String)
 
     /**
+     * Tap on a recipe-to-recipe link (`chefmate://recipe/<clientId>`) inside the ingredients or
+     * directions. Resolves the target recipe locally by its
+     * [com.plusmobileapps.chefmate.recipe.data.Recipe.clientId] and opens it, or shows a "recipe
+     * not found" message when it isn't in the local collection.
+     */
+    fun onRecipeLinkClicked(clientId: String)
+
+    /**
      * Share a Chef Mate link to this recipe. Prompts to make it public first if it isn't already.
      */
     fun onShareLinkClicked()
@@ -94,6 +102,9 @@ interface RecipeDetailBloc : BackClickBloc, ComposeScreen {
         data object Finished : Output()
 
         data class EditRecipe(val recipeId: Long) : Output()
+
+        /** Open another recipe's detail, e.g. from a tapped recipe-to-recipe link. */
+        data class OpenRecipe(val recipeId: Long) : Output()
 
         data class OpenUrl(val url: String) : Output()
 

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -1925,6 +1925,7 @@ val previewRecipeDetailBloc: RecipeDetailBloc =
                                 - 2 garlic cloves, crushed
                                 - 400g minced beef
                                 - 800g canned tomatoes
+                                - A batch of [Garlic Bread](chefmate://recipe/garlic-bread-id)
                                 - Salt and **pepper** to taste
                                 """
                                     .trimIndent(),

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -157,6 +157,7 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
+import com.plusmobileapps.chefmate.ChefMateUrls
 import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.letIfTrue
 import com.plusmobileapps.chefmate.recipe.categories.pickerLabelRes
@@ -307,6 +308,15 @@ private fun RecipeDetailBody(
 ) {
     val toastService = LocalToastService.current
     val copiedMessage = ResourceString(Res.string.recipe_detail_copied_to_clipboard)
+    // Links inside ingredients/directions: a chefmate://recipe/<clientId> link opens that recipe
+    // in-app; any other URL is treated like the source link and opened externally.
+    val onRecipeLinkClick: (String) -> Unit =
+        remember(bloc) {
+            { url ->
+                ChefMateUrls.recipeLinkClientId(url)?.let(bloc::onRecipeLinkClicked)
+                    ?: bloc.onSourceUrlClicked(url)
+            }
+        }
     Box(modifier = Modifier.fillMaxSize().testTag(RecipeDetailTestTags.SCREEN)) {
         PlusResponsiveContainer(modifier = Modifier.fillMaxSize()) { windowSizeClass ->
             val isCompact = windowSizeClass == WindowSizeClass.COMPACT
@@ -465,6 +475,7 @@ private fun RecipeDetailBody(
                                         formattedTotalTime = state.formattedTotalTime,
                                         onSourceUrlClicked = bloc::onSourceUrlClicked,
                                         onImageClicked = bloc::onImageClicked,
+                                        onRecipeLinkClick = onRecipeLinkClick,
                                     )
                                 isCompact ->
                                     RecipeDetailCompactContent(
@@ -476,6 +487,7 @@ private fun RecipeDetailBody(
                                         formattedTotalTime = state.formattedTotalTime,
                                         onSourceUrlClicked = bloc::onSourceUrlClicked,
                                         onImageClicked = bloc::onImageClicked,
+                                        onRecipeLinkClick = onRecipeLinkClick,
                                         modifier = Modifier.weight(1f),
                                     )
                                 else ->
@@ -488,6 +500,7 @@ private fun RecipeDetailBody(
                                         formattedTotalTime = state.formattedTotalTime,
                                         onSourceUrlClicked = bloc::onSourceUrlClicked,
                                         onImageClicked = bloc::onImageClicked,
+                                        onRecipeLinkClick = onRecipeLinkClick,
                                         metadataCollapsed = metadataCollapsed,
                                         onMetadataCollapsedChange = onMetadataCollapsedChange,
                                     )
@@ -756,6 +769,7 @@ private fun RecipeDetailCompactContent(
     formattedTotalTime: TextData?,
     onSourceUrlClicked: (String) -> Unit,
     onImageClicked: () -> Unit,
+    onRecipeLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val pagerState = rememberPagerState(pageCount = { 2 })
@@ -852,6 +866,7 @@ private fun RecipeDetailCompactContent(
                             IngredientsContent(
                                 lines = ingredientLines,
                                 crossedOut = crossedOut,
+                                onRecipeLinkClick = onRecipeLinkClick,
                                 modifier =
                                     Modifier.fillMaxWidth().onSizeChanged {
                                         ingredientsHeightPx = it.height
@@ -862,6 +877,7 @@ private fun RecipeDetailCompactContent(
                                 directions = recipe.directions,
                                 highlightedIndex = highlightedDirectionIndex,
                                 onHighlightedIndexChanged = { highlightedDirectionIndex = it },
+                                onRecipeLinkClick = onRecipeLinkClick,
                                 modifier =
                                     Modifier.fillMaxWidth().onSizeChanged {
                                         directionsHeightPx = it.height
@@ -890,6 +906,7 @@ private fun ColumnScope.RecipeDetailLandscapeContent(
     formattedTotalTime: TextData?,
     onSourceUrlClicked: (String) -> Unit,
     onImageClicked: () -> Unit,
+    onRecipeLinkClick: (String) -> Unit,
 ) {
     val padding = ChefMateTheme.dimens.paddingNormal
     val navBarBottom = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
@@ -1020,6 +1037,7 @@ private fun ColumnScope.RecipeDetailLandscapeContent(
                             IngredientsContent(
                                 lines = ingredientLines,
                                 crossedOut = crossedOut,
+                                onRecipeLinkClick = onRecipeLinkClick,
                                 modifier = Modifier.fillMaxWidth(),
                             )
                         1 ->
@@ -1027,6 +1045,7 @@ private fun ColumnScope.RecipeDetailLandscapeContent(
                                 directions = recipe.directions,
                                 highlightedIndex = highlightedDirectionIndex,
                                 onHighlightedIndexChanged = { highlightedDirectionIndex = it },
+                                onRecipeLinkClick = onRecipeLinkClick,
                                 modifier = Modifier.fillMaxWidth(),
                             )
                     }
@@ -1053,6 +1072,7 @@ private fun ColumnScope.RecipeDetailExpandedContent(
     formattedTotalTime: TextData?,
     onSourceUrlClicked: (String) -> Unit,
     onImageClicked: () -> Unit,
+    onRecipeLinkClick: (String) -> Unit,
     metadataCollapsed: Boolean,
     onMetadataCollapsedChange: (Boolean) -> Unit,
 ) {
@@ -1180,6 +1200,7 @@ private fun ColumnScope.RecipeDetailExpandedContent(
                     text = line,
                     crossedOut = ingredientCrossedOut[index],
                     onClick = { ingredientCrossedOut[index] = !ingredientCrossedOut[index] },
+                    onRecipeLinkClick = onRecipeLinkClick,
                     modifier = Modifier.padding(horizontal = padding),
                 )
             }
@@ -1218,6 +1239,7 @@ private fun ColumnScope.RecipeDetailExpandedContent(
                         directionHighlightedIndex =
                             if (directionHighlightedIndex == index) -1 else index
                     },
+                    onRecipeLinkClick = onRecipeLinkClick,
                     modifier = Modifier.padding(horizontal = padding),
                 )
             }
@@ -1600,11 +1622,20 @@ private fun formatRecipeAsText(recipe: Recipe): String = buildString {
     }
 }
 
+/** The span style applied to recipe-to-recipe links inside ingredients/directions. */
+@Composable
+private fun recipeLinkStyle(): SpanStyle =
+    SpanStyle(
+        color = MaterialTheme.colorScheme.primary,
+        textDecoration = TextDecoration.Underline,
+    )
+
 @Composable
 private fun IngredientLineItem(
     text: String,
     crossedOut: Boolean,
     onClick: () -> Unit,
+    onRecipeLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (IngredientSection.isHeader(text)) {
@@ -1625,7 +1656,11 @@ private fun IngredientLineItem(
         return
     }
     Text(
-        text = text.toInlineMarkdownAnnotatedString(),
+        text =
+            text.toInlineMarkdownAnnotatedString(
+                linkStyle = recipeLinkStyle(),
+                onLinkClick = onRecipeLinkClick,
+            ),
         style = MaterialTheme.typography.bodyLarge.copy(lineHeight = 22.sp),
         textDecoration = if (crossedOut) TextDecoration.LineThrough else TextDecoration.None,
         color =
@@ -1655,6 +1690,7 @@ private fun DirectionLineItem(
     isHeader: Boolean,
     highlighted: Boolean,
     onClick: () -> Unit,
+    onRecipeLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (isHeader) {
@@ -1674,13 +1710,19 @@ private fun DirectionLineItem(
         return
     }
     val dimens = ChefMateTheme.dimens
+    val linkStyle = recipeLinkStyle()
     val rendered =
-        remember(text, number) {
+        remember(text, number, linkStyle, onRecipeLinkClick) {
             buildAnnotatedString {
                 if (number != null) {
                     withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("$number. ") }
                 }
-                append(text.toInlineMarkdownAnnotatedString())
+                append(
+                    text.toInlineMarkdownAnnotatedString(
+                        linkStyle = linkStyle,
+                        onLinkClick = onRecipeLinkClick,
+                    )
+                )
             }
         }
     Text(
@@ -1740,6 +1782,7 @@ internal fun directionSteps(directions: String): List<DirectionStep> =
 private fun IngredientsContent(
     lines: List<String>,
     crossedOut: SnapshotStateList<Boolean>,
+    onRecipeLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val dimens = ChefMateTheme.dimens
@@ -1752,6 +1795,7 @@ private fun IngredientsContent(
                 text = line,
                 crossedOut = crossedOut[index],
                 onClick = { crossedOut[index] = !crossedOut[index] },
+                onRecipeLinkClick = onRecipeLinkClick,
             )
         }
     }
@@ -1762,6 +1806,7 @@ private fun DirectionsContent(
     directions: String,
     highlightedIndex: Int,
     onHighlightedIndexChanged: (Int) -> Unit,
+    onRecipeLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val steps = remember(directions) { directionSteps(directions) }
@@ -1780,6 +1825,7 @@ private fun DirectionsContent(
                 onClick = {
                     onHighlightedIndexChanged(if (highlightedIndex == index) -1 else index)
                 },
+                onRecipeLinkClick = onRecipeLinkClick,
             )
         }
     }
@@ -1964,6 +2010,10 @@ val previewRecipeDetailBloc: RecipeDetailBloc =
 
         override fun onSourceUrlClicked(url: String) {
             TODO("Not yet implemented")
+        }
+
+        override fun onRecipeLinkClicked(clientId: String) {
+            // Preview no-op
         }
 
         override fun onShareLinkClicked() {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeBloc.kt
@@ -2,15 +2,19 @@ package com.plusmobileapps.chefmate.recipe.core.edit
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.arkivanov.decompose.router.slot.ChildSlot
+import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.BackClickBloc
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
+import com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.Category
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.ui.ComposeScreen
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 interface EditRecipeBloc : BackClickBloc, ComposeScreen {
@@ -63,6 +67,15 @@ interface EditRecipeBloc : BackClickBloc, ComposeScreen {
      * editor, false uses the raw markdown editor with a preview toggle. Persisted across launches.
      */
     val richTextEditorMode: StateFlow<Boolean>
+
+    /** The recipe picker shown when linking a recipe into ingredients or directions, when open. */
+    val recipePickerSlot: Value<ChildSlot<*, RecipePickerBloc>>
+
+    /**
+     * One-shot recipe links to splice into an editor field once the user picks a recipe. The screen
+     * collects these and calls the targeted field's editor controller so insertion is caret-aware.
+     */
+    val linkInsertions: Flow<LinkInsertion>
 
     fun onTitleChanged(title: String)
 
@@ -138,6 +151,12 @@ interface EditRecipeBloc : BackClickBloc, ComposeScreen {
     /** Marks the first-run coach mark with [id] as seen so it never shows again. */
     fun onCoachMarkDismissed(id: String)
 
+    /** Opens the recipe picker to insert a link into the given [field]. */
+    fun onLinkRecipeClicked(field: LinkField)
+
+    /** Dismisses the recipe-link picker without inserting anything. */
+    fun onLinkPickerDismissed()
+
     data class Model(
         val title: TextData,
         val isLoading: Boolean,
@@ -147,6 +166,15 @@ interface EditRecipeBloc : BackClickBloc, ComposeScreen {
         /** Id of the first-run coach mark currently allowed to show, or null when none. */
         val activeCoachMark: String? = null,
     )
+
+    /** The editor field a recipe link is being inserted into. */
+    enum class LinkField {
+        INGREDIENTS,
+        DIRECTIONS,
+    }
+
+    /** A resolved recipe link and the [field] it should be inserted into. */
+    data class LinkInsertion(val field: LinkField, val label: String, val url: String)
 
     sealed class Output {
         data class Finished(val recipeId: Long) : Output()

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/edit/EditRecipeScreen.kt
@@ -30,10 +30,13 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.InputChip
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -91,6 +94,7 @@ import chefmate.client.recipe.core.public.generated.resources.edit_recipe_sectio
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_upload_photo
 import chefmate.client.recipe.core.public.generated.resources.edit_recipe_upload_photo_dismiss
 import coil3.compose.AsyncImage
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.recipe.categories.pickerLabelRes
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
@@ -101,6 +105,7 @@ import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.components.PlusMarkdownEditor
+import com.plusmobileapps.chefmate.ui.components.PlusMarkdownEditorController
 import com.plusmobileapps.chefmate.ui.components.PlusOnboardingTooltip
 import com.plusmobileapps.chefmate.ui.components.PlusOutlinedContainer
 import com.plusmobileapps.chefmate.ui.components.PlusResponsiveContainer
@@ -128,6 +133,25 @@ fun EditRecipeScreen(
     moreDetailsInitiallyExpanded: Boolean = false,
 ) {
     val state by bloc.state.collectAsState()
+
+    // One controller per markdown field so a picked recipe link is spliced into whichever field
+    // requested it. Insertion events are single-consumer (a Channel), so collect them here — the
+    // one
+    // place that can see both controllers — rather than inside the field composables.
+    val ingredientsController = remember { PlusMarkdownEditorController() }
+    val directionsController = remember { PlusMarkdownEditorController() }
+    LaunchedEffect(bloc) {
+        bloc.linkInsertions.collect { insertion ->
+            val controller =
+                when (insertion.field) {
+                    EditRecipeBloc.LinkField.INGREDIENTS -> ingredientsController
+                    EditRecipeBloc.LinkField.DIRECTIONS -> directionsController
+                }
+            controller.insertLink(label = insertion.label, url = insertion.url)
+        }
+    }
+
+    RecipeLinkPickerSheet(bloc = bloc)
 
     if (state.showDiscardChangesDialog) {
         DiscardChangesDialog(
@@ -167,11 +191,15 @@ fun EditRecipeScreen(
                 WideEditRecipeContent(
                     bloc = bloc,
                     moreDetailsInitiallyExpanded = moreDetailsInitiallyExpanded,
+                    ingredientsController = ingredientsController,
+                    directionsController = directionsController,
                 )
             } else {
                 EditRecipeContent(
                     bloc = bloc,
                     moreDetailsInitiallyExpanded = moreDetailsInitiallyExpanded,
+                    ingredientsController = ingredientsController,
+                    directionsController = directionsController,
                 )
             }
         }
@@ -240,6 +268,8 @@ private fun LoadingIndicator(modifier: Modifier = Modifier) {
 private fun EditRecipeContent(
     bloc: EditRecipeBloc,
     moreDetailsInitiallyExpanded: Boolean,
+    ingredientsController: PlusMarkdownEditorController,
+    directionsController: PlusMarkdownEditorController,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -252,8 +282,8 @@ private fun EditRecipeContent(
         RecipeStarRatingField(bloc = bloc)
         RecipePhotoUploader(bloc = bloc)
         RecipeMoreDetailsSection(bloc = bloc, initiallyExpanded = moreDetailsInitiallyExpanded)
-        RecipeIngredientsField(bloc = bloc)
-        RecipeDirectionsField(bloc = bloc)
+        RecipeIngredientsField(bloc = bloc, controller = ingredientsController)
+        RecipeDirectionsField(bloc = bloc, controller = directionsController)
         // Clearance so the floating Save button never covers the last field.
         Spacer(modifier = Modifier.height(ChefMateTheme.dimens.fabClearance))
     }
@@ -268,6 +298,8 @@ private fun EditRecipeContent(
 private fun WideEditRecipeContent(
     bloc: EditRecipeBloc,
     moreDetailsInitiallyExpanded: Boolean,
+    ingredientsController: PlusMarkdownEditorController,
+    directionsController: PlusMarkdownEditorController,
     modifier: Modifier = Modifier,
 ) {
     val spacing = ChefMateTheme.dimens.paddingNormal
@@ -293,8 +325,12 @@ private fun WideEditRecipeContent(
         }
 
         Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
-            Column(modifier = Modifier.weight(1f)) { RecipeIngredientsField(bloc = bloc) }
-            Column(modifier = Modifier.weight(1f)) { RecipeDirectionsField(bloc = bloc) }
+            Column(modifier = Modifier.weight(1f)) {
+                RecipeIngredientsField(bloc = bloc, controller = ingredientsController)
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                RecipeDirectionsField(bloc = bloc, controller = directionsController)
+            }
         }
         // Clearance so the floating Save button never covers the last field.
         Spacer(modifier = Modifier.height(ChefMateTheme.dimens.fabClearance))
@@ -715,7 +751,11 @@ private fun RecipeCaloriesField(bloc: EditRecipeBloc, modifier: Modifier = Modif
 }
 
 @Composable
-private fun RecipeIngredientsField(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
+private fun RecipeIngredientsField(
+    bloc: EditRecipeBloc,
+    controller: PlusMarkdownEditorController,
+    modifier: Modifier = Modifier,
+) {
     val ingredients by bloc.ingredients.collectAsState()
     val richTextMode by bloc.richTextEditorMode.collectAsState()
 
@@ -729,11 +769,17 @@ private fun RecipeIngredientsField(bloc: EditRecipeBloc, modifier: Modifier = Mo
         modifier = modifier,
         initialHeight = 320.dp,
         maxHeight = 640.dp,
+        controller = controller,
+        onInsertLinkClick = { bloc.onLinkRecipeClicked(EditRecipeBloc.LinkField.INGREDIENTS) },
     )
 }
 
 @Composable
-private fun RecipeDirectionsField(bloc: EditRecipeBloc, modifier: Modifier = Modifier) {
+private fun RecipeDirectionsField(
+    bloc: EditRecipeBloc,
+    controller: PlusMarkdownEditorController,
+    modifier: Modifier = Modifier,
+) {
     val directions by bloc.directions.collectAsState()
     val richTextMode by bloc.richTextEditorMode.collectAsState()
     val model by bloc.state.collectAsState()
@@ -754,7 +800,25 @@ private fun RecipeDirectionsField(bloc: EditRecipeBloc, modifier: Modifier = Mod
             onRichTextModeChange = bloc::onRichTextEditorModeChanged,
             initialHeight = 320.dp,
             maxHeight = 640.dp,
+            controller = controller,
+            onInsertLinkClick = { bloc.onLinkRecipeClicked(EditRecipeBloc.LinkField.DIRECTIONS) },
         )
+    }
+}
+
+/**
+ * The recipe picker shown as a modal bottom sheet when the user taps "Link a recipe" on the
+ * ingredients or directions editor. Selecting a recipe inserts a link and closes the sheet; the
+ * bloc owns which field the link targets.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RecipeLinkPickerSheet(bloc: EditRecipeBloc) {
+    val slot by bloc.recipePickerSlot.subscribeAsState()
+    val picker = slot.child?.instance ?: return
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = bloc::onLinkPickerDismissed, sheetState = sheetState) {
+        picker.Content(modifier = Modifier.fillMaxWidth())
     }
 }
 
@@ -852,6 +916,23 @@ Salt for pasta water"""
         override val selectedBookIds: StateFlow<Set<Long>> = MutableStateFlow(setOf(1L))
         override val pendingPhotoBytes: StateFlow<ByteArray?> = MutableStateFlow(null)
         override val richTextEditorMode: StateFlow<Boolean> = MutableStateFlow(false)
+        override val recipePickerSlot:
+            com.arkivanov.decompose.value.Value<
+                com.arkivanov.decompose.router.slot.ChildSlot<
+                    *,
+                    com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc,
+                >
+            > =
+            com.arkivanov.decompose.value.MutableValue(
+                com.arkivanov.decompose.router.slot.ChildSlot<
+                    Any,
+                    com.plusmobileapps.chefmate.recipe.core.addmeal.RecipePickerBloc,
+                >(
+                    null
+                )
+            )
+        override val linkInsertions: kotlinx.coroutines.flow.Flow<EditRecipeBloc.LinkInsertion> =
+            kotlinx.coroutines.flow.emptyFlow()
 
         override fun onTitleChanged(title: String) {}
 
@@ -908,6 +989,10 @@ Salt for pasta water"""
         override fun onRichTextEditorModeChanged(richTextMode: Boolean) {}
 
         override fun onCoachMarkDismissed(id: String) {}
+
+        override fun onLinkRecipeClicked(field: EditRecipeBloc.LinkField) {}
+
+        override fun onLinkPickerDismissed() {}
 
         override fun onBackClicked() {}
 

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
@@ -186,6 +186,14 @@ class RecipeRepositoryImpl(
                 ?.toRecipe()
         }
 
+    override suspend fun getRecipeByClientId(clientId: String): Recipe? =
+        withContext(ioContext) {
+            db.getByClientId(clientId)
+                .executeAsOneOrNull()
+                ?.takeUnless { it.isPendingDelete }
+                ?.toRecipe()
+        }
+
     override suspend fun fetchPublicRecipe(remoteId: String): Result<Recipe> = runCatching {
         val remote =
             remoteDataSource.fetchPublicRecipe(remoteId)
@@ -654,6 +662,7 @@ class RecipeRepositoryImpl(
             recipeBookIds = bookJoinDb.getBookIdsForRecipe(id).executeAsList().toSet(),
             syncStatus = syncStatus,
             remoteId = remoteId,
+            clientId = clientId,
             isPublic = isPublic,
             createdAt = Instant.parse(createdAt),
             updatedAt = Instant.parse(updatedAt),

--- a/client/recipe/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImplTest.kt
+++ b/client/recipe/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImplTest.kt
@@ -20,6 +20,7 @@ import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookReposit
 import com.plusmobileapps.chefmate.util.testing.FakeDateTimeUtil
 import com.plusmobileapps.chefmate.util.testing.FakeUnique
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import kotlin.test.Test
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -460,6 +461,22 @@ class RecipeRepositoryImplTest {
             val remoteId = recipeRepository.getRecipe(created.id).first()?.remoteId
 
             recipeRepository.getRecipeByRemoteId(remoteId!!)?.title shouldBe "Findable"
+        }
+
+    @Test
+    fun getRecipeByClientId_returns_the_local_recipe() =
+        runTest(testDispatcher) {
+            val created = recipeRepository.createRecipe(blankRecipe("ByClient"))
+            val clientId = recipeRepository.getRecipe(created.id).first()?.clientId
+
+            clientId shouldNotBe null
+            recipeRepository.getRecipeByClientId(clientId!!)?.title shouldBe "ByClient"
+        }
+
+    @Test
+    fun getRecipeByClientId_returns_null_when_absent() =
+        runTest(testDispatcher) {
+            recipeRepository.getRecipeByClientId("no-such-client-id") shouldBe null
         }
 
     private fun blankRecipe(title: String, categories: Set<Category> = emptySet()) =

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/Recipe.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/Recipe.kt
@@ -29,6 +29,12 @@ data class Recipe(
     val syncStatus: SyncStatus = SyncStatus.NOT_SYNCED,
     /** The recipe's global Supabase id, present once synced; the identifier used in share links. */
     val remoteId: String? = null,
+    /**
+     * A device-generated UUID assigned when the recipe is first created (offline included) and
+     * preserved across sync and every device that pulls the recipe. Stable and owner-scoped, so it
+     * is the identifier embedded in recipe-to-recipe links (`chefmate://recipe/<clientId>`).
+     */
+    val clientId: String? = null,
     /** True when the owner has published this recipe so anyone with its share link can view it. */
     val isPublic: Boolean = false,
     val createdAt: Instant,

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeRepository.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeRepository.kt
@@ -32,6 +32,13 @@ interface RecipeRepository {
     suspend fun getRecipeByRemoteId(remoteId: String): Recipe?
 
     /**
+     * Looks up a locally-stored recipe by its device-generated [Recipe.clientId], or null if none
+     * is stored. Used to resolve a recipe-to-recipe link (`chefmate://recipe/<clientId>`) to the
+     * local recipe on whichever device the link is tapped.
+     */
+    suspend fun getRecipeByClientId(clientId: String): Recipe?
+
+    /**
      * Fetches a public recipe by its global [remoteId] from the remote source, for a recipient
      * opening a share link to a recipe they don't have locally. The returned [Recipe] is transient
      * (not persisted; local [Recipe.id] is -1) — call [createRecipe] to save an owned copy. Fails

--- a/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeRepository.kt
+++ b/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeRepository.kt
@@ -52,6 +52,9 @@ class FakeRecipeRepository(
     override suspend fun getRecipeByRemoteId(remoteId: String): Recipe? =
         recipes.value.firstOrNull { it.remoteId == remoteId }
 
+    override suspend fun getRecipeByClientId(clientId: String): Recipe? =
+        recipes.value.firstOrNull { it.clientId == clientId }
+
     override suspend fun fetchPublicRecipe(remoteId: String): Result<Recipe> =
         publicRecipes[remoteId]?.let { Result.success(it) }
             ?: Result.failure(NoSuchElementException("No public recipe with id $remoteId"))

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/ChefMateUrls.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/ChefMateUrls.kt
@@ -20,4 +20,24 @@ object ChefMateUrls {
      * id — is used so the link resolves to the same recipe for every user.
      */
     fun recipeShareUrl(remoteId: String): String = "https://$WEB_HOST/recipe/$remoteId"
+
+    /**
+     * An in-app recipe-to-recipe link embedded in ingredient/direction markdown, keyed by the
+     * target recipe's device-generated [clientId]. Unlike [recipeShareUrl] (a public https link
+     * keyed by remoteId), this is owner-scoped and resolved locally via
+     * `RecipeRepository.getRecipeByClientId`, so it works offline and survives sync to any device.
+     */
+    fun recipeLink(clientId: String): String = "$SCHEME://recipe/$clientId"
+
+    /**
+     * Extracts the target clientId from a [recipeLink], or null if [url] is not one. Only the
+     * custom `chefmate://recipe/<clientId>` scheme form matches; the public https share link (keyed
+     * by remoteId) is intentionally excluded so the two identifier spaces stay separate.
+     */
+    fun recipeLinkClientId(url: String): String? {
+        val prefix = "$SCHEME://recipe/"
+        if (!url.startsWith(prefix)) return null
+        val clientId = url.substring(prefix.length).substringBefore('/').substringBefore('?')
+        return clientId.ifBlank { null }
+    }
 }

--- a/client/shared/src/commonTest/kotlin/com/plusmobileapps/chefmate/ChefMateUrlsTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/plusmobileapps/chefmate/ChefMateUrlsTest.kt
@@ -1,0 +1,41 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ChefMateUrlsTest {
+
+    @Test
+    fun recipeLink_builds_the_custom_scheme_form() {
+        assertEquals("chefmate://recipe/abc-123", ChefMateUrls.recipeLink("abc-123"))
+    }
+
+    @Test
+    fun recipeLinkClientId_round_trips_a_built_link() {
+        val clientId = "9f2c-uuid"
+        assertEquals(clientId, ChefMateUrls.recipeLinkClientId(ChefMateUrls.recipeLink(clientId)))
+    }
+
+    @Test
+    fun recipeLinkClientId_ignores_query_and_trailing_path() {
+        assertEquals("id42", ChefMateUrls.recipeLinkClientId("chefmate://recipe/id42/extra"))
+        assertEquals("id42", ChefMateUrls.recipeLinkClientId("chefmate://recipe/id42?x=1"))
+    }
+
+    @Test
+    fun recipeLinkClientId_rejects_the_public_https_share_link() {
+        // The https share link is keyed by remoteId, a separate identifier space — not a client
+        // link.
+        assertNull(ChefMateUrls.recipeLinkClientId(ChefMateUrls.recipeShareUrl("remote-uuid")))
+    }
+
+    @Test
+    fun recipeLinkClientId_rejects_unrelated_and_blank_urls() {
+        assertNull(ChefMateUrls.recipeLinkClientId("https://example.com/recipe/x"))
+        assertNull(ChefMateUrls.recipeLinkClientId("chefmate://recipe/"))
+        assertNull(ChefMateUrls.recipeLinkClientId("chefmate://groceries"))
+    }
+}

--- a/client/ui/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/ui/public/src/commonMain/composeResources/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="markdown_editor_tab_preview">Preview</string>
     <string name="markdown_editor_bold_a11y">Bold</string>
     <string name="markdown_editor_italic_a11y">Italic</string>
+    <string name="markdown_editor_link_recipe_a11y">Link a recipe</string>
     <string name="markdown_editor_resize_handle_a11y">Drag to resize %1$s field</string>
     <string name="markdown_editor_preview_empty">Nothing to preview yet</string>
     <string name="plus_outlined_container_expand_a11y">Expand %1$s</string>

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusMarkdownEditor.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusMarkdownEditor.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddLink
 import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.FormatBold
 import androidx.compose.material.icons.filled.FormatItalic
@@ -61,6 +62,7 @@ import androidx.compose.ui.unit.dp
 import chefmate.client.ui.public.generated.resources.Res
 import chefmate.client.ui.public.generated.resources.markdown_editor_bold_a11y
 import chefmate.client.ui.public.generated.resources.markdown_editor_italic_a11y
+import chefmate.client.ui.public.generated.resources.markdown_editor_link_recipe_a11y
 import chefmate.client.ui.public.generated.resources.markdown_editor_mode_markdown
 import chefmate.client.ui.public.generated.resources.markdown_editor_mode_rich_text
 import chefmate.client.ui.public.generated.resources.markdown_editor_preview_empty
@@ -71,11 +73,26 @@ import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material3.OutlinedRichTextEditor
 import com.plusmobileapps.chefmate.ui.text.BOLD_MARKER
 import com.plusmobileapps.chefmate.ui.text.ITALIC_MARKER
+import com.plusmobileapps.chefmate.ui.text.insertMarkdownLink
 import com.plusmobileapps.chefmate.ui.text.toInlineMarkdownAnnotatedString
 import com.plusmobileapps.chefmate.ui.text.toggleInlineMarker
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Imperative handle for inserting a `[label](url)` link into a [PlusMarkdownEditor] from outside
+ * the composable — e.g. after a recipe picker returns a selection. Create one with `remember`, pass
+ * it to the editor, and call [insertLink]; the editor splices the link into the active mode (raw
+ * markdown at the caret, or a rendered link in rich-text mode).
+ */
+class PlusMarkdownEditorController {
+    internal var insertLinkImpl: ((label: String, url: String) -> Unit)? = null
+
+    fun insertLink(label: String, url: String) {
+        insertLinkImpl?.invoke(label, url)
+    }
+}
 
 /**
  * A shared, resizable editor for plain-text fields that carry inline markdown (`**bold**`,
@@ -103,6 +120,8 @@ fun PlusMarkdownEditor(
     minHeight: Dp = 160.dp,
     maxHeight: Dp = 480.dp,
     initialHeight: Dp = 200.dp,
+    controller: PlusMarkdownEditorController? = null,
+    onInsertLinkClick: (() -> Unit)? = null,
 ) {
     var heightDp by rememberSaveable { mutableStateOf(initialHeight.value) }
     var showPreview by rememberSaveable { mutableStateOf(false) }
@@ -156,6 +175,16 @@ fun PlusMarkdownEditor(
         else applyMarkdownMarker(ITALIC_MARKER)
     }
 
+    // Bind the imperative insert handle to the active mode. Reassigned every recomposition so it
+    // always closes over the current mode and field state.
+    controller?.insertLinkImpl = { label, url ->
+        if (richTextMode) {
+            richTextState.addLink(text = label, url = url)
+        } else {
+            updateMarkdown(fieldValue.insertMarkdownLink(label, url))
+        }
+    }
+
     // A light rounded outline groups each editor as one unit, so it's clear which toolbar/toggle
     // belongs to which field when several editors stack on the form.
     PlusOutlinedContainer(modifier = modifier) {
@@ -180,7 +209,11 @@ fun PlusMarkdownEditor(
         val showFormatButtons = richTextMode || !showPreview
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
             if (showFormatButtons) {
-                MarkdownFormatToolbar(onBold = ::onBold, onItalic = ::onItalic)
+                MarkdownFormatToolbar(
+                    onBold = ::onBold,
+                    onItalic = ::onItalic,
+                    onInsertLinkClick = onInsertLinkClick,
+                )
             }
             Spacer(modifier = Modifier.weight(1f))
             if (!richTextMode) {
@@ -280,6 +313,7 @@ private fun WritePreviewToggle(
 private fun MarkdownFormatToolbar(
     onBold: () -> Unit,
     onItalic: () -> Unit,
+    onInsertLinkClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -296,6 +330,13 @@ private fun MarkdownFormatToolbar(
             contentDescription = stringResource(Res.string.markdown_editor_italic_a11y),
             onClick = onItalic,
         )
+        if (onInsertLinkClick != null) {
+            FormatButton(
+                icon = Icons.Default.AddLink,
+                contentDescription = stringResource(Res.string.markdown_editor_link_recipe_a11y),
+                onClick = onInsertLinkClick,
+            )
+        }
     }
 }
 

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/text/InlineMarkdown.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/text/InlineMarkdown.kt
@@ -1,10 +1,13 @@
 package com.plusmobileapps.chefmate.ui.text
 
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 
 /**
@@ -18,19 +21,39 @@ const val ITALIC_MARKER: String = "_"
 
 /**
  * Parses a single line of lightweight inline markdown into an [AnnotatedString], supporting
- * `**bold**` and `_italic_` (nestable, e.g. `**bold _and italic_**`). Markers without a matching
- * partner are left as literal text, so plain recipe lines — and stray `*` or `_` characters —
- * render unchanged. This is intentionally inline-only: ingredients and directions stay one item per
- * line, so block markdown (headings, lists, etc.) is not interpreted.
+ * `**bold**`, `_italic_` (nestable, e.g. `**bold _and italic_**`), and `[label](url)` links.
+ * Markers without a matching partner are left as literal text, so plain recipe lines — and stray
+ * `*` or `_` characters — render unchanged. This is intentionally inline-only: ingredients and
+ * directions stay one item per line, so block markdown (headings, lists, etc.) is not interpreted.
+ *
+ * A `[label](url)` link always renders as just its [label] (the raw markdown is never shown). When
+ * [onLinkClick] is non-null the label is wrapped in a clickable [LinkAnnotation] — styled with
+ * [linkStyle] — whose listener is invoked with the link's `url`; when it is null (read-only
+ * surfaces like cook mode) the label renders as plain, inert text.
  */
-fun String.toInlineMarkdownAnnotatedString(): AnnotatedString = buildAnnotatedString {
-    appendInlineMarkdown(this@toInlineMarkdownAnnotatedString)
+fun String.toInlineMarkdownAnnotatedString(
+    linkStyle: SpanStyle? = null,
+    onLinkClick: ((String) -> Unit)? = null,
+): AnnotatedString = buildAnnotatedString {
+    appendInlineMarkdown(this@toInlineMarkdownAnnotatedString, linkStyle, onLinkClick)
 }
 
-private fun AnnotatedString.Builder.appendInlineMarkdown(text: String) {
+private fun AnnotatedString.Builder.appendInlineMarkdown(
+    text: String,
+    linkStyle: SpanStyle?,
+    onLinkClick: ((String) -> Unit)?,
+) {
     var literalStart = 0
     var i = 0
     while (i < text.length) {
+        val link = linkAt(text, i)
+        if (link != null) {
+            if (literalStart < i) append(text.substring(literalStart, i))
+            appendLink(link, linkStyle, onLinkClick)
+            i = link.end
+            literalStart = i
+            continue
+        }
         val marker = markerAt(text, i)
         if (marker == null) {
             i++
@@ -44,11 +67,52 @@ private fun AnnotatedString.Builder.appendInlineMarkdown(text: String) {
             continue
         }
         if (literalStart < i) append(text.substring(literalStart, i))
-        withStyle(styleFor(marker)) { appendInlineMarkdown(text.substring(contentStart, close)) }
+        withStyle(styleFor(marker)) {
+            appendInlineMarkdown(text.substring(contentStart, close), linkStyle, onLinkClick)
+        }
         i = close + marker.length
         literalStart = i
     }
     if (literalStart < text.length) append(text.substring(literalStart))
+}
+
+private fun AnnotatedString.Builder.appendLink(
+    link: InlineLink,
+    linkStyle: SpanStyle?,
+    onLinkClick: ((String) -> Unit)?,
+) {
+    if (onLinkClick == null) {
+        // No handler — render the label as plain (still inline-styled) text; the link is inert.
+        appendInlineMarkdown(link.label, linkStyle, null)
+        return
+    }
+    val annotation =
+        LinkAnnotation.Clickable(
+            tag = link.url,
+            styles = linkStyle?.let { TextLinkStyles(style = it) },
+            linkInteractionListener = { onLinkClick(link.url) },
+        )
+    withLink(annotation) { appendInlineMarkdown(link.label, linkStyle, onLinkClick) }
+}
+
+/** A parsed `[label](url)` link and the index just past its closing `)`. */
+private class InlineLink(val label: String, val url: String, val end: Int)
+
+/**
+ * Attempts to parse a `[label](url)` link starting at [index]. Uses the first `]` and first `)` so
+ * a non-link `[` (e.g. a stray bracket) falls through to literal text. Empty label or url is
+ * rejected.
+ */
+private fun linkAt(text: String, index: Int): InlineLink? {
+    if (text[index] != '[') return null
+    val labelEnd = text.indexOf(']', index + 1)
+    if (labelEnd == -1 || labelEnd + 1 >= text.length || text[labelEnd + 1] != '(') return null
+    val urlEnd = text.indexOf(')', labelEnd + 2)
+    if (urlEnd == -1) return null
+    val label = text.substring(index + 1, labelEnd)
+    val url = text.substring(labelEnd + 2, urlEnd)
+    if (label.isEmpty() || url.isEmpty()) return null
+    return InlineLink(label = label, url = url, end = urlEnd + 1)
 }
 
 private fun markerAt(text: String, index: Int): String? =

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/text/MarkdownFormatting.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/text/MarkdownFormatting.kt
@@ -37,3 +37,16 @@ fun TextFieldValue.toggleInlineMarker(marker: String): TextFieldValue {
         )
     }
 }
+
+/**
+ * Replaces the current selection with a `[label](url)` markdown link and places the cursor just
+ * after it. With an empty selection the link is inserted at the caret.
+ */
+fun TextFieldValue.insertMarkdownLink(label: String, url: String): TextFieldValue {
+    val start = minOf(selection.start, selection.end)
+    val end = maxOf(selection.start, selection.end)
+    val markdown = "[$label]($url)"
+    val newText = text.substring(0, start) + markdown + text.substring(end)
+    val cursor = start + markdown.length
+    return TextFieldValue(text = newText, selection = TextRange(cursor))
+}

--- a/client/ui/public/src/commonTest/kotlin/com/plusmobileapps/chefmate/ui/text/InlineMarkdownTest.kt
+++ b/client/ui/public/src/commonTest/kotlin/com/plusmobileapps/chefmate/ui/text/InlineMarkdownTest.kt
@@ -1,5 +1,6 @@
 package com.plusmobileapps.chefmate.ui.text
 
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import io.kotest.matchers.shouldBe
@@ -59,5 +60,47 @@ class InlineMarkdownTest {
         val result = "salt _ pepper".toInlineMarkdownAnnotatedString()
         result.text shouldBe "salt _ pepper"
         result.spanStyles.size shouldBe 0
+    }
+
+    @Test
+    fun linkWithoutHandlerRendersPlainLabel() {
+        val result = "add [Green Sauce](chefmate://recipe/abc)".toInlineMarkdownAnnotatedString()
+        result.text shouldBe "add Green Sauce"
+        result.getLinkAnnotations(0, result.length).size shouldBe 0
+    }
+
+    @Test
+    fun linkWithHandlerStripsMarkdownAndAnnotates() {
+        var clicked: String? = null
+        val result =
+            "add [Green Sauce](chefmate://recipe/abc)"
+                .toInlineMarkdownAnnotatedString(onLinkClick = { clicked = it })
+
+        result.text shouldBe "add Green Sauce"
+        val link = result.getLinkAnnotations(0, result.length).single()
+        link.start shouldBe 4
+        link.end shouldBe 15
+        val clickable = link.item as LinkAnnotation.Clickable
+        clickable.tag shouldBe "chefmate://recipe/abc"
+
+        clickable.linkInteractionListener!!.onClick(clickable)
+        clicked shouldBe "chefmate://recipe/abc"
+    }
+
+    @Test
+    fun linkLabelCanContainInlineStyles() {
+        val result =
+            "[**Bold** sauce](chefmate://recipe/abc)"
+                .toInlineMarkdownAnnotatedString(onLinkClick = {})
+        result.text shouldBe "Bold sauce"
+        result.getLinkAnnotations(0, result.length).size shouldBe 1
+        result.spanStyles.single().item.fontWeight shouldBe FontWeight.Bold
+    }
+
+    @Test
+    fun unmatchedLinkSyntaxIsLiteral() {
+        val result = "see [Sauce] later".toInlineMarkdownAnnotatedString(onLinkClick = {})
+        result.text shouldBe "see [Sauce] later"
+        result.getLinkAnnotations(0, result.length).size shouldBe 0
     }
 }

--- a/client/ui/public/src/commonTest/kotlin/com/plusmobileapps/chefmate/ui/text/MarkdownFormattingTest.kt
+++ b/client/ui/public/src/commonTest/kotlin/com/plusmobileapps/chefmate/ui/text/MarkdownFormattingTest.kt
@@ -48,4 +48,23 @@ class MarkdownFormattingTest {
         result.text shouldBe "**preheat** the oven"
         result.selection shouldBe TextRange(2, 9)
     }
+
+    @Test
+    fun insertMarkdownLinkAtCursorPlacesLinkAndMovesCursorAfter() {
+        val value = TextFieldValue("serve with ", selection = TextRange(11))
+
+        val result = value.insertMarkdownLink("Green Sauce", "chefmate://recipe/abc")
+
+        result.text shouldBe "serve with [Green Sauce](chefmate://recipe/abc)"
+        result.selection shouldBe TextRange(result.text.length)
+    }
+
+    @Test
+    fun insertMarkdownLinkReplacesSelection() {
+        val value = TextFieldValue("serve with sauce", selection = TextRange(11, 16))
+
+        val result = value.insertMarkdownLink("Green Sauce", "chefmate://recipe/abc")
+
+        result.text shouldBe "serve with [Green Sauce](chefmate://recipe/abc)"
+    }
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/InlineMarkdownScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/InlineMarkdownScreenshotTest.kt
@@ -10,6 +10,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.android.tools.screenshot.PreviewTest
@@ -17,14 +19,15 @@ import com.plusmobileapps.chefmate.ui.text.toInlineMarkdownAnnotatedString
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
 // Renders sample ingredient/direction lines through the same inline-markdown parser the recipe
-// detail screen uses, so the snapshot shows exactly how stored `**bold**` / `_italic_` markers
-// display once a recipe is saved.
+// detail screen uses, so the snapshot shows exactly how stored `**bold**` / `_italic_` markers and
+// `[label](url)` recipe links display once a recipe is saved.
 private val sampleLines =
     listOf(
         "400g spaghetti (plain line)",
         "**400g** spaghetti — bold quantity",
         "Cook until _al dente_ — italic note",
         "**Sauce:** stir in _gently_ — bold and italic",
+        "Serve with [Green Sauce](chefmate://recipe/abc) — recipe link",
         "A stray * or _ stays literal",
     )
 
@@ -32,13 +35,22 @@ private val sampleLines =
 private fun InlineMarkdownSample(darkTheme: Boolean = false) {
     ChefMateTheme(darkTheme = darkTheme) {
         Surface(color = MaterialTheme.colorScheme.background) {
+            val linkStyle =
+                SpanStyle(
+                    color = MaterialTheme.colorScheme.primary,
+                    textDecoration = TextDecoration.Underline,
+                )
             Column(
                 modifier = Modifier.fillMaxWidth().padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 sampleLines.forEach { line ->
                     Text(
-                        text = line.toInlineMarkdownAnnotatedString(),
+                        text =
+                            line.toInlineMarkdownAnnotatedString(
+                                linkStyle = linkStyle,
+                                onLinkClick = {},
+                            ),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeDarkScreenshot_a850d601_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeDarkScreenshot_a850d601_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9791e23db1a934c2c67e95b0a11ed6fc666fb72f25638844d9e1a71f46aeac01
-size 286092
+oid sha256:4f1783a86894a859284cb3c3e73c48e270b30bab65010463ff0a200b79c3e549
+size 287960

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeLightScreenshot_c017aa92_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeLightScreenshot_c017aa92_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:354aeb454946bf72bf64e92ab521528cc8414030611cd553a4fff29f8c27c91d
-size 288116
+oid sha256:02d23b3d555afd0ab1fcddabdb18f6b95d1a5f1b87fa3d5a113281db79c57c76
+size 289754

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeMoreDetailsExpandedScreenshot_3c7a6d46_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeScreenshotTestKt/EditRecipeMoreDetailsExpandedScreenshot_3c7a6d46_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4405e72b76bf70638c0af49b896cb917b2328a0002de162c30954dc32427a25b
-size 411613
+oid sha256:10a85b3d16460986f5d3fa60574056afc9b4ca2aac1defe91ef7feeed2a6c0a3
+size 414500

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/InlineMarkdownScreenshotTestKt/InlineMarkdownDarkScreenshot_4d30ee2f_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/InlineMarkdownScreenshotTestKt/InlineMarkdownDarkScreenshot_4d30ee2f_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be3274692c295abaeb2293501b393095a4b14483ae501a44a2ffb104831bc313
-size 38201
+oid sha256:0c6ebe47490bf5c7266cb9acefec801f0fff7ec72a2926092faa92f470b5ad72
+size 47724

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/InlineMarkdownScreenshotTestKt/InlineMarkdownLightScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/InlineMarkdownScreenshotTestKt/InlineMarkdownLightScreenshot_748aa731_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3133996b03b3c0b023d9866dfb453e786c862407c549edd83c61c96b50a20ea4
-size 38245
+oid sha256:c8d39368ea732edd9a992be6eb7e45d974f4b566c70466d66503fcf614e21244
+size 47615

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailCompactScreenshot_39ac46f6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailCompactScreenshot_39ac46f6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:843bddb1af3da642a2679a2187d1e48f064ade319e76852a92d56b74f1431f96
-size 131699
+oid sha256:9b268e94a92fe6744152fc72f14d726c71ecefc7d45e0da05f7891b7dcfa56fc
+size 138646

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailTabletDarkScreenshot_1f3c2a8a_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailTabletDarkScreenshot_1f3c2a8a_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15aa596533f712d64609b2dcbb08a53bb25c88dedcbe452b3d9100694fc3e37b
-size 223641
+oid sha256:26f2cf866b4f54a60d9bfe0be3cf8df50d1be33760358e4e88ca3085545c6e64
+size 231280

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailTabletScreenshot_f0f0faa5_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailTabletScreenshot_f0f0faa5_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f787a78ae16c3725118f23a7730082b81bd44fc5d2ae7d8268246c591e9e960d
-size 229235
+oid sha256:95f584ffa020acf9565c548f77c3a4104aa4cebcf71365aa8d6513aa41af2948
+size 236264


### PR DESCRIPTION
Closes #377.

Ingredients and directions already support inline markdown (`**bold**`, `_italic_`). This adds a way to **link from one recipe to another** inside those fields — e.g. an ingredient that is itself a sub-recipe.

## The linking format
Standard markdown `[Label](chefmate://recipe/<clientId>)`, stored inline in the recipe text.

The embedded identifier is the recipe's **`clientId`** — a UUID assigned at creation (offline included), stored locally, uploaded as `client_id` (`onConflict = "client_id"`), and pulled back on every device. This is the only identifier that is both available offline *and* stable across sync and devices:

- local `id` (`Long`) — device-local; a link made on one device points at the wrong recipe after sync ❌
- `remoteId` (Supabase UUID) — only assigned *after* first sync, so offline/signed-out users couldn't create links ❌
- **`clientId`** — assigned at creation, preserved through sync, resolvable via `getRecipeByClientId` on any device ✅

Links are owner-scoped (a `clientId` only means something to the owner), which matches the intra-collection scope of the issue. Kept deliberately separate from the public https share link (keyed by `remoteId`).

## What you get
- **Render**: ingredients/directions render `[label](url)` as a tappable, primary-underlined link (raw markdown stripped).
- **Navigate**: a tap resolves the `clientId` to the local recipe and opens it (bringing an existing entry forward so links can't grow the back-stack unbounded); a link to a recipe not in your collection shows a toast. Non-recipe URLs fall through to the existing external-open path.
- **Author**: a **"Link a recipe"** button on the ingredients/directions markdown toolbar opens the existing `RecipePicker`; selecting a recipe splices the link in at the caret, in both raw-markdown and rich-text modes.

## Commits (split by concern)
1. `feat(recipe): clientId in domain model + getRecipeByClientId`
2. `feat(shared): recipe-link URL helper`
3. `feat(ui): render [label](url) links in inline markdown`
4. `feat(recipe): tap recipe links to navigate in detail`
5. `feat(recipe): insert recipe links from the editor via picker`
6. `test(recipe): snapshot coverage for rendered recipe links`

## Testing
- Unit tests across `shared`, `ui:public`, `recipe:data:impl`, `recipe:core:impl` — clientId resolution, link parse/render (incl. the `LinkAnnotation` click listener firing), detail navigation, markdown insertion, picker→link resolution.
- `composeApp` compiles (DI resolves the new `RecipePickerBloc.Factory` dependency).
- Screenshots re-recorded **and validated**: the inline-markdown reference shows the link styled correctly; the EditRecipe references show the new toolbar button.

### Worth a manual pass
The **rich-text editor** path (compose-rich-editor `addLink` → `toMarkdown` round-trip back to `[label](url)`) isn't covered by an automated test — worth confirming a link inserted in Rich text mode saves and renders on the detail screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)