### PR TITLE
feat(desktop): distribute macOS via the Mac App Store

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -13,10 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15
-            task: packageReleaseDmg
-            artifact-name: desktop-macos
-            artifact-path: client/composeApp/build/compose/binaries/main-release/dmg/*.dmg
           - os: windows-latest
             task: packageReleaseMsi
             artifact-name: desktop-windows
@@ -36,69 +32,12 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
-      - uses: ruby/setup-ruby@v1
-        if: matrix.os == 'macos-15'
-        with:
-          ruby-version: "3.2"
-          bundler-cache: true
-
-      - name: Install signing certificate (macOS)
-        if: matrix.os == 'macos-15'
-        env:
-          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY: ${{ secrets.ASC_API_KEY }}
-          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-          MATCH_GIT_URL: https://github.com/Plus-Mobile-Apps/certificates.git
-        run: bundle exec fastlane mac certificates
-
-      - name: Resolve signing identity (macOS)
-        if: matrix.os == 'macos-15'
-        run: |
-          # A Developer ID leaf cert only forms a *valid* codesigning identity when its issuing
-          # "Developer ID Certification Authority" intermediate is present to complete the chain to
-          # Apple Root CA. CI runners don't ship it, so import the vendored copy (this cert's issuer
-          # is OU=Apple Certification Authority, NOT the G2 intermediate).
-          security import .github/certs/DeveloperIDCA.pem -k "$HOME/Library/Keychains/login.keychain-db" 2>/dev/null || true
-          TMP_KEYCHAIN="$HOME/Library/Keychains/fastlane_tmp_keychain-db"
-          [ -f "$TMP_KEYCHAIN" ] && security import .github/certs/DeveloperIDCA.pem -k "$TMP_KEYCHAIN" 2>/dev/null || true
-
-          IDENTITY=$(security find-identity -v -p codesigning \
-            | grep "Developer ID Application" | head -1 \
-            | sed -E 's/.*"(.*)"/\1/')
-          echo "Resolved signing identity: '$IDENTITY'"
-          echo "MACOS_SIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
-
       - name: Build native package
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
         run: ./gradlew :client:composeApp:${{ matrix.task }}
-
-      - name: Dump codesign logs on failure (macOS)
-        if: failure() && matrix.os == 'macos-15'
-        run: |
-          echo "== compose signing logs =="
-          for f in client/composeApp/build/compose/logs/createReleaseDistributable/*.txt; do
-            echo "----- $f -----"
-            cat "$f" || true
-          done
-
-      - name: Notarize and staple DMG (macOS)
-        if: matrix.os == 'macos-15'
-        env:
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-          ASC_API_KEY: ${{ secrets.ASC_API_KEY }}
-        run: |
-          echo "$ASC_API_KEY" | base64 -d > AuthKey.p8
-          DMG=$(ls client/composeApp/build/compose/binaries/main-release/dmg/*.dmg | head -1)
-          xcrun notarytool submit "$DMG" \
-            --key AuthKey.p8 --key-id "$ASC_KEY_ID" --issuer "$ASC_ISSUER_ID" --wait
-          xcrun stapler staple "$DMG"
-          rm -f AuthKey.p8
 
       - name: Build app image for MSIX (Windows)
         if: runner.os == 'Windows'
@@ -166,6 +105,45 @@ jobs:
           name: desktop-windows-msix
           path: ${{ runner.temp }}/ChefMate.msix
 
+  # Builds the Mac App Store .pkg and uploads it to App Store Connect. Tag pushes only — every
+  # upload creates a new build in App Store Connect, so we don't want manual dispatches doing it.
+  # (To test the signed .pkg build without uploading, run `bundle exec fastlane mac release` locally
+  # after generating the certs once with `bundle exec fastlane mac certificates`.)
+  macos:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+
+      - name: Build .pkg and upload to App Store Connect
+        # The fastlane mac release lane fetches the App Store certs + provisioning profile via match,
+        # resolves the signing identity, runs packageReleasePkg (BuildKonfig reads the Supabase/
+        # Bugsnag secrets at Gradle configuration time), then uploads the .pkg to App Store Connect.
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.ASC_API_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          MATCH_GIT_URL: https://github.com/Plus-Mobile-Apps/certificates.git
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
+        run: bundle exec fastlane mac release
+
   release:
     needs: build
     # Only publish a GitHub Release for tag pushes; a manual workflow_dispatch on a
@@ -181,28 +159,18 @@ jobs:
           merge-multiple: true
 
       - name: Generate update feed
-        # Windows is intentionally omitted: it ships via the Microsoft Store and updates there,
-        # so the in-app updater is inert on Windows and never reads this feed.
+        # Only Linux reads this feed. macOS ships via the Mac App Store and Windows via the
+        # Microsoft Store; the in-app updater is a no-op on both, so neither appears here.
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           BASE="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}"
-          # Compose names the macOS artifact "Chef Mate-<ver>.dmg" (packageName has a space).
-          # GitHub rewrites spaces to periods on asset upload, so a feed URL built from the raw
-          # local name 404s at download time. Rename the space out *before* both feed generation
-          # and the release upload (files: artifacts/*) so the served name matches the feed exactly.
-          DMG=$(cd artifacts && ls *.dmg)
-          if [ "$DMG" != "${DMG// /.}" ]; then
-            (cd artifacts && mv "$DMG" "${DMG// /.}")
-            DMG="${DMG// /.}"
-          fi
           DEB=$(cd artifacts && ls *.deb)
           cat > artifacts/latest.json <<EOF
           {
             "version": "${VERSION}",
             "notesUrl": "https://github.com/${{ github.repository }}/releases/tag/${GITHUB_REF_NAME}",
             "downloads": {
-              "macos": "${BASE}/${DMG}",
               "linux": "${BASE}/${DEB}"
             }
           }

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -313,7 +313,9 @@ compose.desktop {
             // macOS configuration — Mac App Store distribution
             macOS {
                 packageVersion = "1.9.24"
-                bundleID = "com.plusmobileapps.chefmate"
+                // Matches the iOS app id so macOS joins the same App Store record (Universal
+                // Purchase / one "Chef Mate" listing), NOT the Android-style id used above.
+                bundleID = "com.plusmobileapps.chefmate.ChefMate"
                 dockName = "Chef Mate"
                 // Mac App Store build: emits a Store-ready .pkg and makes jpackage apply the
                 // App Store signing/sandbox conventions (--mac-app-store).

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -254,7 +254,7 @@ compose.desktop {
         // Pass deep link URI as argument when app is launched via URL scheme
         args += listOf()
 
-        // Ship distributables via the release packaging tasks (packageReleaseDmg/Msi/Deb) so the
+        // Ship distributables via the release packaging tasks (packageReleasePkg/Msi/Deb) so the
         // requested task name contains "Release". That marker is what flips BuildConfig.IS_DEBUG to
         // false and hides the developer-only UI — see client/shared/build.gradle.kts. Keep
         // R8/ProGuard
@@ -266,7 +266,10 @@ compose.desktop {
         }
 
         nativeDistributions {
-            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            // macOS ships through the Mac App Store as a signed .pkg (Pkg, not Dmg — the direct
+            // Developer ID DMG was retired in favor of Store distribution). Msi/Deb are ignored on
+            // the OSes they don't apply to, so this one list is correct for all three legs.
+            targetFormats(TargetFormat.Pkg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Chef Mate"
             packageVersion = "1.9.24"
             description = "Chef Mate - Your AI Cooking Assistant"
@@ -307,19 +310,45 @@ compose.desktop {
                 "jdk.xml.dom",
             )
 
-            // macOS configuration
+            // macOS configuration — Mac App Store distribution
             macOS {
                 packageVersion = "1.9.24"
                 bundleID = "com.plusmobileapps.chefmate"
                 dockName = "Chef Mate"
+                // Mac App Store build: emits a Store-ready .pkg and makes jpackage apply the
+                // App Store signing/sandbox conventions (--mac-app-store).
+                // LSApplicationCategoryType
+                // is required for Store submission.
+                appStore = true
+                appCategory = "public.app-category.food-and-drink"
 
                 iconFile.set(project.file("src/jvmMain/resources/app-icon.icns"))
 
-                // Sign with a Developer ID Application certificate when an identity is
-                // provided via env var (set in CI). Left unset for local/unsigned builds.
-                // Hardened runtime + the default Compose entitlements (allow-jit,
-                // unsigned-executable-memory, disable-library-validation) are applied
-                // automatically when signing is enabled — required for notarization.
+                // App Sandbox is mandatory for the Mac App Store. The app and the bundled JRE are
+                // signed as separate nested bundles, so each gets its own entitlements: the app
+                // opts into the sandbox + the capabilities it actually uses (network client, user-
+                // selected files); the runtime inherits the sandbox so the JVM stays contained.
+                entitlementsFile.set(rootProject.file("packaging/macos/entitlements.plist"))
+                runtimeEntitlementsFile.set(
+                    rootProject.file("packaging/macos/runtime-entitlements.plist")
+                )
+
+                // Mac App Store provisioning profiles. Fetched by Fastlane match in CI and passed
+                // by
+                // path via env vars; unset for local/unsigned builds. Both are registered against
+                // the same App ID — the runtime profile signs the nested JRE bundle.
+                System.getenv("MACOS_PROVISIONING_PROFILE")?.let {
+                    provisioningProfile.set(rootProject.file(it))
+                }
+                System.getenv("MACOS_RUNTIME_PROVISIONING_PROFILE")?.let {
+                    runtimeProvisioningProfile.set(rootProject.file(it))
+                }
+
+                // Sign with the App Store distribution identity ("Apple Distribution: …") when one
+                // is
+                // provided via env var (resolved by the Fastlane mac lane in CI). Left unset for
+                // local/unsigned builds. jpackage derives the matching "3rd Party Mac Developer
+                // Installer" identity from the keychain to sign the .pkg installer.
                 signing {
                     sign.set(System.getenv("MACOS_SIGN_IDENTITY") != null)
                     identity.set(System.getenv("MACOS_SIGN_IDENTITY"))

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/update/DesktopUpdater.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/update/DesktopUpdater.kt
@@ -30,11 +30,11 @@ private const val DEFAULT_FEED_URL =
 /**
  * Desktop-only self-update driver. Polls a `latest.json` feed published by CI, and when a newer
  * version exists, downloads the platform installer and opens it. Signed-installer model — we never
- * patch jars in place, so the macOS notarization staple stays intact.
+ * patch jars in place, so the installer's signature stays intact.
  *
- * Inert on Windows: that platform ships through the Microsoft Store, which both forbids
- * self-updating (Store certification policy) and sandboxes the MSIX install so it can't replace
- * itself anyway. Updates there are the Store's job.
+ * In-app updates run on **Linux only**. macOS ships through the Mac App Store and Windows through
+ * the Microsoft Store; both stores forbid self-updating (certification policy) and sandbox the
+ * install so it can't replace itself anyway. Updates on those platforms are the store's job.
  */
 class DesktopUpdater(
     private val currentVersion: String = BuildConfig.VERSION_NAME,
@@ -50,8 +50,8 @@ class DesktopUpdater(
 
     private var available: UpdateState.Available? = null
 
-    /** In-app updates run on macOS and Linux only; Windows defers to the Microsoft Store. */
-    private val isSupported: Boolean = platformKey() != "windows"
+    /** In-app updates run on Linux only; macOS and Windows defer to their respective app stores. */
+    private val isSupported: Boolean = platformKey() == "linux"
 
     fun checkForUpdates() {
         if (!isSupported) return
@@ -100,7 +100,7 @@ class DesktopUpdater(
         val dest = File(System.getProperty("java.io.tmpdir"), fileName)
         http.prepareGet(target.downloadUrl).execute { response ->
             // A stale/misbuilt feed can point at a URL that 404s. Without this guard we'd stream
-            // the error page into the .dmg and hand macOS a "disk image is corrupted" dialog.
+            // the error page into the .deb and hand the user a corrupt-package dialog on install.
             // Fail loudly so startDownload() reverts to the retryable Available banner instead.
             if (!response.status.isSuccess()) {
                 error("Download failed: HTTP ${response.status.value} for ${target.downloadUrl}")

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -374,8 +374,15 @@ macOS ships through the **Mac App Store** as a sandboxed `.pkg` uploaded to App 
 with `macOS { appStore = true }` in `client/composeApp/build.gradle.kts` (`packageReleasePkg`); the
 `macos` job in `desktop-release.yml` runs `fastlane mac release` to sign, build, and upload it.
 
-**Bundle ID:** `com.plusmobileapps.chefmate` — distinct from the iOS app id
-`com.plusmobileapps.chefmate.ChefMate`. It needs its own App Store Connect record.
+**Bundle ID:** `com.plusmobileapps.chefmate.ChefMate` — the **same** as the iOS app id, so macOS ships
+under the one "Chef Mate" App Store record (Universal Purchase / a single product page across iOS +
+Mac) rather than a separate listing. The App ID already exists from iOS; you enable the **macOS
+platform** on the existing app record instead of creating a new one.
+
+> The App ID's iOS capabilities (App Groups, Associated Domains, share-extension/watch relationships)
+> carry into the macOS App Store provisioning profile. That's normally fine — the profile is a
+> superset and the Mac entitlements simply don't claim them — but it's worth confirming the profile
+> builds cleanly on the first `mac certificates` run.
 
 **Certificates & profile** (fetched via Fastlane `match`, `type: "appstore"`, `platform: "macos"`,
 from the same private certificates repo used for iOS):
@@ -404,11 +411,13 @@ sandbox-inherit + JVM exceptions), wired via `entitlementsFile` / `runtimeEntitl
 > entitlements or face rejection.
 
 **One-time bootstrap:**
-1. In **App Store Connect → Apps → +**, create a new **macOS** app for bundle id
-   `com.plusmobileapps.chefmate`.
-2. Register the App ID and generate the certs + provisioning profile (run locally, read-write match):
+1. In **App Store Connect → the existing "Chef Mate" app → add the macOS platform** (Universal
+   Purchase) so Mac builds land under the same record. No new app record or App ID is created — both
+   already exist from iOS. The App ID needs **no extra capabilities** enabled (App Sandbox, network,
+   and file access come from the build's entitlements, not the portal).
+2. Generate the macOS certs + provisioning profile (run locally, read-write match):
    ```bash
-   bundle exec fastlane mac certificates            # registers the App ID via produce, then match
+   bundle exec fastlane mac certificates            # match only; the App ID already exists
    ```
    (Pass `force:true` after enabling a new capability on the App ID to regenerate the profile.)
 3. From then on CI consumes the stored assets read-only inside `fastlane mac release`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,21 +17,22 @@ Either way, the tag triggers three independent workflows that run in parallel:
 |----------|----------|-------------|
 | Android | `android-release.yml` | Play Store (internal track) |
 | iOS | `ios-release.yml` | App Store Connect (TestFlight) |
-| Desktop | `desktop-release.yml` | GitHub Releases (signed DMG + DEB) and `latest.json` update feed |
+| Desktop | `desktop-release.yml` | macOS → App Store Connect (Mac App Store); Linux `.deb` + `latest.json` feed on GitHub Releases; Windows → Microsoft Store (MSIX) |
 
 All workflows also support manual triggering via the "Run workflow" button in the GitHub Actions UI (`workflow_dispatch`).
 
 ### Desktop update strategy
 
-Desktop uses **two different update channels** depending on platform:
+Desktop distribution + updates depend on platform:
 
 | Platform | Distribution | Updates |
 |----------|--------------|---------|
-| macOS | Notarized `.dmg` on GitHub Releases | **In-app updater** (`DesktopUpdater`) polls the `latest.json` feed and prompts the user to download + install |
-| Linux | `.deb` on GitHub Releases | **In-app updater** (same feed) |
-| Windows | **Microsoft Store** (MSIX) | **The Store** — the in-app updater is intentionally a no-op on Windows (Store policy forbids self-updating, and the MSIX sandbox can't replace its own install) |
+| macOS | **Mac App Store** (`.pkg` uploaded to App Store Connect) | **The Store** — the in-app updater is a no-op on macOS (Store policy forbids self-updating, and the sandbox can't replace its own install) |
+| Linux | `.deb` on GitHub Releases | **In-app updater** (`DesktopUpdater`) polls the `latest.json` feed and prompts the user to download + install |
+| Windows | **Microsoft Store** (MSIX) | **The Store** — the in-app updater is a no-op on Windows for the same reasons |
 
-See [Windows: Microsoft Store (MSIX)](#windows-microsoft-store-msix) for the Windows path.
+**Only Linux runs the in-app updater.** See [macOS: Mac App Store](#macos-mac-app-store) and
+[Windows: Microsoft Store (MSIX)](#windows-microsoft-store-msix) for the store paths.
 
 ---
 
@@ -94,7 +95,7 @@ These are read by BuildKonfig at build time. See [buildconfig-setup.md](buildcon
 
 #### Desktop Code Signing
 
-**macOS** desktop signing reuses the **existing iOS `MATCH_*` and `ASC_*` secrets** — no desktop-specific secrets are required. The `desktop-release.yml` workflow installs the Developer ID certificate via `fastlane mac certificates` (Fastlane match), resolves the identity into `MACOS_SIGN_IDENTITY` at runtime, signs during `packageReleaseDmg`, and notarizes/staples the DMG with `xcrun notarytool`. See [Desktop macOS code signing](#desktop-macos-code-signing).
+**macOS** desktop signing reuses the **existing iOS `MATCH_*` and `ASC_*` secrets** — no desktop-specific secrets are required. The `macos` job in `desktop-release.yml` runs `fastlane mac release`, which fetches the App Store certs + provisioning profile via Fastlane match, resolves the "Apple Distribution" identity into `MACOS_SIGN_IDENTITY`, builds a Store-signed `.pkg` with `packageReleasePkg`, and uploads it to App Store Connect. See [macOS: Mac App Store](#macos-mac-app-store).
 
 **Windows** code signing is **not required** — the Microsoft Store signs MSIX packages on ingestion.
 
@@ -169,8 +170,7 @@ releaseStorePassword=YOUR_STORE_PASSWORD
 **Workflow:** `.github/workflows/desktop-release.yml`
 
 **What it does:**
-1. Builds native packages in parallel on three runners:
-   - `macos-15` — builds `.dmg` via `./gradlew :client:composeApp:packageReleaseDmg`
+1. The `build` job builds native packages in parallel on two runners:
    - `windows-latest` — builds `.msi` via `./gradlew :client:composeApp:packageReleaseMsi`
    - `ubuntu-latest` — builds `.deb` via `./gradlew :client:composeApp:packageReleaseDeb`
 
@@ -179,27 +179,31 @@ releaseStorePassword=YOUR_STORE_PASSWORD
    UI. R8/ProGuard minification is disabled for the release build type in
    `client/composeApp/build.gradle.kts`, so the binary is functionally identical to the old debug
    packaging — it just carries the release marker.
-2. On macOS, signs and notarizes the DMG (see [Code signing](#desktop-macos-code-signing) below)
+2. The `macos` job (tag pushes only) runs `fastlane mac release`, which builds a Store-signed `.pkg`
+   via `./gradlew :client:composeApp:packageReleasePkg` and uploads it to App Store Connect (see
+   [macOS: Mac App Store](#macos-mac-app-store)).
 3. On Windows, also builds the app image (`createReleaseDistributable`) and packs an MSIX via `makeappx`
-4. Uploads each package (and, on Windows, the MSIX) as build artifacts
-5. Generates `latest.json` (the in-app update feed) with the macOS + Linux download URLs — **Windows is intentionally omitted** because it updates via the Store
-6. Creates a GitHub Release from the tag with the packages + `latest.json` attached
+4. Uploads the Windows/Linux packages (and the MSIX) as build artifacts. macOS emits no GitHub-Release
+   artifact — its `.pkg` goes straight to App Store Connect.
+5. Generates `latest.json` (the in-app update feed) with the **Linux** download URL only — macOS and
+   Windows are omitted because both ship via their app stores and the updater is a no-op there.
+6. Creates a GitHub Release from the tag with the Windows/Linux packages + `latest.json` attached
 7. Auto-generates release notes from commits since the last tag
 8. On tag pushes, the `publish-store` job submits the MSIX to the Microsoft Store via the MSStore CLI (no-ops until `STORE_PRODUCT_ID` is set)
 
-**Package configuration:** Native distribution settings (package name, version, vendor, platform-specific options) are in `client/composeApp/build.gradle.kts` under the `compose.desktop.application.nativeDistributions` block. The macOS `signing { }` / `notarization { }` blocks are gated on `MACOS_SIGN_IDENTITY` so local `packageDmg` works without a cert.
+**Package configuration:** Native distribution settings (package name, version, vendor, platform-specific options) are in `client/composeApp/build.gradle.kts` under the `compose.desktop.application.nativeDistributions` block. The macOS `signing { }` block and the provisioning-profile paths are gated on env vars (`MACOS_SIGN_IDENTITY`, `MACOS_PROVISIONING_PROFILE`) so a local `packageReleasePkg` works unsigned without certs.
 
-#### In-app updater (macOS + Linux)
+#### In-app updater (Linux only)
 
-The desktop app embeds `DesktopUpdater` (`client/composeApp/src/jvmMain/.../update/`). On launch it polls the stable feed URL:
+The desktop app embeds `DesktopUpdater` (`client/composeApp/src/jvmMain/.../update/`). On Linux it polls the stable feed URL on launch:
 
 ```
 https://github.com/Plus-Mobile-Apps/chef-mate/releases/latest/download/latest.json
 ```
 
-GitHub always serves `releases/latest/download/<asset>` from the newest non-prerelease release, so no separate hosting is needed. The updater compares the feed `version` against `BuildConfig.VERSION_NAME`; if newer, it surfaces a banner to download the platform installer and open it. It is a **no-op on Windows** by design.
+GitHub always serves `releases/latest/download/<asset>` from the newest non-prerelease release, so no separate hosting is needed. The updater compares the feed `version` against `BuildConfig.VERSION_NAME`; if newer, it surfaces a banner to download the `.deb` and open it. It is a **no-op on macOS and Windows** by design — both ship through app stores that forbid self-updating and sandbox the install.
 
-This is a *signed-installer* model (download + run the new signed package), **not** in-place jar patching — patching jars inside the bundle would invalidate the macOS notarization staple.
+This is a *signed-installer* model (download + run the new signed package), **not** in-place jar patching.
 
 **`latest.json` shape:**
 
@@ -208,22 +212,10 @@ This is a *signed-installer* model (download + run the new signed package), **no
   "version": "1.8.0",
   "notesUrl": "https://github.com/Plus-Mobile-Apps/chef-mate/releases/tag/v1.8.0",
   "downloads": {
-    "macos": "https://github.com/.../releases/download/v1.8.0/Chef-Mate-1.8.0.dmg",
     "linux": "https://github.com/.../releases/download/v1.8.0/chef-mate_1.8.0_amd64.deb"
   }
 }
 ```
-
-#### macOS notarization
-
-The `.p12` for `MACOS_CERT_P12_BASE64` is a "Developer ID Application" certificate exported from Keychain Access (include the private key). Export and encode:
-
-```bash
-# In Keychain Access: right-click the "Developer ID Application" cert → Export → .p12
-base64 -i DeveloperID.p12 | pbcopy   # store as MACOS_CERT_P12_BASE64
-```
-
-`APPLE_APP_PASSWORD` is an app-specific password generated at <https://appleid.apple.com> (Sign-In and Security → App-Specific Passwords). Without notarization, Gatekeeper refuses to launch the app ("damaged / cannot be opened").
 
 ---
 
@@ -375,67 +367,53 @@ The MSIX is then built by laying that directory next to an `AppxManifest.xml` an
 
 > **Status:** the MSIX packaging steps and `publish-store` job are wired into `desktop-release.yml`. The MSIX builds on every run (with placeholder identity until the Store secrets are set); submission only fires on tag pushes once `STORE_PRODUCT_ID` is configured. The unsigned `.msi` is still built as a fallback/sideload artifact.
 
-#### Desktop macOS code signing
+## macOS: Mac App Store
 
-The macOS DMG is signed with a **Developer ID Application** certificate and notarized so it opens without a Gatekeeper warning. Windows and Linux packages remain unsigned.
+macOS ships through the **Mac App Store** as a sandboxed `.pkg` uploaded to App Store Connect
+(TestFlight → release). The direct Developer-ID DMG has been retired. Compose builds the Store `.pkg`
+with `macOS { appStore = true }` in `client/composeApp/build.gradle.kts` (`packageReleasePkg`); the
+`macos` job in `desktop-release.yml` runs `fastlane mac release` to sign, build, and upload it.
 
-**Certificate:** Stored and fetched via Fastlane `match` (`type: "developer_id"`) from the same private certificates repo used for iOS. The `mac certificates` lane (`fastlane/Fastfile`) runs `setup_ci` + `match` (readonly) to import the cert into a temporary CI keychain.
+**Bundle ID:** `com.plusmobileapps.chefmate` — distinct from the iOS app id
+`com.plusmobileapps.chefmate.ChefMate`. It needs its own App Store Connect record.
 
-**Signing:** Enabled in `client/composeApp/build.gradle.kts` via the `macOS { signing { ... } }` block, gated on the `MACOS_SIGN_IDENTITY` env var (resolved in CI from the keychain). Local builds without that var stay unsigned. Compose Desktop applies hardened runtime + default entitlements automatically when signing.
+**Certificates & profile** (fetched via Fastlane `match`, `type: "appstore"`, `platform: "macos"`,
+from the same private certificates repo used for iOS):
+- **Apple Distribution** application cert — signs the `.app` bundle.
+- **Mac Installer Distribution** cert — signs the `.pkg` installer (fetched via match
+  `additional_cert_types: ["mac_installer_distribution"]`).
+- **Mac App Store provisioning profile** — embedded in the `.app`. The `mac release` lane passes its
+  path to Compose via `MACOS_PROVISIONING_PROFILE` / `MACOS_RUNTIME_PROVISIONING_PROFILE`.
 
-**Notarization:** The workflow submits the built DMG with `xcrun notarytool submit --wait` and then `xcrun stapler staple`, reusing the App Store Connect API key (`ASC_*` secrets) — no app-specific password needed.
+**Signing:** The `mac release` lane resolves the "Apple Distribution" identity from the keychain into
+`MACOS_SIGN_IDENTITY`. jpackage signs the app with that identity (passed as
+`--mac-signing-key-user-name`) and derives the matching "3rd Party Mac Developer Installer" identity
+from the keychain to sign the `.pkg`. Local builds without these env vars stay unsigned.
 
-**One-time bootstrap:** Apple does **not** allow creating a Developer ID Application certificate via
-the App Store Connect API (only the Account Holder can, through an interactive session), so the cert
-must be created manually once and then imported into the Match repo:
+**App Sandbox (mandatory):** The Mac App Store requires App Sandbox. Entitlements live in
+`packaging/macos/entitlements.plist` (app: sandbox + `network.client` + `files.user-selected.read-write`
++ JVM hardened-runtime exceptions) and `packaging/macos/runtime-entitlements.plist` (the nested JRE:
+sandbox-inherit + JVM exceptions), wired via `entitlementsFile` / `runtimeEntitlementsFile`.
 
-1. Create the cert as the Account Holder — in Xcode: **Settings → Accounts → Manage Certificates → +
-   → Developer ID Application** (or via developer.apple.com → Certificates). This also places the
-   cert + private key in your login keychain.
-2. Download the certificate `.cer` (developer.apple.com → Certificates → the Developer ID Application
-   row → Download), e.g. `developerID_application.cer`.
-3. Export the private key from **Keychain Access** as a `.p12` (any password), then convert it to the
-   exact format `match` + `security import` expect — a **password-less PKCS#1 PEM key**:
+> **Known risk — validate before the first real submission.** This is a bundled-JRE app that uses a
+> JavaFX WebView (the recipe browser), native file dialogs, and Supabase networking. Sandboxed
+> JVM/JavaFX apps are a known source of runtime breakage and App Store review rejection, and the
+> `disable-library-validation` / `allow-unsigned-executable-memory` entitlements are scrutinized in
+> review. **Smoke-test the signed `.pkg` sandboxed** (WebView loads, file open/save works, sign-in +
+> sync work, no sandbox denials in Console.app) before submitting, and be prepared to iterate on the
+> entitlements or face rejection.
 
+**One-time bootstrap:**
+1. In **App Store Connect → Apps → +**, create a new **macOS** app for bundle id
+   `com.plusmobileapps.chefmate`.
+2. Register the App ID and generate the certs + provisioning profile (run locally, read-write match):
    ```bash
-   # strip the p12 password (OpenSSL 3 needs -legacy for Apple's RC2 container)
-   openssl pkcs12 -legacy -in developer_id.p12 -nodes -nocerts -out /tmp/nopass.pem   # enter export pw
-   # emit a bare PKCS#1 key ("BEGIN RSA PRIVATE KEY"); PKCS#8 ("BEGIN PRIVATE KEY") is rejected as
-   # "Unknown format" when the file has a .p12 extension, and bag-attribute preambles break pairing
-   openssl rsa -traditional -in /tmp/nopass.pem -out developer_id_key.p12
-   head -1 developer_id_key.p12   # MUST be: -----BEGIN RSA PRIVATE KEY-----
-   rm -f /tmp/nopass.pem
+   bundle exec fastlane mac certificates            # registers the App ID via produce, then match
    ```
+   (Pass `force:true` after enabling a new capability on the App ID to regenerate the profile.)
+3. From then on CI consumes the stored assets read-only inside `fastlane mac release`.
 
-   Why: `match` stores the key as `<id>.p12` and installs it in CI with `security import … -P ""`
-   (empty password). That only works if the file is a bare PKCS#1 PEM key — a real PKCS12 container
-   fails MAC verification (OpenSSL↔Apple empty-password mismatch), and a PKCS#8 key is "Unknown
-   format" under the `.p12` extension.
-
-4. Import both into the certificates repo. **Unset the ASC API key env vars first** — `match` reads
-   `APP_STORE_CONNECT_API_KEY` as its `api_key` option and fails with `'api_key' value must be a Hash`:
-
-   ```bash
-   unset APP_STORE_CONNECT_API_KEY APP_STORE_CONNECT_API_KEY_ID APP_STORE_CONNECT_API_ISSUER_ID
-   export MATCH_PASSWORD=<match repo passphrase>
-
-   bundle exec fastlane match import \
-     --type developer_id \
-     --git_url git@github.com:Plus-Mobile-Apps/certificates.git
-   # Certificate (.cer): developerID_application.cer
-   # Private Key (.p12): developer_id_key.p12
-   # Provisioning Profile: <press Enter — Developer ID apps use none>
-   ```
-
-CI then consumes the stored cert read-only via `fastlane mac certificates`.
-
-**Intermediate CA:** a Developer ID leaf only forms a *valid* codesigning identity when its issuing
-intermediate is in the keychain. CI runners lack it, so the correct one (subject
-`CN=Developer ID Certification Authority, OU=Apple Certification Authority` — **not** the G2
-intermediate) is vendored at `.github/certs/DeveloperIDCA.pem` and imported by the workflow. If you
-rotate to a cert issued by a different intermediate, replace that file to match the new leaf's issuer.
-
-**Reused secrets:** `MATCH_PASSWORD`, `MATCH_GIT_BASIC_AUTHORIZATION`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_API_KEY` (no new secrets required).
+**Reused secrets:** `MATCH_PASSWORD`, `MATCH_GIT_BASIC_AUTHORIZATION`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_API_KEY`, `APPLE_TEAM_ID` (no new secrets required).
 
 ---
 
@@ -612,7 +590,7 @@ bundle exec fastlane ios release
 # Desktop — build release packages for your current OS (hides developer-only UI).
 # Output lands in build/compose/binaries/main-release/. Use the plain package* tasks
 # only for local debug builds where you want the Developer Settings row visible.
-./gradlew :client:composeApp:packageReleaseDmg    # macOS
+./gradlew :client:composeApp:packageReleasePkg    # macOS (Mac App Store .pkg; unsigned without certs)
 ./gradlew :client:composeApp:packageReleaseMsi    # Windows
 ./gradlew :client:composeApp:packageReleaseDeb    # Linux
 ```
@@ -663,7 +641,7 @@ CLI flags are also available for non-interactive use:
 
 ## Known Limitations
 
-- **Windows MSI and Linux DEB are unsigned** — only the macOS DMG is signed/notarized (see [Desktop macOS code signing](#desktop-macos-code-signing)). Windows ships via the Microsoft Store (Store-signed), so this only affects the fallback MSI.
+- **Windows MSI and Linux DEB are unsigned.** macOS ships a Store-signed `.pkg` to the Mac App Store (see [macOS: Mac App Store](#macos-mac-app-store)) and Windows ships via the Microsoft Store (Store-signed), so this only affects the fallback MSI and the Linux DEB.
 - **MSIX packaging logo assets are placeholders** — CI reuses the app icon for all three Store logos, which won't pass Store certification. Replace with correctly-sized PNGs (see [Windows: Microsoft Store (MSIX)](#windows-microsoft-store-msix)).
 - **MSStore CLI is in preview** — the `publish-store` job's action ref and `publish` flags should be verified against current docs on first real submission.
 - **Store releases lag** — Microsoft Store certification review delays Windows releases relative to the GitHub Release and mobile stores.

--- a/docs/developer-settings.md
+++ b/docs/developer-settings.md
@@ -86,12 +86,12 @@ The "Developer Settings" row only appears when `BuildConfig.IS_DEBUG` is `true`.
 |---|---|
 | `./gradlew :client:composeApp:installDebug` | `true` |
 | `./gradlew :client:composeApp:run` (desktop) | `true` |
-| `./gradlew :client:composeApp:packageDmg` (desktop debug package) | `true` |
+| `./gradlew :client:composeApp:packagePkg` (desktop debug package) | `true` |
 | `./gradlew :client:composeApp:bundleRelease` | `false` |
-| `./gradlew :client:composeApp:packageReleaseDmg` (desktop release package) | `false` |
+| `./gradlew :client:composeApp:packageReleasePkg` (desktop release package) | `false` |
 | IDE sync (no tasks) | `true` |
 
-> **Desktop packaging caveat:** the plain `packageDmg` / `packageMsi` / `packageDeb` tasks do **not**
+> **Desktop packaging caveat:** the plain `packagePkg` / `packageMsi` / `packageDeb` tasks do **not**
 > contain "Release", so they ship with the developer UI visible. The desktop release workflow uses the
 > `packageRelease*` variants (output under `build/compose/binaries/main-release/`) precisely so
 > `IS_DEBUG` is `false`. See [deployment.md](deployment.md).

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,9 +22,10 @@ platform :android do
 end
 
 platform :mac do
-  # The desktop app's bundle id (matches `macOS.bundleID` in composeApp/build.gradle.kts). Distinct
-  # from the iOS app id `com.plusmobileapps.chefmate.ChefMate`.
-  MAC_APP_IDENTIFIER = "com.plusmobileapps.chefmate"
+  # The desktop app's bundle id (matches `macOS.bundleID` in composeApp/build.gradle.kts). It is the
+  # SAME as the iOS app id so macOS ships under the one "Chef Mate" App Store record (Universal
+  # Purchase). The App ID already exists (created for iOS), so no `produce` registration is needed.
+  MAC_APP_IDENTIFIER = "com.plusmobileapps.chefmate.ChefMate"
 
   def asc_api_key
     # Build the App Store Connect API key Hash `match`/`upload_to_app_store` expect. Running match
@@ -55,22 +56,14 @@ platform :mac do
   end
 
   desc "Generate/refresh the Mac App Store certs + provisioning profile (read-write match)."
-  desc "Run once locally after creating the macOS App Store Connect record."
+  desc "Run once locally after enabling the macOS platform on the Chef Mate App Store record."
   desc "Pass force:true to regenerate the profile after enabling a new capability on the App ID."
   lane :certificates do |options|
     api_key = asc_api_key
 
-    # match creates provisioning profiles but not App IDs, so register the desktop bundle id on the
-    # Developer Portal first. skip_itc — the App Store Connect record is created manually in the
-    # portal (see docs/deployment.md). Idempotent once the App ID exists.
-    produce(
-      app_identifier: MAC_APP_IDENTIFIER,
-      app_name: "Chef Mate",
-      platform: "osx",
-      skip_itc: true,
-      team_id: ENV["TEAM_ID"] || "Y89258SF5P",
-    )
-
+    # The App ID already exists (shared with iOS), so no `produce` registration is needed — match
+    # only mints the macOS App Store provisioning profile + fetches the certs for it. If the App ID
+    # gained a capability, pass force:true to regenerate the profile.
     fetch_mac_app_store_signing(api_key, readonly: false, force: options.fetch(:force, false))
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,28 +22,109 @@ platform :android do
 end
 
 platform :mac do
-  desc "Install the Developer ID cert into the keychain for desktop signing."
-  desc "Read-only by default (CI). Run once locally with `readonly:false` to generate & store the cert."
-  lane :certificates do |options|
-    # Build the App Store Connect API key Hash `match` expects. Running `fastlane match` standalone
-    # instead picks up a String from the environment and fails with "'api_key' value must be a Hash".
-    api_key = app_store_connect_api_key(
+  # The desktop app's bundle id (matches `macOS.bundleID` in composeApp/build.gradle.kts). Distinct
+  # from the iOS app id `com.plusmobileapps.chefmate.ChefMate`.
+  MAC_APP_IDENTIFIER = "com.plusmobileapps.chefmate"
+
+  def asc_api_key
+    # Build the App Store Connect API key Hash `match`/`upload_to_app_store` expect. Running match
+    # standalone picks up a String from the environment and fails with "'api_key' must be a Hash".
+    app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
       key_content: ENV["APP_STORE_CONNECT_API_KEY"],
       is_key_content_base64: true,
     )
+  end
+
+  # Fetch (or generate) the Mac App Store signing assets into the keychain:
+  #   * "Apple Distribution" application cert  -> signs the .app bundle
+  #   * "Mac Installer Distribution" cert      -> signs the .pkg installer
+  #   * the Mac App Store provisioning profile -> embedded in the .app
+  # Read-only in CI; run the certificates lane (readonly:false) once to create and store them.
+  def fetch_mac_app_store_signing(api_key, readonly:, force: false)
+    match(
+      type: "appstore",
+      platform: "macos",
+      app_identifier: MAC_APP_IDENTIFIER,
+      additional_cert_types: ["mac_installer_distribution"],
+      readonly: readonly,
+      force: force,
+      api_key: api_key,
+    )
+  end
+
+  desc "Generate/refresh the Mac App Store certs + provisioning profile (read-write match)."
+  desc "Run once locally after creating the macOS App Store Connect record."
+  desc "Pass force:true to regenerate the profile after enabling a new capability on the App ID."
+  lane :certificates do |options|
+    api_key = asc_api_key
+
+    # match creates provisioning profiles but not App IDs, so register the desktop bundle id on the
+    # Developer Portal first. skip_itc — the App Store Connect record is created manually in the
+    # portal (see docs/deployment.md). Idempotent once the App ID exists.
+    produce(
+      app_identifier: MAC_APP_IDENTIFIER,
+      app_name: "Chef Mate",
+      platform: "osx",
+      skip_itc: true,
+      team_id: ENV["TEAM_ID"] || "Y89258SF5P",
+    )
+
+    fetch_mac_app_store_signing(api_key, readonly: false, force: options.fetch(:force, false))
+  end
+
+  desc "Build the Mac App Store .pkg and upload it to App Store Connect."
+  lane :release do
+    api_key = asc_api_key
 
     setup_ci
 
-    # A Developer ID app is directly distributed and uses no provisioning profiles, so fetch only the
-    # certificate. Without this, match tries to resolve `Direct_*` profiles for the Matchfile's app
-    # identifiers and fails under `readonly`.
-    match(
-      type: "developer_id",
-      readonly: options.fetch(:readonly, true),
-      skip_provisioning_profiles: true,
+    fetch_mac_app_store_signing(api_key, readonly: true)
+
+    # jpackage signs the app with the identity we pass as --mac-signing-key-user-name (Compose's
+    # macOS.signing.identity) and derives the matching "3rd Party Mac Developer Installer" identity
+    # from the keychain to sign the .pkg. Resolve the "Apple Distribution" identity match imported.
+    identity = sh(
+      "security find-identity -v -p codesigning | grep 'Apple Distribution' | head -1 | " \
+      "sed -E 's/.*\"(.*)\"/\\1/'"
+    ).strip
+    UI.user_error!("No 'Apple Distribution' signing identity found in keychain") if identity.empty?
+
+    # match writes the .provisionprofile to disk and exposes its path via a sigh_* env var. The
+    # macOS key carries a `_macos` segment; fall back to the unsuffixed name across fastlane versions.
+    profile =
+      ENV["sigh_#{MAC_APP_IDENTIFIER}_appstore_macos_profile-path"] ||
+      ENV["sigh_#{MAC_APP_IDENTIFIER}_appstore_profile-path"]
+    UI.user_error!("Mac App Store provisioning profile path not found in sigh_* env") if profile.nil?
+
+    # composeApp/build.gradle.kts reads these at Gradle configuration time via System.getenv. The
+    # runtime (nested JRE) bundle reuses the same profile as the app.
+    ENV["MACOS_SIGN_IDENTITY"] = identity
+    ENV["MACOS_PROVISIONING_PROFILE"] = profile
+    ENV["MACOS_RUNTIME_PROVISIONING_PROFILE"] = profile
+
+    gradle(task: ":client:composeApp:packageReleasePkg")
+
+    # Anchor to the repo root via the Fastfile location (__dir__ == fastlane/) so this is independent
+    # of fastlane's inconsistent working directory between the sh action and the gradle action.
+    pkg = Dir[
+      File.expand_path(
+        "../client/composeApp/build/compose/binaries/main-release/pkg/*.pkg", __dir__
+      )
+    ].first
+    UI.user_error!("No .pkg produced by packageReleasePkg") if pkg.nil?
+
+    upload_to_app_store(
       api_key: api_key,
+      app_identifier: MAC_APP_IDENTIFIER,
+      platform: "osx",
+      pkg: pkg,
+      skip_metadata: true,
+      skip_screenshots: true,
+      submit_for_review: false,
+      precheck_include_in_app_purchases: false,
+      force: true,
     )
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -34,9 +34,19 @@ Build release AAB and upload to Play Store internal track
 [bundle exec] fastlane mac certificates
 ```
 
-Install the Developer ID cert into the keychain for desktop signing.
+Generate/refresh the Mac App Store certs + provisioning profile (read-write match).
 
-Read-only by default (CI). Run once locally with `readonly:false` to generate & store the cert.
+Run once locally after creating the macOS App Store Connect record.
+
+Pass force:true to regenerate the profile after enabling a new capability on the App ID.
+
+### mac release
+
+```sh
+[bundle exec] fastlane mac release
+```
+
+Build the Mac App Store .pkg and upload it to App Store Connect.
 
 ----
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -36,7 +36,7 @@ Build release AAB and upload to Play Store internal track
 
 Generate/refresh the Mac App Store certs + provisioning profile (read-write match).
 
-Run once locally after creating the macOS App Store Connect record.
+Run once locally after enabling the macOS platform on the Chef Mate App Store record.
 
 Pass force:true to regenerate the profile after enabling a new capability on the App ID.
 

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      App Sandbox is mandatory for the Mac App Store. This file REPLACES Compose's default
+      entitlements, so the JVM hardened-runtime exceptions Compose normally applies are repeated
+      here alongside the sandbox capabilities.
+    -->
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+
+    <!-- Outbound network: Supabase sync/auth, the update feed on Linux, Bugsnag, and the recipe
+         browser's WebView all make client HTTP requests. -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+
+    <!-- Recipe import/export (zip open + save) goes through native file dialogs, which grant the
+         sandbox access to whatever the user explicitly picks. -->
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+
+    <!--
+      JVM requirements. The HotSpot JIT writes then executes generated machine code, so it needs
+      both allow-jit and allow-unsigned-executable-memory. disable-library-validation lets the app
+      bundle load the nested JRE's native dylibs.
+
+      NOTE (review risk): allow-unsigned-executable-memory and disable-library-validation are
+      permitted with App Sandbox but are scrutinized in App Store review. If a submission is
+      rejected for these, revisit whether the bundled runtime can be signed such that library
+      validation passes without disabling it.
+    -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/packaging/macos/runtime-entitlements.plist
+++ b/packaging/macos/runtime-entitlements.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      Entitlements for the bundled JRE, signed as a separate nested bundle. It inherits the App
+      Sandbox and carries the JVM hardened-runtime exceptions (the java/JIT executables live here).
+      It intentionally does NOT request network/file capabilities — those belong to the app.
+    -->
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## What & why

Moves macOS desktop distribution from a notarized **Developer-ID DMG on GitHub Releases** to the **Mac App Store** (`.pkg` uploaded to App Store Connect), and disables the in-app self-updater on macOS as a consequence — the Store forbids self-updating and sandboxes the install. The DMG is retired; the in-app `DesktopUpdater` now runs on **Linux only** (Windows already deferred to the Microsoft Store).

macOS ships under the **same bundle id as iOS** (`com.plusmobileapps.chefmate.ChefMate`), so it lands in the single "Chef Mate" App Store record via **Universal Purchase** rather than a separate listing (App Store names are globally unique, so a second "Chef Mate" record wasn't possible anyway).

## Changes

- **Updater** — `DesktopUpdater.isSupported` is now `platformKey() == "linux"`; macOS joins Windows in deferring to its store.
- **Packaging** (`composeApp/build.gradle.kts`) — macOS target `Dmg` → `Pkg`, `appStore = true`, `appCategory`, App Sandbox entitlements + provisioning-profile env vars, and `bundleID` set to the iOS app id `com.plusmobileapps.chefmate.ChefMate` (was the Android-style `com.plusmobileapps.chefmate`). New `packaging/macos/entitlements.plist` (app) and `runtime-entitlements.plist` (nested JRE).
- **CI / Fastlane** — new `mac release` lane (match fetches Apple Distribution + Mac Installer Distribution certs + MAS profile, builds the signed `.pkg`, uploads to App Store Connect); `mac certificates` lane runs match only (the App ID already exists from iOS — no `produce`). `desktop-release.yml` gains a tag-only `macos` job and drops macOS from the GitHub Release artifacts and `latest.json` feed.
- **Docs** — new "macOS: Mac App Store" section, revised update-strategy table + feed shape, `packageReleasePkg` task references.

## Verification done

- `./gradlew :client:composeApp:packageReleasePkg --dry-run` resolves; `compileKotlinJvm` passes.
- Workflow YAML and Fastfile Ruby both parse.
- Not run: the actual signed `.pkg` build + App Store upload (needs the Apple-side setup below).

## Reviewer notes — required Apple-side setup before this can ship

Neither can be done from CI/code; they gate the first upload:

1. **Enable the macOS platform on the existing "Chef Mate" App Store Connect record** (Universal Purchase). No new App ID or app record — both already exist from iOS. The App ID needs **no extra capabilities** (sandbox/network/file access come from the build entitlements, not the portal).
2. **Run `bundle exec fastlane mac certificates` once locally** to mint the macOS App Store provisioning profile + certs into the `certificates` match repo. CI then consumes them read-only.

## ⚠️ Risks to validate

- **Sandbox + bundled JRE:** App Sandbox is mandatory, but this is a bundled-JRE app with a JavaFX WebView (recipe browser) + native file dialogs. Sandboxed JVM/JavaFX apps — especially with `disable-library-validation` / `allow-unsigned-executable-memory` — are a real App Store **rejection risk**. Smoke-test the signed `.pkg` sandboxed (WebView loads, file dialogs, sign-in/sync, no Console.app sandbox denials) before submitting.
- **Shared App ID capabilities:** the iOS App ID's capabilities (App Groups, Associated Domains, share-extension/watch) carry into the macOS provisioning profile. Normally fine (superset profile), but confirm it builds cleanly on the first `mac certificates` run.
- The first CI run should also confirm the `sigh_*` profile-path env var name and jpackage's installer-cert derivation (flagged in code comments).

Minor: `.github/certs/DeveloperIDCA.pem` is now unused (retired Developer-ID flow); left in place. The internal `admin/` module still builds a DMG and was intentionally not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)