### PR TITLE
fix(ci): sign macOS with the Mac App Distribution cert

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -386,16 +386,25 @@ platform** on the existing app record instead of creating a new one.
 
 **Certificates & profile** (fetched via Fastlane `match`, `type: "appstore"`, `platform: "macos"`,
 from the same private certificates repo used for iOS):
-- **Apple Distribution** application cert — signs the `.app` bundle.
-- **Mac Installer Distribution** cert — signs the `.pkg` installer (fetched via match
-  `additional_cert_types: ["mac_installer_distribution"]`).
+- **Mac App Distribution** cert (CN `3rd Party Mac Developer Application: …`) — signs the `.app`
+  bundle. **Must be this cert, not the unified "Apple Distribution".** Compose's signer only matches
+  the legacy `3rd Party Mac Developer Application:` / `Developer ID Application:` names (true through
+  Compose 1.12.0-beta), so an "Apple Distribution" cert fails with `Could not find certificate … in
+  keychain []`.
+- **Mac Installer Distribution** cert (CN `3rd Party Mac Developer Installer: …`) — signs the `.pkg`
+  installer (fetched via match `additional_cert_types: ["mac_installer_distribution"]`).
 - **Mac App Store provisioning profile** — embedded in the `.app`. The `mac release` lane passes its
   path to Compose via `MACOS_PROVISIONING_PROFILE` / `MACOS_RUNTIME_PROVISIONING_PROFILE`.
 
-**Signing:** The `mac release` lane resolves the "Apple Distribution" identity from the keychain into
-`MACOS_SIGN_IDENTITY`. jpackage signs the app with that identity (passed as
-`--mac-signing-key-user-name`) and derives the matching "3rd Party Mac Developer Installer" identity
-from the keychain to sign the `.pkg`. Local builds without these env vars stay unsigned.
+**Signing:** The `mac release` lane resolves the **bare** cert name (org + team, no prefix) from the
+`3rd Party Mac Developer Application` cert into `MACOS_SIGN_IDENTITY`. Compose prepends
+`3rd Party Mac Developer Application: ` to sign the app; jpackage prepends
+`3rd Party Mac Developer Installer: ` (via `--mac-signing-key-user-name`) to sign the `.pkg`. Passing
+the bare name lets each tool add its own prefix. Local builds without these env vars stay unsigned.
+
+> If your account only has the unified "Apple Distribution" cert, create a **Mac App Distribution**
+> certificate at developer.apple.com → Certificates and re-run `fastlane mac certificates`. The lane
+> fails fast with that instruction if the `3rd Party Mac Developer Application` cert is missing.
 
 **App Sandbox (mandatory):** The Mac App Store requires App Sandbox. Entitlements live in
 `packaging/macos/entitlements.plist` (app: sandbox + `network.client` + `files.user-selected.read-write`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -387,10 +387,11 @@ platform** on the existing app record instead of creating a new one.
 **Certificates & profile** (fetched via Fastlane `match`, `type: "appstore"`, `platform: "macos"`,
 from the same private certificates repo used for iOS):
 - **Mac App Distribution** cert (CN `3rd Party Mac Developer Application: …`) — signs the `.app`
-  bundle. **Must be this cert, not the unified "Apple Distribution".** Compose's signer only matches
-  the legacy `3rd Party Mac Developer Application:` / `Developer ID Application:` names (true through
-  Compose 1.12.0-beta), so an "Apple Distribution" cert fails with `Could not find certificate … in
-  keychain []`.
+  bundle. **Must be this legacy cert, not the unified "Apple Distribution".** Compose's signer only
+  matches the legacy `3rd Party Mac Developer Application:` / `Developer ID Application:` names (true
+  through Compose 1.12.0-beta), so an "Apple Distribution" cert fails with `Could not find certificate
+  … in keychain []`. The lane passes **`generate_apple_certs: false`** to match so it mints this
+  legacy cert instead of the modern unified one.
 - **Mac Installer Distribution** cert (CN `3rd Party Mac Developer Installer: …`) — signs the `.pkg`
   installer (fetched via match `additional_cert_types: ["mac_installer_distribution"]`).
 - **Mac App Store provisioning profile** — embedded in the `.app`. The `mac release` lane passes its
@@ -402,9 +403,11 @@ from the same private certificates repo used for iOS):
 `3rd Party Mac Developer Installer: ` (via `--mac-signing-key-user-name`) to sign the `.pkg`. Passing
 the bare name lets each tool add its own prefix. Local builds without these env vars stay unsigned.
 
