### PR TITLE
fix(macos): declare min macOS 12.0 so the arm64-only App Store build validates

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -323,6 +323,11 @@ compose.desktop {
                 // is required for Store submission.
                 appStore = true
                 appCategory = "public.app-category.food-and-drink"
+                // The App Store build is arm64-only (jpackage produces a single-arch app with a
+                // bundled arm64 JRE). Apple accepts an arm64-only Mac app only if it declares a
+                // minimum macOS of 12.0+ (LSMinimumSystemVersion) — otherwise it demands a
+                // universal arm64+x86_64 binary. This drops Intel Mac support.
+                minimumSystemVersion = "12.0"
 
                 iconFile.set(project.file("src/jvmMain/resources/app-icon.icns"))
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -455,6 +455,13 @@ sandbox-inherit + JVM exceptions), wired via `entitlementsFile` / `runtimeEntitl
 
 **Reused secrets:** `MATCH_PASSWORD`, `MATCH_GIT_BASIC_AUTHORIZATION`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_API_KEY`, `APPLE_TEAM_ID` (no new secrets required).
 
+**Architecture — arm64 only (Intel Macs not supported).** CI builds on an Apple-Silicon runner, so
+jpackage produces an **arm64-only** app with a bundled arm64 JRE. App Store Connect rejects an
+arm64-only Mac app unless it declares a minimum macOS of 12.0+, so `macOS.minimumSystemVersion =
+"12.0"` is set in `build.gradle.kts` (`LSMinimumSystemVersion`). Supporting Intel would require a
+universal (arm64+x86_64) binary — a much larger change (build both arches + a universal JRE, `lipo`
+them) that jpackage does not do natively.
+
 **Validating signing without a release.** The `macos` job also runs on **workflow_dispatch**
 (Actions → Desktop Release → Run workflow). A manual run **builds + signs** the `.pkg` and uploads it
 as a `desktop-macos-pkg` artifact, but sets `MAC_UPLOAD=false` so it does **not** push to App Store


### PR DESCRIPTION
## Why

The `v1.9.27` tag built, signed, and **uploaded** the Mac App Store `.pkg` successfully — but Apple's server-side validation rejected it:

> Invalid bundle. The "Chef Mate.app" bundle supports arm64 but not Intel-based Mac computers. Your build must include the x86_64 architecture … To support arm64 only, your macOS deployment target must be 12.0 or higher.

CI builds on an Apple-Silicon runner, so jpackage emits an **arm64-only** app with a bundled arm64 JRE. Apple accepts arm64-only Mac apps only if they declare a minimum macOS of 12.0+.

## Change

Set `macOS.minimumSystemVersion = "12.0"` in `build.gradle.kts` (→ `LSMinimumSystemVersion`).

## Trade-off

**Intel Macs are not supported.** Reasonable for a modern app (macOS 12 = 2021; all Apple Silicon Macs qualify). A universal binary would be a much larger change — build both arches + a universal JRE and `lipo` them, which jpackage doesn't do natively. Flagging in case Intel support is a hard requirement.

Everything upstream of Apple's validation is now proven working (build → sign → upload). After merge, cut the next tag and the upload should pass validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)