### PR TITLE
fix(ci): inject Supabase secrets into Windows MSIX app-image build

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -102,6 +102,14 @@ jobs:
 
       - name: Build app image for MSIX (Windows)
         if: runner.os == 'Windows'
+        # BuildKonfig reads these at Gradle configuration time via System.getenv, and GitHub
+        # Actions env vars are per-step. The MSIX is packed from THIS step's app image, so it
+        # needs the secrets too — without them BuildConfig regenerates with placeholder Supabase
+        # keys and every auth call fails at runtime.
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
         run: ./gradlew :client:composeApp:createReleaseDistributable
 
       - name: Package MSIX (Windows)


### PR DESCRIPTION
## Problem

The Windows Store MSIX build ships **placeholder Supabase credentials**, so every auth method fails immediately at runtime. All other targets (Android, iOS, macOS DMG, Linux DEB, Windows MSI) work fine.

## Root cause

The MSIX is packed from the app image produced by the standalone **"Build app image for MSIX (Windows)"** step, which runs `createReleaseDistributable` *without* the `SUPABASE_URL` / `SUPABASE_KEY` / `BUGSNAG_API_KEY` env vars. Only the earlier **"Build native package"** step (which builds the `.msi`, not the MSIX) set those secrets.

BuildKonfig reads these via `System.getenv(...)` at Gradle **configuration time** (`client/shared/build.gradle.kts`), and GitHub Actions env vars are **per-step**. So the second Gradle invocation saw them as `null`, regenerated `BuildConfig` with the placeholder defaults (`https://your-project-id.supabase.co` / `your-anon-public-key`), and recompiled the app image. The MSIX therefore points at the fake project — hence instant auth failure.

This is exactly why "all other targets work": they're packaged by the step that has the secrets.

## Fix

Add the same `env:` block (`SUPABASE_URL`, `SUPABASE_KEY`, `BUGSNAG_API_KEY`) to the MSIX app-image step so the Store build compiles with real credentials.

## Reviewer notes

- `BUGSNAG_API_KEY` was also missing from that step; included it so crash reporting isn't silently disabled in the Store build.
- No functional/app-code change — CI workflow only.
- **To validate:** trigger the workflow via `workflow_dispatch` on this branch (builds artifacts without cutting a release), download the `desktop-windows-msix` artifact, install it, and confirm auth works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)