### PR TITLE
fix(browser): import own share links via API instead of scraping

### DIFF
--- a/client/browser/impl/build.gradle.kts
+++ b/client/browser/impl/build.gradle.kts
@@ -21,7 +21,10 @@ kotlin {
             implementation(libs.ktor.serialization.json)
             implementation(compose.components.resources)
         }
-        commonTest.dependencies { implementation(libs.multiplatform.settings.test) }
+        commonTest.dependencies {
+            implementation(libs.multiplatform.settings.test)
+            implementation(projects.client.recipe.data.testing)
+        }
         getByName("androidMain").dependencies { implementation(libs.ktor.client.cio) }
         getByName("jvmMain").dependencies { implementation(libs.ktor.client.cio) }
         getByName("iosMain").dependencies { implementation(libs.ktor.client.darwin) }

--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/RecipeExtractorService.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/RecipeExtractorService.kt
@@ -3,10 +3,13 @@ package com.plusmobileapps.chefmate.browser.impl
 import com.fleeksoft.ksoup.Ksoup
 import com.fleeksoft.ksoup.nodes.Element
 import com.fleeksoft.ksoup.parser.Parser
+import com.plusmobileapps.chefmate.ChefMateUrls
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.di.IO
 import com.plusmobileapps.chefmate.recipe.data.ExtractedRecipeData
 import com.plusmobileapps.chefmate.recipe.data.IngredientSection
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -33,8 +36,10 @@ interface RecipeExtractorService {
 @SingleIn(AppScope::class)
 @Inject
 @ContributesBinding(AppScope::class)
-class RecipeExtractorServiceImpl(@IO private val ioContext: CoroutineContext) :
-    RecipeExtractorService {
+class RecipeExtractorServiceImpl(
+    @IO private val ioContext: CoroutineContext,
+    private val recipeRepository: RecipeRepository,
+) : RecipeExtractorService {
 
     private val httpClient = HttpClient()
 
@@ -42,6 +47,16 @@ class RecipeExtractorServiceImpl(@IO private val ioContext: CoroutineContext) :
 
     override suspend fun extractRecipe(url: String): ExtractedRecipeData =
         withContext(ioContext) {
+            // Our own share links render their recipe content client-side after load (fetched from
+            // Supabase), so there's no server-rendered markup for the scraper below to parse —
+            // fetch the recipe directly instead of scraping the page.
+            ChefMateUrls.recipeShareUrlRemoteId(url)?.let { remoteId ->
+                return@withContext recipeRepository
+                    .fetchPublicRecipe(remoteId)
+                    .getOrElse { throw IllegalStateException("No recipe data found on this page") }
+                    .toExtractedRecipeData(url)
+            }
+
             val response = httpClient.get(url) { header("User-Agent", USER_AGENT) }
             if (!response.status.isSuccess()) {
                 throw IllegalStateException(
@@ -65,6 +80,23 @@ class RecipeExtractorServiceImpl(@IO private val ioContext: CoroutineContext) :
 
             throw IllegalStateException("No recipe data found on this page")
         }
+
+    private fun Recipe.toExtractedRecipeData(sourceUrl: String): ExtractedRecipeData =
+        ExtractedRecipeData(
+            title = title,
+            description = description,
+            ingredients = ingredients.splitLines(),
+            directions = directions.splitLines(),
+            imageUrl = imageUrl,
+            sourceUrl = sourceUrl,
+            servings = servings,
+            prepTime = prepTime,
+            cookTime = cookTime,
+            totalTime = totalTime,
+            calories = calories,
+        )
+
+    private fun String.splitLines(): List<String> = split("\n").filter { it.isNotBlank() }
 
     /**
      * Recovers grouped ingredients (with their sub-section headers) from WP Recipe Maker markup,

--- a/client/browser/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/browser/impl/RecipeExtractorServiceTest.kt
+++ b/client/browser/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/browser/impl/RecipeExtractorServiceTest.kt
@@ -2,13 +2,21 @@
 
 package com.plusmobileapps.chefmate.browser.impl
 
+import com.plusmobileapps.chefmate.ChefMateUrls
+import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
 
+@OptIn(ExperimentalTime::class)
 class RecipeExtractorServiceTest {
 
-    private val service = RecipeExtractorServiceImpl(Dispatchers.Default)
+    private val recipeRepository = FakeRecipeRepository()
+    private val service = RecipeExtractorServiceImpl(Dispatchers.Default, recipeRepository)
 
     // region parseDuration
 
@@ -211,6 +219,59 @@ class RecipeExtractorServiceTest {
         """<html><body>${groups.joinToString("")}</body></html>"""
 
     // endregion
+
+    // region own share links
+
+    @Test
+    fun When_url_is_our_own_share_link_Then_fetches_the_public_recipe_directly() = runTest {
+        val remoteId = "08c5daa3-5de0-4045-a660-ea396ce25d3e"
+        val url = ChefMateUrls.recipeShareUrl(remoteId)
+        recipeRepository.publicRecipes[remoteId] =
+            testRecipe(
+                title = "Weeknight Tacos",
+                ingredients = "For the tacos:\n1 lb ground beef\n8 tortillas",
+                directions = "Brown the beef.\nWarm the tortillas.",
+            )
+
+        val extracted = service.extractRecipe(url)
+
+        extracted.title shouldBe "Weeknight Tacos"
+        extracted.ingredients shouldBe listOf("For the tacos:", "1 lb ground beef", "8 tortillas")
+        extracted.directions shouldBe listOf("Brown the beef.", "Warm the tortillas.")
+        extracted.sourceUrl shouldBe url
+    }
+
+    @Test
+    fun When_our_own_share_link_has_no_matching_public_recipe_Then_throws() = runTest {
+        val url = ChefMateUrls.recipeShareUrl("missing-id")
+
+        val error = runCatching { service.extractRecipe(url) }.exceptionOrNull()
+
+        error?.message shouldBe "No recipe data found on this page"
+    }
+
+    // endregion
+
+    private fun testRecipe(title: String, ingredients: String, directions: String) =
+        Recipe(
+            id = 1L,
+            title = title,
+            description = null,
+            ingredients = ingredients,
+            directions = directions,
+            imageUrl = null,
+            sourceUrl = null,
+            servings = null,
+            prepTime = null,
+            cookTime = null,
+            totalTime = null,
+            calories = null,
+            starRating = null,
+            remoteId = "08c5daa3-5de0-4045-a660-ea396ce25d3e",
+            isPublic = true,
+            createdAt = Instant.DISTANT_PAST,
+            updatedAt = Instant.DISTANT_PAST,
+        )
 
     private fun recipeJson(
         name: String = "Test Recipe",

--- a/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/ChefMateUrls.kt
+++ b/client/shared/src/commonMain/kotlin/com/plusmobileapps/chefmate/ChefMateUrls.kt
@@ -40,4 +40,21 @@ object ChefMateUrls {
         val clientId = url.substring(prefix.length).substringBefore('/').substringBefore('?')
         return clientId.ifBlank { null }
     }
+
+    /**
+     * Extracts the remoteId from a [recipeShareUrl], or null if [url] is not one. The share page
+     * itself renders its recipe content client-side (fetched from Supabase after load), so it has
+     * no server-rendered markup for a generic scraper to parse — callers that recognize our own
+     * share links should fetch the recipe directly instead (`RecipeRepository.fetchPublicRecipe`).
+     */
+    fun recipeShareUrlRemoteId(url: String): String? {
+        val prefix = "https://$WEB_HOST/recipe/"
+        if (!url.startsWith(prefix, ignoreCase = true)) return null
+        val remoteId =
+            url.substring(prefix.length)
+                .substringBefore('/')
+                .substringBefore('?')
+                .substringBefore('#')
+        return remoteId.ifBlank { null }
+    }
 }

--- a/client/shared/src/commonTest/kotlin/com/plusmobileapps/chefmate/ChefMateUrlsTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/plusmobileapps/chefmate/ChefMateUrlsTest.kt
@@ -38,4 +38,35 @@ class ChefMateUrlsTest {
         assertNull(ChefMateUrls.recipeLinkClientId("chefmate://recipe/"))
         assertNull(ChefMateUrls.recipeLinkClientId("chefmate://groceries"))
     }
+
+    @Test
+    fun recipeShareUrlRemoteId_round_trips_a_built_link() {
+        assertEquals(
+            "remote-uuid",
+            ChefMateUrls.recipeShareUrlRemoteId(ChefMateUrls.recipeShareUrl("remote-uuid")),
+        )
+    }
+
+    @Test
+    fun recipeShareUrlRemoteId_ignores_query_and_trailing_path() {
+        val base = "https://${ChefMateUrls.WEB_HOST}/recipe/id42"
+        assertEquals("id42", ChefMateUrls.recipeShareUrlRemoteId("$base/extra"))
+        assertEquals("id42", ChefMateUrls.recipeShareUrlRemoteId("$base?x=1"))
+    }
+
+    @Test
+    fun recipeShareUrlRemoteId_rejects_the_custom_scheme_link() {
+        // The chefmate:// link is keyed by clientId, a separate identifier space — not a share
+        // link.
+        assertNull(ChefMateUrls.recipeShareUrlRemoteId(ChefMateUrls.recipeLink("client-id")))
+    }
+
+    @Test
+    fun recipeShareUrlRemoteId_rejects_unrelated_and_blank_urls() {
+        assertNull(ChefMateUrls.recipeShareUrlRemoteId("https://example.com/recipe/x"))
+        assertNull(ChefMateUrls.recipeShareUrlRemoteId("https://${ChefMateUrls.WEB_HOST}/recipe/"))
+        assertNull(
+            ChefMateUrls.recipeShareUrlRemoteId("https://${ChefMateUrls.WEB_HOST}/groceries")
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- The in-app browser's recipe importer scrapes the static HTML of the loaded page for `<script type="application/ld+json">` recipe data.
- `chefmate.plusmobileapps.com/recipe/<uuid>` (the share link) renders its recipe entirely client-side via JS after fetching from Supabase, so the scraper never finds anything there — import always failed for chefmate share links, including your own recipes.
- Recognize our own share links (`ChefMateUrls.recipeShareUrlRemoteId`) and fetch the recipe directly through `RecipeRepository.fetchPublicRecipe` instead of scraping the page. Falls back to the existing scrape path for every other URL.

## Test plan
- [x] `:client:shared:jvmTest` — new `recipeShareUrlRemoteId` coverage
- [x] `:client:browser:impl:jvmTest` — new coverage for the share-link short-circuit (success + missing/private recipe) in `RecipeExtractorServiceTest`
- [ ] Manual: open a chefmate.plusmobileapps.com/recipe/<uuid> share link in the in-app browser and confirm "extract recipe" now imports it

🤖 Generated with [Claude Code](https://claude.com/claude-code)