### PR TITLE
feat: AI chat as an expandable peek sheet on recipe detail & cook mode

### DIFF
--- a/client/aichat/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/robots/AiChatRobot.kt
+++ b/client/aichat/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/robots/AiChatRobot.kt
@@ -20,9 +20,25 @@ import com.plusmobileapps.chefmate.aichat.AiChatTestTags
 class AiChatRobot(private val test: ComposeUiTest) {
 
     private val onScreen = hasAnyAncestor(hasTestTag(AiChatTestTags.SCREEN))
+    private val onPeek = hasAnyAncestor(hasTestTag(AiChatTestTags.PEEK))
 
     fun typeMessage(text: String): AiChatRobot = apply {
         test.onNode(hasTestTag(AiChatTestTags.INPUT) and onScreen).performTextInput(text)
+    }
+
+    /** Waits for the collapsed sheet "peek" (input over the recipe, no header) to appear. */
+    fun awaitPeekShown(): AiChatRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(AiChatTestTags.PEEK))
+    }
+
+    /** Focuses the peek input, which asks the sheet to expand to the full-screen chat. */
+    fun expandFromPeek(): AiChatRobot = apply {
+        test.onNode(hasTestTag(AiChatTestTags.INPUT) and onPeek).performClick()
+    }
+
+    /** Waits for the expanded, full-screen chat (its header) to be shown. */
+    fun awaitExpanded(): AiChatRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(AiChatTestTags.SCREEN))
     }
 
     fun tapSend(): AiChatRobot = apply {

--- a/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatPreviews.kt
+++ b/client/aichat/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/impl/ui/AiChatPreviews.kt
@@ -1,11 +1,14 @@
 package com.plusmobileapps.chefmate.aichat.impl.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.plusmobileapps.chefmate.aichat.AiChatBloc
+import com.plusmobileapps.chefmate.aichat.AiChatPresentation
 import com.plusmobileapps.chefmate.aichat.AiChatScreen
 import com.plusmobileapps.chefmate.aichat.ChatMessage
+import com.plusmobileapps.chefmate.aichat.LocalAiChatPresentation
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -164,4 +167,17 @@ internal fun AiChatScreenThinkingPreview() {
 @Composable
 internal fun AiChatScreenErrorPreview() {
     ChefMateTheme { previewAiChatBlocError.Content() }
+}
+
+/**
+ * Collapsed sheet "peek" — only the recipe chip and input, as shown before the sheet is expanded.
+ */
+@Preview(showBackground = true, heightDp = 240)
+@Composable
+internal fun AiChatScreenPeekPreview() {
+    ChefMateTheme {
+        CompositionLocalProvider(LocalAiChatPresentation provides AiChatPresentation.SheetPeek) {
+            previewAiChatBlocWithRecipeContext.Content()
+        }
+    }
 }

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatPresentation.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatPresentation.kt
@@ -1,0 +1,34 @@
+package com.plusmobileapps.chefmate.aichat
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * How the AI chat is currently being presented. The chat screen renders the same content in every
+ * case except [SheetPeek], where it collapses to a compact "peek" (just the input over the recipe)
+ * so it can be dragged up to full screen.
+ *
+ * Defaults to [FullScreen] so the standalone chat (opened from the More tab) and all previews
+ * render exactly as before — only the recipe-grounded sheet flips this to a sheet value.
+ */
+enum class AiChatPresentation {
+    /** Standalone, full-screen chat (More tab). Header + messages + input. */
+    FullScreen,
+
+    /**
+     * Bottom sheet at its partially-expanded detent — show only the input to invite a first tap.
+     */
+    SheetPeek,
+
+    /** Bottom sheet dragged up to full height — same layout as [FullScreen]. */
+    SheetExpanded,
+}
+
+/** The active presentation for the chat below this point in the tree. */
+val LocalAiChatPresentation = compositionLocalOf { AiChatPresentation.FullScreen }
+
+/**
+ * Requests that the hosting sheet expand to full height. Wired by the sheet host; a no-op in the
+ * full-screen presentation. Static because the callback identity rarely changes.
+ */
+val LocalAiChatRequestExpand = staticCompositionLocalOf<() -> Unit> { {} }

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatRootScreen.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatRootScreen.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.aichat
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.extensions.compose.stack.Children
@@ -9,8 +10,13 @@ import com.plusmobileapps.chefmate.ui.backAnimation
 
 @Composable
 fun AiChatRootScreen(bloc: AiChatRootBloc, modifier: Modifier = Modifier) {
+    // In the collapsed sheet "peek" the chat must hug its content height so the sheet stays small;
+    // everywhere else it fills the available space.
+    val sizeModifier =
+        if (LocalAiChatPresentation.current == AiChatPresentation.SheetPeek) Modifier.fillMaxWidth()
+        else Modifier.fillMaxSize()
     Children(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.then(sizeModifier),
         stack = bloc.routerState,
         animation = backAnimation(backHandler = bloc.backHandler, onBack = bloc::onBackClicked),
     ) { child ->

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatScreen.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatScreen.kt
@@ -9,6 +9,9 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -99,6 +102,14 @@ import org.jetbrains.compose.resources.stringResource
 fun AiChatScreen(bloc: AiChatBloc, modifier: Modifier = Modifier) {
     val state by bloc.state.collectAsState()
 
+    // When hosted in the recipe-grounded sheet at its collapsed detent, render just the input (plus
+    // the recipe chip) so the sheet hugs a small "peek" over the dimmed recipe. Tapping, focusing,
+    // or dragging up expands the sheet to the full-screen chat below.
+    if (LocalAiChatPresentation.current == AiChatPresentation.SheetPeek) {
+        AiChatPeek(bloc = bloc, state = state, modifier = modifier)
+        return
+    }
+
     PlusHeaderContainer(
         modifier = modifier.fillMaxSize().testTag(AiChatTestTags.SCREEN),
         data =
@@ -171,6 +182,57 @@ fun AiChatScreen(bloc: AiChatBloc, modifier: Modifier = Modifier) {
         },
     )
 }
+
+/**
+ * Collapsed "peek" presentation used by the recipe-grounded sheet: only the recipe-context chip and
+ * the input, so the sheet stays small over the dimmed recipe. Focusing the input, or dragging the
+ * strip upward, asks the host to expand to the full-screen chat.
+ */
+@Composable
+private fun AiChatPeek(bloc: AiChatBloc, state: AiChatBloc.Model, modifier: Modifier = Modifier) {
+    val onExpand = LocalAiChatRequestExpand.current
+    var dragAccumulation by remember { mutableStateOf(0f) }
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .testTag(AiChatTestTags.PEEK)
+                .draggable(
+                    orientation = Orientation.Vertical,
+                    state =
+                        rememberDraggableState { delta ->
+                            dragAccumulation += delta
+                            if (dragAccumulation < PEEK_DRAG_EXPAND_THRESHOLD) {
+                                dragAccumulation = 0f
+                                onExpand()
+                            }
+                        },
+                    onDragStopped = { dragAccumulation = 0f },
+                )
+    ) {
+        state.recipeContextTitle?.let { title ->
+            RecipeContextChip(
+                title = title,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(start = 12.dp, end = 12.dp, top = 4.dp, bottom = 4.dp),
+            )
+        }
+        AiChatInput(
+            inputText = bloc.inputText,
+            isSending = state.isSending,
+            isExtracting = state.isExtractingRecipe,
+            onInputChange = bloc::onInputChange,
+            onSendClick = bloc::onSendClick,
+            onPhotoPicked = bloc::onPhotoPicked,
+            onFocused = onExpand,
+        )
+    }
+}
+
+/** Upward drag (negative delta) past this many pixels on the peek strip expands the sheet. */
+private const val PEEK_DRAG_EXPAND_THRESHOLD = -40f
 
 @Composable
 private fun MessageList(
@@ -484,6 +546,7 @@ private fun AiChatInput(
     onSendClick: () -> Unit,
     onPhotoPicked: (ByteArray, String) -> Unit,
     modifier: Modifier = Modifier,
+    onFocused: () -> Unit = {},
 ) {
     val text by inputText.collectAsState()
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -526,7 +589,10 @@ private fun AiChatInput(
             onValueChange = onInputChange,
             modifier =
                 Modifier.weight(1f)
-                    .onFocusChanged { isFocused = it.isFocused }
+                    .onFocusChanged {
+                        isFocused = it.isFocused
+                        if (it.isFocused) onFocused()
+                    }
                     .testTag(AiChatTestTags.INPUT),
             placeholder = { Text(stringResource(Res.string.aichat_input_hint)) },
             keyboardOptions =

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatTestTags.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatTestTags.kt
@@ -2,6 +2,7 @@ package com.plusmobileapps.chefmate.aichat
 
 object AiChatTestTags {
     const val SCREEN = "AiChatScreen"
+    const val PEEK = "AiChatPeek"
     const val INPUT = "AiChatInput"
     const val SEND_BUTTON = "AiChatSendButton"
     const val HISTORY_BUTTON = "AiChatHistoryButton"

--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/AiChatSheetNavigationUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/AiChatSheetNavigationUiTest.kt
@@ -1,0 +1,31 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package com.plusmobileapps.chefmate.tests
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.plusmobileapps.chefmate.aichat.robots.aiChat
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
+import com.plusmobileapps.chefmate.fixtures.TestRecipes
+import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.recipe.core.robots.recipeDetail
+import com.plusmobileapps.chefmate.recipe.list.robots.recipeList
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class AiChatSheetNavigationUiTest {
+
+    /**
+     * Opening the AI chat from a recipe shows it as a collapsed sheet "peek" (input over the
+     * recipe), and focusing the input expands it to the full-screen chat — the recipe detail
+     * underneath is never replaced by a full-screen chat child.
+     */
+    @Test
+    fun ai_chat_from_recipe_detail_opens_as_a_peek_then_expands() = runRootBlocTest { component ->
+        component.testFeatureFlags.set(FeatureFlagRegistry.AiChat, true)
+
+        recipeList().clickRecipe(TestRecipes.fullyPopulated.title)
+        recipeDetail().awaitDisplayed().tapAiChat()
+
+        aiChat().awaitPeekShown().expandFromPeek().awaitExpanded()
+    }
+}

--- a/client/recipe/core/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/robots/RecipeDetailRobot.kt
+++ b/client/recipe/core/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/robots/RecipeDetailRobot.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailTestTags
 
@@ -25,6 +26,13 @@ class RecipeDetailRobot(private val test: ComposeUiTest) {
 
     fun assertRecipeDisplayed(recipeName: String): RecipeDetailRobot = apply {
         test.onNode(hasText(recipeName) and hasAnyAncestor(onScreen)).assertIsDisplayed()
+    }
+
+    /** Taps the AI chat action, opening the recipe-grounded chat sheet. */
+    fun tapAiChat(): RecipeDetailRobot = apply {
+        test
+            .onNode(hasTestTag(RecipeDetailTestTags.AI_CHAT_BUTTON) and hasAnyAncestor(onScreen))
+            .performClick()
     }
 }
 

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -454,7 +454,11 @@ private fun RecipeDetailBody(
                                     }
                                 }
                                 if (state.showAiChat) {
-                                    IconButton(onClick = bloc::onAiChatClicked) {
+                                    IconButton(
+                                        onClick = bloc::onAiChatClicked,
+                                        modifier =
+                                            Modifier.testTag(RecipeDetailTestTags.AI_CHAT_BUTTON),
+                                    ) {
                                         Icon(
                                             imageVector = Icons.Default.AutoAwesome,
                                             contentDescription =

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailTestTags.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailTestTags.kt
@@ -6,4 +6,5 @@ package com.plusmobileapps.chefmate.recipe.core.detail
  */
 object RecipeDetailTestTags {
     const val SCREEN: String = "recipe_detail_screen"
+    const val AI_CHAT_BUTTON: String = "recipe_detail_ai_chat_button"
 }

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -3,6 +3,11 @@
 package com.plusmobileapps.chefmate.root
 
 import com.arkivanov.decompose.DelicateDecomposeApi
+import com.arkivanov.decompose.router.slot.ChildSlot
+import com.arkivanov.decompose.router.slot.SlotNavigation
+import com.arkivanov.decompose.router.slot.activate
+import com.arkivanov.decompose.router.slot.childSlot
+import com.arkivanov.decompose.router.slot.dismiss
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.bringToFront
@@ -11,6 +16,7 @@ import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.router.stack.replaceAll
 import com.arkivanov.decompose.router.stack.replaceCurrent
 import com.arkivanov.decompose.value.Value
+import com.arkivanov.essenty.backhandler.BackCallback
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.aichat.AiChatRootBloc
 import com.plusmobileapps.chefmate.auth.data.AuthState
@@ -132,8 +138,52 @@ class RootBlocImpl(
 
     override val state: Value<ChildStack<*, RootBloc.Child>> = stack
 
+    // The recipe-grounded AI chat lives in its own slot so it can be presented as a bottom sheet
+    // over the current screen, rather than a full-screen stack child (which the More-tab chat still
+    // uses via Configuration.AiChat).
+    private val aiChatSheetNavigation = SlotNavigation<AiChatSheetConfig>()
+    private val aiChatSheetRouter =
+        childSlot(
+            source = aiChatSheetNavigation,
+            serializer = AiChatSheetConfig.serializer(),
+            key = "RootRouter_AiChatSheet",
+            childFactory = { config, childContext ->
+                RootBloc.AiChatSheet.Chat(
+                    bloc =
+                        aiChat.create(
+                            context = childContext,
+                            recipeContextId = config.recipeContextId,
+                            output = ::handleAiChatSheetOutput,
+                        )
+                )
+            },
+        )
+
+    override val aiChatSheetSlot: Value<ChildSlot<*, RootBloc.AiChatSheet>> = aiChatSheetRouter
+
+    // Register after the stack's own back callback so a back press closes the sheet first.
+    private val aiChatSheetBackCallback =
+        BackCallback(isEnabled = aiChatSheetRouter.value.child != null) {
+            aiChatSheetNavigation.dismiss()
+        }
+
+    init {
+        backHandler.register(aiChatSheetBackCallback)
+        aiChatSheetRouter.subscribe { slot ->
+            aiChatSheetBackCallback.isEnabled = slot.child != null
+        }
+    }
+
     override fun onBackClicked() {
-        navigation.pop()
+        if (aiChatSheetRouter.value.child != null) {
+            aiChatSheetNavigation.dismiss()
+        } else {
+            navigation.pop()
+        }
+    }
+
+    override fun onAiChatSheetDismiss() {
+        aiChatSheetNavigation.dismiss()
     }
 
     override fun handleSharedUrl(url: String) {
@@ -590,7 +640,7 @@ class RootBlocImpl(
                 navigation.bringToFront(Configuration.CookMode(output.recipeId))
             }
             is RecipeRootBloc.Output.OpenAiChat -> {
-                navigation.bringToFront(Configuration.AiChat(recipeContextId = output.recipeId))
+                aiChatSheetNavigation.activate(AiChatSheetConfig(recipeContextId = output.recipeId))
             }
         }
     }
@@ -599,7 +649,25 @@ class RootBlocImpl(
         when (output) {
             CookModeBloc.Output.Finished -> navigation.pop()
             is CookModeBloc.Output.OpenAiChat ->
-                navigation.bringToFront(Configuration.AiChat(recipeContextId = output.recipeId))
+                aiChatSheetNavigation.activate(AiChatSheetConfig(recipeContextId = output.recipeId))
+        }
+    }
+
+    private fun handleAiChatSheetOutput(output: AiChatRootBloc.Output) {
+        when (output) {
+            AiChatRootBloc.Output.Finished -> aiChatSheetNavigation.dismiss()
+            is AiChatRootBloc.Output.AddAsRecipe -> {
+                aiChatSheetNavigation.dismiss()
+                navigation.bringToFront(
+                    RecipeRoot(
+                        RecipeRootBloc.Props.CreateFromExtracted(
+                            extracted = output.extracted,
+                            fromAi = true,
+                            consumePendingPhoto = output.consumePendingPhoto,
+                        )
+                    )
+                )
+            }
         }
     }
 
@@ -679,6 +747,9 @@ class RootBlocImpl(
             OtpBloc.Output.Cancelled -> navigation.pop()
         }
     }
+
+    /** Slot config for the recipe-grounded AI chat sheet. */
+    @Serializable private data class AiChatSheetConfig(val recipeContextId: Long?)
 
     @Serializable
     private sealed class Configuration {

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -54,6 +54,7 @@ class RootBlocTest {
     var otpOutput: Consumer<OtpBloc.Output> = Consumer {}
     var otpProps: OtpBloc.Props? = null
     var aiChatOutput: Consumer<AiChatRootBloc.Output> = Consumer {}
+    var cookModeOutput: Consumer<CookModeBloc.Output> = Consumer {}
     var exportRecipesOutput: Consumer<ExportRecipesBloc.Output> = Consumer {}
     var exportRecipesProps: ExportRecipesBloc.Props? = null
     var bottomNavInitialTab: BottomNavBloc.Tab? = null
@@ -133,7 +134,11 @@ class RootBlocTest {
                 developerSettingsOutput = output
                 mock()
             },
-            cookMode = CookModeBloc.Factory { _, _, _ -> mock() },
+            cookMode =
+                CookModeBloc.Factory { _, _, output ->
+                    cookModeOutput = output
+                    mock()
+                },
             featureFlags = FakeFeatureFlags(),
             featureFlagsBlocFactory = { _, _ -> mock() },
             aiChat = { _, _, output ->
@@ -564,5 +569,95 @@ class RootBlocTest {
 
         rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
         dev.mokkery.verify { bottomNavChild.onExportFinished() }
+    }
+
+    @Test
+    fun When_recipe_root_opens_ai_chat_Then_it_is_shown_in_the_sheet_slot_not_the_stack() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenRecipe(123L))
+        rootBloc.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
+
+        recipeOutput.onNext(RecipeRootBloc.Output.OpenAiChat(recipeId = 123L))
+
+        // The chat opens as a sheet over the recipe — the stack top is unchanged (still RecipeRoot)
+        // and no full-screen AiChat child was pushed.
+        rootBloc.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
+        rootBloc.state.value.backStack.size shouldBe 1
+        rootBloc.aiChatSheetSlot.value.child?.instance should
+            instanceOf<RootBloc.AiChatSheet.Chat>()
+    }
+
+    @Test
+    fun When_cook_mode_opens_ai_chat_Then_it_is_shown_in_the_sheet_slot() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenCookMode(7L))
+        rootBloc.instance() should instanceOf<RootBloc.Child.CookMode>()
+
+        cookModeOutput.onNext(CookModeBloc.Output.OpenAiChat(recipeId = 7L))
+
+        rootBloc.instance() should instanceOf<RootBloc.Child.CookMode>()
+        rootBloc.aiChatSheetSlot.value.child?.instance should
+            instanceOf<RootBloc.AiChatSheet.Chat>()
+    }
+
+    @Test
+    fun Given_ai_chat_sheet_open_When_dismissed_Then_slot_is_cleared() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenRecipe(123L))
+        recipeOutput.onNext(RecipeRootBloc.Output.OpenAiChat(recipeId = 123L))
+        rootBloc.aiChatSheetSlot.value.child?.instance should
+            instanceOf<RootBloc.AiChatSheet.Chat>()
+
+        rootBloc.onAiChatSheetDismiss()
+
+        rootBloc.aiChatSheetSlot.value.child shouldBe null
+    }
+
+    @Test
+    fun Given_ai_chat_sheet_open_When_back_clicked_Then_sheet_closes_before_the_stack() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenRecipe(123L))
+        recipeOutput.onNext(RecipeRootBloc.Output.OpenAiChat(recipeId = 123L))
+
+        rootBloc.onBackClicked()
+
+        // Back closes the sheet, leaving the recipe underneath untouched.
+        rootBloc.aiChatSheetSlot.value.child shouldBe null
+        rootBloc.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
+        rootBloc.state.value.backStack.size shouldBe 1
+    }
+
+    @Test
+    fun Given_ai_chat_sheet_When_output_Finished_Then_slot_is_cleared() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenRecipe(123L))
+        recipeOutput.onNext(RecipeRootBloc.Output.OpenAiChat(recipeId = 123L))
+
+        // Activating the slot re-captures aiChatOutput as the sheet's output handler.
+        aiChatOutput.onNext(AiChatRootBloc.Output.Finished)
+
+        rootBloc.aiChatSheetSlot.value.child shouldBe null
+    }
+
+    @Test
+    fun Given_ai_chat_sheet_When_AddAsRecipe_Then_slot_cleared_and_recipe_root_shown() {
+        val extracted =
+            ExtractedRecipeData(
+                title = "Sheet-extracted",
+                description = "From the grounded chat",
+                ingredients = listOf("eggs", "flour"),
+                directions = listOf("whisk", "cook"),
+                imageUrl = null,
+                sourceUrl = "",
+                servings = 2,
+                prepTime = 5,
+                cookTime = 10,
+                totalTime = 15,
+                calories = null,
+            )
+
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenRecipe(123L))
+        recipeOutput.onNext(RecipeRootBloc.Output.OpenAiChat(recipeId = 123L))
+
+        aiChatOutput.onNext(AiChatRootBloc.Output.AddAsRecipe(extracted))
+
+        rootBloc.aiChatSheetSlot.value.child shouldBe null
+        rootBloc.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
+        recipeProps shouldBe RecipeRootBloc.Props.CreateFromExtracted(extracted, fromAi = true)
     }
 }

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -1,5 +1,6 @@
 package com.plusmobileapps.chefmate.root
 
