### PR TITLE
feat(aichat): expandable chat sheet with Close-in-app-bar layout

### DIFF
--- a/client/aichat/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/aichat/public/src/commonMain/composeResources/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="aichat_input_hint">Ask anything…</string>
     <string name="aichat_send">Send</string>
     <string name="aichat_history">Conversation history</string>
+    <string name="aichat_close">Close</string>
     <string name="aichat_add_recipe">Add recipe</string>
     <string name="aichat_attach_photo">Scan recipe from a photo</string>
     <string name="aichat_extracting_recipe">Extracting recipe…</string>

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatScreen.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.automirrored.filled.NoteAdd
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.AddPhotoAlternate
 import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material3.AssistChip
@@ -75,6 +76,7 @@ import androidx.compose.ui.unit.dp
 import chefmate.client.aichat.public.generated.resources.Res
 import chefmate.client.aichat.public.generated.resources.aichat_add_recipe
 import chefmate.client.aichat.public.generated.resources.aichat_attach_photo
+import chefmate.client.aichat.public.generated.resources.aichat_close
 import chefmate.client.aichat.public.generated.resources.aichat_done
 import chefmate.client.aichat.public.generated.resources.aichat_empty_description
 import chefmate.client.aichat.public.generated.resources.aichat_empty_title
@@ -110,25 +112,42 @@ fun AiChatScreen(bloc: AiChatBloc, modifier: Modifier = Modifier) {
         return
     }
 
-    PlusHeaderContainer(
-        modifier = modifier.fillMaxSize().testTag(AiChatTestTags.SCREEN),
-        data =
+    // In the expanded sheet there's no navigation stack to pop, so the app bar drops the back
+    // arrow and instead carries History plus a Close (X) on the right; the X dismisses the whole
+    // sheet (onBackClicked finishes the chat, which the host tears down). The standalone,
+    // full-screen chat (More tab) keeps its back arrow.
+    val headerData =
+        if (LocalAiChatPresentation.current == AiChatPresentation.SheetExpanded) {
+            PlusHeaderData.Parent(
+                title = Res.string.aichat_title.asTextData(),
+                trailingAccessory =
+                    PlusHeaderData.TrailingAccessory.Custom {
+                        HistoryButton(onClick = bloc::onHistoryClick)
+                        IconButton(
+                            onClick = bloc::onBackClicked,
+                            modifier = Modifier.testTag(AiChatTestTags.CLOSE_BUTTON),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = stringResource(Res.string.aichat_close),
+                            )
+                        }
+                    },
+            )
+        } else {
             PlusHeaderData.Child(
                 title = Res.string.aichat_title.asTextData(),
                 onBackClick = bloc::onBackClicked,
                 trailingAccessory =
                     PlusHeaderData.TrailingAccessory.Custom {
-                        IconButton(
-                            onClick = bloc::onHistoryClick,
-                            modifier = Modifier.testTag(AiChatTestTags.HISTORY_BUTTON),
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.History,
-                                contentDescription = stringResource(Res.string.aichat_history),
-                            )
-                        }
+                        HistoryButton(onClick = bloc::onHistoryClick)
                     },
-            ),
+            )
+        }
+
+    PlusHeaderContainer(
+        modifier = modifier.fillMaxSize().testTag(AiChatTestTags.SCREEN),
+        data = headerData,
         scrollEnabled = false,
         content = {
             state.recipeContextTitle?.let { title ->
@@ -181,6 +200,17 @@ fun AiChatScreen(bloc: AiChatBloc, modifier: Modifier = Modifier) {
             )
         },
     )
+}
+
+/** Opens the conversation-history list; shared by the standalone and expanded-sheet app bars. */
+@Composable
+private fun HistoryButton(onClick: () -> Unit) {
+    IconButton(onClick = onClick, modifier = Modifier.testTag(AiChatTestTags.HISTORY_BUTTON)) {
+        Icon(
+            imageVector = Icons.Default.History,
+            contentDescription = stringResource(Res.string.aichat_history),
+        )
+    }
 }
 
 /**

--- a/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatTestTags.kt
+++ b/client/aichat/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/aichat/AiChatTestTags.kt
@@ -6,6 +6,7 @@ object AiChatTestTags {
     const val INPUT = "AiChatInput"
     const val SEND_BUTTON = "AiChatSendButton"
     const val HISTORY_BUTTON = "AiChatHistoryButton"
+    const val CLOSE_BUTTON = "AiChatCloseButton"
     const val MESSAGE_LIST = "AiChatMessageList"
     const val THINKING_INDICATOR = "AiChatThinkingIndicator"
     const val ADD_RECIPE_PILL = "AiChatAddRecipePill"

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -2,8 +2,12 @@
 
 package com.plusmobileapps.chefmate.root
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -16,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 import com.arkivanov.decompose.FaultyDecomposeApi
@@ -110,7 +115,19 @@ private fun AiChatSheet(rootBloc: RootBloc) {
                 if (expanded) AiChatPresentation.SheetExpanded else AiChatPresentation.SheetPeek,
             LocalAiChatRequestExpand provides { expanded = true },
         ) {
-            currentChild.bloc.Content()
+            // Grow (and shrink) the sheet smoothly between the compact peek and the full-height
+            // chat instead of snapping. Anchoring the size change to the bottom keeps the input
+            // pinned to the bottom edge while the app bar and messages fill in above as it expands.
+            Box(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .animateContentSize(
+                            animationSpec = tween(),
+                            alignment = Alignment.BottomCenter,
+                        )
+            ) {
+                currentChild.bloc.Content()
+            }
         }
     }
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTest.kt
@@ -45,6 +45,23 @@ private fun AiChatPeekScreenshot(bloc: AiChatBloc, darkTheme: Boolean = false) {
     }
 }
 
+/**
+ * Renders the sheet dragged up to full height — the app bar drops the back arrow and carries
+ * History + a Close (X) on the right, with the input anchored at the bottom.
+ */
+@Composable
+private fun AiChatExpandedScreenshot(bloc: AiChatBloc, darkTheme: Boolean = false) {
+    ChefMateTheme(darkTheme = darkTheme) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            CompositionLocalProvider(
+                LocalAiChatPresentation provides AiChatPresentation.SheetExpanded
+            ) {
+                bloc.Content()
+            }
+        }
+    }
+}
+
 @PreviewTest
 @Preview(showBackground = true, heightDp = 900)
 @Composable