-> If your account only has the unified "Apple Distribution" cert, create a **Mac App Distribution**
-> certificate at developer.apple.com → Certificates and re-run `fastlane mac certificates`. The lane
-> fails fast with that instruction if the `3rd Party Mac Developer Application` cert is missing.
+> With `generate_apple_certs: false`, `fastlane mac certificates` mints the legacy Mac App
+> Distribution cert automatically. If you'd previously generated the Apple Distribution profile, run
+> `bundle exec fastlane mac certificates force:true` once to regenerate the provisioning profile
+> against the legacy cert. The lane fails fast if the `3rd Party Mac Developer Application` cert is
+> missing.
 
 **App Sandbox (mandatory):** The Mac App Store requires App Sandbox. Entitlements live in
 `packaging/macos/entitlements.plist` (app: sandbox + `network.client` + `files.user-selected.read-write`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -403,11 +403,12 @@ from the same private certificates repo used for iOS):
 `3rd Party Mac Developer Installer: ` (via `--mac-signing-key-user-name`) to sign the `.pkg`. Passing
 the bare name lets each tool add its own prefix. Local builds without these env vars stay unsigned.
 
-> With `generate_apple_certs: false`, `fastlane mac certificates` mints the legacy Mac App
-> Distribution cert automatically. If you'd previously generated the Apple Distribution profile, run
-> `bundle exec fastlane mac certificates force:true` once to regenerate the provisioning profile
-> against the legacy cert. The lane fails fast if the `3rd Party Mac Developer Application` cert is
-> missing.
+> **Getting the legacy cert (one-time, fiddly).** Apple no longer *issues* the "Mac App
+> Distribution" cert through the automated flow — even with `generate_apple_certs: false`, match
+> reuses the unified "Apple Distribution" cert unless the legacy cert already exists in the repo. So
+> it must be **created by hand once** and imported (see the one-time bootstrap below). After that,
+> `generate_apple_certs: false` makes match resolve to it and generate a matching profile. The lane
+> fails fast if the `3rd Party Mac Developer Application` cert is missing.
 
 **App Sandbox (mandatory):** The Mac App Store requires App Sandbox. Entitlements live in
 `packaging/macos/entitlements.plist` (app: sandbox + `network.client` + `files.user-selected.read-write`
@@ -427,12 +428,30 @@ sandbox-inherit + JVM exceptions), wired via `entitlementsFile` / `runtimeEntitl
    Purchase) so Mac builds land under the same record. No new app record or App ID is created — both
    already exist from iOS. The App ID needs **no extra capabilities** enabled (App Sandbox, network,
    and file access come from the build's entitlements, not the portal).
-2. Generate the macOS certs + provisioning profile (run locally, read-write match):
+2. Create the **Mac App Distribution** certificate by hand (match won't — see the note above):
+   - In **Keychain Access → Certificate Assistant → Request a Certificate from a Certificate
+     Authority** ("Saved to disk"), generate a CSR (this also puts the private key in your login
+     keychain).
+   - At developer.apple.com → Certificates → ➕ → **Mac App Distribution**, upload the CSR, download
+     the `.cer`, and double-click it to install.
+3. Import that cert + its key into the match repo (its key isn't there yet since you made it by hand).
+   The key must be a bare PKCS#1 PEM (same conversion the Developer ID cert used — see below), then:
    ```bash
-   bundle exec fastlane mac certificates            # match only; the App ID already exists
+   unset APP_STORE_CONNECT_API_KEY APP_STORE_CONNECT_API_KEY_ID APP_STORE_CONNECT_API_ISSUER_ID
+   export MATCH_PASSWORD=<match repo passphrase>
+   bundle exec fastlane match import --type appstore --platform macos \
+     --git_url git@github.com:Plus-Mobile-Apps/certificates.git
+   # Certificate (.cer): the Mac App Distribution cert; Private Key (.p12): the converted key;
+   # Provisioning Profile: leave empty (generated next).
    ```
-   (Pass `force:true` after enabling a new capability on the App ID to regenerate the profile.)
-3. From then on CI consumes the stored assets read-only inside `fastlane mac release`.
+4. Generate the Mac App Store provisioning profile against the imported cert (re-export the `ASC_*`
+   values first, since step 3 unset them):
+   ```bash
+   bundle exec fastlane mac certificates force:true
+   ```
+   Confirm the output installs `3rd Party Mac Developer Application` and the profile's Certificate
+   Name is that cert (not Apple Distribution).
+5. From then on CI consumes the stored assets read-only inside `fastlane mac release`.
 
 **Reused secrets:** `MATCH_PASSWORD`, `MATCH_GIT_BASIC_AUTHORIZATION`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_API_KEY`, `APPLE_TEAM_ID` (no new secrets required).
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -75,14 +75,27 @@ platform :mac do
 
     fetch_mac_app_store_signing(api_key, readonly: true)
 
