### PR TITLE
feat: AI chat button on cook mode & recipe detail, grounded in the recipe

### DIFF
--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatRepository.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatRepository.kt
@@ -70,6 +70,7 @@ class AiChatRepository(
     suspend fun sendMessage(
         conversationId: Long?,
         text: String,
+        recipeContextPreamble: String? = null,
         onConversationStarted: (Long) -> Unit = {},
     ): Long? {
         val trimmed = text.trim()
@@ -123,6 +124,18 @@ class AiChatRepository(
                 }
             }
 
+        // Fold the recipe context into the first user turn (rather than sending it as an extra
+        // turn) so the request keeps strict user/model alternation while still grounding the reply.
+        // It only travels with the request — the persisted conversation is untouched.
+        val outgoingMessages =
+            if (recipeContextPreamble != null && historyMessages.isNotEmpty()) {
+                val first = historyMessages.first()
+                listOf(first.copy(content = recipeContextPreamble + "\n\n" + first.content)) +
+                    historyMessages.drop(1)
+            } else {
+                historyMessages
+            }
+
         var modelId: Long? = null
         val accumulated = StringBuilder()
         // Persisting every token re-runs the message query and recomposes the whole chat per token,
@@ -132,7 +145,7 @@ class AiChatRepository(
         // final flush below always persists the complete content.
         var lastWriteAt = 0L
         try {
-            geminiClient.streamReply(historyMessages).collect { delta ->
+            geminiClient.streamReply(outgoingMessages).collect { delta ->
                 accumulated.append(delta)
                 val content = accumulated.toString()
                 val id = modelId

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatRootBlocImpl.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatRootBlocImpl.kt
@@ -28,6 +28,7 @@ import kotlinx.serialization.Serializable
 )
 class AiChatRootBlocImpl(
     @Assisted context: BlocContext,
+    @Assisted private val recipeContextId: Long?,
     @Assisted private val output: Consumer<AiChatRootBloc.Output>,
     private val chatFactory: AiChatBloc.Factory,
     private val historyFactory: AiChatHistoryBloc.Factory,
@@ -39,7 +40,9 @@ class AiChatRootBlocImpl(
         childStack(
             source = navigation,
             serializer = Configuration.serializer(),
-            initialStack = { listOf(Configuration.Chat(conversationId = null)) },
+            initialStack = {
+                listOf(Configuration.Chat(conversationId = null, recipeContextId = recipeContextId))
+            },
             handleBackButton = true,
             key = "AiChatRootRouter",
             childFactory = ::createChild,
@@ -67,7 +70,10 @@ class AiChatRootBlocImpl(
                             props =
                                 config.conversationId?.let {
                                     AiChatBloc.Props.ExistingConversation(it)
-                                } ?: AiChatBloc.Props.NewConversation,
+                                }
+                                    ?: AiChatBloc.Props.NewConversation(
+                                        recipeContextId = config.recipeContextId
+                                    ),
                             output = ::handleChatOutput,
                         )
                 )
@@ -103,7 +109,9 @@ class AiChatRootBlocImpl(
 
     @Serializable
     private sealed class Configuration {
-        @Serializable data class Chat(val conversationId: Long?) : Configuration()
+        @Serializable
+        data class Chat(val conversationId: Long?, val recipeContextId: Long? = null) :
+            Configuration()
 
         @Serializable data object History : Configuration()
     }

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatViewModel.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatViewModel.kt
@@ -8,9 +8,11 @@ import com.plusmobileapps.chefmate.aichat.AiChatNoApiKeyError
 import com.plusmobileapps.chefmate.aichat.ChatMessage
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.recipe.data.PendingRecipePhotoStore
+import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import com.plusmobileapps.chefmate.recipe.data.RecipeImageExtractor
+import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.util.mimeTypeForImageExtension
 import dev.zacsweers.metro.Assisted
@@ -44,6 +46,7 @@ class AiChatViewModel(
     private val recipeExtractor: GeminiRecipeExtractor,
     private val imageExtractor: RecipeImageExtractor,
     private val pendingPhotoStore: PendingRecipePhotoStore,
+    private val recipeRepository: RecipeRepository,
 ) : ViewModel(mainContext) {
 
     private val _conversationId =
@@ -53,6 +56,14 @@ class AiChatViewModel(
                 is AiChatBloc.Props.ExistingConversation -> props.conversationId
             }
         )
+
+    private val recipeContextId = (props as? AiChatBloc.Props.NewConversation)?.recipeContextId
+
+    // The recipe this chat is grounded in (title drives the chip; full details are folded into the
+    // outgoing prompt). Loaded once from the local DB when a context recipe was supplied; stays
+    // null
+    // for the standalone chat or if the recipe can't be found.
+    private val _recipeContext = MutableStateFlow<Recipe?>(null)
     private val _inputText = MutableStateFlow("")
     private val _isSending = MutableStateFlow(false)
     private val _isExtractingRecipe = MutableStateFlow(false)
@@ -95,7 +106,17 @@ class AiChatViewModel(
                     error = error,
                 )
             }
+            .combine(_recipeContext) { model, recipe ->
+                model.copy(recipeContextTitle = recipe?.title?.takeIf { it.isNotBlank() })
+            }
             .stateIn(scope, SharingStarted.Eagerly, AiChatBloc.Model())
+
+    init {
+        // Load the context recipe (if any) so the chip and prompt preamble can use its details.
+        recipeContextId?.let { id ->
+            scope.launch { recipeRepository.getRecipe(id).collect { _recipeContext.value = it } }
+        }
+    }
 
     fun onInputChange(text: String) {
         _inputText.value = text
@@ -107,10 +128,15 @@ class AiChatViewModel(
         if (message.isEmpty() || _isSending.value) return
         _inputText.value = ""
         _error.value = null
+        val preamble = _recipeContext.value?.let(::recipeContextPreamble)
         scope.launch {
             _isSending.value = true
             try {
-                repository.sendMessage(_conversationId.value, message) { startedId ->
+                repository.sendMessage(
+                    conversationId = _conversationId.value,
+                    text = message,
+                    recipeContextPreamble = preamble,
+                ) { startedId ->
                     // Publish the conversation id as soon as the user message is persisted so the
                     // message list switches to observing it immediately, rather than waiting for
                     // the whole reply to stream back.
@@ -185,5 +211,25 @@ class AiChatViewModel(
     @AssistedFactory
     fun interface Factory {
         fun create(props: AiChatBloc.Props): AiChatViewModel
+    }
+}
+
+/**
+ * Builds the context preamble folded into the first outgoing user turn so Gemini's replies stay
+ * grounded in [recipe]. Kept out of the persisted messages — it only travels with the request.
+ */
+private fun recipeContextPreamble(recipe: Recipe): String = buildString {
+    append(
+        "The user is looking at the following recipe and may ask questions about it or how to " +
+            "adapt it. Use it as the context for your answers.\n\n"
+    )
+    append("Recipe: ${recipe.title}\n")
+    recipe.servings?.let { append("Servings: $it\n") }
+    recipe.description?.takeIf { it.isNotBlank() }?.let { append("Description: $it\n") }
+    if (recipe.ingredients.isNotBlank()) {
+        append("\nIngredients:\n${recipe.ingredients.trim()}\n")
+    }
+    if (recipe.directions.isNotBlank()) {
+        append("\nDirections:\n${recipe.directions.trim()}\n")
     }
 }

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatPreviews.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatPreviews.kt
@@ -84,6 +84,16 @@ val previewAiChatBlocExtracting: AiChatBloc =
         )
     )
 
+/** Conversation grounded in a recipe — shows the recipe-context chip above the input. */
+val previewAiChatBlocWithRecipeContext: AiChatBloc =
+    aiChatBloc(
+        AiChatBloc.Model(
+            messages = sampleConversation,
+            canAddRecipe = true,
+            recipeContextTitle = "Pasta Carbonara",
+        )
+    )
+
 /** Streaming response — last model bubble is mid-stream and shows the progress indicator. */
 val previewAiChatBlocStreaming: AiChatBloc =
     aiChatBloc(
@@ -130,6 +140,12 @@ internal fun AiChatScreenPreview() {
 @Composable
 internal fun AiChatScreenEmptyPreview() {
     ChefMateTheme { previewAiChatBlocEmpty.Content() }
+}
+
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+internal fun AiChatScreenWithRecipeContextPreview() {
+    ChefMateTheme { previewAiChatBlocWithRecipeContext.Content() }
 }
 
 @Preview(showBackground = true, heightDp = 900)

--- a/client/aichat/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatViewModelTest.kt
+++ b/client/aichat/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/aichat/impl/AiChatViewModelTest.kt
@@ -10,10 +10,12 @@ import com.plusmobileapps.chefmate.aichat.AiChatNoApiKeyError
 import com.plusmobileapps.chefmate.aichat.ChatMessage
 import com.plusmobileapps.chefmate.database.testing.createTestDatabase
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
+import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionError
 import com.plusmobileapps.chefmate.recipe.data.RecipeExtractionException
 import com.plusmobileapps.chefmate.recipe.data.RecipeImageExtractor
 import com.plusmobileapps.chefmate.recipe.data.testing.FakePendingRecipePhotoStore
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.plusmobileapps.chefmate.util.testing.FakeDateTimeUtil
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
@@ -25,6 +27,7 @@ import kotlin.test.Test
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -39,6 +42,8 @@ class AiChatViewModelTest {
     private val recipeExtractor = mock<GeminiRecipeExtractor>()
     private val imageExtractor = mock<RecipeImageExtractor>()
     private val pendingPhotoStore = FakePendingRecipePhotoStore()
+    private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
+    private val recipeRepository = FakeRecipeRepository(recipes)
 
     private val repository =
         AiChatRepository(
@@ -49,7 +54,7 @@ class AiChatViewModelTest {
             ioContext = dispatcher,
         )
 
-    private fun newViewModel(props: AiChatBloc.Props = AiChatBloc.Props.NewConversation) =
+    private fun newViewModel(props: AiChatBloc.Props = AiChatBloc.Props.NewConversation()) =
         AiChatViewModel(
             mainContext = dispatcher,
             props = props,
@@ -57,6 +62,7 @@ class AiChatViewModelTest {
             recipeExtractor = recipeExtractor,
             imageExtractor = imageExtractor,
             pendingPhotoStore = pendingPhotoStore,
+            recipeRepository = recipeRepository,
         )
 
     @Test
@@ -250,6 +256,86 @@ class AiChatViewModelTest {
 
             gate.complete(Unit)
         }
+
+    @Test
+    fun recipe_context_exposes_title_and_folds_details_into_prompt() =
+        runTest(dispatcher) {
+            val capturing = CapturingGeminiClient()
+            val viewModel =
+                viewModelWith(
+                    geminiClient = capturing,
+                    props = AiChatBloc.Props.NewConversation(recipeContextId = 42L),
+                ) {
+                    recipes.value =
+                        listOf(
+                            Recipe.Sample.copy(
+                                id = 42L,
+                                title = "Grandma’s Lasagna",
+                                ingredients = "pasta\nsauce",
+                                directions = "layer it up",
+                            )
+                        )
+                }
+
+            viewModel.state.value.recipeContextTitle shouldBe "Grandma’s Lasagna"
+
+            viewModel.onInputChange("Can I make this gluten free?")
+            viewModel.send()
+
+            val sentFirstMessage = capturing.histories.single().first().content
+            sentFirstMessage.contains("Grandma’s Lasagna") shouldBe true
+            sentFirstMessage.contains("layer it up") shouldBe true
+            sentFirstMessage.contains("Can I make this gluten free?") shouldBe true
+        }
+
+    @Test
+    fun no_recipe_context_leaves_title_null_and_prompt_unchanged() =
+        runTest(dispatcher) {
+            val capturing = CapturingGeminiClient()
+            val viewModel = viewModelWith(geminiClient = capturing)
+
+            viewModel.state.value.recipeContextTitle shouldBe null
+
+            viewModel.onInputChange("hello")
+            viewModel.send()
+
+            capturing.histories.single().single().content shouldBe "hello"
+        }
+
+    /** Builds a view model backed by a real repository over [geminiClient], for prompt-capture. */
+    private fun viewModelWith(
+        geminiClient: GeminiClient,
+        props: AiChatBloc.Props = AiChatBloc.Props.NewConversation(),
+        seed: () -> Unit = {},
+    ): AiChatViewModel {
+        seed()
+        val repo =
+            AiChatRepository(
+                messageQueries = db.aiChatMessageQueries,
+                conversationQueries = db.aiChatConversationQueries,
+                geminiClient = geminiClient,
+                dateTimeUtil = dateTimeUtil,
+                ioContext = dispatcher,
+            )
+        return AiChatViewModel(
+            mainContext = dispatcher,
+            props = props,
+            repository = repo,
+            recipeExtractor = recipeExtractor,
+            imageExtractor = imageExtractor,
+            pendingPhotoStore = pendingPhotoStore,
+            recipeRepository = recipeRepository,
+        )
+    }
+
+    private class CapturingGeminiClient : GeminiClient {
+        val histories = mutableListOf<List<ChatMessage>>()
+
+        override fun streamReply(history: List<ChatMessage>): kotlinx.coroutines.flow.Flow<String> {
+            histories += history
+            return flow { emit("sure") }
+        }
+    }
 
     @Test
     fun existing_conversation_props_loads_history() =

--- a/client/aichat/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/aichat/public/src/commonMain/composeResources/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="aichat_extracting_recipe">Extracting recipe…</string>
     <string name="aichat_error_extract_recipe">Couldn’t pull a recipe from that reply. Try asking Gemini to be more specific.</string>
     <string name="aichat_done">Done</string>
+    <string name="aichat_recipe_context">Recipe in context</string>
     <string name="aichat_empty_title">Start a conversation</string>
     <string name="aichat_empty_description">Ask Gemini about recipes, ingredients, or anything else.</string>
     <string name="aichat_error_no_api_key">AI features aren’t available right now. Please try again later.</string>

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatBloc.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatBloc.kt
@@ -44,12 +44,22 @@ interface AiChatBloc : BackClickBloc, ComposeScreen {
         val canAddRecipe: Boolean = false,
         val isExtractingRecipe: Boolean = false,
         val error: TextData? = null,
+        /**
+         * Title of the recipe this chat is grounded in, shown as a chip above the input. Non-null
+         * only when the chat was opened from a recipe (Cook Mode or the recipe detail screen); the
+         * recipe's details are also folded into the prompt so replies stay on-topic.
+         */
+        val recipeContextTitle: String? = null,
     )
 
     @Serializable
     sealed class Props {
-        /** A fresh chat — the conversation row is created lazily on first send. */
-        @Serializable data object NewConversation : Props()
+        /**
+         * A fresh chat — the conversation row is created lazily on first send. When
+         * [recipeContextId] is set, the chat is seeded with that recipe as context (a chip plus a
+         * prompt preamble) so the user can ask about or tweak it.
+         */
+        @Serializable data class NewConversation(val recipeContextId: Long? = null) : Props()
 
         /** Reopening an existing conversation by id. */
         @Serializable data class ExistingConversation(val conversationId: Long) : Props()

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatRootBloc.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatRootBloc.kt
@@ -39,6 +39,14 @@ interface AiChatRootBloc : BackHandlerOwner, BackClickBloc, ComposeScreen {
     }
 
     fun interface Factory {
-        fun create(context: BlocContext, output: Consumer<Output>): AiChatRootBloc
+        /**
+         * [recipeContextId] seeds the initial chat with a recipe as context (chip + prompt
+         * preamble). Null for the standalone AI Chat entry (e.g. the More tab).
+         */
+        fun create(
+            context: BlocContext,
+            recipeContextId: Long?,
+            output: Consumer<Output>,
+        ): AiChatRootBloc
     }
 }

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatScreen.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.AddPhotoAlternate
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Icon
@@ -66,6 +67,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import chefmate.client.aichat.public.generated.resources.Res
 import chefmate.client.aichat.public.generated.resources.aichat_add_recipe
@@ -76,6 +78,7 @@ import chefmate.client.aichat.public.generated.resources.aichat_empty_title
 import chefmate.client.aichat.public.generated.resources.aichat_extracting_recipe
 import chefmate.client.aichat.public.generated.resources.aichat_history
 import chefmate.client.aichat.public.generated.resources.aichat_input_hint
+import chefmate.client.aichat.public.generated.resources.aichat_recipe_context
 import chefmate.client.aichat.public.generated.resources.aichat_role_gemini
 import chefmate.client.aichat.public.generated.resources.aichat_role_you
 import chefmate.client.aichat.public.generated.resources.aichat_send
@@ -117,6 +120,14 @@ fun AiChatScreen(bloc: AiChatBloc, modifier: Modifier = Modifier) {
             ),
         scrollEnabled = false,
         content = {
+            state.recipeContextTitle?.let { title ->
+                RecipeContextChip(
+                    title = title,
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(start = 12.dp, end = 12.dp, top = 8.dp, bottom = 4.dp),
+                )
+            }
             Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
                 if (state.messages.isEmpty()) {
                     EmptyState(modifier = Modifier.fillMaxSize())
@@ -403,6 +414,35 @@ private fun AddRecipePill(isLoading: Boolean, onClick: () -> Unit, modifier: Mod
                     )
                 }
             },
+        )
+    }
+}
+
+/**
+ * Chip surfacing the recipe this chat is grounded in. Purely informational (non-clickable) — it
+ * mirrors the recipe context that is also folded into the prompt so the user can see what Gemini is
+ * answering about.
+ */
+@Composable
+private fun RecipeContextChip(title: String, modifier: Modifier = Modifier) {
+    Row(modifier = modifier, horizontalArrangement = Arrangement.Start) {
+        AssistChip(
+            onClick = {},
+            enabled = false,
+            modifier = Modifier.testTag(AiChatTestTags.RECIPE_CONTEXT_CHIP),
+            label = { Text(text = title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Restaurant,
+                    contentDescription = stringResource(Res.string.aichat_recipe_context),
+                    modifier = Modifier.size(AssistChipDefaults.IconSize),
+                )
+            },
+            colors =
+                AssistChipDefaults.assistChipColors(
+                    disabledLabelColor = MaterialTheme.colorScheme.onSurface,
+                    disabledLeadingIconContentColor = MaterialTheme.colorScheme.primary,
+                ),
         )
     }
 }

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatTestTags.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatTestTags.kt
@@ -9,6 +9,7 @@ object AiChatTestTags {
     const val THINKING_INDICATOR = "AiChatThinkingIndicator"
     const val ADD_RECIPE_PILL = "AiChatAddRecipePill"
     const val ATTACH_PHOTO_BUTTON = "AiChatAttachPhotoButton"
+    const val RECIPE_CONTEXT_CHIP = "AiChatRecipeContextChip"
 }
 
 object AiChatHistoryTestTags {

--- a/client/cook/impl/build.gradle.kts
+++ b/client/cook/impl/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             implementation(projects.client.database.core)
             implementation(projects.client.text.public)
             implementation(projects.client.ui.public)
+            implementation(projects.client.featureflag.public)
             implementation(libs.arkivanov.decompose.core)
             implementation(libs.arkivanov.decompose.compose.extensions)
             implementation(libs.kotlinx.serialization.json)
@@ -22,6 +23,7 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.multiplatform.settings.test)
             implementation(projects.client.recipe.data.testing)
+            implementation(projects.client.featureflag.testing)
         }
     }
 }

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeBlocImpl.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeBlocImpl.kt
@@ -50,6 +50,8 @@ class CookModeBlocImpl(
                 layoutMode = vm.layoutMode,
                 keepScreenOn = vm.keepScreenOn,
                 activeCoachMark = vm.activeCoachMark,
+                // Only offer AI chat once a recipe is active — it's the context handed to the chat.
+                showAiChat = vm.showAiChat && active != null,
             )
         }
 
@@ -63,6 +65,11 @@ class CookModeBlocImpl(
 
     override fun onRecipeChipClicked(recipeId: Long) {
         viewModel.selectRecipe(recipeId)
+    }
+
+    override fun onAiChatClicked() {
+        val activeRecipeId = state.value.activeRecipe?.id ?: return
+        output.onNext(CookModeBloc.Output.OpenAiChat(activeRecipeId))
     }
 
     override fun onLayoutToggled() {

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModel.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModel.kt
@@ -8,6 +8,9 @@ import com.plusmobileapps.chefmate.di.CoachMarkController
 import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.KeepScreenOnRepository
 import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
+import com.plusmobileapps.chefmate.featureflag.FeatureFlags
+import com.plusmobileapps.chefmate.featureflag.isEnabled
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import com.russhwolf.settings.Settings
@@ -31,7 +34,10 @@ class CookModeViewModel(
     settings: Settings,
     private val keepScreenOnRepository: KeepScreenOnRepository,
     private val coachMarkController: CoachMarkController,
+    featureFlags: FeatureFlags,
 ) : ViewModel(mainContext) {
+
+    private val showAiChat = featureFlags.isEnabled(FeatureFlagRegistry.AiChat)
 
     // Split view is the default; users can toggle to the scrolling (Stacked) list, which persists.
     private var splitLayoutPref by settings.boolean(KEY_LAYOUT_SPLIT, defaultValue = true)
@@ -49,8 +55,13 @@ class CookModeViewModel(
     // Fold the shared controller's active mark into state so the screen shows at most one coach
     // mark at a time across the whole app.
     val state: StateFlow<State> =
-        combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
-            state.copy(activeCoachMark = activeCoachMark)
+        combineStates(
+            combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
+                state.copy(activeCoachMark = activeCoachMark)
+            },
+            showAiChat,
+        ) { state, showChat ->
+            state.copy(showAiChat = showChat)
         }
 
     init {
@@ -139,6 +150,7 @@ class CookModeViewModel(
         val layoutMode: CookModeBloc.LayoutMode = CookModeBloc.LayoutMode.Split,
         val keepScreenOn: Boolean = true,
         val activeCoachMark: String? = null,
+        val showAiChat: Boolean = false,
     )
 
     @AssistedFactory

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/ui/CookModePreviews.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/ui/CookModePreviews.kt
@@ -45,6 +45,8 @@ private fun cookBloc(model: CookModeBloc.Model): CookModeBloc =
 
         override fun onRecipeChipClicked(recipeId: Long) = Unit
 
+        override fun onAiChatClicked() = Unit
+
         override fun onLayoutToggled() = Unit
 
         override fun onKeepScreenOnToggled() = Unit
@@ -88,6 +90,10 @@ val previewCookBlocStacked: CookModeBloc =
 
 val previewCookBlocSplit: CookModeBloc =
     cookBloc(previewCookBlocStacked.state.value.copy(layoutMode = CookModeBloc.LayoutMode.Split))
+
+// AI Chat feature flag on: the header surfaces the "Ask AI about this recipe" button.
+val previewCookBlocWithAiChat: CookModeBloc =
+    cookBloc(previewCookBlocStacked.state.value.copy(showAiChat = true))
 
 val previewCookBlocLoading: CookModeBloc = cookBloc(CookModeBloc.Model(isLoading = true))
 

--- a/client/cook/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModelTest.kt
+++ b/client/cook/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModelTest.kt
@@ -7,6 +7,8 @@ import com.plusmobileapps.chefmate.cook.data.CookingSessionRepository
 import com.plusmobileapps.chefmate.di.CoachMarkController
 import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.KeepScreenOnRepository
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
+import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.russhwolf.settings.MapSettings
@@ -34,7 +36,8 @@ class CookModeViewModelTest {
     }
 
     private fun createViewModel(
-        coachMarkController: CoachMarkController = CoachMarkController(MapSettings())
+        coachMarkController: CoachMarkController = CoachMarkController(MapSettings()),
+        featureFlags: FakeFeatureFlags = FakeFeatureFlags(),
     ) =
         CookModeViewModel(
             initialRecipeId = 1L,
@@ -44,6 +47,7 @@ class CookModeViewModelTest {
             settings = MapSettings(),
             keepScreenOnRepository = KeepScreenOnRepository(MapSettings()),
             coachMarkController = coachMarkController,
+            featureFlags = featureFlags,
         )
 
     @Test
@@ -61,6 +65,21 @@ class CookModeViewModelTest {
 
         controller.hasSeen(CoachMarkId.COOK_MODE_KEEP_SCREEN_ON) shouldBe true
         vm.state.value.activeCoachMark shouldBe CoachMarkId.COOK_MODE_LAYOUT
+    }
+
+    @Test
+    fun When_ai_chat_flag_off_Then_showAiChat_is_false() {
+        val vm = createViewModel()
+        vm.state.value.showAiChat shouldBe false
+    }
+
+    @Test
+    fun When_ai_chat_flag_on_Then_showAiChat_is_true() {
+        val vm =
+            createViewModel(
+                featureFlags = FakeFeatureFlags(mapOf(FeatureFlagRegistry.AiChat to true))
+            )
+        vm.state.value.showAiChat shouldBe true
     }
 
     @Test

--- a/client/cook/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/cook/public/src/commonMain/composeResources/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="cook_mode_finish_confirm_button">Finish</string>
     <string name="cook_mode_finish_cancel_button">Cancel</string>
     <string name="cook_mode_whats_cooking">What’s Cooking</string>
+    <string name="cook_mode_ai_chat">Ask AI about this recipe</string>
     <string name="cook_mode_ingredients">Ingredients</string>
     <string name="cook_mode_directions">Directions</string>
     <string name="cook_mode_loading">Loading recipe…</string>

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeBloc.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeBloc.kt
@@ -28,6 +28,9 @@ interface CookModeBloc : BackClickBloc, ComposeScreen {
 
     fun onRecipeChipClicked(recipeId: Long)
 
+    /** Open the AI chat grounded in the active recipe. Only surfaced when [Model.showAiChat]. */
+    fun onAiChatClicked()
+
     fun onLayoutToggled()
 
     fun onKeepScreenOnToggled()
@@ -53,12 +56,17 @@ interface CookModeBloc : BackClickBloc, ComposeScreen {
         val keepScreenOn: Boolean = true,
         /** Id of the first-run coach mark currently allowed to show, or null when none. */
         val activeCoachMark: String? = null,
+        /** Gated on the AI Chat feature flag — hides the chat button entirely when off. */
+        val showAiChat: Boolean = false,
     ) {
         data class Chip(val recipeId: Long, val title: String, val isActive: Boolean)
     }
 
     sealed class Output {
         data object Finished : Output()
+
+        /** Open the AI chat grounded in the recipe with this id. */
+        data class OpenAiChat(val recipeId: Long) : Output()
     }
 
     fun interface Factory {

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/ui/CookModeScreen.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/ui/CookModeScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.ViewAgenda
@@ -90,6 +91,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import chefmate.client.cook.public.generated.resources.Res
+import chefmate.client.cook.public.generated.resources.cook_mode_ai_chat
 import chefmate.client.cook.public.generated.resources.cook_mode_allow_screen_off
 import chefmate.client.cook.public.generated.resources.cook_mode_directions
 import chefmate.client.cook.public.generated.resources.cook_mode_finish
@@ -180,6 +182,21 @@ private fun CookModeCoachMark(
 }
 
 /**
+ * Header control that opens the AI chat grounded in the active recipe. Rendered only when the AI
+ * Chat feature flag is on (via [visible]); nothing is emitted otherwise.
+ */
+@Composable
+private fun CookModeAiChatButton(visible: Boolean, onClick: () -> Unit) {
+    if (!visible) return
+    IconButton(onClick = onClick) {
+        Icon(
+            imageVector = Icons.Default.AutoAwesome,
+            contentDescription = stringResource(Res.string.cook_mode_ai_chat),
+        )
+    }
+}
+
+/**
  * Check-mark control that ends cook mode. Tapping it opens a confirmation dialog first; confirming
  * runs [onFinish], which clears every recipe from cook mode and closes the screen.
  */
@@ -233,6 +250,10 @@ private fun CookModeTabletLayout(
                                     )
                                 }
                             }
+                            CookModeAiChatButton(
+                                visible = state.showAiChat,
+                                onClick = bloc::onAiChatClicked,
+                            )
                             CookModeCoachMark(
                                 id = CoachMarkId.COOK_MODE_KEEP_SCREEN_ON,
                                 text = Res.string.cook_mode_keep_screen_on_onboarding.asTextData(),
@@ -384,6 +405,10 @@ private fun CookModeMobileLayout(
                         onCloseClick = bloc::onCloseClicked,
                         trailingAccessory =
                             PlusHeaderData.TrailingAccessory.Custom {
+                                CookModeAiChatButton(
+                                    visible = state.showAiChat,
+                                    onClick = bloc::onAiChatClicked,
+                                )
                                 CookModeCoachMark(
                                     id = CoachMarkId.COOK_MODE_KEEP_SCREEN_ON,
                                     text =

--- a/client/recipe/core/impl/build.gradle.kts
+++ b/client/recipe/core/impl/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             implementation(projects.client.recipe.categories.public)
             implementation(projects.client.ui.public)
             implementation(projects.client.toast.public)
+            implementation(projects.client.featureflag.public)
             implementation(libs.arkivanov.decompose.core)
             implementation(libs.arkivanov.decompose.compose.extensions)
             implementation(projects.client.shared)
@@ -30,6 +31,7 @@ kotlin {
             implementation(projects.client.recipebook.data.testing)
             implementation(projects.client.grocery.data.testing)
             implementation(projects.client.toast.testing)
+            implementation(projects.client.featureflag.testing)
             implementation(libs.multiplatform.settings.test)
         }
     }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -122,6 +122,7 @@ class RecipeDetailBlocImpl(
                 formattedTotalTime =
                     it.recipe.totalTime?.let { time -> timeFormatterUtil.formatMinutes(time) },
                 activeCoachMark = it.activeCoachMark,
+                showAiChat = it.showAiChat,
             )
         }
 
@@ -171,6 +172,10 @@ class RecipeDetailBlocImpl(
     override fun onCookModeClicked() {
         viewModel.dismissCoachMark(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
         output.onNext(Output.OpenCookMode(recipeId))
+    }
+
+    override fun onAiChatClicked() {
+        output.onNext(Output.OpenAiChat(recipeId))
     }
 
     override fun onCoachMarkDismissed(id: String) {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -9,6 +9,9 @@ import com.plusmobileapps.chefmate.combineStates
 import com.plusmobileapps.chefmate.di.CoachMarkController
 import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.di.Main
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
+import com.plusmobileapps.chefmate.featureflag.FeatureFlags
+import com.plusmobileapps.chefmate.featureflag.isEnabled
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import com.plusmobileapps.chefmate.text.ResourceString
@@ -33,6 +36,7 @@ class RecipeDetailViewModel(
     private val repository: RecipeRepository,
     private val coachMarkController: CoachMarkController,
     private val toastService: ToastService,
+    featureFlags: FeatureFlags,
 ) : ViewModel(mainContext) {
 
     private val _output = Channel<Output>(Channel.BUFFERED)
@@ -43,11 +47,18 @@ class RecipeDetailViewModel(
 
     private val _state = MutableStateFlow(State())
 
+    private val showAiChat = featureFlags.isEnabled(FeatureFlagRegistry.AiChat)
+
     // Surface the shared controller's active mark so the screen can show one coach mark at a time;
     // only ids in CoachMarkId.recipeDetailSequence are anchored on this screen.
     val state: StateFlow<State> =
-        combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
-            state.copy(activeCoachMark = activeCoachMark)
+        combineStates(
+            combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
+                state.copy(activeCoachMark = activeCoachMark)
+            },
+            showAiChat,
+        ) { state, showChat ->
+            state.copy(showAiChat = showChat)
         }
 
     init {
@@ -159,6 +170,7 @@ class RecipeDetailViewModel(
         val showShareConfirmation: Boolean = false,
         val recipe: Recipe = Recipe.Empty,
         val activeCoachMark: String? = null,
+        val showAiChat: Boolean = false,
     )
 
     sealed class Output {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/root/RecipeRootBlocImpl.kt
@@ -138,6 +138,9 @@ class RecipeRootBlocImpl(
             is RecipeDetailBloc.Output.OpenCookMode -> {
                 this.output.onNext(RecipeRootBloc.Output.OpenCookMode(output.recipeId))
             }
+            is RecipeDetailBloc.Output.OpenAiChat -> {
+                this.output.onNext(RecipeRootBloc.Output.OpenAiChat(output.recipeId))
+            }
         }
     }
 

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
@@ -10,6 +10,8 @@ import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.di.CoachMarkController
 import com.plusmobileapps.chefmate.di.CoachMarkId
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
+import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.data.Recipe
@@ -68,10 +70,12 @@ class RecipeDetailBlocImplTest {
     private fun createBloc(
         recipe: Recipe? = sampleRecipe,
         cookModeTooltipSeen: Boolean = false,
+        aiChatEnabled: Boolean = false,
     ): RecipeDetailBlocImpl {
         if (recipe != null) recipes.value = listOf(recipe)
         coachMarkController = CoachMarkController(MapSettings())
         if (cookModeTooltipSeen) coachMarkController.dismiss(CoachMarkId.RECIPE_DETAIL_COOK_MODE)
+        val featureFlags = FakeFeatureFlags(mapOf(FeatureFlagRegistry.AiChat to aiChatEnabled))
         val viewModelFactory = RecipeDetailViewModel.Factory { id ->
             RecipeDetailViewModel(
                 recipeId = id,
@@ -79,6 +83,7 @@ class RecipeDetailBlocImplTest {
                 repository = repository,
                 coachMarkController = coachMarkController,
                 toastService = toastService,
+                featureFlags = featureFlags,
             )
         }
         val dateTimeUtil = FakeDateTimeUtil()
@@ -124,6 +129,25 @@ class RecipeDetailBlocImplTest {
         val bloc = createBloc(recipe = sampleRecipe.copy(imageUrl = null))
         bloc.onImageClicked()
         bloc.fullImageSlot.value.child shouldBe null
+    }
+
+    @Test
+    fun When_ai_chat_flag_off_Then_showAiChat_is_false() {
+        val bloc = createBloc(aiChatEnabled = false)
+        bloc.state.value.showAiChat shouldBe false
+    }
+
+    @Test
+    fun When_ai_chat_flag_on_Then_showAiChat_is_true() {
+        val bloc = createBloc(aiChatEnabled = true)
+        bloc.state.value.showAiChat shouldBe true
+    }
+
+    @Test
+    fun When_onAiChatClicked_Then_open_ai_chat_output_emitted_with_recipe_id() {
+        val bloc = createBloc()
+        bloc.onAiChatClicked()
+        output.lastValue shouldBe RecipeDetailBloc.Output.OpenAiChat(sampleRecipe.id)
     }
 
     @Test

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="recipe_add_to_grocery_list_view">View</string>
     <string name="recipe_detail_back">Back</string>
     <string name="recipe_detail_cook_mode">Cook this recipe</string>
+    <string name="recipe_detail_ai_chat">Ask AI about this recipe</string>
     <string name="recipe_detail_cook_mode_onboarding">Tap here to cook hands-free in Cook Mode</string>
     <string name="recipe_detail_add_to_grocery_onboarding">Add this recipe’s ingredients to your grocery list</string>
     <string name="recipe_detail_favorite_onboarding">Save this recipe to your favorites for quick access</string>

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -51,6 +51,9 @@ interface RecipeDetailBloc : BackClickBloc, ComposeScreen {
 
     fun onCookModeClicked()
 
+    /** Open the AI chat grounded in this recipe. Only surfaced when [Model.showAiChat]. */
+    fun onAiChatClicked()
+
     fun onAddToMealPlanClicked()
 
     /** Dismiss the coach mark with the given [com.plusmobileapps.chefmate.di.CoachMarkId]. */
@@ -96,12 +99,17 @@ interface RecipeDetailBloc : BackClickBloc, ComposeScreen {
         val formattedTotalTime: TextData? = null,
         /** Id of the coach mark currently allowed to show on this screen, or null. */
         val activeCoachMark: String? = null,
+        /** Gated on the AI Chat feature flag — hides the chat button entirely when off. */
+        val showAiChat: Boolean = false,
     )
 
     sealed class Output {
         data object Finished : Output()
 
         data class EditRecipe(val recipeId: Long) : Output()
+
+        /** Open the AI chat grounded in the recipe with this id. */
+        data class OpenAiChat(val recipeId: Long) : Output()
 
         /** Open another recipe's detail, e.g. from a tapped recipe-to-recipe link. */
         data class OpenRecipe(val recipeId: Long) : Output()

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuOpen
 import androidx.compose.material.icons.filled.AddShoppingCart
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -115,6 +116,7 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_grocery_onboarding
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_meal_plan
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_add_to_meal_plan_onboarding
+import chefmate.client.recipe.core.public.generated.resources.recipe_detail_ai_chat
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_calories
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_mode
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_cook_mode_onboarding
@@ -448,6 +450,15 @@ private fun RecipeDetailBody(
                                                 stringResource(
                                                     Res.string.recipe_detail_add_to_meal_plan
                                                 ),
+                                        )
+                                    }
+                                }
+                                if (state.showAiChat) {
+                                    IconButton(onClick = bloc::onAiChatClicked) {
+                                        Icon(
+                                            imageVector = Icons.Default.AutoAwesome,
+                                            contentDescription =
+                                                stringResource(Res.string.recipe_detail_ai_chat),
                                         )
                                     }
                                 }
@@ -1991,6 +2002,10 @@ val previewRecipeDetailBloc: RecipeDetailBloc =
             TODO("Not yet implemented")
         }
 
+        override fun onAiChatClicked() {
+            TODO("Not yet implemented")
+        }
+
         override fun onCoachMarkDismissed(id: String) {
             TODO("Not yet implemented")
         }
@@ -2026,6 +2041,15 @@ val previewRecipeDetailBloc: RecipeDetailBloc =
         override fun onBackClicked() {
             TODO("Not yet implemented")
         }
+
+        @Composable override fun Content(modifier: Modifier) = RecipeDetailScreen(this, modifier)
+    }
+
+/** Same as [previewRecipeDetailBloc] but with the AI Chat toolbar button surfaced. */
+val previewRecipeDetailBlocWithAiChat: RecipeDetailBloc =
+    object : RecipeDetailBloc by previewRecipeDetailBloc {
+        override val state: StateFlow<RecipeDetailBloc.Model> =
+            MutableStateFlow(previewRecipeDetailBloc.state.value.copy(showAiChat = true))
 
         @Composable override fun Content(modifier: Modifier) = RecipeDetailScreen(this, modifier)
     }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/root/RecipeRootBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/root/RecipeRootBloc.kt
@@ -42,6 +42,8 @@ interface RecipeRootBloc : BackHandlerOwner, BackClickBloc, ComposeScreen {
         data class OpenMealPlanner(val props: MealPlannerRootBloc.Props) : Output()
 
         data class OpenCookMode(val recipeId: Long) : Output()
+
+        data class OpenAiChat(val recipeId: Long) : Output()
     }
 
     @Serializable

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -328,9 +328,14 @@ class RootBlocImpl(
                         )
                 )
 
-            Configuration.AiChat ->
+            is Configuration.AiChat ->
                 RootBloc.Child.AiChat(
-                    bloc = aiChat.create(context = context, output = ::handleAiChatOutput)
+                    bloc =
+                        aiChat.create(
+                            context = context,
+                            recipeContextId = config.recipeContextId,
+                            output = ::handleAiChatOutput,
+                        )
                 )
 
             is Configuration.ExportRecipes ->
@@ -454,7 +459,7 @@ class RootBlocImpl(
             }
 
             BottomNavBloc.Output.OpenAiChat -> {
-                navigation.bringToFront(Configuration.AiChat)
+                navigation.bringToFront(Configuration.AiChat())
             }
 
             BottomNavBloc.Output.OpenDeveloperSettings -> {
@@ -584,12 +589,17 @@ class RootBlocImpl(
             is RecipeRootBloc.Output.OpenCookMode -> {
                 navigation.bringToFront(Configuration.CookMode(output.recipeId))
             }
+            is RecipeRootBloc.Output.OpenAiChat -> {
+                navigation.bringToFront(Configuration.AiChat(recipeContextId = output.recipeId))
+            }
         }
     }
 
     private fun handleCookModeOutput(output: CookModeBloc.Output) {
         when (output) {
             CookModeBloc.Output.Finished -> navigation.pop()
+            is CookModeBloc.Output.OpenAiChat ->
+                navigation.bringToFront(Configuration.AiChat(recipeContextId = output.recipeId))
         }
     }
 
@@ -708,7 +718,7 @@ class RootBlocImpl(
 
         @Serializable data class CookMode(val recipeId: Long) : Configuration()
 
-        @Serializable data object AiChat : Configuration()
+        @Serializable data class AiChat(val recipeContextId: Long? = null) : Configuration()
 
         @Serializable data class ExportRecipes(val recipeIds: Set<Long>?) : Configuration()
 

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -136,7 +136,7 @@ class RootBlocTest {
             cookMode = CookModeBloc.Factory { _, _, _ -> mock() },
             featureFlags = FakeFeatureFlags(),
             featureFlagsBlocFactory = { _, _ -> mock() },
-            aiChat = { _, output ->
+            aiChat = { _, _, output ->
                 aiChatOutput = output
                 mock()
             },

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTest.kt
@@ -15,6 +15,7 @@ import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocError
 import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocExtracting
 import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocStreaming
 import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocThinking
+import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocWithRecipeContext
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
@@ -53,6 +54,20 @@ fun AiChatConversationLightScreenshot() {
 @Composable
 fun AiChatConversationDarkScreenshot() {
     AiChatScreenshot(bloc = previewAiChatBloc, darkTheme = true)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun AiChatRecipeContextLightScreenshot() {
+    AiChatScreenshot(bloc = previewAiChatBlocWithRecipeContext)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun AiChatRecipeContextDarkScreenshot() {
+    AiChatScreenshot(bloc = previewAiChatBlocWithRecipeContext, darkTheme = true)
 }
 
 @PreviewTest

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTest.kt
@@ -10,6 +10,7 @@ import com.plusmobileapps.chefmate.cook.impl.ui.previewCookBlocLongTitle
 import com.plusmobileapps.chefmate.cook.impl.ui.previewCookBlocSections
 import com.plusmobileapps.chefmate.cook.impl.ui.previewCookBlocSplit
 import com.plusmobileapps.chefmate.cook.impl.ui.previewCookBlocStacked
+import com.plusmobileapps.chefmate.cook.impl.ui.previewCookBlocWithAiChat
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 
@@ -27,6 +28,14 @@ fun CookModePhonePortraitLightScreenshot() {
 @Composable
 fun CookModePhonePortraitDarkScreenshot() {
     ChefMateTheme(darkTheme = true) { previewCookBlocStacked.Content() }
+}
+
+// AI Chat feature flag on: the header shows the "Ask AI about this recipe" button.
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+fun CookModeAiChatButtonScreenshot() {
+    ChefMateTheme { previewCookBlocWithAiChat.Content() }
 }
 
 @PreviewTest

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.android.tools.screenshot.PreviewTest
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailScreen
 import com.plusmobileapps.chefmate.recipe.core.detail.previewRecipeDetailBloc
+import com.plusmobileapps.chefmate.recipe.core.detail.previewRecipeDetailBlocWithAiChat
 import com.plusmobileapps.chefmate.toast.LocalToastService
 import com.plusmobileapps.chefmate.toast.testing.FakeToastService
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -14,12 +15,20 @@ import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 // RecipeDetailScreen reads LocalToastService.current directly, so it must be provided for the
 // screen to compose at all.
 @Composable
-private fun RecipeDetailPreview(darkTheme: Boolean = false) {
+private fun RecipeDetailPreview(
+    darkTheme: Boolean = false,
+    bloc: com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc = previewRecipeDetailBloc,
+) {
     CompositionLocalProvider(LocalToastService provides FakeToastService()) {
-        ChefMateTheme(darkTheme = darkTheme) {
-            RecipeDetailScreen(bloc = previewRecipeDetailBloc)
-        }
+        ChefMateTheme(darkTheme = darkTheme) { RecipeDetailScreen(bloc = bloc) }
     }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 1000)
+@Composable
+fun RecipeDetailAiChatButtonScreenshot() {
+    RecipeDetailPreview(bloc = previewRecipeDetailBlocWithAiChat)
 }
 
 @PreviewTest

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatRecipeContextDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatRecipeContextDarkScreenshot_658f3c84_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:263e7492f9330da30f67f3740d5859eb1472a7fb56b6beb7b8ca7e60773dae07
+size 126558

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatRecipeContextLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatRecipeContextLightScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2ce445faecaba9a54c41aeb68d101bab8bd93d56aaac9ac80fa694be3c5db72
+size 126643

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeAiChatButtonScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/CookModeScreenshotTestKt/CookModeAiChatButtonScreenshot_73588fdf_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a58a99cccaf854cb6b374df990a7f5b9dbecb93917bc1ea1d048de4519246436
+size 132846

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailAiChatButtonScreenshot_39ac46f6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeDetailScreenshotTestKt/RecipeDetailAiChatButtonScreenshot_39ac46f6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6467266dc8a47f72662a0ce373fa0b37155ef9d378cae6cfada873d84e10b857
+size 140981


### PR DESCRIPTION
## What & why

Adds an entry point to the AI chat from the two screens where a user is actively working with a single recipe — **Cook Mode** and the **Recipe detail** screen — so they can ask questions about the recipe or how to modify it without leaving that recipe's flow.

Tapping the button opens the AI chat seeded with that recipe as context:
- the recipe title shows as a **chip** above the input, and
- the recipe's details (title, servings, description, ingredients, directions) are folded into the first outgoing turn so Gemini's replies stay grounded in it.

The button is **only visible when the `ai_chat` feature flag is on**, matching the existing More-tab gating.

## How it works

- `AiChatBloc.Props.NewConversation` now carries an optional `recipeContextId`. `AiChatViewModel` loads that recipe from the local DB to drive the chip (`Model.recipeContextTitle`) and to build the prompt preamble passed through `AiChatRepository.sendMessage`. The preamble is folded into the first user turn only — it travels with the request and is never persisted, keeping strict user/model alternation.
- The recipe screens emit an `OpenAiChat(recipeId)` output; `RootBlocImpl` routes it into `Configuration.AiChat(recipeContextId)` → `AiChatRootBloc`. The standalone More-tab entry passes `null` (no context), unchanged.
- `showAiChat` on each screen's `Model` is driven by `FeatureFlags.isEnabled(AiChatFlag)`; the button isn't composed at all when off (and in cook mode, only when a recipe is active).

## Tests

- Unit tests for the context chip title + prompt injection (`AiChatViewModelTest`), and for flag gating + output on both entry points (`CookModeViewModelTest`, `RecipeDetailBlocImplTest`).
- Updated `RootBlocTest` for the new factory signature.
- Snapshot references (light + dark) for the recipe-context chip and both entry-point buttons.

All affected module unit tests and `validateDebugScreenshotTest` pass; `:client:composeApp:compileDebugKotlinAndroid` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)