@@ -113,6 +130,20 @@ fun AiChatErrorLightScreenshot() {
 @Composable
 fun AiChatExtractingPillLightScreenshot() {
     AiChatScreenshot(bloc = previewAiChatBlocExtracting)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun AiChatExpandedLightScreenshot() {
+    AiChatExpandedScreenshot(bloc = previewAiChatBlocWithRecipeContext)
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun AiChatExpandedDarkScreenshot() {
+    AiChatExpandedScreenshot(bloc = previewAiChatBlocWithRecipeContext, darkTheme = true)
 }
 
 @PreviewTest

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatExpandedDarkScreenshot_658f3c84_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatExpandedDarkScreenshot_658f3c84_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b5d3afddaa608865e61d1041d12292c408895ac60c9cb537e83b6f0b6e1fbf8
+size 125165

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatExpandedLightScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AiChatScreenshotTestKt/AiChatExpandedLightScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a9f38ae4ad4bc23d0d36689e56254908f201d66791c258e757a47b50654a6dd
+size 125454


### PR DESCRIPTION
## Summary

Reworks the recipe-grounded AI chat sheet so it expands smoothly from its peek and adopts a Close-in-the-app-bar layout, matching the requested design.

- **Smoother expand.** The sheet now grows between its compact peek and full height via `animateContentSize` instead of a snap. The size change is anchored to the **bottom**, so the input field stays pinned to the bottom edge while the app bar and message list fill in above it as it expands.
- **App bar with X on the right.** In the expanded sheet the app bar drops the back arrow (there's no navigation stack to pop) and carries **History + Close (X)** on the right, title on the left. The X finishes the chat, which the host tears down to dismiss the sheet.
- The **standalone full-screen chat (More tab) is unchanged** — it keeps its back arrow, and no existing screenshot reference shifts.

Kept the existing two-state peek↔expanded model (peek = just the input for a quick question); a truly continuous single-drag fights the chat's bottom-anchored input because bottom sheets reveal their *top* as they grow.

## Screenshots

New references cover the expanded sheet (light + dark): AI Chat title left, History + X right, recipe chip, messages centered, input anchored at the bottom.

## Testing

- `:client:composeApp:jvmTest --tests "com.plusmobileapps.chefmate.tests.AiChat*"` — green (peek→expand, history, sheet nav)
- `:client:ui:screenshot-test:validateDebugScreenshotTest` — green; only the two new expanded-sheet references added, no existing reference changed
- Formatted with `ktfmt --kotlinlang-style`

🤖 Generated with [Claude Code](https://claude.com/claude-code)