### PR TITLE
feat(desktop): native file dialogs instead of Swing JFileChooser

### DIFF
--- a/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.jvm.kt
+++ b/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ImagePickerUtil.jvm.kt
@@ -5,9 +5,13 @@ package com.plusmobileapps.chefmate.util
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import javax.swing.JFileChooser
+import java.awt.FileDialog
+import java.awt.Frame
+import java.io.File
+import java.io.FilenameFilter
 import javax.swing.SwingUtilities
-import javax.swing.filechooser.FileNameExtensionFilter
+
+private val imageExtensions = setOf("jpg", "jpeg", "png", "webp", "gif", "heic")
 
 @Composable
 actual fun rememberImagePickerLauncher(onResult: (PickedImage?) -> Unit): () -> Unit {
@@ -15,27 +19,21 @@ actual fun rememberImagePickerLauncher(onResult: (PickedImage?) -> Unit): () -> 
     return remember {
         {
             SwingUtilities.invokeLater {
-                val chooser =
-                    JFileChooser().apply {
-                        dialogTitle = "Select recipe photo"
-                        fileFilter =
-                            FileNameExtensionFilter(
-                                "Images",
-                                "jpg",
-                                "jpeg",
-                                "png",
-                                "webp",
-                                "gif",
-                                "heic",
-                            )
+                val dialog =
+                    FileDialog(null as Frame?, "Select recipe photo", FileDialog.LOAD).apply {
+                        filenameFilter = FilenameFilter { _, name ->
+                            name.substringAfterLast('.', "").lowercase() in imageExtensions
+                        }
+                        isVisible = true
                     }
-                val approved = chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION
-                if (!approved) {
+                val directory = dialog.directory
+                val name = dialog.file
+                if (directory == null || name == null) {
                     currentOnResult.value(null)
                     return@invokeLater
                 }
-                val file = chooser.selectedFile
-                if (file == null || !file.canRead()) {
+                val file = File(directory, name)
+                if (!file.canRead()) {
                     currentOnResult.value(null)
                     return@invokeLater
                 }

--- a/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ZipPickerUtil.jvm.kt
+++ b/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ZipPickerUtil.jvm.kt
@@ -5,9 +5,11 @@ package com.plusmobileapps.chefmate.util
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import javax.swing.JFileChooser
+import java.awt.FileDialog
+import java.awt.Frame
+import java.io.File
+import java.io.FilenameFilter
 import javax.swing.SwingUtilities
-import javax.swing.filechooser.FileNameExtensionFilter
 
 @Composable
 actual fun rememberZipPickerLauncher(onResult: (PickedFile?) -> Unit): () -> Unit {
@@ -15,18 +17,21 @@ actual fun rememberZipPickerLauncher(onResult: (PickedFile?) -> Unit): () -> Uni
     return remember {
         {
             SwingUtilities.invokeLater {
-                val chooser =
-                    JFileChooser().apply {
-                        dialogTitle = "Select recipe archive"
-                        fileFilter = FileNameExtensionFilter("Zip archives", "zip")
+                val dialog =
+                    FileDialog(null as Frame?, "Select recipe archive", FileDialog.LOAD).apply {
+                        filenameFilter = FilenameFilter { _, name ->
+                            name.endsWith(".zip", ignoreCase = true)
+                        }
+                        isVisible = true
                     }
-                val approved = chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION
-                if (!approved) {
+                val directory = dialog.directory
+                val name = dialog.file
+                if (directory == null || name == null) {
                     currentOnResult.value(null)
                     return@invokeLater
                 }
-                val file = chooser.selectedFile
-                if (file == null || !file.canRead()) {
+                val file = File(directory, name)
+                if (!file.canRead()) {
                     currentOnResult.value(null)
                     return@invokeLater
                 }

--- a/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ZipSaveUtil.jvm.kt
+++ b/client/util/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/util/ZipSaveUtil.jvm.kt
@@ -5,10 +5,10 @@ package com.plusmobileapps.chefmate.util
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import java.awt.FileDialog
+import java.awt.Frame
 import java.io.File
-import javax.swing.JFileChooser
 import javax.swing.SwingUtilities
-import javax.swing.filechooser.FileNameExtensionFilter
 
 @Composable
 actual fun rememberZipSaveLauncher(
@@ -18,17 +18,18 @@ actual fun rememberZipSaveLauncher(
     return remember {
         { fileName, bytes ->
             SwingUtilities.invokeLater {
-                val chooser =
-                    JFileChooser().apply {
-                        dialogTitle = "Save recipe archive"
-                        fileFilter = FileNameExtensionFilter("Zip archives", "zip")
-                        selectedFile = File(fileName)
+                val dialog =
+                    FileDialog(null as Frame?, "Save recipe archive", FileDialog.SAVE).apply {
+                        file = fileName
+                        isVisible = true
                     }
-                if (chooser.showSaveDialog(null) != JFileChooser.APPROVE_OPTION) {
+                val directory = dialog.directory
+                val name = dialog.file
+                if (directory == null || name == null) {
                     currentOnResult.value(false)
                     return@invokeLater
                 }
-                val chosen = chooser.selectedFile
+                val chosen = File(directory, name)
                 val target =
                     if (chosen.name.endsWith(".zip", ignoreCase = true)) chosen
                     else File(chosen.parentFile, chosen.name + ".zip")


### PR DESCRIPTION
## What

The JVM/desktop file pickers used Swing's `JFileChooser`, which renders the cross-platform Metal look-and-feel — visibly non-native and clunky on macOS. This swaps all three to `java.awt.FileDialog`, which maps to the real OS dialog (`NSOpenPanel`/`NSSavePanel` on macOS, the native Explorer dialog on Windows).

**No new dependencies** — only the `jvmMain` source set of `client/util/public` changes.

## Files

- `ImagePickerUtil.jvm.kt` — `LOAD` dialog, `FilenameFilter` restricts to the same image extensions.
- `ZipPickerUtil.jvm.kt` — `LOAD` dialog filtered to `.zip`.
- `ZipSaveUtil.jvm.kt` — `SAVE` dialog seeded with the suggested filename; still appends `.zip` if the user drops the extension.

## Behavior notes

- Cancel is now detected via a null `dialog.file` (replaces the old `APPROVE_OPTION` check) — semantics preserved.
- The extension filter is honored on macOS but effectively ignored on Windows; harmless since each flow already re-derives/validates the extension after selection.
- Same `SwingUtilities.invokeLater` off-thread pattern as before, so no Compose-thread blocking.

## Testing

- `:client:util:public:compileKotlinJvm` passes.
- Not clicked through the native panel manually (not drivable from this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)