### PR TITLE
fix(grocery): stop a new account's own default list showing under "Shared with you"

### DIFF
--- a/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
+++ b/client/grocery/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImpl.kt
@@ -383,6 +383,15 @@ class GroceryRepositoryImpl(
                         RemoteGroceryList(name = entity.name, ownerId = authState.user.userId)
                     )
                 listQueries.updateRemoteId(remoteId = remoteList.id!!, id = localId)
+                // Record ownership locally right away. Without this the local ownerId
+                // stays NULL until a later pull, and syncListMembers would flag our own
+                // freshly-pushed list as "shared with you".
+                listQueries.updateOwnership(
+                    ownerId = authState.user.userId,
+                    role = "owner",
+                    isShared = false,
+                    id = localId,
+                )
             } catch (t: Throwable) {
                 if (t is CancellationException) throw t
                 Logger.e(throwable = t, tag = TAG) { "grocery remote sync operation failed" }
@@ -577,6 +586,14 @@ class GroceryRepositoryImpl(
                         )
                     withContext(ioContext) {
                         listQueries.updateRemoteId(remoteId = remoteList.id!!, id = list.id)
+                        // Record ownership locally so this just-pushed list isn't later
+                        // mistaken for a shared list when its local ownerId is still NULL.
+                        listQueries.updateOwnership(
+                            ownerId = userId,
+                            role = "owner",
+                            isShared = false,
+                            id = list.id,
+                        )
                     }
                 } catch (t: Throwable) {
                     if (t is CancellationException) throw t
@@ -925,10 +942,15 @@ class GroceryRepositoryImpl(
                 withContext(ioContext) {
                     val myMember = remoteMembers.firstOrNull { it.userId == userId }
                     if (myMember != null) {
+                        // Trust the member role rather than the local ownerId, which may
+                        // still be NULL right after we pushed the list (see pushListToRemote).
+                        // Deriving isShared from a NULL ownerId would flag our own list as
+                        // "shared with you".
+                        val isOwner = myMember.role == "owner"
                         listQueries.updateOwnership(
-                            ownerId = list.ownerId,
+                            ownerId = if (isOwner) userId else list.ownerId,
                             role = myMember.role,
-                            isShared = list.ownerId != userId,
+                            isShared = !isOwner,
                             id = list.id,
                         )
                     }

--- a/client/grocery/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImplTest.kt
+++ b/client/grocery/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/grocery/data/impl/GroceryRepositoryImplTest.kt
@@ -425,6 +425,36 @@ class GroceryRepositoryImplTest {
         }
 
     @Test
+    fun syncWithRemote_marks_freshly_pushed_default_list_as_owned_not_shared() =
+        runTest(testDispatcher) {
+            // New account: a local default list exists, and the remote has nothing yet.
+            repository.ensureDefaultList()
+
+            // Sign in. Sync pushes the local list to the remote, the fake mirrors the
+            // production trigger by inserting an owner member row, and syncListMembers runs.
+            fakeAuth.setState(
+                AuthState.Authenticated(
+                    ChefMateUser(
+                        userId = "user-1",
+                        userName = "Test",
+                        userEmail = "test@test.com",
+                        userProfileImageUrl = null,
+                    )
+                )
+            )
+            advanceUntilIdle()
+
+            // The user's own list must not be flagged as "shared with you".
+            repository.getGroceryLists().test {
+                val lists = awaitItem()
+                lists.size shouldBe 1
+                val defaultList = lists.first()
+                defaultList.name shouldBe "My Grocery List"
+                defaultList.isShared shouldBe false
+            }
+        }
+
+    @Test
     fun refreshListMembers_caches_pending_and_accepted_collaborators_from_remote() =
         runTest(testDispatcher) {
             val listId = repository.ensureDefaultList()

--- a/client/grocery/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/testing/FakeGroceryRemoteDataSource.kt
+++ b/client/grocery/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/grocery/data/testing/FakeGroceryRemoteDataSource.kt
@@ -32,6 +32,7 @@ class FakeGroceryRemoteDataSource : GroceryRemoteDataSource {
                 ownerId = ownerId,
             )
         lists.add(newList)
+        addOwnerMember(newList)
         return newList.id!!
     }
 
@@ -66,7 +67,29 @@ class FakeGroceryRemoteDataSource : GroceryRemoteDataSource {
         val result = list.copy(id = list.id ?: "remote-list-${nextListId++}")
         val ownerLists = remoteLists.getOrPut(list.ownerId) { mutableListOf() }
         ownerLists.add(result)
+        addOwnerMember(result)
         return result
+    }
+
+    /**
+     * Mirrors the production DB trigger that auto-inserts an owner row into `grocery_list_members`
+     * whenever a list is created. Without this, `syncListMembers` would never observe the owner
+     * membership that revealed the "own list shows up under Shared with you" bug.
+     */
+    private fun addOwnerMember(list: RemoteGroceryList) {
+        val id = list.id ?: return
+        remoteMembers
+            .getOrPut(id) { mutableListOf() }
+            .add(
+                RemoteGroceryListMember(
+                    id = "remote-owner-${Uuid.random()}",
+                    listId = id,
+                    userId = list.ownerId,
+                    invitedEmail = "",
+                    role = "owner",
+                    status = "accepted",
+                )
+            )
     }
 
     override suspend fun fetchGroceryLists(ownerId: String): List<RemoteGroceryList> =


### PR DESCRIPTION
## What

On a brand-new account, the default **My Grocery List** appeared under the **Shared with you** header instead of **My Lists**.

## Why

The default list is created locally with a NULL `ownerId`. The first sync pushes it to Supabase (sending `ownerId = userId`) but only recorded the `remoteId` locally — the local `ownerId` stayed NULL. The DB trigger then auto-inserts an owner row into `grocery_list_members`, and `syncListMembers`, running in the *same* sync pass, computed `isShared` from the still-NULL local `ownerId`:

```
isShared = list.ownerId != userId   // null != userId → true
```

`GroceryListScreen` splits lists purely on `isShared`, so the user's own list rendered as shared. It self-healed on a later pull (which fills in `ownerId`), which is why it looked like a transient new-account glitch.

## Changes

- **`pushListToRemote`** and the **unsynced-list push loop in `syncWithRemote`** now write ownership locally (`ownerId = userId`, `role = "owner"`, `isShared = false`) right after a successful remote create, so `ownerId` is never left NULL.
- **`syncListMembers`** now derives `isShared` from the authoritative member `role` (`role != "owner"`) rather than a possibly-NULL local `ownerId`. Belt-and-suspenders: even a stale local `ownerId` can't misclassify the list.

## Tests

- `FakeGroceryRemoteDataSource` now mirrors the production owner-member trigger by inserting an owner row on list creation — previously omitted, which is why the bug wasn't caught.
- Added `syncWithRemote_marks_freshly_pushed_default_list_as_owned_not_shared`, reproducing the new-account push-then-member-sync flow and asserting `isShared == false`.
- Full `GroceryRepositoryImplTest` suite passes.

## Reviewer notes

No schema or migration changes. The fix is entirely client-side sync bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)