### PR TITLE
refactor(recipe): rebuild the recipe book picker on the grocery selector pattern

### DIFF
--- a/client/recipe/list/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/robots/RecipeListRobot.kt
+++ b/client/recipe/list/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/robots/RecipeListRobot.kt
@@ -68,6 +68,33 @@ class RecipeListRobot(private val test: ComposeUiTest) {
     fun openBookPicker(): RecipeListRobot = apply {
         test.onNodeWithTag(RecipeListTestTags.BOOK_SELECTOR).performClick()
     }
+
+    // The picker renders in a sheet/popup outside [RecipeListTestTags.SCREEN], so the matchers
+    // below are scoped to the picker's own root tag instead of the screen's.
+
+    private val inBookPicker = hasAnyAncestor(hasTestTag(RecipeListTestTags.BOOK_PICKER))
+
+    fun assertBookListed(name: String): RecipeListRobot = apply {
+        test.waitUntilExactlyOneExists(hasText(name) and inBookPicker)
+        test.onNode(hasText(name) and inBookPicker).assertIsDisplayed()
+    }
+
+    /** Asserts the picker groups collaborators' books under their own "Shared with you" header. */
+    fun assertSharedBooksSectionShown(): RecipeListRobot = apply {
+        test.onNodeWithTag(RecipeListTestTags.BOOK_PICKER_SHARED_HEADER).assertIsDisplayed()
+    }
+
+    fun selectBook(name: String): RecipeListRobot = apply {
+        test.onNode(hasText(name) and inBookPicker).performClick()
+    }
+
+    fun selectAllRecipes(): RecipeListRobot = apply {
+        test.onNodeWithTag(RecipeListTestTags.BOOK_PICKER_ALL_RECIPES).performClick()
+    }
+
+    fun tapCreateBook(): RecipeListRobot = apply {
+        test.onNodeWithTag(RecipeListTestTags.BOOK_PICKER_CREATE).performClick()
+    }
 }
 
 fun ComposeUiTest.recipeList(): RecipeListRobot = RecipeListRobot(this)

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.SyncStatus
+import com.plusmobileapps.chefmate.recipe.list.RecipeBookPickerContent
 import com.plusmobileapps.chefmate.recipe.list.RecipeFilterOption
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc
 import com.plusmobileapps.chefmate.recipe.list.RecipeListItem
@@ -265,6 +266,27 @@ val previewRecipeListBlocScanError: RecipeListBloc =
         )
     )
 
