### PR TITLE
fix(recipe): drop duplicate status-bar inset in the add-to-grocery sheet

### DIFF
--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListScreen.kt
@@ -1,8 +1,12 @@
 package com.plusmobileapps.chefmate.recipe.core.addgrocery
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -50,6 +54,10 @@ fun AddRecipeToGroceryListScreen(bloc: AddRecipeToGroceryListBloc, modifier: Mod
                 title = stringResource(Res.string.recipe_add_to_grocery_list).asTextData(),
                 onCloseClick = bloc::onBackClicked,
             ),
+        // This screen only ever renders inside the recipe detail's bottom sheet, whose drag handle
+        // already accounts for the status bar. Without dropping the top inset the app bar adds a
+        // second status-bar gap between the drag handle and the title.
+        headerWindowInsets = WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal),
         scrollEnabled = false,
         floatingActionButton = {
             if (!state.isLoading && state.hasSelectedIngredients) {
@@ -133,7 +141,8 @@ private fun GroceryListSelector(
             label = { Text(stringResource(Res.string.recipe_add_to_grocery_list_select_list)) },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             modifier =
-                Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
+                Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                    .fillMaxWidth(),
         )
         ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             groceryLists.forEach { list ->

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusHeaderContainer.kt
@@ -77,6 +77,11 @@ fun PlusHeaderContainer(
     floatingHeader: Boolean = false,
     headerContainerAlpha: Float = 1f,
     centerAlignTitle: Boolean = false,
+    // Insets applied to the header itself. Defaults to null, which lets [PlusHeader] reserve the
+    // status bar at the top. Pass insets without a top component when the container is hosted
+    // somewhere already below the status bar (e.g. inside a ModalBottomSheet, where the drag handle
+    // owns that spacing) so the app bar doesn't add a second gap. Ignored when [floatingHeader].
+    headerWindowInsets: WindowInsets? = null,
     // When true the container reserves status-bar + app-bar space at the top *and* applies
     // horizontal display-cutout padding to the content. Pass false when the content manages all
     // its own insets (e.g. Cook Mode applies horizontal insets per body region) so the cutout
@@ -146,7 +151,7 @@ fun PlusHeaderContainer(
             horizontalAlignment = horizontalAlignment,
         ) {
             if (data !is PlusHeaderData.None) {
-                PlusHeader(data = data)
+                PlusHeader(data = data, windowInsets = headerWindowInsets)
             }
 
             Surface(


### PR DESCRIPTION
## What

The "Add to grocery list" bottom sheet, opened from recipe detail, showed an empty gap between the drag handle and the top of its app bar.

## Why

`RecipeDetailSheet` supplies a custom `dragHandle` that already inserts a status-bar-height spacer and zeroes the sheet's `contentWindowInsets`. But `PlusHeader` defaults its `TopAppBar` insets to include `statusBars.getTop(density)`, so the app bar reserved that height a second time — directly below the drag handle.

## How

- `PlusHeaderContainer` gains an optional `headerWindowInsets: WindowInsets?`, forwarded to `PlusHeader` in the non-floating branch. The default `null` preserves today's behavior for every other caller, including full-screen modals like Cook Mode, Browser, and Edit Recipe Book.
- `AddRecipeToGroceryListScreen` passes horizontal display-cutout insets only, dropping the duplicate top inset. That screen is only ever rendered inside this sheet (`AddRecipeToGroceryListBloc.Content`), so hard-coding it there is safe.

## Reviewer notes

- No snapshot coverage change: `ModalBottomSheet` doesn't render reliably under the Compose screenshot plugin, and insets are zero in the screenshot host, so this is invisible to snapshot tests. The fix is verified by the inset math rather than a rendered reference — worth an eyeball on a device with a status bar / notch.
- `:client:recipe:core:public:compileKotlinIosSimulatorArm64` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)