### PR TITLE
fix(desktop): sign JavaFX WebView dylibs into the Mac App Store bundle

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -1,6 +1,7 @@
 import java.util.Properties
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.compose.desktop.application.tasks.AbstractJPackageTask
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
@@ -446,3 +447,66 @@ tasks
     .configureEach {
         dependsOn(extractSqliteJdbcMacDylib)
     }
+
+// --- Bundle JavaFX's macOS native libraries next to the app jars in the signed app image ---
+// The desktop browser is a JavaFX WebView (see browser/public .../PlatformWebView.jvm.kt), whose
+// native code ships *inside* the `org.openjfx:javafx-*:mac-aarch64` jars. When the WebView opens,
+// JavaFX's NativeLibLoader loads each `.dylib`: it first looks next to the JavaFX jars
+// (loadLibraryFullPath); only if that misses does it extract the lib from the jar to an unsigned
+// cache dir and dlopen() it. The Mac App Store sandbox forbids loading code that isn't part of the
+// signed bundle, so that extracted copy is blocked ("could not verify … free of malware") and
+// opening the browser fails on the Store/TestFlight build (libprism_es2.dylib).
+//
+// Fix (same idea as the sqlite-jdbc block above, but JavaFX searches next to its jars rather than a
+// resources dir): extract the JavaFX dylibs and hand them to jpackage's `files` input so Compose
+// copies them — signed via MacJarSignFileCopyingProcessor, exactly like the bundled skiko native —
+// into the app-image libs dir ($APPDIR) next to the JavaFX jars. loadLibraryFullPath then loads the
+// signed copies and JavaFX never extracts. macOS-only; Linux/Windows builds aren't sandboxed and
+// load JavaFX natives normally, and `./gradlew run` uses the full JDK/JavaFX off the module path.
+val isMacBuildHost =
+    System.getProperty("os.name").orEmpty().lowercase().let {
+        it.contains("mac") || it.contains("darwin")
+    }
+
+if (isMacBuildHost) {
+    val javafxMacNatives: Configuration by configurations.creating {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+    }
+
+    val fxClassifier = osClassifier()
+    val fxVersion = libs.versions.openjfx.get()
+    dependencies {
+        // The same set of JavaFX modules pulled by jvmMain; only some ship dylibs (graphics: prism/
+        // glass/font, web: jfxwebkit, media: jfxmedia) but resolving all keeps this in lockstep.
+        listOf("base", "controls", "graphics", "media", "swing", "web").forEach { module ->
+            javafxMacNatives("org.openjfx:javafx-$module:$fxVersion:$fxClassifier")
+        }
+    }
+
+    val extractJavaFxMacDylibs by
+        tasks.registering(Sync::class) {
+            from(javafxMacNatives.map { zipTree(it) }) {
+                include("**/*.dylib")
+                // The dylibs sit at the jar root; flatten defensively so they land directly in the
+                // output dir (and therefore in $APPDIR, next to the jars) regardless of jar layout.
+                eachFile { path = name }
+                includeEmptyDirs = false
+            }
+            into(layout.buildDirectory.dir("javafxNatives"))
+        }
+
+    // Feed the extracted dylibs into the app-image assembly (createDistributable /
+    // createReleaseDistributable). Compose's prepareWorkingDir copies each non-jar `files` entry
+    // into the libs dir under its own name and signs it — how the skiko native gets signed in
+    // $APPDIR. Not the pkg/dmg packaging tasks: those wrap the already-built app image.
+    tasks
+        .matching { it.name == "createDistributable" || it.name == "createReleaseDistributable" }
+        .withType<AbstractJPackageTask>()
+        .configureEach {
+            // Add the extracted dylibs as individual files (a file tree), not the task's output
+            // directory — prepareWorkingDir copies each `files` entry as-is, so a bare directory
+            // would be copied whole instead of the loose dylibs landing next to the jars.
+            files.from(extractJavaFxMacDylibs.map { fileTree(it.destinationDir) })
+        }
+}


### PR DESCRIPTION
## Problem

Opening the in-app browser on the **macOS TestFlight / Mac App Store** build fails with:

> Apple could not verify "libprism_es2.dylib" is free of malware that may harm your Mac or compromise your privacy.

The desktop browser is a **JavaFX WebView** (`client/browser/public/.../PlatformWebView.jvm.kt`), whose native code ships *inside* the `org.openjfx:javafx-*:mac-aarch64` jars. When the WebView first opens, JavaFX's `NativeLibLoader`:

1. looks for each `.dylib` **next to the JavaFX jars** (`loadLibraryFullPath`), and
2. only if that misses, **extracts the lib from the jar to an unsigned cache dir and `dlopen()`s it**.

Because the dylibs live inside the jars, step 2 always runs — and the Mac App Store **sandbox forbids loading code that isn't part of the signed bundle**, so the unsigned extracted copy is blocked. `libprism_es2.dylib` is the first Prism graphics lib loaded, hence the error. (This is the same class of failure the repo already fixed for `sqlite-jdbc`.)

## Fix

Extract the JavaFX dylibs at build time and hand them to jpackage's `files` input so Compose copies them — **signed, via `MacJarSignFileCopyingProcessor`, exactly like the bundled skiko native** — into the app-image libs dir (`$APPDIR`) **next to the JavaFX jars**. `loadLibraryFullPath` then loads the signed copies and JavaFX never extracts.

This mirrors the existing `extractSqliteJdbcMacDylib` bundling, adapted to where JavaFX searches (next to its jars, rather than the `resources/` dir the sqlite lib uses).

- **macOS-only** — gated on the build host; Linux/Windows builds aren't sandboxed, and `./gradlew run` uses the full JDK/JavaFX off the module path.
- Build-only change; no runtime code, no reflection.

## Verification

`./gradlew :client:composeApp:createDistributable` (unsigned local build):

- All 13 JavaFX dylibs (`libprism_es2`, `libjfxwebkit`, `libglass`, …) now land in `Contents/app` next to the jars, alongside `libskiko-macos-arm64.dylib`.
- They pick up the bundle signature (ad-hoc locally; the Apple Distribution cert in CI, same path skiko takes).
- **0** dylibs leaked into the `.cfg` classpath.
- `:client:composeApp:jvmTest` passes.

⚠️ Requires a real signed TestFlight build to confirm end-to-end, since sandbox enforcement can't be exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)