### PR TITLE
fix(macos): bundle sqlite-jdbc native lib into the signed app (App Store sandbox)

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.util.Properties
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -275,6 +276,11 @@ compose.desktop {
             description = "Chef Mate - Your AI Cooking Assistant"
             vendor = "Plus Mobile Apps"
 
+            // Staged app resources. The macOS-arm64 subdir gets the sqlite-jdbc native lib
+            // (see `extractSqliteJdbcMacDylib` at the bottom of this file) so it ships inside the
+            // signed .app instead of being extracted to an unsigned temp file at runtime.
+            appResourcesRootDir.set(layout.buildDirectory.dir("appResources"))
+
             // jdk.unsupported.desktop provides jdk.swing.interop.SwingInterOpUtils, which
             // JavaFX's Swing interop (JFXPanel, used by the desktop browser's WebView) loads at
             // runtime. Without it the jlink/jpackage runtime image omits the class and the browser
@@ -383,3 +389,48 @@ compose.desktop {
         }
     }
 }
+
+// --- Bundle the sqlite-jdbc macOS native library into the signed app image ---
+// The Mac App Store build is sandboxed, which forbids loading code that isn't part of the signed
+// bundle. sqlite-jdbc (pulled by SQLDelight's JVM driver) otherwise extracts its native .dylib to a
+// temp dir at runtime and dlopen()s it, which the sandbox blocks ("could not verify … free of
+// malware"). Extract the arm64 .dylib from the sqlite-jdbc jar into the Compose app-resources dir
+// so
+// jpackage code-signs it into the bundle; DriverFactory.jvm.kt then points sqlite-jdbc at this copy
+// (org.sqlite.lib.path) so it loads the signed lib instead of extracting an unsigned one.
+val sqliteJdbcNative: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+dependencies {
+    // sqldelight-drivers-jvm (app.cash.sqldelight:sqlite-driver) pulls org.xerial:sqlite-jdbc.
+    sqliteJdbcNative(libs.sqldelight.drivers.jvm)
+}
+
+val extractSqliteJdbcMacDylib by
+    tasks.registering(Sync::class) {
+        val sqliteJdbcJars =
+            sqliteJdbcNative.incoming
+                .artifactView {
+                    componentFilter {
+                        it is ModuleComponentIdentifier && it.moduleIdentifier.name == "sqlite-jdbc"
+                    }
+                }
+                .files
+        from(sqliteJdbcJars.map { zipTree(it) }) {
+            include("org/sqlite/native/Mac/aarch64/libsqlitejdbc.dylib")
+            // Flatten into the Compose macos-arm64 resources dir (staged into the app for that
+            // target).
+            eachFile { path = "macos-arm64/libsqlitejdbc.dylib" }
+            includeEmptyDirs = false
+        }
+        into(layout.buildDirectory.dir("appResources"))
+    }
+
+// Ensure the native lib is staged before Compose copies app resources into the image.
+tasks
+    .matching { it.name == "prepareAppResources" }
+    .configureEach {
+        dependsOn(extractSqliteJdbcMacDylib)
+    }

