### PR TITLE
fix(ci): complete macOS App Store signing (profile path/name) + dispatch validation

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -110,7 +110,10 @@ jobs:
   # (To test the signed .pkg build without uploading, run `bundle exec fastlane mac release` locally
   # after generating the certs once with `bundle exec fastlane mac certificates`.)
   macos:
-    if: startsWith(github.ref, 'refs/tags/')
+    # Tag pushes build + upload to App Store Connect. A manual workflow_dispatch also runs, but
+    # builds + signs the .pkg only (MAC_UPLOAD=false) so you can validate signing without creating
+    # an App Store Connect build.
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -127,10 +130,11 @@ jobs:
           ruby-version: "3.2"
           bundler-cache: true
 
-      - name: Build .pkg and upload to App Store Connect
+      - name: Build .pkg (and upload to App Store Connect on tags)
         # The fastlane mac release lane fetches the App Store certs + provisioning profile via match,
         # resolves the signing identity, runs packageReleasePkg (BuildKonfig reads the Supabase/
-        # Bugsnag secrets at Gradle configuration time), then uploads the .pkg to App Store Connect.
+        # Bugsnag secrets at Gradle configuration time), then uploads the .pkg to App Store Connect
+        # when MAC_UPLOAD=true (tag builds only).
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
@@ -142,7 +146,27 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
+          MAC_UPLOAD: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: bundle exec fastlane mac release
+
+      - name: Dump jpackage / codesign logs on failure
+        if: failure()
+        run: |
+          echo "== compose jpackage + signing logs =="
+          for f in client/composeApp/build/compose/logs/**/*.txt; do
+            echo "----- $f -----"
+            cat "$f" || true
+          done
+
+      - name: Upload .pkg + logs (dispatch debugging)
+        if: always() && github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-macos-pkg
+          if-no-files-found: warn
+          path: |
+            client/composeApp/build/compose/binaries/main-release/pkg/*.pkg
+            client/composeApp/build/compose/logs/**/*.txt
 
   release:
     needs: build

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -455,6 +455,22 @@ sandbox-inherit + JVM exceptions), wired via `entitlementsFile` / `runtimeEntitl
 
 **Reused secrets:** `MATCH_PASSWORD`, `MATCH_GIT_BASIC_AUTHORIZATION`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_API_KEY`, `APPLE_TEAM_ID` (no new secrets required).
 
+**Validating signing without a release.** The `macos` job also runs on **workflow_dispatch**
+(Actions → Desktop Release → Run workflow). A manual run **builds + signs** the `.pkg` and uploads it
+as a `desktop-macos-pkg` artifact, but sets `MAC_UPLOAD=false` so it does **not** push to App Store
+Connect — use it to verify signing (e.g. after a cert rotation) without cutting a version tag. Only
+tag pushes set `MAC_UPLOAD=true` and upload. The build runs with `-Pcompose.desktop.verbose=true` so
+jpackage's internal `codesign` errors are visible in the log (otherwise they surface only as an
+opaque `codesign … exited with 1` `IOException`).
+
+**Signing pitfalls that bit us** (all handled by the `mac release` lane, noted here for cert
+rotation): Compose only matches the legacy `3rd Party Mac Developer Application:` cert name, so the
+lane resolves the **bare** identity and needs the **Mac App Distribution** cert (not the unified
+Apple Distribution — created + imported by hand, see bootstrap). Compose embeds the app profile via
+jpackage `--app-content`, which (a) splits the path on whitespace in its @arg-file and (b) keeps the
+filename — so the lane copies match's profile to a **space-free path named exactly
+`embedded.provisionprofile`** before building.
+
 ---
 
 ## First-Time Setup

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,7 +125,13 @@ platform :mac do
     ENV["MACOS_PROVISIONING_PROFILE"] = safe_profile
     ENV["MACOS_RUNTIME_PROVISIONING_PROFILE"] = safe_profile
 
-    gradle(task: ":client:composeApp:packageReleasePkg")
+    # compose.desktop.verbose makes jpackage run with --verbose, which surfaces the underlying
+    # codesign stderr in the build log (otherwise a signing failure is just an opaque
+    # "codesign ... exited with 1" IOException).
+    gradle(
+      task: ":client:composeApp:packageReleasePkg",
+      flags: "-Pcompose.desktop.verbose=true",
+    )
 
     # Anchor to the repo root via the Fastfile location (__dir__ == fastlane/) so this is independent
     # of fastlane's inconsistent working directory between the sh action and the gradle action.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,17 +126,23 @@ platform :mac do
     ].first
     UI.user_error!("No .pkg produced by packageReleasePkg") if pkg.nil?
 
-    upload_to_app_store(
-      api_key: api_key,
-      app_identifier: MAC_APP_IDENTIFIER,
-      platform: "osx",
-      pkg: pkg,
-      skip_metadata: true,
-      skip_screenshots: true,
-      submit_for_review: false,
-      precheck_include_in_app_purchases: false,
-      force: true,
-    )
+    # Upload only when explicitly enabled (tag releases set MAC_UPLOAD=true). A manual
+    # workflow_dispatch builds + signs the .pkg to validate signing without creating an ASC build.
+    if ENV["MAC_UPLOAD"] == "true"
+      upload_to_app_store(
+        api_key: api_key,
+        app_identifier: MAC_APP_IDENTIFIER,
+        platform: "osx",
+        pkg: pkg,
+        skip_metadata: true,
+        skip_screenshots: true,
+        submit_for_review: false,
+        precheck_include_in_app_purchases: false,
+        force: true,
+      )
+    else
+      UI.important("MAC_UPLOAD != true — built and signed #{File.basename(pkg)}, skipping App Store upload.")
+    end
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,11 +109,21 @@ platform :mac do
       ENV["sigh_#{MAC_APP_IDENTIFIER}_appstore_profile-path"]
     UI.user_error!("Mac App Store provisioning profile path not found in sigh_* env") if profile.nil?
 
