### PR TITLE
feat(watch): Material Expressive style with aisle sticky headers

### DIFF
--- a/iosApp/ChefMateWatch/AddItemView.swift
+++ b/iosApp/ChefMateWatch/AddItemView.swift
@@ -7,17 +7,25 @@ struct AddItemView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var name = ""
 
+    private var isValid: Bool { !name.trimmingCharacters(in: .whitespaces).isEmpty }
+
     var body: some View {
         NavigationStack {
             Form {
                 TextField("Item", text: $name)
-                Button("Add") {
+                Button {
                     onAdd(name)
                     dismiss()
+                } label: {
+                    Text("Add")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
                 }
-                .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                .foregroundStyle(isValid ? WatchTheme.primary : WatchTheme.onSurfaceVariant)
+                .disabled(!isValid)
             }
             .navigationTitle("Add Item")
         }
+        .tint(WatchTheme.primary)
     }
 }

--- a/iosApp/ChefMateWatch/ChefMateWatchApp.swift
+++ b/iosApp/ChefMateWatch/ChefMateWatchApp.swift
@@ -9,6 +9,7 @@ struct ChefMateWatchApp: App {
         WindowGroup {
             RootView()
                 .environmentObject(store)
+                .tint(WatchTheme.primary)
         }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active { store.refresh() }

--- a/iosApp/ChefMateWatch/GroceryItemsView.swift
+++ b/iosApp/ChefMateWatch/GroceryItemsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
-/// Second screen: view items for the selected list, toggle them, and add new ones.
+/// Second screen: view items for the selected list grouped by aisle (with sticky category headers,
+/// mirroring the Compose grocery list), toggle them, and add new ones.
 struct GroceryItemsView: View {
     let listId: Int64
     let title: String
@@ -8,41 +9,101 @@ struct GroceryItemsView: View {
     @EnvironmentObject private var store: GroceryStore
     @State private var showingAdd = false
 
-    private var items: [WatchGroceryItem] { store.items(for: listId) }
+    private var groups: [WatchGroceryGroup] { store.items(for: listId).groupedByAisle() }
 
     var body: some View {
         List {
             Section {
-                Button {
-                    showingAdd = true
-                } label: {
-                    Label("Add item", systemImage: "plus.circle.fill")
-                }
+                AddItemRow { showingAdd = true }
             }
+            .listRowInsets(EdgeInsets())
+            .listRowBackground(Color.clear)
 
-            ForEach(items, id: \.id) { item in
-                Button {
-                    store.setChecked(itemId: item.id, isChecked: !item.isChecked)
-                } label: {
-                    HStack {
-                        Image(systemName: item.isChecked ? "checkmark.circle.fill" : "circle")
-                            .foregroundStyle(item.isChecked ? .green : .secondary)
-                        VStack(alignment: .leading) {
-                            Text(item.name)
-                                .strikethrough(item.isChecked)
-                            if let quantity = item.quantity, !quantity.isEmpty {
-                                Text(quantity).font(.footnote).foregroundStyle(.secondary)
-                            }
+            ForEach(groups) { group in
+                Section {
+                    ForEach(group.items, id: \.id) { item in
+                        GroceryItemRow(item: item) {
+                            store.setChecked(itemId: item.id, isChecked: !item.isChecked)
                         }
                     }
+                } header: {
+                    CategoryHeader(title: group.title)
                 }
             }
         }
+        .listStyle(.plain)
         .navigationTitle(title)
         .sheet(isPresented: $showingAdd) {
             AddItemView { name in
                 store.addItem(listId: listId, name: name)
             }
         }
+    }
+}
+
+/// Sticky section header styled like the Compose `CategoryHeader` (surfaceVariant pill,
+/// onSurfaceVariant label).
+private struct CategoryHeader: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(WatchTheme.onSurfaceVariant)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(WatchTheme.surfaceVariant, in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+/// A single grocery row: a Material-style checkbox, the item name, and its quantity subtitle.
+private struct GroceryItemRow: View {
+    let item: WatchGroceryItem
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 10) {
+                Image(systemName: item.isChecked ? "checkmark.square.fill" : "square")
+                    .font(.title3)
+                    .foregroundStyle(item.isChecked ? WatchTheme.primary : WatchTheme.onSurfaceVariant)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.name)
+                        .foregroundStyle(item.isChecked ? WatchTheme.onSurfaceVariant : WatchTheme.onSurface)
+                        .strikethrough(item.isChecked)
+                    if let quantity = item.quantity, !quantity.isEmpty {
+                        Text(quantity)
+                            .font(.footnote)
+                            .foregroundStyle(WatchTheme.onSurfaceVariant)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Primary "Add item" affordance styled with the app's accent.
+private struct AddItemRow: View {
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 8) {
+                Image(systemName: "plus.circle.fill")
+                Text("Add item").fontWeight(.medium)
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(WatchTheme.primary)
+            .padding(.vertical, 6)
+            .padding(.horizontal, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(WatchTheme.primary.opacity(0.15), in: RoundedRectangle(cornerRadius: 12))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/iosApp/ChefMateWatch/GroceryItemsView.swift
+++ b/iosApp/ChefMateWatch/GroceryItemsView.swift
@@ -12,26 +12,37 @@ struct GroceryItemsView: View {
     private var groups: [WatchGroceryGroup] { store.items(for: listId).groupedByAisle() }
 
     var body: some View {
-        List {
-            Section {
-                AddItemRow { showingAdd = true }
-            }
-            .listRowInsets(EdgeInsets())
-            .listRowBackground(Color.clear)
+        // The list extends edge-to-edge horizontally so category headers can run the full width of
+        // the screen; `hInset` is the horizontal safe-area inset we then re-apply to the actual
+        // content (row + header text) so text still clears the display's rounded corners.
+        GeometryReader { proxy in
+            let hInset = max(proxy.safeAreaInsets.leading, proxy.safeAreaInsets.trailing, 8)
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 6, pinnedViews: [.sectionHeaders]) {
+                    AddItemRow { showingAdd = true }
+                        .padding(.horizontal, hInset)
+                        .padding(.top, 2)
 
-            ForEach(groups) { group in
-                Section {
-                    ForEach(group.items, id: \.id) { item in
-                        GroceryItemRow(item: item) {
-                            store.setChecked(itemId: item.id, isChecked: !item.isChecked)
+                    ForEach(groups) { group in
+                        Section {
+                            ForEach(Array(group.items.enumerated()), id: \.element.id) { index, item in
+                                GroceryItemRow(item: item) {
+                                    store.setChecked(itemId: item.id, isChecked: !item.isChecked)
+                                }
+                                .padding(.horizontal, hInset)
+                                if index < group.items.count - 1 {
+                                    Divider().padding(.leading, hInset)
+                                }
+                            }
+                        } header: {
+                            CategoryHeader(title: group.title, textInset: hInset)
                         }
                     }
-                } header: {
-                    CategoryHeader(title: group.title)
                 }
+                .padding(.bottom, 8)
             }
         }
-        .listStyle(.plain)
+        .ignoresSafeArea(.container, edges: .horizontal)
         .navigationTitle(title)
         .sheet(isPresented: $showingAdd) {
             AddItemView { name in
@@ -41,19 +52,20 @@ struct GroceryItemsView: View {
     }
 }
 
-/// Sticky section header styled like the Compose `CategoryHeader` (surfaceVariant pill,
-/// onSurfaceVariant label).
+/// Sticky section header styled like the Compose `CategoryHeader`: a surfaceVariant bar that spans
+/// the full screen width, with the label inset by the safe area so it lines up with the item text.
 private struct CategoryHeader: View {
     let title: String
+    let textInset: CGFloat
 
     var body: some View {
         Text(title)
             .font(.footnote.weight(.semibold))
             .foregroundStyle(WatchTheme.onSurfaceVariant)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 10)
+            .padding(.horizontal, textInset)
             .padding(.vertical, 5)
-            .background(WatchTheme.surfaceVariant, in: RoundedRectangle(cornerRadius: 8))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(WatchTheme.surfaceVariant)
     }
 }
 
@@ -80,6 +92,7 @@ private struct GroceryItemRow: View {
                 }
                 Spacer(minLength: 0)
             }
+            .padding(.vertical, 4)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/iosApp/ChefMateWatch/GroceryListsView.swift
+++ b/iosApp/ChefMateWatch/GroceryListsView.swift
@@ -8,15 +8,21 @@ struct GroceryListsView: View {
         List {
             if store.lists.isEmpty {
                 Text("No grocery lists yet.")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WatchTheme.onSurfaceVariant)
             } else {
                 ForEach(store.lists, id: \.id) { list in
                     NavigationLink(value: list.id) {
-                        Label(list.name, systemImage: list.isShared ? "person.2" : "cart")
+                        Label {
+                            Text(list.name).foregroundStyle(WatchTheme.onSurface)
+                        } icon: {
+                            Image(systemName: list.isShared ? "person.2.fill" : "cart.fill")
+                                .foregroundStyle(WatchTheme.primary)
+                        }
                     }
                 }
             }
         }
+        .listStyle(.plain)
         .navigationTitle("Lists")
         .navigationDestination(for: Int64.self) { listId in
             GroceryItemsView(

--- a/iosApp/ChefMateWatch/WatchModels.swift
+++ b/iosApp/ChefMateWatch/WatchModels.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 /// Native mirror of the JSON snapshot the phone sends over WatchConnectivity. The watch holds no
 /// Kotlin/Supabase — the phone (source of truth) serializes its grocery data into this shape.
@@ -28,5 +29,81 @@ struct WatchGroceryItem: Codable, Identifiable, Hashable {
             id: id, listId: listId, name: name, quantity: quantity, category: category,
             isChecked: !isChecked
         )
+    }
+}
+
+// MARK: - Material Expressive theme
+
+/// Colours lifted from the shared Compose `ChefMateTheme` dark palette so the watch reads as the
+/// same app as the phone/desktop/web clients (`purple200` primary, `teal200` secondary, plus the
+/// Material 3 dark neutrals the scheme fills in). watchOS is always dark, so we only need the dark
+/// values.
+enum WatchTheme {
+    static let primary = Color(red: 0xBB / 255, green: 0x86 / 255, blue: 0xFC / 255) // purple200
+    static let secondary = Color(red: 0x03 / 255, green: 0xDA / 255, blue: 0xC5 / 255) // teal200
+    static let surfaceVariant = Color(red: 0x49 / 255, green: 0x45 / 255, blue: 0x4F / 255)
+    static let onSurface = Color(red: 0xE6 / 255, green: 0xE1 / 255, blue: 0xE5 / 255)
+    static let onSurfaceVariant = Color(red: 0xCA / 255, green: 0xC4 / 255, blue: 0xD0 / 255)
+    static let primaryContainer = Color(red: 0x4F / 255, green: 0x37 / 255, blue: 0x8B / 255)
+}
+
+// MARK: - Categories (mirrors the shared `GroceryCategory` enum + `displayName()`)
+
+/// A category as it arrives from the phone (the Kotlin `GroceryCategory.name`), paired with the
+/// display label and aisle order used by the Compose clients so the watch groups items identically.
+enum WatchGroceryCategory: String, CaseIterable {
+    case produce = "PRODUCE"
+    case dairy = "DAIRY"
+    case meat = "MEAT"
+    case bakery = "BAKERY"
+    case frozen = "FROZEN"
+    case cannedGoods = "CANNED_GOODS"
+    case condiments = "CONDIMENTS"
+    case snacks = "SNACKS"
+    case beverages = "BEVERAGES"
+    case grains = "GRAINS"
+    case baking = "BAKING"
+    case spices = "SPICES"
+    case other = "OTHER"
+
+    var displayName: String {
+        switch self {
+        case .produce: return "Produce"
+        case .dairy: return "Dairy"
+        case .meat: return "Meat & Seafood"
+        case .bakery: return "Bakery"
+        case .frozen: return "Frozen"
+        case .cannedGoods: return "Canned Goods"
+        case .condiments: return "Condiments & Sauces"
+        case .snacks: return "Snacks"
+        case .beverages: return "Beverages"
+        case .grains: return "Grains & Pasta"
+        case .baking: return "Baking"
+        case .spices: return "Spices & Seasonings"
+        case .other: return "Other"
+        }
+    }
+}
+
+/// One aisle's worth of items, ready to render as a sticky-header section.
+struct WatchGroceryGroup: Identifiable {
+    let category: WatchGroceryCategory
+    let items: [WatchGroceryItem]
+    var id: String { category.rawValue }
+    var title: String { category.displayName }
+}
+
+extension Array where Element == WatchGroceryItem {
+    /// Groups items by aisle and orders the groups the way the phone does (by the shared enum's
+    /// declaration order), preserving each item's incoming order within a group. Any unrecognised
+    /// category falls into `OTHER`.
+    func groupedByAisle() -> [WatchGroceryGroup] {
+        let buckets = Dictionary(grouping: self) {
+            WatchGroceryCategory(rawValue: $0.category) ?? .other
+        }
+        return WatchGroceryCategory.allCases.compactMap { category in
+            guard let items = buckets[category], !items.isEmpty else { return nil }
+            return WatchGroceryGroup(category: category, items: items)
+        }
     }
 }


### PR DESCRIPTION
## What

Restyles the watchOS SwiftUI grocery app so it reads as the same app as the Compose (Android/iOS/Desktop/Web) clients, and groups items by aisle with **sticky category headers** — mirroring the phone grocery list.

## Why

The watch companion was a plain, unstyled SwiftUI list (green checkmarks, flat item list, no grouping) that looked nothing like the Material Expressive design the rest of the clients share. This brings it in line: same palette, same iconography, same aisle grouping.

## Changes

- **`WatchTheme`** — colors lifted from the shared `ChefMateTheme` dark palette (`purple200` primary, `teal200` secondary, and the Material 3 dark neutrals `surfaceVariant`/`onSurface`/`onSurfaceVariant`). watchOS is always dark, so only the dark values are needed.
- **`WatchGroceryCategory` + `groupedByAisle()`** — mirrors the shared `GroceryCategory` enum, its `displayName()` strings ("Meat & Seafood", "Grains & Pasta", …), and the phone's aisle ordering (enum declaration order), so the watch groups items identically to the phone.
- **Grocery items screen** — now renders `List` sections with sticky category headers (surfaceVariant pill, onSurfaceVariant label) and Material-style checkbox rows: filled purple `checkmark.square.fill` when checked, outline `square` when not, strikethrough + dimmed name on check, and a quantity subtitle — matching Compose's `GroceryDisplayListItem`. "Add item" is now an accent pill.
- **Lists screen / Add Item sheet / app root** — accent-tinted controls and themed cart/people iconography.

## Notes for reviewers

- **No phone-side changes.** Category, quantity, and grouping all come from the JSON snapshot the phone already sends via `WatchDataBridge` (`category = it.category.name`), so nothing on the Kotlin/data side moved.
- The category display names and aisle order are duplicated in Swift because the watch holds no Kotlin — kept intentionally in lockstep with `GroceryCategory` / `GroceryCategoryTextData`.

## Verification

Built the `ChefMateWatch` scheme for the watchOS 26 simulator (BUILD SUCCEEDED) and ran it with temporary sample data to confirm visually: lists screen, "Produce" sticky header with checkbox rows + quantities, and checked-item styling (purple fill + strikethrough). All temporary seed scaffolding was removed and the final code rebuilds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)