### PR TITLE
feat(recipebook): delete a recipe book you own, or leave one shared with you

### DIFF
--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
@@ -240,6 +240,23 @@ class RecipeRepositoryImpl(
         }
     }
 
+    override suspend fun deleteLocalRecipesInBook(recipeBookId: Long) {
+        withContext(ioContext) {
+            db.transaction {
+                for (recipeId in bookJoinDb.getRecipeIdsForBook(recipeBookId).executeAsList()) {
+                    val books = bookJoinDb.getBookIdsForRecipe(recipeId).executeAsList()
+                    if (books.size <= 1) {
+                        // The join row goes with it via ON DELETE CASCADE. No remote delete and no
+                        // tombstone: the recipe still exists for whoever owns the book.
+                        db.delete(recipeId)
+                    } else {
+                        bookJoinDb.detach(recipeBookId = recipeBookId, recipeId = recipeId)
+                    }
+                }
+            }
+        }
+    }
+
     override suspend fun clearLocalData() {
         withContext(ioContext) { db.deleteAll() }
     }

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeRepository.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeRepository.kt
@@ -55,6 +55,14 @@ interface RecipeRepository {
 
     suspend fun deleteRecipe(id: Long)
 
+    /**
+     * Drops the recipes that live *only* in the book with local id [recipeBookId] from the local
+     * cache, and detaches the rest from that book. Nothing is deleted remotely — this is for
+     * leaving a shared book, where the recipes belong to the book's owner and must survive on the
+     * server. Recipes also filed under another book are kept locally.
+     */
+    suspend fun deleteLocalRecipesInBook(recipeBookId: Long)
+
     suspend fun clearLocalData()
 
     suspend fun syncAllUnsynced()

--- a/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeRepository.kt
+++ b/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeRepository.kt
@@ -69,6 +69,17 @@ class FakeRecipeRepository(
         recipes.value = recipes.value.filterNot { it.id == id }
     }
 
+    override suspend fun deleteLocalRecipesInBook(recipeBookId: Long) {
+        recipes.value =
+            recipes.value.mapNotNull { recipe ->
+                when {
+                    recipeBookId !in recipe.recipeBookIds -> recipe
+                    recipe.recipeBookIds.size <= 1 -> null
+                    else -> recipe.copy(recipeBookIds = recipe.recipeBookIds - recipeBookId)
+                }
+            }
+    }
+
     override suspend fun clearLocalData() {
         recipes.value = emptyList()
     }

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImpl.kt
@@ -85,6 +85,22 @@ class RecipeBookCollaborationRepositoryImpl(
         remote.deleteMember(memberId)
     }
 
+    override suspend fun leaveBook(bookId: Long) {
+        val email = currentUser?.userEmail?.trim()?.lowercase() ?: error("Not signed in")
+        val remoteId = bookRemoteId(bookId) ?: error("Book not synced yet")
+        // Find our own member row. The owner has no member row of their own, so a match here also
+        // proves we're a collaborator rather than the owner.
+        val membership =
+            remote.fetchCollaborators(remoteId).firstOrNull {
+                !it.isOwner && it.email.trim().lowercase() == email
+            } ?: error("Not a collaborator on book $bookId")
+        remote.deleteMember(membership.memberId ?: error("Membership is missing its id"))
+        // Access is gone the moment the member row is deleted, so purge the local copy: the
+        // recipes this book alone held, then the book itself.
+        recipeRepository.deleteLocalRecipesInBook(bookId)
+        recipeBookRepository.removeLocalBook(bookId)
+    }
+
     override suspend fun pendingInvites(): List<RecipeBookInvite> {
         val email = currentUser?.userEmail?.trim()?.lowercase() ?: return emptyList()
         return remote.fetchPendingInvites(email).map {

--- a/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImpl.kt
+++ b/client/recipebook/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImpl.kt
@@ -129,6 +129,44 @@ class RecipeBookRepositoryImpl(
         return book
     }
 
+    override suspend fun deleteBook(id: Long) {
+        val entity = withContext(ioContext) { db.getById(id).executeAsOneOrNull() } ?: return
+        // "My Recipes" is the fallback book new recipes file under — it always has to exist.
+        if (entity.isDefault) return
+        val remoteId = entity.remoteId
+
+        if (remoteId == null) {
+            // Never synced, so there's nothing on the server to tombstone for.
+            withContext(ioContext) { db.delete(id) }
+            resetActiveBookIfRemoved(id)
+            return
+        }
+
+        withContext(ioContext) { db.markPendingDelete(id) }
+        resetActiveBookIfRemoved(id)
+
+        if (authRepository.state.value !is AuthState.Authenticated) return
+
+        try {
+            remoteDataSource.deleteRecipeBook(remoteId)
+            withContext(ioContext) { db.delete(id) }
+        } catch (t: Throwable) {
+            // Leave the tombstone for syncWithRemote to retry the remote delete.
+            Logger.e(throwable = t, tag = TAG) { "deleteBook failed remotely (localId=$id)" }
+        }
+    }
+
+    override suspend fun removeLocalBook(id: Long) {
+        withContext(ioContext) { db.delete(id) }
+        resetActiveBookIfRemoved(id)
+    }
+
+    /** Falls the selection back to "My Recipes" when the book that just went away was active. */
+    private suspend fun resetActiveBookIfRemoved(id: Long) {
+        if (_activeBookId.value != id) return
+        setActiveBook(ensureDefaultBookId())
+    }
+
     override suspend fun syncAllUnsynced() {
         val authState = authRepository.state.value
         if (authState is AuthState.Authenticated) {

--- a/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImplTest.kt
+++ b/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookCollaborationRepositoryImplTest.kt
@@ -6,6 +6,7 @@ package com.plusmobileapps.chefmate.recipebook.data.impl
 import com.plusmobileapps.chefmate.auth.data.testing.FakeAuthenticationRepository
 import com.plusmobileapps.chefmate.database.Database
 import com.plusmobileapps.chefmate.database.testing.createTestDatabase
+import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMemberStatus
 import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RecipeBookMemberRemoteDataSource
@@ -13,10 +14,12 @@ import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteCollaborato
 import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteRecipeBookInvite
 import com.plusmobileapps.chefmate.recipebook.data.impl.remote.RemoteRecipeBookMember
 import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookRepository
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 
@@ -26,14 +29,18 @@ class RecipeBookCollaborationRepositoryImplTest {
     private val db: Database = createTestDatabase()
     private val fakeAuth = FakeAuthenticationRepository()
 
-    private fun repository(remote: RecipeBookMemberRemoteDataSource) =
+    private fun repository(
+        remote: RecipeBookMemberRemoteDataSource,
+        recipeBookRepository: FakeRecipeBookRepository = FakeRecipeBookRepository(),
+        recipeRepository: FakeRecipeRepository = FakeRecipeRepository(),
+    ) =
         RecipeBookCollaborationRepositoryImpl(
             bookDb = db.recipeBookQueries,
             ioContext = testDispatcher,
             remote = remote,
             authRepository = fakeAuth,
-            recipeBookRepository = FakeRecipeBookRepository(),
-            recipeRepository = FakeRecipeRepository(),
+            recipeBookRepository = recipeBookRepository,
+            recipeRepository = recipeRepository,
         )
 
     /** Creates a synced book (with a remote id) and returns its local id. */
@@ -88,6 +95,63 @@ class RecipeBookCollaborationRepositoryImplTest {
             statusByEmail["alex@example.com"] shouldBe RecipeBookMemberStatus.ACCEPTED
             statusByEmail["sam@example.com"] shouldBe RecipeBookMemberStatus.PENDING
             statusByEmail["jordan@example.com"] shouldBe RecipeBookMemberStatus.REJECTED
+        }
+
+    @Test
+    fun leaveBook_deletes_your_own_membership_and_purges_the_local_copy() =
+        runTest(testDispatcher) {
+            fakeAuth.setAuthenticated()
+            val bookId = createSyncedBook(remoteId = "remote-1")
+            val recipes =
+                MutableStateFlow(
+                    listOf(
+                        Recipe.Sample.copy(id = 1, recipeBookIds = setOf(bookId)),
+                        Recipe.Sample.copy(id = 2, recipeBookIds = setOf(99L)),
+                    )
+                )
+            val remote =
+                RecordingMemberRemote(
+                    collaborators =
+                        listOf(
+                            collaborator("owner@example.com", "accepted", isOwner = true),
+                            // The signed-in user's own membership.
+                            collaborator("test@example.com", "accepted"),
+                        )
+                )
+            val bookRepo = FakeRecipeBookRepository()
+            val repo =
+                repository(
+                    remote,
+                    recipeBookRepository = bookRepo,
+                    recipeRepository = FakeRecipeRepository(recipes),
+                )
+
+            repo.leaveBook(bookId)
+
+            remote.deleted shouldContainExactly listOf("m-test@example.com")
+            bookRepo.locallyRemoved shouldContainExactly listOf(bookId)
+            // The book is gone locally along with the recipes only it held; other books' recipes
+            // are untouched. Nothing was deleted on the server — it's still the owner's book.
+            recipes.value.map { it.id } shouldContainExactly listOf(2L)
+            bookRepo.deleted shouldBe emptyList()
+        }
+
+    @Test
+    fun leaveBook_refuses_when_you_have_no_membership_of_your_own() =
+        runTest(testDispatcher) {
+            fakeAuth.setAuthenticated()
+            val bookId = createSyncedBook(remoteId = "remote-1")
+            // Owner rows carry no member id, so an owner has nothing to give up.
+            val remote =
+                RecordingMemberRemote(
+                    collaborators =
+                        listOf(collaborator("test@example.com", "accepted", isOwner = true))
+                )
+            val repo = repository(remote)
+
+            shouldThrow<IllegalStateException> { repo.leaveBook(bookId) }
+
+            remote.deleted shouldBe emptyList()
         }
 
     private fun collaborator(email: String, status: String, isOwner: Boolean = false) =

--- a/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImplTest.kt
+++ b/client/recipebook/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/data/impl/RecipeBookRepositoryImplTest.kt
@@ -163,6 +163,92 @@ class RecipeBookRepositoryImplTest {
         }
 
     @Test
+    fun deleteBook_removes_an_unsynced_book_outright() =
+        runTest(testDispatcher) {
+            val repo = repository()
+            val created = repo.createBook("Weeknight Dinners")
+
+            repo.deleteBook(created.id)
+
+            repo.getRecipeBooks().test {
+                awaitItem().map { it.name } shouldNotContain "Weeknight Dinners"
+            }
+        }
+
+    @Test
+    fun deleteBook_falls_the_active_selection_back_to_the_default_book() =
+        runTest(testDispatcher) {
+            val repo = repository()
+            val created = repo.createBook("Weeknight Dinners")
+            repo.setActiveBook(created.id)
+
+            repo.deleteBook(created.id)
+
+            repo.activeBookId.value shouldBe repo.getDefaultBookId()
+        }
+
+    @Test
+    fun deleteBook_ignores_the_default_book() =
+        runTest(testDispatcher) {
+            val repo = repository()
+            val defaultId = repo.getDefaultBookId()
+
+            repo.deleteBook(defaultId)
+
+            repo.getRecipeBooks().test { awaitItem().map { it.id } shouldContain defaultId }
+        }
+
+    @Test
+    fun deleteBook_tombstones_a_synced_book_when_the_remote_delete_fails() =
+        runTest(testDispatcher) {
+            fakeAuth.setAuthenticated()
+            val failingRemote =
+                object : NoopRecipeBookRemote() {
+                    // Stamp a distinct remote id on each push so books count as synced.
+                    override suspend fun upsertRecipeBook(book: RemoteRecipeBook) =
+                        book.copy(id = "remote-${book.name}")
+
+                    override suspend fun deleteRecipeBook(remoteId: String) {
+                        error("offline")
+                    }
+                }
+            val repo = repository(remoteDataSource = failingRemote)
+            val created = repo.createBook("Weeknight Dinners")
+
+            repo.deleteBook(created.id)
+
+            // Hidden from the list right away, but the row survives so sync can retry the remote
+            // delete.
+            repo.getRecipeBooks().test { awaitItem().map { it.id } shouldNotContain created.id }
+            db.recipeBookQueries.getPendingDeletes().executeAsList().map { it.id } shouldContain
+                created.id
+        }
+
+    @Test
+    fun removeLocalBook_drops_the_row_without_deleting_it_remotely() =
+        runTest(testDispatcher) {
+            fakeAuth.setAuthenticated()
+            val deletedRemotely = mutableListOf<String>()
+            val remote =
+                object : NoopRecipeBookRemote() {
+                    override suspend fun upsertRecipeBook(book: RemoteRecipeBook) =
+                        book.copy(id = "remote-${book.name}")
+
+                    override suspend fun deleteRecipeBook(remoteId: String) {
+                        deletedRemotely += remoteId
+                    }
+                }
+            val repo = repository(remoteDataSource = remote)
+            val created = repo.createBook("Shared with me")
+
+            repo.removeLocalBook(created.id)
+
+            repo.getRecipeBooks().test { awaitItem().map { it.id } shouldNotContain created.id }
+            deletedRemotely.isEmpty() shouldBe true
+            db.recipeBookQueries.getPendingDeletes().executeAsList().isEmpty() shouldBe true
+        }
+
+    @Test
     fun pull_skips_books_with_only_a_pending_invite() =
         runTest(testDispatcher) {
             fakeAuth.setAuthenticated()
@@ -203,7 +289,7 @@ class RecipeBookRepositoryImplTest {
             }
         }
 
-    private class NoopRecipeBookRemote : RecipeBookRemoteDataSource {
+    private open class NoopRecipeBookRemote : RecipeBookRemoteDataSource {
         override suspend fun upsertRecipeBook(book: RemoteRecipeBook): RemoteRecipeBook = book
 
         override suspend fun deleteRecipeBook(remoteId: String) = Unit

--- a/client/recipebook/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/RecipeBookCollaborationRepository.kt
+++ b/client/recipebook/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/RecipeBookCollaborationRepository.kt
@@ -21,6 +21,13 @@ interface RecipeBookCollaborationRepository {
     /** Removes the collaborator / cancels the invite with remote [memberId]. */
     suspend fun removeMember(memberId: String)
 
+    /**
+     * Removes the current user's own membership from the book with local [bookId], then drops the
+     * book — and the recipes only it held — from the local cache. Owners can't leave their own
+     * book; they delete it via [RecipeBookRepository.deleteBook] instead.
+     */
+    suspend fun leaveBook(bookId: Long)
+
     /** Pending invites addressed to the current user's email. */
     suspend fun pendingInvites(): List<RecipeBookInvite>
 

--- a/client/recipebook/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/RecipeBookRepository.kt
+++ b/client/recipebook/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/RecipeBookRepository.kt
@@ -35,6 +35,21 @@ interface RecipeBookRepository {
 
     suspend fun renameBook(id: Long, name: String): RecipeBook
 
+    /**
+     * Deletes the book [id] the current user owns, locally and remotely. The delete is tombstoned
+     * first so a failed remote call is retried on the next sync. No-op for the default "My Recipes"
+     * book — it's the fallback every unfiled recipe lands in, so it can't be removed.
+     *
+     * Recipes filed under the book are kept; they simply stop being listed under it.
+     */
+    suspend fun deleteBook(id: Long)
+
+    /**
+     * Drops the book [id] from the local cache without touching the remote copy. Used after leaving
+     * a shared book: the book lives on for its owner, the current user just loses access to it.
+     */
+    suspend fun removeLocalBook(id: Long)
+
     suspend fun syncAllUnsynced()
 
     suspend fun clearLocalData()

--- a/client/recipebook/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/testing/FakeRecipeBookCollaborationRepository.kt
+++ b/client/recipebook/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/testing/FakeRecipeBookCollaborationRepository.kt
@@ -15,6 +15,7 @@ class FakeRecipeBookCollaborationRepository(
     val invited: MutableList<Triple<Long, String, RecipeBookRole>> = mutableListOf()
     val removed: MutableList<String> = mutableListOf()
     val accepted: MutableList<String> = mutableListOf()
+    val left: MutableList<Long> = mutableListOf()
     val declined: MutableList<String> = mutableListOf()
 
     override suspend fun isOwner(bookId: Long): Boolean = owner
@@ -35,6 +36,11 @@ class FakeRecipeBookCollaborationRepository(
     override suspend fun removeMember(memberId: String) {
         removed += memberId
         members.removeAll { it.id == memberId }
+    }
+
+    override suspend fun leaveBook(bookId: Long) {
+        if (owner) error("Owners can't leave their own book")
+        left += bookId
     }
 
     override suspend fun pendingInvites(): List<RecipeBookInvite> = invites

--- a/client/recipebook/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/testing/FakeRecipeBookRepository.kt
+++ b/client/recipebook/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/data/testing/FakeRecipeBookRepository.kt
@@ -57,6 +57,30 @@ class FakeRecipeBookRepository(
         return books.value.first { it.id == id }
     }
 
+    /** Local ids passed to [deleteBook], in call order. */
+    val deleted: MutableList<Long> = mutableListOf()
+
+    /** Local ids passed to [removeLocalBook], in call order. */
+    val locallyRemoved: MutableList<Long> = mutableListOf()
+
+    override suspend fun deleteBook(id: Long) {
+        if (books.value.firstOrNull { it.id == id }?.isDefault == true) return
+        deleted += id
+        removeBook(id)
+    }
+
+    override suspend fun removeLocalBook(id: Long) {
+        locallyRemoved += id
+        removeBook(id)
+    }
+
+    private fun removeBook(id: Long) {
+        books.value = books.value.filterNot { it.id == id }
+        if (_activeBookId.value == id) {
+            _activeBookId.value = books.value.firstOrNull { it.isDefault }?.id
+        }
+    }
+
     override suspend fun syncAllUnsynced() {}
 
     override suspend fun clearLocalData() {

--- a/client/recipebook/edit/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/robots/EditRecipeBookRobot.kt
+++ b/client/recipebook/edit/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/robots/EditRecipeBookRobot.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
 import com.plusmobileapps.chefmate.recipebook.edit.EditRecipeBookTestTags
@@ -30,6 +31,27 @@ class EditRecipeBookRobot(private val test: ComposeUiTest) {
 
     fun save(): EditRecipeBookRobot = apply {
         test.onNodeWithTag(EditRecipeBookTestTags.SAVE_BUTTON).performClick()
+    }
+
+    fun deleteBook(): EditRecipeBookRobot = apply {
+        test.onNodeWithTag(EditRecipeBookTestTags.DELETE_BOOK_BUTTON).performClick()
+    }
+
+    fun leaveBook(): EditRecipeBookRobot = apply {
+        test.onNodeWithTag(EditRecipeBookTestTags.LEAVE_BOOK_BUTTON).performClick()
+    }
+
+    fun assertDeleteBookNotShown(): EditRecipeBookRobot = apply {
+        test.onNodeWithTag(EditRecipeBookTestTags.DELETE_BOOK_BUTTON).assertDoesNotExist()
+    }
+
+    fun assertLeaveBookNotShown(): EditRecipeBookRobot = apply {
+        test.onNodeWithTag(EditRecipeBookTestTags.LEAVE_BOOK_BUTTON).assertDoesNotExist()
+    }
+
+    /** Taps the confirm button in the delete/leave dialog. */
+    fun confirmDialog(text: String): EditRecipeBookRobot = apply {
+        test.onNodeWithText(text).performClick()
     }
 }
 

--- a/client/recipebook/edit/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookBlocImpl.kt
+++ b/client/recipebook/edit/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookBlocImpl.kt
@@ -53,6 +53,14 @@ class EditRecipeBookBlocImpl(
 
     override fun onDismissRemoveMember() = viewModel.onDismissRemoveMember()
 
+    override fun onDeleteBookClicked() = viewModel.onDeleteBookClicked()
+
+    override fun onLeaveBookClicked() = viewModel.onLeaveBookClicked()
+
+    override fun onConfirmBookAction() = viewModel.onConfirmBookAction()
+
+    override fun onDismissBookAction() = viewModel.onDismissBookAction()
+
     private fun EditRecipeBookViewModel.State.toBlocModel(): Model =
         Model(
             title = title,
@@ -67,5 +75,10 @@ class EditRecipeBookBlocImpl(
             isInviting = isInviting,
             inviteError = inviteError,
             removingMember = removingMember,
+            canDeleteBook = canDeleteBook,
+            canLeaveBook = canLeaveBook,
+            isRemovingBook = isRemovingBook,
+            pendingBookAction = pendingBookAction,
+            bookActionError = bookActionError,
         )
 }

--- a/client/recipebook/edit/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModel.kt
+++ b/client/recipebook/edit/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModel.kt
@@ -2,8 +2,10 @@ package com.plusmobileapps.chefmate.recipebook.edit.impl
 
 import chefmate.client.recipebook.edit.public.generated.resources.Res
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_create_title
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_delete_error
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_edit_title
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_invite_email_error
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_leave_error
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_name_error
 import com.plusmobileapps.chefmate.ViewModel
 import com.plusmobileapps.chefmate.di.IO
@@ -60,7 +62,15 @@ class EditRecipeBookViewModel(
                     _state.update { it.copy(name = book.name) }
                 }
                 val owner = withContext(ioContext) { collaborationRepository.isOwner(props.bookId) }
-                _state.update { it.copy(canManageCollaborators = owner) }
+                _state.update {
+                    it.copy(
+                        canManageCollaborators = owner,
+                        // The default "My Recipes" book is the fallback for unfiled recipes, so
+                        // it can't be deleted. Only a non-owner has a membership to give up.
+                        canDeleteBook = owner && book?.isDefault == false,
+                        canLeaveBook = !owner,
+                    )
+                }
                 // Everyone on the book sees the collaborator list; only the owner can
                 // invite/remove.
                 loadMembers(props.bookId)
@@ -137,6 +147,62 @@ class EditRecipeBookViewModel(
         }
     }
 
+    fun onDeleteBookClicked() {
+        if (!_state.value.canDeleteBook) return
+        _state.update {
+            it.copy(
+                pendingBookAction = EditRecipeBookBloc.BookAction.DELETE,
+                bookActionError = null,
+            )
+        }
+    }
+
+    fun onLeaveBookClicked() {
+        if (!_state.value.canLeaveBook) return
+        _state.update {
+            it.copy(pendingBookAction = EditRecipeBookBloc.BookAction.LEAVE, bookActionError = null)
+        }
+    }
+
+    fun onDismissBookAction() {
+        _state.update { it.copy(pendingBookAction = null) }
+    }
+
+    fun onConfirmBookAction() {
+        val bookId = (props as? EditRecipeBookBloc.Props.Edit)?.bookId ?: return
+        val current = _state.value
+        val action = current.pendingBookAction ?: return
+        if (current.isRemovingBook) return
+        _state.update { it.copy(pendingBookAction = null, isRemovingBook = true) }
+        scope.launch {
+            try {
+                withContext(ioContext) {
+                    when (action) {
+                        EditRecipeBookBloc.BookAction.DELETE -> repository.deleteBook(bookId)
+                        EditRecipeBookBloc.BookAction.LEAVE ->
+                            collaborationRepository.leaveBook(bookId)
+                    }
+                }
+                onSaved()
+            } catch (_: Throwable) {
+                // Both paths need the server, so a failure here is almost always connectivity.
+                _state.update {
+                    it.copy(
+                        isRemovingBook = false,
+                        bookActionError =
+                            ResourceString(
+                                if (action == EditRecipeBookBloc.BookAction.DELETE) {
+                                    Res.string.edit_recipe_book_delete_error
+                                } else {
+                                    Res.string.edit_recipe_book_leave_error
+                                }
+                            ),
+                    )
+                }
+            }
+        }
+    }
+
     fun onSaveClicked() {
         val current = _state.value
         if (current.isSaving) return
@@ -175,6 +241,11 @@ class EditRecipeBookViewModel(
         val isInviting: Boolean = false,
         val inviteError: TextData? = null,
         val removingMember: RecipeBookMember? = null,
+        val canDeleteBook: Boolean = false,
+        val canLeaveBook: Boolean = false,
+        val isRemovingBook: Boolean = false,
+        val pendingBookAction: EditRecipeBookBloc.BookAction? = null,
+        val bookActionError: TextData? = null,
     )
 
     @AssistedFactory

--- a/client/recipebook/edit/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookScreenUiTest.kt
+++ b/client/recipebook/edit/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookScreenUiTest.kt
@@ -27,14 +27,45 @@ class EditRecipeBookScreenUiTest {
         bloc.saveClicks shouldBe 1
     }
 
-    private class RecordingEditBloc : EditRecipeBookBloc {
+    @Test
+    fun an_owner_sees_delete_and_can_confirm_it() = runComposeUiTest {
+        val bloc =
+            RecordingEditBloc(EditRecipeBookBloc.Model(FixedString("Edit"), canDeleteBook = true))
+        setContent { EditRecipeBookScreen(bloc = bloc) }
+
+        editRecipeBook().assertLeaveBookNotShown().deleteBook()
+
+        bloc.deleteClicks shouldBe 1
+
+        bloc.state.value =
+            bloc.state.value.copy(pendingBookAction = EditRecipeBookBloc.BookAction.DELETE)
+        editRecipeBook().confirmDialog("Delete")
+
+        bloc.confirmClicks shouldBe 1
+    }
+
+    @Test
+    fun a_collaborator_sees_leave_instead_of_delete() = runComposeUiTest {
+        val bloc =
+            RecordingEditBloc(EditRecipeBookBloc.Model(FixedString("Edit"), canLeaveBook = true))
+        setContent { EditRecipeBookScreen(bloc = bloc) }
+
+        editRecipeBook().assertDeleteBookNotShown().leaveBook()
+
+        bloc.leaveClicks shouldBe 1
+    }
+
+    private class RecordingEditBloc(
+        model: EditRecipeBookBloc.Model =
+            EditRecipeBookBloc.Model(title = FixedString("New recipe book"), name = "x")
+    ) : EditRecipeBookBloc {
         var lastName: String? = null
         var saveClicks: Int = 0
+        var deleteClicks: Int = 0
+        var leaveClicks: Int = 0
+        var confirmClicks: Int = 0
 
-        override val state =
-            MutableStateFlow(
-                EditRecipeBookBloc.Model(title = FixedString("New recipe book"), name = "x")
-            )
+        override val state = MutableStateFlow(model)
 
         override fun onNameChanged(name: String) {
             lastName = name
@@ -60,6 +91,20 @@ class EditRecipeBookScreenUiTest {
         override fun onConfirmRemoveMember() = Unit
 
         override fun onDismissRemoveMember() = Unit
+
+        override fun onDeleteBookClicked() {
+            deleteClicks++
+        }
+
+        override fun onLeaveBookClicked() {
+            leaveClicks++
+        }
+
+        override fun onConfirmBookAction() {
+            confirmClicks++
+        }
+
+        override fun onDismissBookAction() = Unit
 
         @Composable
         override fun Content(modifier: Modifier) {

--- a/client/recipebook/edit/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModelTest.kt
+++ b/client/recipebook/edit/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipebook/edit/impl/EditRecipeBookViewModelTest.kt
@@ -185,4 +185,131 @@ class EditRecipeBookViewModelTest {
 
             finished shouldBe true
         }
+
+    @Test
+    fun an_owner_can_delete_a_non_default_book_after_confirming() =
+        runTest(testDispatcher) {
+            var finished = false
+            val book = book(id = 7, name = "Holiday Baking")
+            val repo = FakeRecipeBookRepository(MutableStateFlow(listOf(book)))
+            val vm =
+                viewModel(
+                    EditRecipeBookBloc.Props.Edit(book.id),
+                    repository = repo,
+                    collaborationRepository = FakeRecipeBookCollaborationRepository(owner = true),
+                    onSaved = { finished = true },
+                )
+
+            vm.state.value.canDeleteBook shouldBe true
+            vm.state.value.canLeaveBook shouldBe false
+
+            vm.onDeleteBookClicked()
+            // Clicking only opens the confirmation — nothing deleted yet.
+            vm.state.value.pendingBookAction shouldBe EditRecipeBookBloc.BookAction.DELETE
+            repo.deleted.isEmpty() shouldBe true
+
+            vm.onConfirmBookAction()
+
+            repo.deleted shouldBe listOf(book.id)
+            finished shouldBe true
+        }
+
+    @Test
+    fun the_default_book_cannot_be_deleted() =
+        runTest(testDispatcher) {
+            val book = book(id = 1, name = "My Recipes", isDefault = true)
+            val repo = FakeRecipeBookRepository(MutableStateFlow(listOf(book)))
+            val vm =
+                viewModel(
+                    EditRecipeBookBloc.Props.Edit(book.id),
+                    repository = repo,
+                    collaborationRepository = FakeRecipeBookCollaborationRepository(owner = true),
+                )
+
+            vm.state.value.canDeleteBook shouldBe false
+
+            vm.onDeleteBookClicked()
+
+            vm.state.value.pendingBookAction shouldBe null
+        }
+
+    @Test
+    fun a_collaborator_leaves_instead_of_deleting() =
+        runTest(testDispatcher) {
+            var finished = false
+            val book = book(id = 7, name = "Shared with me")
+            val collab = FakeRecipeBookCollaborationRepository(owner = false)
+            val vm =
+                viewModel(
+                    EditRecipeBookBloc.Props.Edit(book.id),
+                    repository = FakeRecipeBookRepository(MutableStateFlow(listOf(book))),
+                    collaborationRepository = collab,
+                    onSaved = { finished = true },
+                )
+
+            vm.state.value.canDeleteBook shouldBe false
+            vm.state.value.canLeaveBook shouldBe true
+
+            vm.onLeaveBookClicked()
+            vm.state.value.pendingBookAction shouldBe EditRecipeBookBloc.BookAction.LEAVE
+            collab.left.isEmpty() shouldBe true
+
+            vm.onConfirmBookAction()
+
+            collab.left shouldBe listOf(book.id)
+            finished shouldBe true
+        }
+
+    @Test
+    fun dismissing_the_confirmation_leaves_the_book_alone() =
+        runTest(testDispatcher) {
+            val book = book(id = 7, name = "Holiday Baking")
+            val repo = FakeRecipeBookRepository(MutableStateFlow(listOf(book)))
+            val vm =
+                viewModel(
+                    EditRecipeBookBloc.Props.Edit(book.id),
+                    repository = repo,
+                    collaborationRepository = FakeRecipeBookCollaborationRepository(owner = true),
+                )
+
+            vm.onDeleteBookClicked()
+            vm.onDismissBookAction()
+
+            vm.state.value.pendingBookAction shouldBe null
+            repo.deleted.isEmpty() shouldBe true
+        }
+
+    @Test
+    fun a_failed_leave_surfaces_an_error_and_keeps_the_modal_open() =
+        runTest(testDispatcher) {
+            var finished = false
+            val book = book(id = 7, name = "Shared with me")
+            // The fake throws when asked to leave a book the user owns; force that mismatch by
+            // flipping ownership after the initial load so `canLeaveBook` is already true.
+            val collab = FakeRecipeBookCollaborationRepository(owner = false)
+            val vm =
+                viewModel(
+                    EditRecipeBookBloc.Props.Edit(book.id),
+                    repository = FakeRecipeBookRepository(MutableStateFlow(listOf(book))),
+                    collaborationRepository = collab,
+                    onSaved = { finished = true },
+                )
+            collab.owner = true
+
+            vm.onLeaveBookClicked()
+            vm.onConfirmBookAction()
+
+            (vm.state.value.bookActionError != null) shouldBe true
+            vm.state.value.isRemovingBook shouldBe false
+            finished shouldBe false
+        }
+
+    private fun book(id: Long, name: String, isDefault: Boolean = false) =
+        RecipeBook(
+            id = id,
+            name = name,
+            isDefault = isDefault,
+            createdAt = Instant.DISTANT_PAST,
+            updatedAt = Instant.DISTANT_PAST,
+        )
 }

--- a/client/recipebook/edit/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipebook/edit/public/src/commonMain/composeResources/values/strings.xml
@@ -24,4 +24,17 @@
     <string name="edit_recipe_book_remove_message">Remove “{name}” from this book? They’ll lose access.</string>
     <string name="edit_recipe_book_remove_confirm">Remove</string>
     <string name="edit_recipe_book_remove_cancel">Cancel</string>
+
+    <!-- Deleting a book you own / leaving one shared with you -->
+    <string name="edit_recipe_book_delete_button">Delete book</string>
+    <string name="edit_recipe_book_delete_title">Delete recipe book</string>
+    <string name="edit_recipe_book_delete_message">Delete “{name}”? Everyone you shared it with will lose access. Your recipes stay in your library.</string>
+    <string name="edit_recipe_book_delete_confirm">Delete</string>
+    <string name="edit_recipe_book_delete_error">Couldn’t delete this book. Check your connection and try again.</string>
+    <string name="edit_recipe_book_leave_button">Leave book</string>
+    <string name="edit_recipe_book_leave_title">Leave recipe book</string>
+    <string name="edit_recipe_book_leave_message">Leave “{name}”? You’ll lose access to it and its recipes until the owner invites you back.</string>
+    <string name="edit_recipe_book_leave_confirm">Leave</string>
+    <string name="edit_recipe_book_leave_error">Couldn’t leave this book. Check your connection and try again.</string>
+    <string name="edit_recipe_book_cancel">Cancel</string>
 </resources>

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookBloc.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookBloc.kt
@@ -40,6 +40,26 @@ interface EditRecipeBookBloc : ComposeScreen {
     /** Dismisses the remove-confirmation dialog without removing. */
     fun onDismissRemoveMember()
 
+    /** Owner tapped "Delete book" — asks for confirmation first. */
+    fun onDeleteBookClicked()
+
+    /** Collaborator tapped "Leave book" — asks for confirmation first. */
+    fun onLeaveBookClicked()
+
+    /** Confirms the pending delete or leave. */
+    fun onConfirmBookAction()
+
+    /** Dismisses the delete/leave confirmation dialog without acting. */
+    fun onDismissBookAction()
+
+    /** The destructive action awaiting confirmation in [Model.pendingBookAction]. */
+    enum class BookAction {
+        /** The owner is deleting the book for everyone. */
+        DELETE,
+        /** A collaborator is removing themselves from the book. */
+        LEAVE,
+    }
+
     data class Model(
         val title: TextData,
         val name: String = "",
@@ -55,6 +75,16 @@ interface EditRecipeBookBloc : ComposeScreen {
         val inviteError: TextData? = null,
         /** The collaborator awaiting remove confirmation; non-null shows the confirm dialog. */
         val removingMember: RecipeBookMember? = null,
+        /** True for a saved book the user owns that isn't the undeletable default one. */
+        val canDeleteBook: Boolean = false,
+        /** True for a saved book the user collaborates on rather than owns. */
+        val canLeaveBook: Boolean = false,
+        /** True while the delete or leave is in flight. */
+        val isRemovingBook: Boolean = false,
+        /** Non-null shows the delete/leave confirmation dialog. */
+        val pendingBookAction: BookAction? = null,
+        /** Set when the delete or leave failed, e.g. offline. */
+        val bookActionError: TextData? = null,
     ) {
         val canSave: Boolean
             get() = name.isNotBlank() && !isSaving

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookPreviews.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookPreviews.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import chefmate.client.recipebook.edit.public.generated.resources.Res
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_create_title
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_edit_title
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_leave_error
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_name_error
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMember
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookMemberStatus
@@ -35,6 +36,14 @@ private fun editRecipeBookBloc(model: Model): EditRecipeBookBloc =
         override fun onConfirmRemoveMember() = Unit
 
         override fun onDismissRemoveMember() = Unit
+
+        override fun onDeleteBookClicked() = Unit
+
+        override fun onLeaveBookClicked() = Unit
+
+        override fun onConfirmBookAction() = Unit
+
+        override fun onDismissBookAction() = Unit
     }
 
 val previewEditRecipeBookCreateBloc: EditRecipeBookBloc =
@@ -76,6 +85,7 @@ val previewEditRecipeBookCollaboratorsBloc: EditRecipeBookBloc =
             name = "Weeknight Dinners",
             isCreate = false,
             canManageCollaborators = true,
+            canDeleteBook = true,
             members =
                 listOf(
                     RecipeBookMember(
@@ -110,7 +120,7 @@ val previewEditRecipeBookCollaboratorsBloc: EditRecipeBookBloc =
         )
     )
 
-/** A non-owner collaborator viewing the book: read-only list, no invite controls. */
+/** A non-owner collaborator viewing the book: read-only list, no invite controls, can leave. */
 val previewEditRecipeBookMemberViewBloc: EditRecipeBookBloc =
     editRecipeBookBloc(
         Model(
@@ -118,6 +128,7 @@ val previewEditRecipeBookMemberViewBloc: EditRecipeBookBloc =
             name = "Weeknight Dinners",
             isCreate = false,
             canManageCollaborators = false,
+            canLeaveBook = true,
             members =
                 listOf(
                     RecipeBookMember(
@@ -182,6 +193,43 @@ val previewEditRecipeBookRemoveConfirmBloc: EditRecipeBookBloc =
         )
     )
 
+/** Owner view with the delete-book confirmation dialog showing. */
+val previewEditRecipeBookDeleteConfirmBloc: EditRecipeBookBloc =
+    editRecipeBookBloc(
+        Model(
+            title = Res.string.edit_recipe_book_edit_title.asTextData(),
+            name = "Weeknight Dinners",
+            isCreate = false,
+            canManageCollaborators = true,
+            canDeleteBook = true,
+            pendingBookAction = EditRecipeBookBloc.BookAction.DELETE,
+        )
+    )
+
+/** Collaborator view with the leave-book confirmation dialog showing. */
+val previewEditRecipeBookLeaveConfirmBloc: EditRecipeBookBloc =
+    editRecipeBookBloc(
+        Model(
+            title = Res.string.edit_recipe_book_edit_title.asTextData(),
+            name = "Weeknight Dinners",
+            isCreate = false,
+            canLeaveBook = true,
+            pendingBookAction = EditRecipeBookBloc.BookAction.LEAVE,
+        )
+    )
+
+/** Collaborator view after a failed leave — the destructive button carries an inline error. */
+val previewEditRecipeBookLeaveErrorBloc: EditRecipeBookBloc =
+    editRecipeBookBloc(
+        Model(
+            title = Res.string.edit_recipe_book_edit_title.asTextData(),
+            name = "Weeknight Dinners",
+            isCreate = false,
+            canLeaveBook = true,
+            bookActionError = Res.string.edit_recipe_book_leave_error.asTextData(),
+        )
+    )
+
 @Preview
 @Composable
 internal fun EditRecipeBookCreatePreview() {
@@ -216,4 +264,16 @@ internal fun EditRecipeBookCollaboratorsPreview() {
 @Composable
 internal fun EditRecipeBookMemberViewPreview() {
     ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookMemberViewBloc) }
+}
+
+@Preview
+@Composable
+internal fun EditRecipeBookDeleteConfirmPreview() {
+    ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookDeleteConfirmBloc) }
+}
+
+@Preview
+@Composable
+internal fun EditRecipeBookLeaveConfirmPreview() {
+    ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookLeaveConfirmBloc) }
 }

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookScreen.kt
@@ -35,12 +35,21 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import chefmate.client.recipebook.edit.public.generated.resources.Res
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_cancel
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_collaborators
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_delete_button
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_delete_confirm
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_delete_message
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_delete_title
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_group_editors
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_group_owner
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_group_viewers
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_invite_button
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_invite_email_label
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_leave_button
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_leave_confirm
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_leave_message
+import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_leave_title
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_member_declined
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_member_pending
 import chefmate.client.recipebook.edit.public.generated.resources.edit_recipe_book_name_label
@@ -107,6 +116,33 @@ fun EditRecipeBookScreen(bloc: EditRecipeBookBloc, modifier: Modifier = Modifier
         if (model.members.isNotEmpty()) {
             CollaboratorsSection(bloc = bloc, model = model)
         }
+
+        if (model.canDeleteBook || model.canLeaveBook) {
+            DangerZone(bloc = bloc, model = model)
+        }
+    }
+
+    model.pendingBookAction?.let { action ->
+        val isDelete = action == EditRecipeBookBloc.BookAction.DELETE
+        PlusDialog(
+            title =
+                (if (isDelete) Res.string.edit_recipe_book_delete_title
+                    else Res.string.edit_recipe_book_leave_title)
+                    .asTextData(),
+            message =
+                PhraseModel(
+                    if (isDelete) Res.string.edit_recipe_book_delete_message
+                    else Res.string.edit_recipe_book_leave_message,
+                    "name" to FixedString(model.name),
+                ),
+            confirmButtonText =
+                (if (isDelete) Res.string.edit_recipe_book_delete_confirm
+                    else Res.string.edit_recipe_book_leave_confirm)
+                    .asTextData(),
+            dismissButtonText = Res.string.edit_recipe_book_cancel.asTextData(),
+            onConfirmClick = bloc::onConfirmBookAction,
+            onDismissRequest = bloc::onDismissBookAction,
+        )
     }
 
     model.removingMember?.let { member ->
@@ -122,6 +158,46 @@ fun EditRecipeBookScreen(bloc: EditRecipeBookBloc, modifier: Modifier = Modifier
             onConfirmClick = bloc::onConfirmRemoveMember,
             onDismissRequest = bloc::onDismissRemoveMember,
         )
+    }
+}
+
+/**
+ * The one destructive control on this screen, kept below everything else. Which one shows follows
+ * from the user's relationship to the book: an owner deletes it for everyone, a collaborator only
+ * removes themselves.
+ */
+@Composable
+private fun DangerZone(bloc: EditRecipeBookBloc, model: EditRecipeBookBloc.Model) {
+    val isDelete = model.canDeleteBook
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(top = ChefMateTheme.dimens.paddingLarge),
+        verticalArrangement = Arrangement.spacedBy(ChefMateTheme.dimens.paddingSmall),
+    ) {
+        HorizontalDivider()
+        PlusButton(
+            text =
+                (if (isDelete) Res.string.edit_recipe_book_delete_button
+                    else Res.string.edit_recipe_book_leave_button)
+                    .asTextData(),
+            variant = PlusButtonVariant.DESTRUCTIVE,
+            isLoading = model.isRemovingBook,
+            enabled = !model.isRemovingBook,
+            onClick = if (isDelete) bloc::onDeleteBookClicked else bloc::onLeaveBookClicked,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(top = ChefMateTheme.dimens.paddingSmall)
+                    .testTag(
+                        if (isDelete) EditRecipeBookTestTags.DELETE_BOOK_BUTTON
+                        else EditRecipeBookTestTags.LEAVE_BOOK_BUTTON
+                    ),
+        )
+        model.bookActionError?.let { error ->
+            Text(
+                text = error.localized(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
     }
 }
 

--- a/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookTestTags.kt
+++ b/client/recipebook/edit/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipebook/edit/EditRecipeBookTestTags.kt
@@ -7,4 +7,6 @@ object EditRecipeBookTestTags {
     const val COLLABORATORS = "edit_recipe_book_collaborators"
     const val INVITE_EMAIL_FIELD = "edit_recipe_book_invite_email_field"
     const val INVITE_BUTTON = "edit_recipe_book_invite_button"
+    const val DELETE_BOOK_BUTTON = "edit_recipe_book_delete_book_button"
+    const val LEAVE_BOOK_BUTTON = "edit_recipe_book_leave_book_button"
 }

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTest.kt
@@ -7,8 +7,11 @@ import com.android.tools.screenshot.PreviewTest
 import com.plusmobileapps.chefmate.recipebook.edit.EditRecipeBookScreen
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookCollaboratorsBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookCreateBloc
+import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookDeleteConfirmBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookEditBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookErrorBloc
+import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookLeaveConfirmBloc
+import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookLeaveErrorBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookMemberViewBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookRemoveConfirmBloc
 import com.plusmobileapps.chefmate.recipebook.edit.previewEditRecipeBookSavingBloc
@@ -68,4 +71,25 @@ fun EditRecipeBookMemberViewScreenshot() {
 @Composable
 fun EditRecipeBookRemoveConfirmScreenshot() {
     ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookRemoveConfirmBloc) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun EditRecipeBookDeleteConfirmScreenshot() {
+    ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookDeleteConfirmBloc) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun EditRecipeBookLeaveConfirmScreenshot() {
+    ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookLeaveConfirmBloc) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 900)
+@Composable
+fun EditRecipeBookLeaveErrorScreenshot() {
+    ChefMateTheme { EditRecipeBookScreen(bloc = previewEditRecipeBookLeaveErrorBloc) }
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookCollaboratorsScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookCollaboratorsScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:69ecf30b3b7b796ad6e17ddbfe45914bbb1ec8eb59c1b9626f4c1b1a6a5fbd51
-size 97285
+oid sha256:be4e75cc10e84ff14e27e0991b930ae855e060f61102f5fbddb61a45ef118e32
+size 101840

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookDeleteConfirmScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookDeleteConfirmScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67b04d2b4d57c90e8d14b17887d0659f3514293d1dbf4ea4b1587c5899561fab
+size 89592

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookLeaveConfirmScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookLeaveConfirmScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebec19ca4813c8cd7b0e7f5cbe5991f65fd116c782bec7b9db2f38165a2af0ca
+size 89795

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookLeaveErrorScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookLeaveErrorScreenshot_7c0f57d6_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2384db513051be75dd1c47212f305d1e041181ed84b83e4d8768bb1faa17d1be
+size 47772

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookMemberViewScreenshot_7c0f57d6_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/EditRecipeBookScreenshotTestKt/EditRecipeBookMemberViewScreenshot_7c0f57d6_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:699aba2ac0413d4e657ba6a6119d90a5d9442ca886aa3e2ef4a3ff5cccdf0559
-size 74912
+oid sha256:5a6648cf0729bc9e6c286657a183618b1a28638a73c3a5c1f2bf0ce2c2386c82
+size 79606


### PR DESCRIPTION
## What

Adds the missing way out of a recipe book. The Edit recipe book modal now shows one destructive control below everything else, picked from your relationship to the book:

- **Owner → "Delete book"** — deletes it locally and on the server, for everyone.
- **Collaborator → "Leave book"** — removes only your own membership. The book lives on for its owner.

Both confirm first, surface an inline error on failure instead of closing, and pop the modal on success.

## Why

Books could be created, renamed and shared, but never removed — an owner was stuck with every book they made, and a collaborator had to ask the owner to evict them from a book they no longer wanted.

## Behavior worth reviewing

- **The default "My Recipes" book can't be deleted**, at both layers: `deleteBook` no-ops on it and the UI doesn't render the button. It's the fallback every unfiled recipe lands in, so it always has to exist.
- **Deleting keeps your recipes.** They stop being listed under the book but stay in your library.
- **Leaving purges local recipes exclusive to that book.** This is the one judgment call here. Keeping someone else's recipes cached after access is revoked would leave them visible under "All recipes" indefinitely, so `deleteLocalRecipesInBook` drops recipes that book alone held; recipes also filed under another book are detached rather than deleted. Nothing is deleted remotely — they're still the owner's. Happy to flip this to "orphan them into the library" if you'd rather; it's a one-line change in `RecipeBookCollaborationRepositoryImpl.leaveBook`.
- **Active-book fallback.** Deleting or leaving the currently active book falls the selection back to "My Recipes".
- **Offline delete doesn't diverge.** `deleteBook` reuses the tombstone plumbing that was already in the schema and sync loop but never wired up: the row is marked pending-delete, hidden from the list immediately, and the remote delete is retried by the next sync.

## No migration needed

Both server paths are already permitted by existing policies — I checked `20260602_add_recipe_books.sql` and `20260608_add_recipe_book_collaboration.sql`:

- `"Users can delete own recipe books"` covers the owner delete, with `ON DELETE CASCADE` onto `recipe_book_members` and `recipe_book_recipes`.
- `"Owner or invitee can delete membership"` already permits self-removal.

## Commits

Split by concern: data layer + repo tests → BLoC/ViewModel/screen + VM tests → snapshots → robots.

## Testing

`./gradlew test` and `:client:ui:screenshot-test:validateDebugScreenshotTest` both pass. New coverage: repository tests (tombstone-on-remote-failure, active-book fallback, default-book refusal, leave deletes only your membership and purges local-only), ViewModel tests (owner vs. collaborator gating, confirm/dismiss, error path), robot-driven screen tests, and 3 new screenshot references (2 existing ones re-recorded to show the new button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)