### PR TITLE
fix(desktop): bundle java.net.http and jdk.unsupported so the browser WebView loads pages

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -278,15 +278,31 @@ compose.desktop {
             // crashes with NoClassDefFoundError the first time the cursor updates over the WebView
             // (see issue #400). Not needed for `./gradlew run`, which uses the full JDK.
             //
-            // jdk.xml.dom exports the org.w3c.dom.{html,css,stylesheets,xpath} interfaces that
-            // JavaFX WebView's WebKit glue (com.sun.webkit.dom.*) implements to build the page
-            // document. Without it in the jlink runtime image the WebView renders every page as a
+            // java.net.http provides java.net.http.HttpClient, which JavaFX WebView's WebKit
+            // network stack (com.sun.webkit.network.NetworkContext.fwkLoad) uses to fetch every
+            // page. Without it in the jlink runtime image every page load throws
+            // NoClassDefFoundError: java/net/http/HttpRequest$BodyPublisher and the WebView stays a
             // blank white screen (see issue #432). Like #400, only packaged builds are affected —
             // ./gradlew run uses the full JDK, which already has the module.
+            //
+            // jdk.unsupported exports sun.misc, where sun.misc.Unsafe lives. JavaFX's Marlin
+            // rasterizer (com.sun.marlin.OffHeapArray) uses Unsafe for its off-heap buffers.
+            // Without it DMarlinRenderingEngine fails to initialize and every shape fill in the
+            // WebView throws NoClassDefFoundError from the QuantumRenderer thread, so page content
+            // never rasterizes. Note this is a *different* module from jdk.unsupported.desktop
+            // above — that one only exports jdk.swing.interop and does not pull this one in.
+            //
+            // jdk.xml.dom exports the org.w3c.dom.{html,css,stylesheets,xpath} interfaces that
+            // javafx.web's com.sun.webkit.dom.* classes implement, so Java-side DOM access
+            // resolves. No code here calls WebEngine.getDocument() today, so this one is
+            // precautionary rather than a demonstrated fix — it is kept because it was part of the
+            // module set the #432 repro was verified against.
             modules(
                 "java.sql",
                 "java.naming",
+                "java.net.http",
                 "jdk.jsobject",
+                "jdk.unsupported",
                 "jdk.unsupported.desktop",
                 "jdk.xml.dom",
             )

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -277,7 +277,19 @@ compose.desktop {
             // runtime. Without it the jlink/jpackage runtime image omits the class and the browser
             // crashes with NoClassDefFoundError the first time the cursor updates over the WebView
             // (see issue #400). Not needed for `./gradlew run`, which uses the full JDK.
-            modules("java.sql", "java.naming", "jdk.jsobject", "jdk.unsupported.desktop")
+            //
+            // jdk.xml.dom exports the org.w3c.dom.{html,css,stylesheets,xpath} interfaces that
+            // JavaFX WebView's WebKit glue (com.sun.webkit.dom.*) implements to build the page
+            // document. Without it in the jlink runtime image the WebView renders every page as a
+            // blank white screen (see issue #432). Like #400, only packaged builds are affected —
+            // ./gradlew run uses the full JDK, which already has the module.
+            modules(
+                "java.sql",
+                "java.naming",
+                "jdk.jsobject",
+                "jdk.unsupported.desktop",
+                "jdk.xml.dom",
+            )
 
             // macOS configuration
             macOS {


### PR DESCRIPTION
## What & why

The packaged desktop **release** browser showed a blank white screen and loaded no pages, while `./gradlew run` worked fine (#432).

Packaged builds run on a trimmed jlink runtime containing only the modules listed in `nativeDistributions { modules(...) }`. Two modules JavaFX WebView needs were missing. Both exist in the full JDK, which is why only packaged builds broke — same class of bug as #400 / #401 (`jdk.unsupported.desktop`).

**1. `java.net.http`** — WebKit's network stack fetches every page through `java.net.http.HttpClient`. Without it, each load threw before anything could render:

```
NoClassDefFoundError: java/net/http/HttpRequest$BodyPublisher
  at com.sun.webkit.network.NetworkContext.fwkLoad(NetworkContext.java:168)
```

**2. `jdk.unsupported`** — exports `sun.misc`, home of `sun.misc.Unsafe`, which JavaFX's Marlin rasterizer (`com.sun.marlin.OffHeapArray`) uses for off-heap buffers. Without it `DMarlinRenderingEngine` fails to initialize and every shape fill throws on the render thread, so page content never rasterizes:

```
NoClassDefFoundError: Could not initialize class com.sun.marlin.DMarlinRenderingEngine
  at com.sun.javafx.webkit.prism.WCGraphicsPrismContext.fillPath(...)
  at com.sun.javafx.sg.prism.web.NGWebView.renderContent(...)
Caused by: NoClassDefFoundError: sun/misc/Unsafe
```

Note this is a **different module** from the `jdk.unsupported.desktop` we already bundled — that one only exports `jdk.swing.interop` and does not pull `jdk.unsupported` in. This is why a plain-text page (`example.com`) could render while real recipe pages stayed blank.

## Change

Adds `java.net.http` and `jdk.unsupported` to the jlink module list in `client/composeApp/build.gradle.kts`, each with a comment explaining the failure mode.

Also adds `jdk.xml.dom` (first commit). Being upfront: that one was my initial hypothesis and is **not** a demonstrated fix — no code calls `WebEngine.getDocument()` today. It's kept because it was part of the module set the fix was verified against, and its comment says exactly that. Happy to drop it if you'd rather keep the runtime minimal.

## Verification

Built `createReleaseDistributable`, launched the packaged app image, and loaded a real recipe page in the in-app browser — it renders, where before it was a white screen. Confirmed fixed by @plusmobileapps.

Fixes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)