### PR TITLE
fix(ci): read macOS signing assets from their own match branch

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,6 +47,15 @@ platform :mac do
   # generate_apple_certs: false forces the LEGACY, platform-specific cert types instead of the
   # unified "Apple Distribution" cert. Compose's MacSigner only understands the legacy
   # "3rd Party Mac Developer Application:" name, so the modern unified cert can't sign the app.
+  #
+  # git_branch keeps the macOS assets on their own branch of the certificates repo, because match
+  # derives its storage path from the cert TYPE alone (appstore -> certs/distribution) and ignores
+  # `platform`. On a shared branch the "3rd Party Mac Developer Application" cert lands in the same
+  # folder as the iOS Distribution cert and match installs whichever one it happens to pick — which
+  # is what broke `ios release` with `No signing certificate "iOS Distribution" found`. The two
+  # platforms can only share a branch if they share a cert, and the unified cert is ruled out above.
+  MATCH_BRANCH = "macos"
+
   def fetch_mac_app_store_signing(api_key, readonly:, force: false)
     match(
       type: "appstore",
@@ -54,6 +63,7 @@ platform :mac do
       app_identifier: MAC_APP_IDENTIFIER,
       additional_cert_types: ["mac_installer_distribution"],
       generate_apple_certs: false,
+      git_branch: MATCH_BRANCH,
       readonly: readonly,
       force: force,
       api_key: api_key,


### PR DESCRIPTION
## Why

The iOS Release workflow has failed on every tag since v1.9.26. xcodebuild dies with:

```
error: No signing certificate "iOS Distribution" found: No "iOS Distribution" signing certificate
matching team ID "***" with a private key was found. (in target 'iosApp')
```

match clones and decrypts fine — it just installs the **wrong certificate**. From the [v1.9.30 log](https://github.com/Plus-Mobile-Apps/chef-mate/actions/runs/29949790107):

```
+-------------------+----------------------------------------------------------+
|                            Installed Certificate                             |
+-------------------+----------------------------------------------------------+
| Common Name       | 3rd Party Mac Developer Application: Plus Mobile Apps LLC |
| Start Datetime    | 2026-07-21 17:47:56 UTC                                  |
```

## Root cause

match derives its storage path from the certificate **type** alone — `appstore` maps to
`certs/distribution` — and ignores the `platform:` argument. So when the Mac App Store lane first
ran (`[fastlane] Updated appstore and platform macos`, 2026-07-21 21:50 UTC) it wrote the Mac cert
into the same folder as the April iOS Distribution cert:

```
certs/distribution/A2775GGJ5H.{cer,p12}   # iOS Distribution   (2026-04-19)
certs/distribution/F2DL6A6XQ4.{cer,p12}   # 3rd Party Mac App  (2026-07-21)
```

The first iOS release after that commit — v1.9.26, one hour later — started failing.

The two platforms can only share a folder if they share a *certificate*, and the unified "Apple
Distribution" cert is already ruled out: Compose's `MacSigner` only matches the legacy
`3rd Party Mac Developer Application:` name, which is why `generate_apple_certs: false` is set.

## Change

`fetch_mac_app_store_signing` now passes `git_branch: "macos"`, so the macOS lanes read a dedicated
branch of the certificates repo and stop colliding with iOS on `master`.

## Required companion change (certificates repo)

This PR is inert on its own — the `macos` branch has to exist first, and it is forked from `master`
so it carries the existing encrypted certs **and their private keys**. No new Apple certificates are
minted and nothing is revoked:

```
git clone git@github.com:plusmobileapps/certificates.git && cd certificates
git checkout -b macos && git push -u origin macos
git checkout master
git rm certs/distribution/F2DL6A6XQ4.cer certs/distribution/F2DL6A6XQ4.p12 \
       certs/mac_installer_distribution/YHR5H47QCW.cer certs/mac_installer_distribution/YHR5H47QCW.p12 \
       profiles/appstore/AppStore_com.plusmobileapps.chefmate.ChefMate.provisionprofile
git commit -m "Move macOS App Store signing assets to the macos branch" && git push origin master
```

Order matters: push `macos` before stripping `master`, and land this PR before stripping `master`,
or the desktop lane loses its certs.

## Not fixed here

The **current** run ([v1.9.31](https://github.com/Plus-Mobile-Apps/chef-mate/actions/runs/29987050383))
fails earlier than this, at the clone, on both iOS and Desktop:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

`MATCH_GIT_BASIC_AUTHORIZATION` expired between v1.9.30 (Jul 22 19:11) and v1.9.31 (Jul 23 07:05)
and needs rotating. Both fixes must be in place before the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)