### PR TITLE
fix(macos): sign application-identifier into the bundle for TestFlight

### DIFF
--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -10,6 +10,21 @@
     <key>com.apple.security.app-sandbox</key>
     <true/>
 
+    <!--
+      App Store / TestFlight identity. Xcode normally injects these into the signature from the
+      provisioning profile; jpackage signs with this static file instead, so they must be declared
+      here or Apple rejects the build ("signature … is missing an application identifier but has an
+      application identifier in the provisioning profile"). The values are the Team ID + the app's
+      bundle id — must match `macOS.bundleID` and the team the profile is issued to. The profile also
+      carries associated-domains / application-groups / keychain-access-groups (inherited from the
+      shared iOS App ID), but the desktop app doesn't use them, so they are intentionally NOT signed
+      in — only the identifiers have to match.
+    -->
+    <key>com.apple.application-identifier</key>
+    <string>Y89258SF5P.com.plusmobileapps.chefmate.ChefMate</string>
+    <key>com.apple.developer.team-identifier</key>
+    <string>Y89258SF5P</string>
+
     <!-- Outbound network: Supabase sync/auth, the update feed on Linux, Bugsnag, and the recipe
          browser's WebView all make client HTTP requests. -->
     <key>com.apple.security.network.client</key>


### PR DESCRIPTION
## Why

The `v1.9.28` Mac App Store build **uploaded successfully**, but App Store Connect flagged it TestFlight-ineligible:

> error 90886: the signature for the bundle at "Chef Mate.app" is missing an application identifier but has an application identifier in the provisioning profile … Bundles … are expected to have the same identifier signed into the bundle.

Xcode normally injects `application-identifier` (and `team-identifier`) into the code signature from the provisioning profile. jpackage signs with our **static** `entitlements.plist`, which didn't have them — so the embedded profile had an app-identifier but the signature didn't.

## Change

Add to `packaging/macos/entitlements.plist` (confirmed against the profile's `Entitlements` dict):

```xml
<key>com.apple.application-identifier</key>
<string>Y89258SF5P.com.plusmobileapps.chefmate.ChefMate</string>
<key>com.apple.developer.team-identifier</key>
<string>Y89258SF5P</string>
```

The profile also carries `associated-domains`, `application-groups`, and `keychain-access-groups` (inherited from the shared iOS App ID), but the desktop app doesn't use those capabilities, so they're intentionally left out of the signature — only the identifiers must match.

## Verify

Signing is unchanged otherwise. Optional local check: `packageReleasePkg` then `codesign -d --entitlements :- "…/Chef Mate.app"` should now list `com.apple.application-identifier`. After merge, cut the next tag and the uploaded build should become TestFlight-eligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)