### PR TITLE
fix(auth): unbreak account creation — signup trigger search_path + OTP onboarding completion

### DIFF
--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -13,6 +13,7 @@ import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
+import com.arkivanov.decompose.router.stack.popWhile
 import com.arkivanov.decompose.router.stack.replaceAll
 import com.arkivanov.decompose.router.stack.replaceCurrent
 import com.arkivanov.decompose.value.Value
@@ -709,18 +710,7 @@ class RootBlocImpl(
     private fun handleAuthenticationOutput(output: AuthenticationBloc.Output) {
         when (output) {
             AuthenticationBloc.Output.Finished -> navigation.pop()
-            AuthenticationBloc.Output.AuthenticationSuccess -> {
-                val cameFromOnboarding =
-                    stack.value.items.any { it.instance is RootBloc.Child.Onboarding }
-                if (cameFromOnboarding) {
-                    // Signing in from onboarding counts as finishing it: mark complete and drop the
-                    // whole onboarding + auth stack so back can't return to the flow.
-                    onboardingRepository.setOnboardingCompleted()
-                    navigation.replaceAll(Configuration.BottomNavigation)
-                } else {
-                    navigation.pop()
-                }
-            }
+            AuthenticationBloc.Output.AuthenticationSuccess -> finishAuthentication()
             is AuthenticationBloc.Output.EmailVerificationRequired ->
                 navigation.bringToFront(
                     Configuration.OtpVerification(email = output.email, flow = OtpFlow.SignUp)
@@ -743,8 +733,33 @@ class RootBlocImpl(
 
     private fun handleOtpOutput(output: OtpBloc.Output) {
         when (output) {
-            OtpBloc.Output.Verified -> navigation.bringToFront(Configuration.BottomNavigation)
+            // Verifying the code is the last step of sign up / passwordless sign in, so it lands
+            // the
+            // user in the same place a password sign-in does — not on top of the auth stack.
+            OtpBloc.Output.Verified -> finishAuthentication()
             OtpBloc.Output.Cancelled -> navigation.pop()
+        }
+    }
+
+    /**
+     * Leaves the authentication flow after the user is signed in, whether that finished at the
+     * credentials screen (sign in) or at the OTP screen (sign up / passwordless).
+     *
+     * Signing in from onboarding counts as finishing it: mark complete and drop the whole
+     * onboarding
+     * + auth stack so back can't return to the flow, and so the next launch doesn't gate the
+     *   now-signed-in user behind onboarding again. Otherwise just unwind the auth screens,
+     *   preserving whatever the user was doing underneath (e.g. a deep-linked recipe).
+     */
+    private fun finishAuthentication() {
+        val cameFromOnboarding = stack.value.items.any { it.instance is RootBloc.Child.Onboarding }
+        if (cameFromOnboarding) {
+            onboardingRepository.setOnboardingCompleted()
+            navigation.replaceAll(Configuration.BottomNavigation)
+        } else {
+            navigation.popWhile {
+                it is Configuration.Authentication || it is Configuration.OtpVerification
+            }
         }
     }
 

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -256,6 +256,32 @@ class RootBlocTest {
     }
 
     @Test
+    fun When_sign_up_otp_verified_from_onboarding_Then_bottom_nav_replaces_stack_and_completes() {
+        val root = createRoot(onboardingCompleted = false)
+        onboardingOutput.onNext(OnboardingRootBloc.Output.SignUp)
+        authOutput.onNext(AuthenticationBloc.Output.EmailVerificationRequired(EMAIL))
+        root.instance() should instanceOf<RootBloc.Child.OtpVerification>()
+
+        otpOutput.onNext(OtpBloc.Output.Verified)
+
+        root.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+        root.state.value.backStack.size shouldBe 0
+        onboardingRepository.hasCompletedOnboarding shouldBe true
+    }
+
+    @Test
+    fun When_sign_up_otp_verified_in_app_Then_auth_and_otp_screens_are_popped() {
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenSignUp)
+        authOutput.onNext(AuthenticationBloc.Output.EmailVerificationRequired(EMAIL))
+        rootBloc.instance() should instanceOf<RootBloc.Child.OtpVerification>()
+
+        otpOutput.onNext(OtpBloc.Output.Verified)
+
+        rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+        rootBloc.state.value.backStack.size shouldBe 0
+    }
+
+    @Test
     fun When_bottom_nav_outputs_create_recipe_Then_recipe_root_shown_with_create_props() {
         bottomNavOutput.onNext(BottomNavBloc.Output.AddNewRecipe)
         rootBloc.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
@@ -661,3 +687,5 @@ class RootBlocTest {
         recipeProps shouldBe RecipeRootBloc.Props.CreateFromExtracted(extracted, fromAi = true)
     }
 }
+
+private const val EMAIL = "chef@example.com"

--- a/supabase/migrations/20260722_fix_auth_users_trigger_search_path.sql
+++ b/supabase/migrations/20260722_fix_auth_users_trigger_search_path.sql
@@ -1,0 +1,36 @@
+-- Fix sign up failing with "Database error saving new user" (unexpected_failure) on POST /auth/v1/signup.
+--
+-- `migrate_pending_grocery_invitations` runs as an AFTER INSERT trigger on auth.users, so it is
+-- executed by the GoTrue auth server's own database session — not a PostgREST session. That session's
+-- search_path does not include `public`, so the unqualified `grocery_list_members` reference failed to
+-- resolve (42P01). The trigger error aborted the enclosing INSERT, and GoTrue surfaced it as the
+-- generic "Database error saving new user". Every new account creation hit this, including the
+-- anonymous sign-in used by the photo-upload path.
+--
+-- Fix: pin `search_path = public` and schema-qualify, matching every other SECURITY DEFINER function
+-- in these migrations. These two were the only ones missing the pinned search_path.
+
+CREATE OR REPLACE FUNCTION migrate_pending_grocery_invitations()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  UPDATE public.grocery_list_members
+  SET user_id = NEW.id
+  WHERE invited_email = NEW.email AND user_id IS NULL;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Same latent defect, lower blast radius: this one fires on public.grocery_lists, where the caller's
+-- search_path has so far always included `public`. Pin it too rather than leave it depending on that.
+CREATE OR REPLACE FUNCTION auto_add_grocery_list_owner()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  INSERT INTO public.grocery_list_members (list_id, user_id, role, invited_email, status)
+  SELECT NEW.id, NEW.owner_id, 'owner',
+    COALESCE((SELECT email FROM auth.users WHERE id = NEW.owner_id), ''),
+    'accepted'
+  WHERE NEW.owner_id IS NOT NULL;
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
Account creation was failing outright. Two independent defects; the first is the one users hit.

## 1. `Database error saving new user` on every signup (the blocker)

Signup failed server-side with `unexpected_failure` on `POST /auth/v1/signup`:

```
io.github.jan.supabase.auth.exception.AuthRestException: unexpected_failure
Database error saving new user: unexpected_failure
```

`migrate_pending_grocery_invitations` runs as an `AFTER INSERT` trigger on `auth.users`, so it executes in the GoTrue auth server's own database session rather than a PostgREST one. That session's `search_path` does not include `public`, so the function's unqualified `grocery_list_members` reference failed to resolve (42P01). The trigger raised, the enclosing insert rolled back, and GoTrue reported it as the generic "Database error saving new user".

It fails at plan time, so it aborted **every** signup regardless of whether a pending invite actually matched — and it took the anonymous sign-in behind the photo-upload path with it (swallowed there by `ensureSession`'s `Logger.w`).

Fix: pin `SET search_path = public` and schema-qualify. These two were the only `SECURITY DEFINER` functions across all migrations missing the pin — every other one already has it.

`auto_add_grocery_list_owner` has the same defect but fires on `public.grocery_lists` from PostgREST sessions, where `public` has always been on the path. Latent rather than broken; pinned here too rather than left depending on that.

## 2. Sign up completing at the OTP screen never finished onboarding

Separate bug, found while tracing the flow. Signup always routes through OTP verification, but `handleOtpOutput` did something different from the password sign-in path — `bringToFront(BottomNavigation)`, marking nothing complete and unwinding nothing:

- **From onboarding** — stack became `[Onboarding, Authentication, Otp, BottomNav]`. Back walked the user back through the OTP screen into onboarding, and `hasCompletedOnboarding` was never set, so the next launch gated the freshly created account behind onboarding again.
- **From inside the app** — stack reordered to `[Authentication, Otp, BottomNav]`; back returned to a dead OTP screen.

Sign in was unaffected, which is why only account creation misbehaved.

Fix: extract the sign-in completion logic into `finishAuthentication()` and route both `AuthenticationSuccess` and `OtpBloc.Output.Verified` through it. The non-onboarding branch becomes `popWhile { Authentication || OtpVerification }` instead of a bare `pop()`, so it unwinds both auth screens while preserving whatever sits underneath (e.g. a deep-linked recipe) — something a single `pop()` could not do for the OTP path.

## Reviewer notes

- **This PR does not fix prod by itself.** Prod's schema is hand-built and its migration history isn't reconciled with the CLI, so the migration file won't reach it. The two `CREATE OR REPLACE FUNCTION` statements need running against prod directly; they're idempotent. Worth confirming prod's deployed `migrate_pending_grocery_invitations` body actually matches what's in the migration first, since drift means it could differ.
- **The migration is unverified locally** — Docker wasn't running, so `supabase db reset` couldn't be exercised. The diagnosis is from the stack trace plus the fact that this is the only trigger on `auth.users`.
- **Fix 2 is tested**: two new `RootBlocTest` cases covering both entry points. Verified they fail against the previous behavior (2 failed) and pass with the fix (63 passed).
- **Unrelated, worth a second opinion**: `OTP_CODE_LENGTH = 8` in `OtpViewModel` hard-rejects anything that isn't exactly 8 digits before it reaches Supabase. Supabase's default `MAILER_OTP_LENGTH` is 6 and there's no `supabase/config.toml` setting otherwise, so this only works if the dashboard has it set to 8. Left alone — I can't see the project's auth settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)