+    # Compose hands the app provisioning profile to jpackage via `--app-content <path>` in an
+    # @arg-file, and jpackage's arg-file parser splits on whitespace. match installs the profile
+    # under "~/Library/Developer/Xcode/UserData/Provisioning Profiles/…" (note the space), so
+    # jpackage truncates the path at the space and dies with NoSuchFileException. Copy it to a
+    # space-free path first. (Not hit locally because the local smoke build ran without a profile.)
+    require "fileutils"
+    safe_profile = File.expand_path("../build/macos/appstore.provisionprofile", __dir__)
+    FileUtils.mkdir_p(File.dirname(safe_profile))
+    FileUtils.cp(profile, safe_profile)
+
     # composeApp/build.gradle.kts reads these at Gradle configuration time via System.getenv. The
     # runtime (nested JRE) bundle reuses the same profile as the app.
     ENV["MACOS_SIGN_IDENTITY"] = identity
-    ENV["MACOS_PROVISIONING_PROFILE"] = profile
-    ENV["MACOS_RUNTIME_PROVISIONING_PROFILE"] = profile
+    ENV["MACOS_PROVISIONING_PROFILE"] = safe_profile
+    ENV["MACOS_RUNTIME_PROVISIONING_PROFILE"] = safe_profile
 
     gradle(task: ":client:composeApp:packageReleasePkg")
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,13 +109,16 @@ platform :mac do
       ENV["sigh_#{MAC_APP_IDENTIFIER}_appstore_profile-path"]
     UI.user_error!("Mac App Store provisioning profile path not found in sigh_* env") if profile.nil?
 
-    # Compose hands the app provisioning profile to jpackage via `--app-content <path>` in an
-    # @arg-file, and jpackage's arg-file parser splits on whitespace. match installs the profile
-    # under "~/Library/Developer/Xcode/UserData/Provisioning Profiles/…" (note the space), so
-    # jpackage truncates the path at the space and dies with NoSuchFileException. Copy it to a
-    # space-free path first. (Not hit locally because the local smoke build ran without a profile.)
+    # Copy match's profile to a build path before handing it to Compose, for two reasons:
+    #   1. Compose passes the app profile to jpackage via `--app-content <path>` in an @arg-file,
+    #      whose parser splits on whitespace — and match installs it under ".../Provisioning
+    #      Profiles/" (note the space), so jpackage truncates the path and fails NoSuchFileException.
+    #   2. jpackage's --app-content copies the file into Contents/ preserving its name, and a Mac
+    #      app's embedded profile MUST be named `embedded.provisionprofile` or codesign rejects it
+    #      ("code object is not signed at all / In subcomponent: .../<name>.provisionprofile").
+    # (Neither was hit by the local smoke build, which ran without a profile.)
     require "fileutils"
-    safe_profile = File.expand_path("../build/macos/appstore.provisionprofile", __dir__)
+    safe_profile = File.expand_path("../build/macos/embedded.provisionprofile", __dir__)
     FileUtils.mkdir_p(File.dirname(safe_profile))
     FileUtils.cp(profile, safe_profile)
 


### PR DESCRIPTION
Gets the `macos` release job building, signing, and (on tags) uploading a Mac App Store `.pkg`. Validated on `main` via workflow_dispatch — the job is green and produces a ~193 MB signed `.pkg` artifact.

## Signing fixes

- **Provisioning-profile path had a space** — Compose passes the app profile to jpackage via `--app-content` in an `@arg-file`, whose parser splits on whitespace; match installs it under `…/Provisioning Profiles/`, so the path truncated and jpackage failed `NoSuchFileException`.
- **Embedded profile filename** — jpackage's `--app-content` copies the file into `Contents/` keeping its name, and a Mac app's embedded profile must be named exactly `embedded.provisionprofile`, or codesign rejects the bundle (`code object is not signed at all / In subcomponent: …`).
- Both handled by copying match's profile to a **space-free path named `embedded.provisionprofile`** before the build.

## Tooling (kept intentionally)

- **`macos` job runs on `workflow_dispatch`** and gates the App Store upload behind `MAC_UPLOAD` (true only on tags). A manual run builds + signs and uploads the `.pkg` as a `desktop-macos-pkg` artifact **without** pushing to App Store Connect — lets us validate signing (e.g. after cert rotation) without a version tag.
- **`compose.desktop.verbose=true`** on the release build so jpackage's internal codesign errors are visible (kept — signing failures are otherwise opaque `IOException`s).
- **Dumps jpackage/codesign logs on failure.**
- Docs updated with the dispatch-validate flow and the signing pitfalls for future cert rotation.

Depends on the certs work in #449 (merged). After merge: enable the macOS platform on the App Store Connect record, then cut a version tag to do the real upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)