### PR TITLE
fix(macos): declare no non-exempt encryption in packaged Info.plist

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -337,6 +337,18 @@ compose.desktop {
 
                 iconFile.set(project.file("src/jvmMain/resources/app-icon.icns"))
 
+                // Declares no non-exempt encryption (matches iosApp/iosApp/Info.plist), so App
+                // Store Connect skips the manual export-compliance prompt before each TestFlight
+                // build is available to testers.
+                infoPlist {
+                    extraKeysRawXml =
+                        """
+                        <key>ITSAppUsesNonExemptEncryption</key>
+                        <false/>
+                        """
+                            .trimIndent()
+                }
+
                 // App Sandbox is mandatory for the Mac App Store. The app and the bundled JRE are
                 // signed as separate nested bundles, so each gets its own entitlements: the app
                 // opts into the sandbox + the capabilities it actually uses (network client, user-


### PR DESCRIPTION
## Summary
- macOS packaging (`client/composeApp/build.gradle.kts`) now sets `ITSAppUsesNonExemptEncryption = false` via Compose Multiplatform's `infoPlist { extraKeysRawXml }` block, matching what `iosApp/iosApp/Info.plist` already declares.
- App Store Connect reads the export-compliance answer straight from the build's Info.plist, so it no longer prompts to manually confirm "no encryption" before each TestFlight build becomes available to testers.

## Test plan
- [x] `./gradlew :client:composeApp:tasks --offline` — build script parses and evaluates successfully.
- [x] `ktfmt --kotlinlang-style` — no formatting changes needed (matches repo's pre-commit style).
- [ ] Verify in App Store Connect that the next TestFlight build skips the manual encryption-compliance prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)