+import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.essenty.backhandler.BackHandlerOwner
@@ -27,6 +28,16 @@ import com.plusmobileapps.chefmate.ui.ComposeScreen
 
 interface RootBloc : BackHandlerOwner, BackClickBloc {
     val state: Value<ChildStack<*, Child>>
+
+    /**
+     * The recipe-grounded AI chat, presented as an expandable bottom sheet over the current screen
+     * (recipe detail or cook mode). Null when no chat is open. The standalone chat opened from the
+     * More tab is a full-screen [Child.AiChat] instead.
+     */
+    val aiChatSheetSlot: Value<ChildSlot<*, AiChatSheet>>
+
+    /** Dismiss the AI chat sheet (scrim tap or sheet swiped down). */
+    fun onAiChatSheetDismiss()
 
     fun handleSharedUrl(url: String)
 
@@ -76,6 +87,14 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
         data class EditRecipeBook(override val bloc: EditRecipeBookBloc) : Child()
 
         data class EditGroceryList(override val bloc: EditGroceryListBloc) : Child()
+    }
+
+    /** Child of the [aiChatSheetSlot] — the AI chat rendered inside the bottom sheet. */
+    sealed class AiChatSheet {
+
+        abstract val bloc: ComposeScreen
+
+        data class Chat(override val bloc: AiChatRootBloc) : AiChatSheet()
     }
 
     fun interface Factory {

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -1,11 +1,21 @@
-@file:OptIn(FaultyDecomposeApi::class)
+@file:OptIn(FaultyDecomposeApi::class, ExperimentalMaterial3Api::class)
 
 package com.plusmobileapps.chefmate.root
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 import com.arkivanov.decompose.FaultyDecomposeApi
@@ -16,6 +26,9 @@ import com.arkivanov.decompose.extensions.compose.stack.animation.slide
 import com.arkivanov.decompose.extensions.compose.stack.animation.stackAnimation
 import com.arkivanov.decompose.extensions.compose.stack.animation.stackAnimator
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import com.plusmobileapps.chefmate.aichat.AiChatPresentation
+import com.plusmobileapps.chefmate.aichat.LocalAiChatPresentation
+import com.plusmobileapps.chefmate.aichat.LocalAiChatRequestExpand
 import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.backAnimation
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
@@ -48,6 +61,56 @@ fun RootScreen(rootBloc: RootBloc, modifier: Modifier = Modifier) {
             ) { child ->
                 child.instance.bloc.Content()
             }
+        }
+        // Recipe-grounded AI chat, layered over the current screen as an expandable bottom sheet.
+        AiChatSheet(rootBloc)
+    }
+}
+
+/**
+ * The recipe-grounded AI chat sheet. It opens as a small "peek" (just the input over the dimmed
+ * recipe) and grows to full screen once [AiChatPresentation.SheetExpanded] is requested — by
+ * focusing the input, dragging the peek strip up, or sending a message.
+ */
+@Composable
+private fun AiChatSheet(rootBloc: RootBloc) {
+    val slot by rootBloc.aiChatSheetSlot.subscribeAsState()
+    val child = slot.child?.instance
+
+    // Keep the last child in composition through the hide animation after the slot dismisses.
+    var sheetChild by remember { mutableStateOf(child) }
+    if (child != null) sheetChild = child
+
+    // Peek vs full is host state (not a Material detent) so the peek can hug just the input. Keyed
+    // on the child so each newly-opened chat starts collapsed, while staying stable (and expanded)
+    // through the dismiss animation.
+    var expanded by remember(sheetChild) { mutableStateOf(false) }
+
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    LaunchedEffect(child) {
+        if (child == null && sheetChild != null) {
+            sheetState.hide()
+            sheetChild = null
+        }
+    }
+
+    val currentChild = sheetChild ?: return
+    ModalBottomSheet(
+        onDismissRequest = rootBloc::onAiChatSheetDismiss,
+        sheetState = sheetState,
+        contentWindowInsets = { WindowInsets(0, 0, 0, 0) },
+        // When expanded the chat's own header is the top of the sheet; the drag handle only shows
+        // in
+        // the peek, where it invites the drag-to-expand gesture.
+        dragHandle = if (expanded) null else ({ BottomSheetDefaults.DragHandle() }),
+    ) {
+        CompositionLocalProvider(
+            LocalAiChatPresentation provides
+                if (expanded) AiChatPresentation.SheetExpanded else AiChatPresentation.SheetPeek,
+            LocalAiChatRequestExpand provides { expanded = true },
+        ) {
+            currentChild.bloc.Content()
         }
     }
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTest.kt
@@ -5,10 +5,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.android.tools.screenshot.PreviewTest
 import com.plusmobileapps.chefmate.aichat.AiChatBloc
+import com.plusmobileapps.chefmate.aichat.AiChatPresentation
+import com.plusmobileapps.chefmate.aichat.LocalAiChatPresentation
 import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBloc
 import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocEmpty
 import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBlocError
@@ -24,6 +27,20 @@ private fun AiChatScreenshot(bloc: AiChatBloc, darkTheme: Boolean = false) {
     ChefMateTheme(darkTheme = darkTheme) {
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
             bloc.Content()
+        }
+    }
+}
+
+/** Renders the collapsed sheet "peek" — recipe chip + input only, as before the sheet expands. */
+@Composable
+private fun AiChatPeekScreenshot(bloc: AiChatBloc, darkTheme: Boolean = false) {
+    ChefMateTheme(darkTheme = darkTheme) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            CompositionLocalProvider(
+                LocalAiChatPresentation provides AiChatPresentation.SheetPeek
+            ) {
+                bloc.Content()
+            }
         }
     }
 }
