### PR TITLE
feat(db): let anon read public recipes for the web fallback page

### DIFF
--- a/supabase/migrations/20260715_public_recipes_anon_read.sql
+++ b/supabase/migrations/20260715_public_recipes_anon_read.sql
@@ -1,0 +1,30 @@
+-- Widens the public-recipe SELECT policy to the `anon` role so a logged-out web visitor can read a
+-- recipe that its owner marked public.
+--
+-- 20260713_add_recipe_public_sharing.sql deliberately scoped "Anyone can view public recipes" to
+-- `authenticated`, and said: "Widen to `anon` later if a logged-out web fallback page is built."
+-- That page now exists — `web/404.html` in the chefmate-site repo, served for
+-- https://chefmate.plusmobileapps.com/recipe/<uuid> when the recipient doesn't have the app. It
+-- queries PostgREST with the anon key, so until this lands the page can only ever render
+-- "This recipe isn't available".
+--
+-- Why this exposes nothing new: the apps bootstrap a Supabase session with signInAnonymously()
+-- (SupabaseAuthenticationRepository.kt), so Anonymous Sign-ins are enabled on the project and the
+-- anon key is public by construction — anyone can already mint an `authenticated` session and read
+-- exactly these rows. Adding `anon` removes a pointless sign-in round-trip rather than widening
+-- the blast radius.
+--
+-- Scope is otherwise unchanged: still only rows explicitly flagged is_public, so private recipes
+-- stay owner/collaborator scoped. The share link remains a capability URL — an unguessable UUID.
+-- Still additive to the existing owner and shared-book-member SELECT policies (Postgres ORs
+-- permissive policies together), and it still references no other table, so it cannot reintroduce
+-- the RLS recursion fixed in 20260610_fix_recipe_rls_recursion.sql.
+
+DROP POLICY IF EXISTS "Anyone can view public recipes" ON recipes;
+CREATE POLICY "Anyone can view public recipes" ON recipes
+    FOR SELECT TO anon, authenticated USING (is_public = true);
+
+-- RLS filters rows for a role that already holds the table privilege; it does not grant that
+-- privilege. Supabase's default privileges on `public` normally cover this, but `recipes` was
+-- created out-of-band (see 20260713), so don't assume — GRANT is idempotent.
+GRANT SELECT ON recipes TO anon;


### PR DESCRIPTION
`20260713_add_recipe_public_sharing.sql` scoped the `"Anyone can view public recipes"` SELECT policy to the `authenticated` role only, and explicitly deferred the rest:

> Widen to `anon` later if a logged-out web fallback page is built.

That page now exists — [`web/404.html`](https://github.com/Plus-Mobile-Apps/chefmate-site/pull/15) in the chefmate-site repo, served for `https://chefmate.plusmobileapps.com/recipe/<uuid>` when the recipient doesn't have the app. It queries PostgREST with the anon key, so **until this migration lands that page can only ever render "This recipe isn't available."**

## What it does

- Widens the existing policy to `anon` as well as `authenticated`.
- Adds a defensive `GRANT SELECT ON recipes TO anon`. RLS filters rows for a role that already holds the table privilege; it doesn't grant it. Supabase's defaults on `public` normally cover this, but the `recipes` table was created out-of-band (see the note in 20260713), so this doesn't assume. `GRANT` is idempotent.

Scope is otherwise unchanged: still only rows flagged `is_public`, still additive to the owner and shared-book-member SELECT policies (Postgres ORs permissive policies together), and it references no other table, so it can't reintroduce the RLS recursion fixed in `20260610_fix_recipe_rls_recursion.sql`.

## Why this exposes nothing new

The apps bootstrap a Supabase session with `signInAnonymously()` (`SupabaseAuthenticationRepository.kt`), so Anonymous Sign-ins are enabled on the project and the anon key is public by construction. Anyone holding that key can already mint an `authenticated` session and read exactly these rows — adding `anon` removes a pointless sign-in round-trip rather than widening the blast radius. The share link stays a capability URL: an unguessable UUID.

## Verification

Not run against a live database from here. Before merge, apply to the local Supabase stack and confirm with the anon key:

- a recipe flagged `is_public = true` returns the row;
- a private recipe returns `[]` (RLS still hides it);
- owner/collaborator reads of private recipes are unaffected.

## Companion PR

Plus-Mobile-Apps/chefmate-site#15 — the web fallback page this unblocks. Order doesn't matter for correctness (that page degrades to "isn't available" until this lands), but both are needed for the feature to work end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)