### PR TITLE
feat(recipe): richer shared recipe screen with details & floating save button

### DIFF
--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeBlocImpl.kt
@@ -46,6 +46,10 @@ class PublicRecipeBlocImpl(
 
     override fun onRetryClicked() = viewModel.onRetry()
 
+    override fun onSourceUrlClicked(url: String) {
+        output.onNext(PublicRecipeBloc.Output.OpenUrl(url))
+    }
+
     override fun onBackClicked() {
         output.onNext(PublicRecipeBloc.Output.Finished)
     }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeViewModel.kt
@@ -3,7 +3,9 @@ package com.plusmobileapps.chefmate.recipe.core.impl.share
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.core.share.PublicRecipeBloc
+import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
+import com.plusmobileapps.chefmate.util.TimeFormatterUtil
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
@@ -21,6 +23,7 @@ class PublicRecipeViewModel(
     @Assisted private val remoteId: String,
     @Main mainContext: CoroutineContext,
     private val repository: RecipeRepository,
+    private val timeFormatterUtil: TimeFormatterUtil,
 ) : ViewModel(mainContext) {
 
     private val _output = Channel<Output>(Channel.BUFFERED)
@@ -45,7 +48,7 @@ class PublicRecipeViewModel(
             repository
                 .fetchPublicRecipe(remoteId)
                 .onSuccess { recipe ->
-                    _state.value = PublicRecipeBloc.Model.Loaded(recipe = recipe)
+                    _state.value = recipe.toLoaded()
                 }
                 .onFailure { error ->
                     // A missing/private recipe is a definitive "not found"; anything else (network,
@@ -77,6 +80,14 @@ class PublicRecipeViewModel(
             _output.send(Output.OpenRecipe(saved.id))
         }
     }
+
+    private fun Recipe.toLoaded(): PublicRecipeBloc.Model.Loaded =
+        PublicRecipeBloc.Model.Loaded(
+            recipe = this,
+            formattedPrepTime = prepTime?.let(timeFormatterUtil::formatMinutes),
+            formattedCookTime = cookTime?.let(timeFormatterUtil::formatMinutes),
+            formattedTotalTime = totalTime?.let(timeFormatterUtil::formatMinutes),
+        )
 
     override fun onCleared() {
         super.onCleared()

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/share/PublicRecipeBlocImplTest.kt
@@ -8,6 +8,8 @@ import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.util.TimeFormatterUtil
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlin.test.Test
@@ -43,12 +45,20 @@ class PublicRecipeBlocImplTest {
             updatedAt = Instant.DISTANT_PAST,
         )
 
+    // Formats minutes as "<n> min" — enough to assert times are surfaced without pulling in the
+    // real localized formatter.
+    private val timeFormatterUtil =
+        object : TimeFormatterUtil {
+            override fun formatMinutes(totalMinutes: Int) = FixedString("$totalMinutes min")
+        }
+
     private fun createBloc(remoteId: String = "remote-1"): PublicRecipeBlocImpl {
         val viewModelFactory = PublicRecipeViewModel.Factory { id ->
             PublicRecipeViewModel(
                 remoteId = id,
                 mainContext = context.mainContext,
                 repository = repository,
+                timeFormatterUtil = timeFormatterUtil,
             )
         }
         return PublicRecipeBlocImpl(
@@ -90,5 +100,24 @@ class PublicRecipeBlocImplTest {
         // that a copy was created and an OpenRecipe output emitted.
         output.lastValue.shouldBeInstanceOf<PublicRecipeBloc.Output.OpenRecipe>()
         recipes.value.any { it.title == "Shared Soup" } shouldBe true
+    }
+
+    @Test
+    fun When_recipe_has_times_Then_they_are_formatted_in_loaded_state() {
+        repository.publicRecipes["remote-1"] =
+            publicRecipe.copy(prepTime = 10, cookTime = 20, totalTime = 30)
+        val bloc = createBloc()
+        val model = bloc.state.value.shouldBeInstanceOf<PublicRecipeBloc.Model.Loaded>()
+        model.formattedPrepTime shouldBe FixedString("10 min")
+        model.formattedCookTime shouldBe FixedString("20 min")
+        model.formattedTotalTime shouldBe FixedString("30 min")
+    }
+
+    @Test
+    fun When_source_url_clicked_Then_open_url_emitted() {
+        repository.publicRecipes["remote-1"] = publicRecipe
+        val bloc = createBloc()
+        bloc.onSourceUrlClicked("https://example.com/recipe")
+        output.lastValue shouldBe PublicRecipeBloc.Output.OpenUrl("https://example.com/recipe")
     }
 }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/share/PublicRecipeBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/share/PublicRecipeBloc.kt
@@ -6,6 +6,7 @@ import com.plusmobileapps.chefmate.BackClickBloc
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.ui.ComposeScreen
 import kotlinx.coroutines.flow.StateFlow
 
@@ -29,10 +30,23 @@ interface PublicRecipeBloc : BackClickBloc, ComposeScreen {
     /** Retries the fetch after a load failure. */
     fun onRetryClicked()
 
+    /** Opens the recipe's source [url] in the in-app browser. */
+    fun onSourceUrlClicked(url: String)
+
     sealed interface Model {
         data object Loading : Model
 
-        data class Loaded(val recipe: Recipe, val isSaving: Boolean = false) : Model
+        data class Loaded(
+            val recipe: Recipe,
+            val isSaving: Boolean = false,
+            /**
+             * Prep/cook/total times pre-formatted for display (e.g. "1 hr 30 min"), null when
+             * unset.
+             */
+            val formattedPrepTime: TextData? = null,
+            val formattedCookTime: TextData? = null,
+            val formattedTotalTime: TextData? = null,
+        ) : Model
 
         /** The recipe isn't public, was deleted, or the id is invalid. */
         data object NotFound : Model
@@ -49,6 +63,9 @@ interface PublicRecipeBloc : BackClickBloc, ComposeScreen {
          * recipient already had the recipe locally (resolved by remote id) and after saving a copy.
          */
         data class OpenRecipe(val recipeId: Long) : Output()
+
+        /** Open the recipe's source [url] in the in-app browser. */
+        data class OpenUrl(val url: String) : Output()
     }
 
     fun interface Factory {

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/share/PublicRecipePreviewScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/share/PublicRecipePreviewScreen.kt
@@ -2,17 +2,32 @@
 
 package com.plusmobileapps.chefmate.recipe.core.share
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,8 +36,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import chefmate.client.recipe.core.public.generated.resources.Res
 import chefmate.client.recipe.core.public.generated.resources.public_recipe_directions
@@ -34,11 +53,23 @@ import chefmate.client.recipe.core.public.generated.resources.public_recipe_offl
 import chefmate.client.recipe.core.public.generated.resources.public_recipe_retry
 import chefmate.client.recipe.core.public.generated.resources.public_recipe_save
 import chefmate.client.recipe.core.public.generated.resources.public_recipe_title
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_calories
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_time
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_details
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_kcal
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_prep_time
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_servings
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_source
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_total_time
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.PhraseModel
+import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusButton
 import com.plusmobileapps.chefmate.ui.components.PlusButtonVariant
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
+import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainerDefaults
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
 import com.plusmobileapps.chefmate.ui.components.PlusLoadingIndicator
 import com.plusmobileapps.chefmate.ui.components.RecipeImage
@@ -55,6 +86,7 @@ object PublicRecipeTestTags {
 @Composable
 fun PublicRecipePreviewScreen(bloc: PublicRecipeBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
+    val loaded = state as? PublicRecipeBloc.Model.Loaded
     Box(modifier = modifier.fillMaxSize().testTag(PublicRecipeTestTags.SCREEN)) {
         PlusHeaderContainer(
             modifier = Modifier.fillMaxSize(),
@@ -64,6 +96,12 @@ fun PublicRecipePreviewScreen(bloc: PublicRecipeBloc, modifier: Modifier = Modif
                     onBackClick = bloc::onBackClicked,
                 ),
             scrollEnabled = false,
+            // Float the "Save" CTA at the bottom over the scrolling content so it stays visible on
+            // open, instead of hiding at the very end of a long recipe.
+            floatingToolbar =
+                loaded?.let { model ->
+                    { SaveRecipeToolbar(isSaving = model.isSaving, onSave = bloc::onSaveClicked) }
+                },
         ) {
             when (val model = state) {
                 PublicRecipeBloc.Model.Loading ->
@@ -87,15 +125,26 @@ fun PublicRecipePreviewScreen(bloc: PublicRecipeBloc, modifier: Modifier = Modif
                             onClick = bloc::onRetryClicked,
                         )
                     }
-                is PublicRecipeBloc.Model.Loaded -> LoadedContent(model, bloc::onSaveClicked)
+                is PublicRecipeBloc.Model.Loaded ->
+                    LoadedContent(
+                        model = model,
+                        onSourceUrlClicked = bloc::onSourceUrlClicked,
+                    )
             }
         }
     }
 }
 
 @Composable
-private fun LoadedContent(model: PublicRecipeBloc.Model.Loaded, onSave: () -> Unit) {
+private fun LoadedContent(
+    model: PublicRecipeBloc.Model.Loaded,
+    onSourceUrlClicked: (String) -> Unit,
+) {
     val recipe = model.recipe
+    // Clearance so the last line of the recipe can scroll clear above the floating Save toolbar
+    // (its height + the bottom system-bar inset it already accounts for).
+    val bottomClearance =
+        SaveToolbarHeight + WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
     Column(
         modifier =
             Modifier.fillMaxSize()
@@ -116,6 +165,13 @@ private fun LoadedContent(model: PublicRecipeBloc.Model.Loaded, onSave: () -> Un
             ?.let { description ->
                 Text(text = description, style = MaterialTheme.typography.bodyMedium)
             }
+        RecipeDetailsCard(
+            recipe = recipe,
+            formattedPrepTime = model.formattedPrepTime,
+            formattedCookTime = model.formattedCookTime,
+            formattedTotalTime = model.formattedTotalTime,
+            onSourceUrlClicked = onSourceUrlClicked,
+        )
         RecipeSection(
             title = stringResource(Res.string.public_recipe_ingredients),
             body = recipe.ingredients,
@@ -124,12 +180,149 @@ private fun LoadedContent(model: PublicRecipeBloc.Model.Loaded, onSave: () -> Un
             title = stringResource(Res.string.public_recipe_directions),
             body = recipe.directions,
         )
-        PlusButton(
-            text = Res.string.public_recipe_save.asTextData(),
-            isLoading = model.isSaving,
-            modifier = Modifier.fillMaxWidth().testTag(PublicRecipeTestTags.SAVE_BUTTON),
-            onClick = onSave,
-        )
+        Spacer(modifier = Modifier.height(bottomClearance))
+    }
+}
+
+/** Approximate height reserved below the scrolling content for the floating Save toolbar. */
+private val SaveToolbarHeight: Dp = 88.dp
+
+/** Bottom-anchored floating Save CTA, spanning the content width with a small side gutter. */
+@Composable
+private fun SaveRecipeToolbar(isSaving: Boolean, onSave: () -> Unit) {
+    PlusButton(
+        text = Res.string.public_recipe_save.asTextData(),
+        isLoading = isSaving,
+        modifier =
+            Modifier.fillMaxWidth()
+                .widthIn(max = PlusHeaderContainerDefaults.MaxContentWidth)
+                .padding(horizontal = ChefMateTheme.dimens.paddingNormal)
+                .testTag(PublicRecipeTestTags.SAVE_BUTTON),
+        onClick = onSave,
+    )
+}
+
+/**
+ * Key recipe metadata for the read-only shared preview: servings, prep/cook/total time, calories,
+ * and a tappable source link that opens in the in-app browser. Renders nothing when the recipe
+ * carries none of these fields.
+ */
+@Composable
+private fun RecipeDetailsCard(
+    recipe: Recipe,
+    formattedPrepTime: TextData?,
+    formattedCookTime: TextData?,
+    formattedTotalTime: TextData?,
+    onSourceUrlClicked: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val hasDetails =
+        recipe.servings != null ||
+            formattedPrepTime != null ||
+            formattedCookTime != null ||
+            formattedTotalTime != null ||
+            recipe.calories != null ||
+            recipe.sourceUrl != null
+    if (!hasDetails) return
+    Card(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(Res.string.recipe_detail_details),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            recipe.servings?.let { servings ->
+                DetailRow(
+                    icon = Icons.Default.Restaurant,
+                    label = stringResource(Res.string.recipe_detail_servings),
+                    value = "$servings",
+                )
+            }
+            formattedPrepTime?.let {
+                DetailRow(
+                    icon = Icons.Default.Timer,
+                    label = stringResource(Res.string.recipe_detail_prep_time),
+                    value = it.localized(),
+                )
+            }
+            formattedCookTime?.let {
+                DetailRow(
+                    icon = Icons.Default.Timer,
+                    label = stringResource(Res.string.recipe_detail_cook_time),
+                    value = it.localized(),
+                )
+            }
+            formattedTotalTime?.let {
+                DetailRow(
+                    icon = Icons.Default.Timer,
+                    label = stringResource(Res.string.recipe_detail_total_time),
+                    value = it.localized(),
+                )
+            }
+            recipe.calories?.let { calories ->
+                DetailRow(
+                    icon = Icons.Default.LocalFireDepartment,
+                    label = stringResource(Res.string.recipe_detail_calories),
+                    value =
+                        PhraseModel(
+                                Res.string.recipe_detail_kcal,
+                                "calories" to FixedString(calories.toString()),
+                            )
+                            .localized(),
+                )
+            }
+            recipe.sourceUrl?.let { sourceUrl ->
+                Column(verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingExtraSmall)) {
+                    Text(
+                        text = stringResource(Res.string.recipe_detail_source),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = sourceUrl,
+                        modifier =
+                            Modifier.fillMaxWidth().clickable { onSourceUrlClicked(sourceUrl) },
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        textDecoration = TextDecoration.Underline,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(
+    label: String,
+    value: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Text(text = value, style = MaterialTheme.typography.bodyMedium)
     }
 }
 
@@ -178,11 +371,20 @@ fun previewPublicRecipeBloc(model: PublicRecipeBloc.Model): PublicRecipeBloc =
 
         override fun onRetryClicked() = Unit
 
+        override fun onSourceUrlClicked(url: String) = Unit
+
         override fun onBackClicked() = Unit
     }
 
 val previewPublicRecipeLoadedBloc: PublicRecipeBloc =
-    previewPublicRecipeBloc(PublicRecipeBloc.Model.Loaded(recipe = Recipe.Sample))
+    previewPublicRecipeBloc(
+        PublicRecipeBloc.Model.Loaded(
+            recipe = Recipe.Sample.copy(sourceUrl = "https://example.com/pasta-carbonara"),
+            formattedPrepTime = FixedString("10 min"),
+            formattedCookTime = FixedString("15 min"),
+            formattedTotalTime = FixedString("25 min"),
+        )
+    )
 
 val previewPublicRecipeNotFoundBloc: PublicRecipeBloc =
     previewPublicRecipeBloc(PublicRecipeBloc.Model.NotFound)

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -623,6 +623,8 @@ class RootBlocImpl(
             // the read-only preview.
             is PublicRecipeBloc.Output.OpenRecipe ->
                 navigation.replaceCurrent(RecipeRoot(Detail(output.recipeId)))
+            is PublicRecipeBloc.Output.OpenUrl ->
+                navigation.bringToFront(Configuration.Browser(output.url))
         }
     }
 

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTestKt/PublicRecipeLoadedDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTestKt/PublicRecipeLoadedDarkScreenshot_658f3c84_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b60f20844349a532733cbf051c5427b0e948f89ad032d18ffaa813fca45b429f
-size 131065
+oid sha256:b4be7401ddfc05a7d421deba49f7034835576b4148b8e40dac7346737d62db9b
+size 170167

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTestKt/PublicRecipeLoadedScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/PublicRecipeScreenshotTestKt/PublicRecipeLoadedScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b04388d7529bbf208a6f75231a45d2f1aef7d187b2e68673916d3e235a1118ea
-size 130621
+oid sha256:f8ca34536ec228d9027f5b0907aa7a1b6b09be466120795c7c1eb5afe42081b6
+size 169772


### PR DESCRIPTION
## What & why

The read-only **shared recipe screen** (`PublicRecipePreviewScreen` — shown when someone opens a `…/recipe/<id>` share link they don't own) previously showed only the title, description, ingredients, and directions. This PR surfaces more of the recipe's metadata and makes the primary action easier to find.

### Added recipe details
A **Details** card between the description and ingredients, showing (only the fields the recipe actually has):
- Servings, Prep Time, Cook Time, Total Time, Calories — styled to match the normal recipe detail screen
- **Source URL** — rendered as an underlined, tappable link that opens in the **in-app browser**

Times are pre-formatted in `PublicRecipeViewModel` via the injected `TimeFormatterUtil` (`"1 hr 30 min"`), mirroring how `RecipeDetailBloc` does it.

### Source URL → in-app browser
Wired the same way the detail screen and settings open URLs:
- New `PublicRecipeBloc.onSourceUrlClicked(url)` + `Output.OpenUrl(url)`
- `RootBlocImpl.handlePublicRecipeOutput` routes it to `navigation.bringToFront(Configuration.Browser(url))` (opens as a modal that pops back to the preview)

### Floating Save button
The **Save to my recipes** CTA was previously the last item in the scroll, so it was easy to miss at the bottom of a long recipe. It's now a **bottom-anchored floating toolbar** using `PlusHeaderContainer`'s `floatingToolbar` slot (the same mechanism the detail screen uses). The scrolling content gets bottom clearance equal to the toolbar height + system-bar inset so the last line scrolls fully clear above the button.

## Reviewer notes
- The floating toolbar is only present in the `Loaded` state (not on loading / not-found / offline).
- The `SAVE_BUTTON` test tag is preserved.
- New unit tests cover: formatted times surfaced in the loaded state, and source-URL tap emitting `OpenUrl`.
- Screenshot references re-recorded (light + dark) and validated.

## Testing
- `:client:recipe:core:impl:jvmTest` and `:client:root:impl:jvmTest` green
- `:client:ui:screenshot-test:validateDebugScreenshotTest` green
- ktfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)