+/**
+ * Books for the picker previews: the user's own books plus two shared with them by collaborators,
+ * so the "Shared with you" section renders.
+ */
+val previewRecipeBooksWithShared: List<RecipeBook> =
+    RecipeBook.Samples +
+        listOf(
+            RecipeBook.Sample.copy(
+                id = 4L,
+                name = "Grandma’s Classics",
+                isDefault = false,
+                isOwnedByCurrentUser = false,
+            ),
+            RecipeBook.Sample.copy(
+                id = 5L,
+                name = "Book Club Bakes",
+                isDefault = false,
+                isOwnedByCurrentUser = false,
+            ),
+        )
+
 @Preview(showBackground = true, heightDp = 1100)
 @Composable
 internal fun RecipeListPreview() {
@@ -287,4 +309,20 @@ internal fun RecipeListCookingTabletPreview() {
 @Composable
 internal fun RecipeListSelectionPreview() {
     ChefMateTheme { RecipeListScreen(bloc = previewRecipeListBlocSelectionMode) }
+}
+
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+internal fun RecipeBookPickerPreview() {
+    ChefMateTheme {
+        RecipeBookPickerContent(
+            books = previewRecipeBooksWithShared,
+            activeBookId = RecipeBook.Sample.id,
+            isAllRecipesSelected = false,
+            onBookSelected = {},
+            onAllRecipesSelected = {},
+            onEditBook = {},
+            onCreateBook = {},
+        )
+    }
 }

--- a/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
@@ -89,7 +89,9 @@
     <string name="recipe_list_book_all_recipes">All recipes</string>
     <string name="recipe_list_book_create">Create new book</string>
     <string name="recipe_list_book_edit">Edit recipe book</string>
-    <string name="recipe_list_book_picker_title">Recipe books</string>
+    <string name="recipe_list_book_my_books">My Books</string>
+    <string name="recipe_list_book_shared_with_you">Shared with you</string>
+    <string name="recipe_list_book_shared_badge">Shared</string>
 
     <!-- Collaboration invite banner -->
     <string name="recipe_list_invite_message">You’ve been invited to “{book}”</string>

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeBookPicker.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeBookPicker.kt
@@ -1,0 +1,228 @@
+package com.plusmobileapps.chefmate.recipe.list
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.MenuBook
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import chefmate.client.recipe.list.public.generated.resources.Res
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_all_recipes
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_create
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_edit
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_my_books
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_shared_badge
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_shared_with_you
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Phone/compact presentation of the recipe-book picker: a modal bottom sheet. ModalBottomSheet
+ * doesn't render reliably under the Compose screenshot test plugin, so snapshots target
+ * [RecipeBookPickerContent] directly.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun RecipeBookPickerSheet(
+    books: List<RecipeBook>,
+    activeBookId: Long?,
+    isAllRecipesSelected: Boolean,
+    onDismiss: () -> Unit,
+    onBookSelected: (Long) -> Unit,
+    onAllRecipesSelected: () -> Unit,
+    onEditBook: (Long) -> Unit,
+    onCreateBook: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        RecipeBookPickerContent(
+            books = books,
+            activeBookId = activeBookId,
+            isAllRecipesSelected = isAllRecipesSelected,
+            onBookSelected = onBookSelected,
+            onAllRecipesSelected = onAllRecipesSelected,
+            onEditBook = onEditBook,
+            onCreateBook = onCreateBook,
+            modifier = Modifier.navigationBarsPadding(),
+        )
+    }
+}
+
+/** Tablet/desktop presentation: a dropdown anchored to the book selector in the header. */
+@Composable
+internal fun RecipeBookPickerDropdown(
+    expanded: Boolean,
+    books: List<RecipeBook>,
+    activeBookId: Long?,
+    isAllRecipesSelected: Boolean,
+    onDismiss: () -> Unit,
+    onBookSelected: (Long) -> Unit,
+    onAllRecipesSelected: () -> Unit,
+    onEditBook: (Long) -> Unit,
+    onCreateBook: () -> Unit,
+) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        RecipeBookPickerContent(
+            books = books,
+            activeBookId = activeBookId,
+            isAllRecipesSelected = isAllRecipesSelected,
+            onBookSelected = onBookSelected,
+            onAllRecipesSelected = onAllRecipesSelected,
+            onEditBook = onEditBook,
+            onCreateBook = onCreateBook,
+        )
+    }
+}
+
+/**
+ * Shared body for both picker presentations, mirroring the grocery list selector: the cross-book
+ * "All recipes" entry, then the user's own books, then the books other people have shared with
+ * them.
+ */
+@Composable
+fun RecipeBookPickerContent(
+    books: List<RecipeBook>,
+    activeBookId: Long?,
+    isAllRecipesSelected: Boolean,
+    onBookSelected: (Long) -> Unit,
+    onAllRecipesSelected: () -> Unit,
+    onEditBook: (Long) -> Unit,
+    onCreateBook: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val myBooks = books.filter { it.isOwnedByCurrentUser }
+    val sharedBooks = books.filter { !it.isOwnedByCurrentUser }
+
+    Column(modifier = modifier.testTag(RecipeListTestTags.BOOK_PICKER)) {
+        ListItem(
+            headlineContent = {
+                Text(
+                    text = stringResource(Res.string.recipe_list_book_all_recipes),
+                    color = selectionColor(isAllRecipesSelected),
+                )
+            },
+            modifier =
+                Modifier.clickable(onClick = onAllRecipesSelected)
+                    .testTag(RecipeListTestTags.BOOK_PICKER_ALL_RECIPES),
+            leadingContent = {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.MenuBook,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = selectionColor(isAllRecipesSelected),
+                )
+            },
+        )
+        HorizontalDivider()
+        SectionHeader(text = stringResource(Res.string.recipe_list_book_my_books))
+        myBooks.forEach { book ->
+            RecipeBookPickerItem(
+                book = book,
+                isSelected = book.id == activeBookId,
+                onBookSelected = onBookSelected,
+                onEditBook = onEditBook,
+            )
+        }
+        HorizontalDivider()
+        ListItem(
+            headlineContent = { Text(stringResource(Res.string.recipe_list_book_create)) },
+            modifier =
+                Modifier.clickable(onClick = onCreateBook)
+                    .testTag(RecipeListTestTags.BOOK_PICKER_CREATE),
+            leadingContent = {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+            },
+        )
+        if (sharedBooks.isNotEmpty()) {
+            HorizontalDivider()
+            SectionHeader(
+                text = stringResource(Res.string.recipe_list_book_shared_with_you),
+                modifier = Modifier.testTag(RecipeListTestTags.BOOK_PICKER_SHARED_HEADER),
+            )
+            sharedBooks.forEach { book ->
+                RecipeBookPickerItem(
+                    book = book,
+                    isSelected = book.id == activeBookId,
+                    onBookSelected = onBookSelected,
+                    onEditBook = onEditBook,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleMedium,
+        modifier =
+            modifier.padding(
+                horizontal = ChefMateTheme.dimens.paddingNormal,
+                vertical = ChefMateTheme.dimens.paddingSmall,
+            ),
+    )
+}
+
+@Composable
+private fun RecipeBookPickerItem(
+    book: RecipeBook,
+    isSelected: Boolean,
+    onBookSelected: (Long) -> Unit,
+    onEditBook: (Long) -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = book.name, color = selectionColor(isSelected))
+                if (!book.isOwnedByCurrentUser) {
+                    Text(
+                        text = stringResource(Res.string.recipe_list_book_shared_badge),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(start = ChefMateTheme.dimens.paddingSmall),
+                    )
+                }
+            }
+        },
+        modifier = Modifier.fillMaxWidth().clickable { onBookSelected(book.id) },
+        trailingContent = {
+            IconButton(onClick = { onEditBook(book.id) }) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = stringResource(Res.string.recipe_list_book_edit),
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun selectionColor(isSelected: Boolean) =
+    if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.FilterList
@@ -101,9 +100,6 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_list_add_on
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_add_recipe
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_apply
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_all_recipes
-import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_create
-import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_edit
-import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_picker_title
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_selector
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_ai
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_appetizer
@@ -295,7 +291,7 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                                     // The dropdown is anchored to the selector on tablet/desktop
                                     // widths.
                                     if (windowSizeClass != WindowSizeClass.COMPACT) {
-                                        BookPickerDropdown(
+                                        RecipeBookPickerDropdown(
                                             expanded = state.isBookPickerOpen,
                                             books = state.recipeBooks,
                                             activeBookId = state.activeBook?.id,
@@ -528,7 +524,7 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
 
             // On phone widths the book picker is a bottom sheet rather than an anchored dropdown.
             if (state.isBookPickerOpen && windowSizeClass == WindowSizeClass.COMPACT) {
-                BookPickerSheet(
+                RecipeBookPickerSheet(
                     books = state.recipeBooks,
                     activeBookId = state.activeBook?.id,
                     isAllRecipesSelected = state.isAllRecipesSelected,
@@ -828,151 +824,6 @@ private fun BookSelector(
             )
         }
         dropdown()
-    }
-}
-
-@Composable
-private fun BookPickerDropdown(
-    expanded: Boolean,
-    books: List<com.plusmobileapps.chefmate.recipebook.data.RecipeBook>,
-    activeBookId: Long?,
-    isAllRecipesSelected: Boolean,
-    onDismiss: () -> Unit,
-    onBookSelected: (Long) -> Unit,
-    onAllRecipesSelected: () -> Unit,
-    onEditBook: (Long) -> Unit,
-    onCreateBook: () -> Unit,
-) {
-    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
-        DropdownMenuItem(
-            text = { Text(stringResource(Res.string.recipe_list_book_all_recipes)) },
-            onClick = onAllRecipesSelected,
-            leadingIcon = {
-                if (isAllRecipesSelected) {
-                    Icon(Icons.Default.Check, contentDescription = null)
-                } else {
-                    Spacer(modifier = Modifier.size(24.dp))
-                }
-            },
-        )
-        books.forEach { book ->
-            DropdownMenuItem(
-                text = { Text(book.name) },
-                onClick = { onBookSelected(book.id) },
-                leadingIcon = {
-                    if (book.id == activeBookId) {
-                        Icon(Icons.Default.Check, contentDescription = null)
-                    } else {
-                        Spacer(modifier = Modifier.size(24.dp))
-                    }
-                },
-                trailingIcon = {
-                    IconButton(onClick = { onEditBook(book.id) }) {
-                        Icon(
-                            imageVector = Icons.Default.Edit,
-                            contentDescription = stringResource(Res.string.recipe_list_book_edit),
-                        )
-                    }
-                },
-            )
-        }
-        DropdownMenuItem(
-            text = { Text(stringResource(Res.string.recipe_list_book_create)) },
-            leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
-            onClick = onCreateBook,
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun BookPickerSheet(
-    books: List<com.plusmobileapps.chefmate.recipebook.data.RecipeBook>,
-    activeBookId: Long?,
-    isAllRecipesSelected: Boolean,
-    onDismiss: () -> Unit,
-    onBookSelected: (Long) -> Unit,
-    onAllRecipesSelected: () -> Unit,
-    onEditBook: (Long) -> Unit,
-    onCreateBook: () -> Unit,
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
-        Column(modifier = Modifier.fillMaxWidth().navigationBarsPadding()) {
-            Text(
-                text = stringResource(Res.string.recipe_list_book_picker_title),
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(ChefMateTheme.dimens.paddingNormal),
-            )
-            Row(
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .clickable { onAllRecipesSelected() }
-                        .padding(
-                            horizontal = ChefMateTheme.dimens.paddingNormal,
-                            vertical = ChefMateTheme.dimens.paddingSmall,
-                        ),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    imageVector =
-                        if (isAllRecipesSelected) Icons.Default.Check else Icons.Outlined.Circle,
-                    contentDescription = null,
-                )
-                Spacer(modifier = Modifier.width(ChefMateTheme.dimens.paddingNormal))
-                Text(
-                    text = stringResource(Res.string.recipe_list_book_all_recipes),
-                    modifier = Modifier.weight(1f),
-                )
-            }
-            books.forEach { book ->
-                Row(
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .clickable { onBookSelected(book.id) }
-                            .padding(
-                                horizontal = ChefMateTheme.dimens.paddingNormal,
-                                vertical = ChefMateTheme.dimens.paddingSmall,
-                            ),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        imageVector =
-                            if (book.id == activeBookId) Icons.Default.Check
-                            else Icons.Outlined.Circle,
-                        contentDescription = null,
-                    )
-                    Spacer(modifier = Modifier.width(ChefMateTheme.dimens.paddingNormal))
-                    Text(text = book.name, modifier = Modifier.weight(1f))
-                    IconButton(onClick = { onEditBook(book.id) }) {
-                        Icon(
-                            imageVector = Icons.Default.Edit,
-                            contentDescription = stringResource(Res.string.recipe_list_book_edit),
-                        )
-                    }
-                }
-            }
-            DropdownRowCreate(onCreateBook = onCreateBook)
-            Spacer(modifier = Modifier.height(ChefMateTheme.dimens.paddingNormal))
-        }
-    }
-}
-
-@Composable
-private fun DropdownRowCreate(onCreateBook: () -> Unit) {
-    Row(
-        modifier =
-            Modifier.fillMaxWidth()
-                .clickable(onClick = onCreateBook)
-                .padding(
-                    horizontal = ChefMateTheme.dimens.paddingNormal,
-                    vertical = ChefMateTheme.dimens.paddingSmall,
-                ),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(imageVector = Icons.Default.Add, contentDescription = null)
-        Spacer(modifier = Modifier.width(ChefMateTheme.dimens.paddingNormal))
-        Text(text = stringResource(Res.string.recipe_list_book_create))
     }
 }
 

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListTestTags.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListTestTags.kt
@@ -13,4 +13,8 @@ object RecipeListTestTags {
     const val SCANNING_DIALOG: String = "recipe_list_scanning_dialog"
     const val SCAN_ERROR_DIALOG: String = "recipe_list_scan_error_dialog"
     const val BOOK_SELECTOR: String = "recipe_list_book_selector"
+    const val BOOK_PICKER: String = "recipe_list_book_picker"
+    const val BOOK_PICKER_ALL_RECIPES: String = "recipe_list_book_picker_all_recipes"
+    const val BOOK_PICKER_CREATE: String = "recipe_list_book_picker_create"
+    const val BOOK_PICKER_SHARED_HEADER: String = "recipe_list_book_picker_shared_header"
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeBookPickerScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/RecipeBookPickerScreenshotTest.kt
@@ -1,0 +1,85 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.recipe.list.RecipeBookPickerContent
+import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeBooksWithShared
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+// Snapshot coverage for the recipe-book picker body. It renders inside a ModalBottomSheet on
+// phones and a DropdownMenu on tablet/desktop, neither of which renders under the screenshot
+// test plugin, so we render `RecipeBookPickerContent` directly.
+
+@Composable
+private fun RecipeBookPickerScreenshot(
+    books: List<RecipeBook>,
+    activeBookId: Long?,
+    isAllRecipesSelected: Boolean = false,
+    darkTheme: Boolean = false,
+) {
+    ChefMateTheme(darkTheme = darkTheme) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+            RecipeBookPickerContent(
+                books = books,
+                activeBookId = activeBookId,
+                isAllRecipesSelected = isAllRecipesSelected,
+                onBookSelected = {},
+                onAllRecipesSelected = {},
+                onEditBook = {},
+                onCreateBook = {},
+            )
+        }
+    }
+}
+
+// ── Owned books plus a "Shared with you" section ───────────────────────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+fun RecipeBookPickerSharedLightScreenshot() {
+    RecipeBookPickerScreenshot(
+        books = previewRecipeBooksWithShared,
+        activeBookId = RecipeBook.Sample.id,
+    )
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 700, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun RecipeBookPickerSharedDarkScreenshot() {
+    RecipeBookPickerScreenshot(
+        books = previewRecipeBooksWithShared,
+        activeBookId = RecipeBook.Sample.id,
+        darkTheme = true,
+    )
+}
+
+// ── No shared books — the shared section is omitted entirely ───────────────
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+fun RecipeBookPickerOwnedOnlyLightScreenshot() {
+    RecipeBookPickerScreenshot(books = RecipeBook.Samples, activeBookId = RecipeBook.Sample.id)
+}
+
+// ── "All recipes" active — cross-book view highlighted, no book selected ───
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+fun RecipeBookPickerAllRecipesLightScreenshot() {
+    RecipeBookPickerScreenshot(
+        books = previewRecipeBooksWithShared,
+        activeBookId = null,
+        isAllRecipesSelected = true,
+    )
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeBookPickerScreenshotTestKt/RecipeBookPickerAllRecipesLightScreenshot_f3522472_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeBookPickerScreenshotTestKt/RecipeBookPickerAllRecipesLightScreenshot_f3522472_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bfb4475240d6e9658f816196fa83626b37e6bd06d837f78a60b0ab530e9f13f
+size 60397

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeBookPickerScreenshotTestKt/RecipeBookPickerOwnedOnlyLightScreenshot_f3522472_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeBookPickerScreenshotTestKt/RecipeBookPickerOwnedOnlyLightScreenshot_f3522472_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58501ff4fb9fc996b34352763bb23d99a84d362abfca808df9cd13fcafe9d8d0
+size 40761

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeBookPickerScreenshotTestKt/RecipeBookPickerSharedDarkScreenshot_39847f23_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeBookPickerScreenshotTestKt/RecipeBookPickerSharedDarkScreenshot_39847f23_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c364c5bfcbcda0dfc1680a275a3ea837b2eb40e51f3a054355b79c6eae2820d
+size 60932

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeBookPickerScreenshotTestKt/RecipeBookPickerSharedLightScreenshot_f3522472_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeBookPickerScreenshotTestKt/RecipeBookPickerSharedLightScreenshot_f3522472_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5951cdb31d87b11c3c9a8c25e0f6890a74399c2e6cbbddd50524078bb95b57f3
+size 60389


### PR DESCRIPTION
## What

Reworks the recipe book picker on the recipe list screen to match the grocery list selector sheet, and splits the books into **My Books** and **Shared with you**.

The picker was previously implemented twice — a `DropdownMenu` of `DropdownMenuItem`s for tablet/desktop, and a hand-rolled `Row` list inside a `ModalBottomSheet` for phones. Both are now thin wrappers over one shared `RecipeBookPickerContent`.

Layout now mirrors grocery exactly — `ListItem` rows, section headers, `HorizontalDivider`s, selection shown as primary-colored text, and a "Shared" label on shared entries:

```
All recipes
─────────────
My Books
  My Recipes / Weeknight Dinners / Holiday Baking
─────────────
+ Create new book
─────────────
Shared with you
  Grandma's Classics  [Shared]
  Book Club Bakes     [Shared]
```

## Why

Two copies of the same list meant every picker change had to be made twice, and the two had drifted in spacing and affordances. Users with collaborator books also had no way to tell their own books apart from ones shared with them — the flat list mixed them together.

## Notes for reviewers

- **No data-layer change.** The ownership split reads `RecipeBook.isOwnedByCurrentUser`, which `RecipeBookRepositoryImpl` already populates from the remote `ownerId`.
- The shared section is omitted entirely when nothing is shared, same as grocery.
- `recipe_list_book_picker_title` is removed — the grocery-style section headers replace the old sheet title.
- Shared books carry a "Shared" badge *and* sit under the "Shared with you" header. That redundancy is deliberate parity with the grocery selector; happy to drop the badge if you'd rather.
- Snapshots target `RecipeBookPickerContent` directly, since neither `ModalBottomSheet` nor `DropdownMenu` renders under the screenshot plugin — same approach as the category picker tests.

## Commits

1. `refactor(recipe)` — the picker, screen wiring, strings, test tags
2. `test(recipe)` — previews + `@PreviewTest` wrappers + recorded references
3. `test(recipe)` — `RecipeListRobot` methods for the picker

## Testing

- `./gradlew :client:recipe:list:impl:jvmTest` — pass
- `./gradlew :client:ui:screenshot-test:validateDebugScreenshotTest` — pass; new references recorded and visually inspected (light + dark), no existing references changed
- New snapshots: shared light/dark, owned-only, "All recipes" active

🤖 Generated with [Claude Code](https://claude.com/claude-code)