-    # jpackage signs the app with the identity we pass as --mac-signing-key-user-name (Compose's
-    # macOS.signing.identity) and derives the matching "3rd Party Mac Developer Installer" identity
-    # from the keychain to sign the .pkg. Resolve the "Apple Distribution" identity match imported.
+    # Resolve the BARE cert name (org + team, no prefix). Compose's MacSigner signs the .app with
+    # "3rd Party Mac Developer Application: <name>" (it prepends that prefix in App Store mode), and
+    # jpackage signs the .pkg installer with "3rd Party Mac Developer Installer: <name>" (via
+    # --mac-signing-key-user-name). Passing the bare name lets each tool add its own prefix.
+    #
+    # IMPORTANT: Compose does NOT understand the unified "Apple Distribution" cert name — it only
+    # matches "3rd Party Mac Developer Application:". The App ID therefore needs a **Mac App
+    # Distribution** cert, which `fastlane mac certificates` fetches for platform macos.
     identity = sh(
-      "security find-identity -v -p codesigning | grep 'Apple Distribution' | head -1 | " \
-      "sed -E 's/.*\"(.*)\"/\\1/'"
+      "security find-identity -v -p codesigning | " \
+      "grep '3rd Party Mac Developer Application' | head -1 | " \
+      "sed -E 's/.*\"3rd Party Mac Developer Application: (.*)\"/\\1/'"
     ).strip
-    UI.user_error!("No 'Apple Distribution' signing identity found in keychain") if identity.empty?
+    if identity.empty?
+      UI.user_error!(
+        "No '3rd Party Mac Developer Application' certificate in the keychain. Compose cannot sign " \
+        "a Mac App Store build with the unified 'Apple Distribution' cert — create a 'Mac App " \
+        "Distribution' certificate (developer.apple.com > Certificates) and re-run " \
+        "`bundle exec fastlane mac certificates`."
+      )
+    end
 
     # match writes the .provisionprofile to disk and exposes its path via a sigh_* env var. The
     # macOS key carries a `_macos` segment; fall back to the unsuffixed name across fastlane versions.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,16 +39,21 @@ platform :mac do
   end
 
   # Fetch (or generate) the Mac App Store signing assets into the keychain:
-  #   * "Apple Distribution" application cert  -> signs the .app bundle
-  #   * "Mac Installer Distribution" cert      -> signs the .pkg installer
-  #   * the Mac App Store provisioning profile -> embedded in the .app
+  #   * "3rd Party Mac Developer Application" cert -> signs the .app bundle
+  #   * "3rd Party Mac Developer Installer" cert   -> signs the .pkg installer
+  #   * the Mac App Store provisioning profile     -> embedded in the .app
   # Read-only in CI; run the certificates lane (readonly:false) once to create and store them.
+  #
+  # generate_apple_certs: false forces the LEGACY, platform-specific cert types instead of the
+  # unified "Apple Distribution" cert. Compose's MacSigner only understands the legacy
+  # "3rd Party Mac Developer Application:" name, so the modern unified cert can't sign the app.
   def fetch_mac_app_store_signing(api_key, readonly:, force: false)
     match(
       type: "appstore",
       platform: "macos",
       app_identifier: MAC_APP_IDENTIFIER,
       additional_cert_types: ["mac_installer_distribution"],
+      generate_apple_certs: false,
       readonly: readonly,
       force: force,
       api_key: api_key,

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -63,6 +63,8 @@ Generate/refresh signing certificates and provisioning profiles (read-write matc
 
 Run this once after adding an app id (e.g. the watch app) so its profile is registered.
 
+Pass force:true to regenerate profiles after enabling a new capability on an App ID.
+
 ### ios release
 
 ```sh


### PR DESCRIPTION
## Why

The first tagged desktop release (`v1.9.25`) failed in the new `macos` job at `createReleaseDistributable`:

```
> Could not find certificate for 'Apple Distribution: Plus Mobile Apps LLC (…)' in keychain []
```

Follow-up to #446 (which is already merged).

## Root cause

Compose's `MacSigner` only recognizes the legacy certificate names — it takes the identity you give it and, in App Store mode, **prepends** `3rd Party Mac Developer Application: `. The `mac release` lane resolved the modern unified **`Apple Distribution`** cert (match reused the iOS one), so Compose searched for `3rd Party Mac Developer Application: Apple Distribution: …` — a doubled name that matches nothing. This is still true through Compose 1.12.0-beta02, so a version bump doesn't help.

## Fix

Resolve the **bare** cert name (org + team, no prefix) from the `3rd Party Mac Developer Application` cert. Compose prepends `3rd Party Mac Developer Application: ` to sign the app; jpackage prepends `3rd Party Mac Developer Installer: ` (via `--mac-signing-key-user-name`) to sign the `.pkg`. Letting each tool add its own prefix makes both match. The lane now **fails fast** with an actionable message if that cert isn't in the keychain.

## ⚠️ Requires a Mac App Distribution certificate

`fastlane match` (`type: appstore, platform: macos`) should create a **Mac App Distribution** cert (CN `3rd Party Mac Developer Application: …`) — Compose can't use the unified `Apple Distribution` cert. If your account only has `Apple Distribution`, create a **Mac App Distribution** certificate at developer.apple.com → Certificates and run `bundle exec fastlane mac certificates` before re-tagging.

## Verification

- `ruby -c fastlane/Fastfile` passes. The end-to-end signing path can only be exercised by a tag push once the cert is confirmed present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)