@@ -96,4 +113,18 @@ fun AiChatErrorLightScreenshot() {
 @Composable
 fun AiChatExtractingPillLightScreenshot() {
     AiChatScreenshot(bloc = previewAiChatBlocExtracting)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 240)
+@Composable
+fun AiChatPeekLightScreenshot() {
+    AiChatPeekScreenshot(bloc = previewAiChatBlocWithRecipeContext)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 240, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun AiChatPeekDarkScreenshot() {
+    AiChatPeekScreenshot(bloc = previewAiChatBlocWithRecipeContext, darkTheme = true)
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatPeekDarkScreenshot_c1dbe087_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatPeekDarkScreenshot_c1dbe087_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37983c9c9a5128f4fcaccb2807da39d3ac329b7963d97b27b90dbe5ce8332df8
+size 17531

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatPeekLightScreenshot_1e98494a_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatPeekLightScreenshot_1e98494a_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbc0353827dade8b8e60f00967c9579ef9de0b77cca21b93644623a24eddd889
+size 17563


### PR DESCRIPTION
## What & why

Tapping the AI chat button on **recipe detail** or **cook mode** used to push a full-screen chat that completely covered the recipe. This reworks that entry so the recipe-grounded chat opens as a **bottom-sheet modal**, using a **Decompose child slot**: it starts as a small **peek** (just the empty input over the dimmed recipe) and expands to full screen — by focusing the input, dragging the peek strip up, or sending a message — so you can keep the recipe in view while you start chatting.

The standalone chat opened from the **More tab** is unchanged (still full screen).

## How it works

- **Child slot at the root.** `RootBloc` now hosts the recipe-grounded `AiChatRootBloc` in a Decompose `childSlot`; `RootScreen` renders it as a `ModalBottomSheet` layered over the current screen. The recipe-detail and cook-mode `OpenAiChat` outputs `activate` the slot instead of pushing a full-screen stack child; back / scrim dismiss the sheet before the underlying stack.
- **Peek → expand.** A new `AiChatPresentation` composition local (default `FullScreen`) lets `AiChatScreen` render just the recipe chip + input while peeking, and the full header + messages + input once expanded. Peek-vs-expanded is explicit host state rather than a Material partial detent, because a modal sheet reveals its content top-down and otherwise couldn't show the input at the bottom.
- Default `FullScreen` means the More-tab chat and all existing previews render exactly as before.

## Commits

1. `feat(aichat)` — peek presentation local + `AiChatScreen` peek layout
2. `feat(root)` — sheet child slot + `ModalBottomSheet` rendering + rerouted detail/cook outputs, with `RootBloc` unit tests
3. `test(aichat)` — collapsed-peek snapshots (light/dark) + recorded references
4. `test` — robot flow (recipe → tap AI chat → peek → focus → expand) + the detail button tag it needs

## Testing

- `RootBloc` unit tests: detail & cook-mode route to the slot (not a full-screen child), back/scrim/`Finished` dismiss, `AddAsRecipe` still opens the pre-filled editor. ✅
- Peek snapshot (light + dark) recorded & `validateDebugScreenshotTest` passes. ✅
- End-to-end headless UI test: recipe detail → tap AI chat → peek shown → focus input → expands to full screen. ✅
- Full `composeApp` Android + JVM compile and the `composeApp` / `recipe:core:impl` test suites pass. ✅

## Reviewer notes

- The one interaction not covered headlessly is the **drag feel** of peek→expand on a real device (tap-to-expand + navigation are covered) — worth eyeballing on device/emulator with the `AiChat` flag on.
- Cook Mode already has its own bottom peek sheet ("What's Cooking"); the AI chat sheet is a separate modal popup layer, so the two don't nest/conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)