--- a/client/database/core/src/jvmMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.jvm.kt
+++ b/client/database/core/src/jvmMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.jvm.kt
@@ -8,6 +8,8 @@ import java.util.Properties
 
 actual class DriverFactory {
     actual fun createDriver(): SqlDriver {
+        useBundledSqliteNativeLibIfPresent()
+
         val dbPath = getAppDataDirectory()
         dbPath.mkdirs()
         val dbFile = File(dbPath, "chefmate.db")
@@ -18,6 +20,27 @@ actual class DriverFactory {
                 schema = Database.Schema,
             )
             .also { it.execute(null, "PRAGMA foreign_keys = ON", 0) }
+    }
+
+    /**
+     * On the macOS App Store build, load sqlite-jdbc's native lib from the signed app bundle
+     * instead of letting it extract an unsigned copy to a temp dir at runtime. The App Store
+     * sandbox forbids loading code that isn't part of the signed bundle, so the default
+     * extract-and-dlopen path is blocked ("could not verify … free of malware"). The build stages
+     * the `.dylib` into Compose's app-resources dir (see composeApp/build.gradle.kts
+     * `extractSqliteJdbcMacDylib`); point sqlite-jdbc at it via `org.sqlite.lib.path`/`name` so it
+     * never extracts. No-op on other platforms and in `./gradlew run` (where the lib isn't staged
+     * and the process isn't sandboxed).
+     */
+    private fun useBundledSqliteNativeLibIfPresent() {
+        val os = System.getProperty("os.name").orEmpty().lowercase()
+        if (!os.contains("mac") && !os.contains("darwin")) return
+        val resourcesDir = System.getProperty("compose.application.resources.dir") ?: return
+        val nativeLib = File(resourcesDir, "libsqlitejdbc.dylib")
+        if (nativeLib.exists()) {
+            System.setProperty("org.sqlite.lib.path", resourcesDir)
+            System.setProperty("org.sqlite.lib.name", nativeLib.name)
+        }
     }
 
     private fun getAppDataDirectory(): File {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -462,6 +462,15 @@ arm64-only Mac app unless it declares a minimum macOS of 12.0+, so `macOS.minimu
 universal (arm64+x86_64) binary — a much larger change (build both arches + a universal JRE, `lipo`
 them) that jpackage does not do natively.
 
+**Native libraries must be bundled + signed (App Store sandbox).** A sandboxed App Store app can only
+load code that's part of its signed bundle. `sqlite-jdbc` (via SQLDelight's JVM driver) otherwise
+extracts its native `libsqlitejdbc.dylib` to a temp dir at runtime and `dlopen`s it, which the
+sandbox blocks at launch ("could not verify … free of malware"). The `extractSqliteJdbcMacDylib` task
+in `build.gradle.kts` stages the arm64 `.dylib` into Compose's app resources so jpackage signs it
+into the bundle, and `DriverFactory.jvm.kt` points sqlite-jdbc at it via `org.sqlite.lib.path` so it
+loads the signed copy instead of extracting. Any **other** JVM library that extracts native code at
+runtime will hit the same wall and need the same treatment.
+
 **Validating signing without a release.** The `macos` job also runs on **workflow_dispatch**
 (Actions → Desktop Release → Run workflow). A manual run **builds + signs** the `.pkg` and uploads it
 as a `desktop-macos-pkg` artifact, but sets `MAC_UPLOAD=false` so it does **not** push to App Store


### PR DESCRIPTION
## Why

The `v1.9.28` build reached TestFlight but **fails to launch**:

> Apple could not verify "sqlite-…-libsqlitejdbc.dylib" is free of malware…

A sandboxed App Store app can only load code that's part of its **signed bundle**. `sqlite-jdbc` (pulled by SQLDelight's JVM driver in [DriverFactory.jvm.kt](client/database/core/src/jvmMain/kotlin/com/plusmobileapps/chefmate/client/database/DriverFactory.jvm.kt)) ships its native `.dylib` inside its jar and, at first DB access, **extracts it to a temp dir and `dlopen`s it** (the UUID in the filename is the runtime-extracted copy). The sandbox blocks that unsigned, out-of-bundle load. This was the "bundled-JRE + native libs + sandbox" risk flagged from the start.

## Fix

Ship the native lib **inside the signed app** and load it from there:

- **Build** (`composeApp/build.gradle.kts`): new `extractSqliteJdbcMacDylib` task pulls the arm64 `libsqlitejdbc.dylib` out of the resolved `sqlite-jdbc` jar into Compose's `appResourcesRootDir/macos-arm64/`, so jpackage code-signs it into the app image. Version-agnostic (extracts by internal path).
- **Runtime** (`DriverFactory.jvm.kt`): before creating the driver, on macOS set `org.sqlite.lib.path` = Compose's resources dir + `org.sqlite.lib.name = libsqlitejdbc.dylib`, so sqlite-jdbc loads the signed bundled copy and never extracts.

No-op on Windows/Linux and in `./gradlew run` (guarded on macOS + the lib being present).

## Verified locally

- `extractSqliteJdbcMacDylib` produces a real `Mach-O …arm64` dylib at `build/appResources/macos-arm64/libsqlitejdbc.dylib`.
- Task graph: `extractSqliteJdbcMacDylib` → `prepareAppResources` → `packageReleasePkg`.
- `:client:database:core:compileKotlinJvm` passes.

Full confirmation requires one more TestFlight upload (runtime sandbox behavior). Stack it with #455 (min-version) and #457 (app-identifier); then tag → the build should launch in TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)