### PR TITLE
fix(desktop): make chefmate:// deep links open the desktop app

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -340,11 +340,31 @@ compose.desktop {
                 // Declares no non-exempt encryption (matches iosApp/iosApp/Info.plist), so App
                 // Store Connect skips the manual export-compliance prompt before each TestFlight
                 // build is available to testers.
+                //
+                // CFBundleURLTypes registers the `chefmate://` custom scheme so LaunchServices
+                // routes `chefmate://…` opens to this app (the invite-email links land on the web
+                // page, which bounces the browser to this scheme — see the chefmate-site
+                // /notifications redirect). macOS delivers the URL as an Apple Event, caught by the
+                // `Desktop.setOpenURIHandler` registered in main.kt, not as a command-line arg.
+                // Windows/Linux register the same scheme at runtime instead (SchemeRegistrar),
+                // since
+                // jpackage has no equivalent for them.
                 infoPlist {
                     extraKeysRawXml =
                         """
                         <key>ITSAppUsesNonExemptEncryption</key>
                         <false/>
+                        <key>CFBundleURLTypes</key>
+                        <array>
+                            <dict>
+                                <key>CFBundleURLName</key>
+                                <string>com.plusmobileapps.chefmate.ChefMate</string>
+                                <key>CFBundleURLSchemes</key>
+                                <array>
+                                    <string>chefmate</string>
+                                </array>
+                            </dict>
+                        </array>
                         """
                             .trimIndent()
                 }

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/deeplink/DeepLinkCoordinator.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/deeplink/DeepLinkCoordinator.kt
@@ -1,0 +1,35 @@
+package com.plusmobileapps.chefmate.deeplink
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Funnels desktop deep links from every runtime source to the running UI:
+ * - the macOS `Desktop.setOpenURIHandler` Apple Event (main.kt),
+ * - the Windows/Linux single-instance socket ([SingleInstance]) when a second launch forwards a
+ *   link.
+ *
+ * The cold-start link (first process argument) is handled separately as the initial navigation
+ * stack in `main`, so it does not flow through here — this coordinator carries only links that
+ * arrive *at* or *after* launch.
+ *
+ * `replay = 1` covers the cold-launch race on macOS, where `open chefmate://…` starts the app and
+ * then delivers the URL as an Apple Event a moment later — potentially before the Compose collector
+ * is attached. The replayed value is delivered to the first collector so the link isn't dropped.
+ * `extraBufferCapacity` lets the non-coroutine callers (AWT event thread, socket thread) [submit]
+ * without suspending.
+ */
+object DeepLinkCoordinator {
+    private val _links = MutableSharedFlow<String>(replay = 1, extraBufferCapacity = 16)
+
+    /** Deep-link URLs (e.g. `chefmate://notifications`) as they arrive. */
+    val links: SharedFlow<String> = _links.asSharedFlow()
+
+    /** Non-suspending; safe to call from any thread. Null/blank links are ignored. */
+    fun submit(url: String?) {
+        val trimmed = url?.trim().orEmpty()
+        if (trimmed.isEmpty()) return
+        _links.tryEmit(trimmed)
+    }
+}

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/deeplink/DesktopOs.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/deeplink/DesktopOs.kt
@@ -1,0 +1,17 @@
+package com.plusmobileapps.chefmate.deeplink
+
+/** The three desktop targets, used to branch the OS-specific deep-link integration. */
+internal enum class DesktopOs {
+    MACOS,
+    WINDOWS,
+    LINUX,
+}
+
+internal fun desktopOs(): DesktopOs {
+    val os = System.getProperty("os.name").orEmpty().lowercase()
+    return when {
+        os.contains("mac") || os.contains("darwin") -> DesktopOs.MACOS
+        os.contains("win") -> DesktopOs.WINDOWS
+        else -> DesktopOs.LINUX
+    }
+}

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/deeplink/SchemeRegistrar.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/deeplink/SchemeRegistrar.kt
@@ -1,0 +1,118 @@
+package com.plusmobileapps.chefmate.deeplink
+
+import co.touchlab.kermit.Logger
+import com.plusmobileapps.chefmate.ChefMateUrls
+import java.io.File
+
+/**
+ * Registers the `chefmate://` custom URL scheme with the host OS so that opening `chefmate://…`
+ * launches this app. macOS registers the scheme declaratively via `CFBundleURLTypes` in the
+ * packaged Info.plist (see `client/composeApp/build.gradle.kts`), so nothing is needed at runtime
+ * there. Windows and Linux have no jpackage equivalent, so the app self-registers on each launch —
+ * writing a per-user handler (no admin required) that is idempotent and self-heals if the app is
+ * moved or reinstalled, since the launcher path is re-derived every run.
+ *
+ * Registration is best-effort: any failure is logged and swallowed so it can never break launch.
+ */
+object SchemeRegistrar {
+    private val log = Logger.withTag("SchemeRegistrar")
+    private const val SCHEME = ChefMateUrls.SCHEME
+    private const val LINUX_DESKTOP_FILE = "chefmate-url-handler.desktop"
+
+    /**
+     * Registers the scheme when running from a packaged app image; a no-op under `./gradlew run`
+     * (there is no installed launcher to point the OS at, and the dev flow passes the link via
+     * `--args` instead).
+     */
+    fun registerIfPackaged() {
+        val launcher = launcherPath() ?: return
+        runCatching {
+            when (desktopOs()) {
+                DesktopOs.WINDOWS -> registerWindows(launcher)
+                DesktopOs.LINUX -> registerLinux(launcher)
+                // macOS registration is declarative (CFBundleURLTypes); LaunchServices handles it.
+                DesktopOs.MACOS -> Unit
+            }
+        }
+            .onFailure { log.w(it) { "Failed to register $SCHEME:// scheme" } }
+    }
+
+    /**
+     * The installed launcher executable, or null when not running from a jpackage image. jpackage
+     * launchers (JDK 18+) expose their own path via the `jpackage.app-path` system property; its
+     * absence is the reliable "not packaged" signal that also skips `./gradlew run`.
+     */
+    private fun launcherPath(): String? =
+        System.getProperty("jpackage.app-path")?.takeIf { it.isNotBlank() }
+
+    // ---- Windows -----------------------------------------------------------------------------
+
+    private fun registerWindows(launcher: String) {
+        // Import a .reg file rather than shelling out to `reg add`: the command value contains
+        // embedded quotes and a `%1`, and Java's Windows argument quoting mangles those. A .reg
+        // file's escaping rules are explicit and predictable.
+        val regFile = File.createTempFile("chefmate-scheme", ".reg")
+        try {
+            regFile.writeText(windowsRegFileContent(launcher))
+            val exit =
+                ProcessBuilder("reg", "import", regFile.absolutePath)
+                    .redirectErrorStream(true)
+                    .start()
+                    .waitFor()
+            if (exit != 0) log.w { "reg import exited with $exit" }
+        } finally {
+            regFile.delete()
+        }
+    }
+
+    /**
+     * The `.reg` file that maps `HKCU\Software\Classes\chefmate` to this launcher.
+     * Pure/deterministic so it can be unit-tested. In a `.reg` value, backslashes and quotes are
+     * escaped (`\\`, `\"`), so a launcher path like `C:\Program Files\Chef Mate\Chef Mate.exe` and
+     * the `"%1"` argument are doubled up accordingly.
+     */
+    internal fun windowsRegFileContent(launcherPath: String): String {
+        val escaped = launcherPath.replace("\\", "\\\\").replace("\"", "\\\"")
+        return buildString {
+            append("Windows Registry Editor Version 5.00\r\n\r\n")
+            append("[HKEY_CURRENT_USER\\Software\\Classes\\$SCHEME]\r\n")
+            append("@=\"URL:Chef Mate\"\r\n")
+            append("\"URL Protocol\"=\"\"\r\n\r\n")
+            append("[HKEY_CURRENT_USER\\Software\\Classes\\$SCHEME\\shell\\open\\command]\r\n")
+            append("@=\"\\\"$escaped\\\" \\\"%1\\\"\"\r\n")
+        }
+    }
+
+    // ---- Linux -------------------------------------------------------------------------------
+
+    private fun registerLinux(launcher: String) {
+        val appsDir = File(System.getProperty("user.home"), ".local/share/applications")
+        appsDir.mkdirs()
+        File(appsDir, LINUX_DESKTOP_FILE).writeText(linuxDesktopFileContent(launcher))
+        // Point the scheme at our handler, then refresh the desktop database so it takes effect.
+        // update-desktop-database is absent on some minimal distros — non-fatal.
+        runProcess("xdg-mime", "default", LINUX_DESKTOP_FILE, "x-scheme-handler/$SCHEME")
+        runProcess("update-desktop-database", appsDir.absolutePath)
+    }
+
+    /**
+     * The `.desktop` handler entry declaring the `x-scheme-handler/chefmate` MIME type. Pure so it
+     * can be unit-tested. The launcher path is quoted per the Desktop Entry spec (it may contain
+     * spaces); `%u` passes the opened URL through as the single argument.
+     */
+    internal fun linuxDesktopFileContent(launcherPath: String): String = buildString {
+        append("[Desktop Entry]\n")
+        append("Type=Application\n")
+        append("Name=Chef Mate\n")
+        append("Exec=\"$launcherPath\" %u\n")
+        append("NoDisplay=true\n")
+        append("MimeType=x-scheme-handler/$SCHEME;\n")
+    }
+
+    private fun runProcess(vararg command: String) {
+        runCatching {
+            ProcessBuilder(*command).redirectErrorStream(true).start().waitFor()
+        }
+            .onFailure { log.w(it) { "command failed: ${command.joinToString(" ")}" } }
+    }
+}

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/deeplink/SingleInstance.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/deeplink/SingleInstance.kt
@@ -1,0 +1,96 @@
+package com.plusmobileapps.chefmate.deeplink
+
+import co.touchlab.kermit.Logger
+import java.io.File
+import java.io.RandomAccessFile
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+
+/**
+ * Keeps the desktop app to a single window and routes deep links from later launches into the
+ * running instance.
+ *
+ * On Windows and Linux the OS starts a **new process** every time `chefmate://…` is opened, so
+ * without this a second window would appear and the already-open app would never see the link. The
+ * first process wins a file lock and becomes the primary, listening on a loopback socket; any later
+ * process forwards its link there and exits. macOS is exempt — LaunchServices reuses the single
+ * running instance and delivers subsequent opens as Apple Events (handled in main.kt), so no socket
+ * is involved.
+ *
+ * Best-effort: if the lock/socket machinery fails for any reason (e.g. a sandbox forbids the
+ * listening socket), the process proceeds as primary rather than refusing to start.
+ */
+object SingleInstance {
+    private val log = Logger.withTag("SingleInstance")
+
+    /**
+     * Returns true if this process should build the UI (it is the primary instance). Returns false
+     * only when another instance already owns the app — in that case the deep link from [args] has
+     * been forwarded to it and this process must exit without opening a window.
+     */
+    fun acquireOrForward(args: Array<String>): Boolean {
+        // macOS enforces single-instance itself and delivers links via Apple Event; no socket
+        // needed.
+        if (desktopOs() == DesktopOs.MACOS) return true
+        return runCatching { acquire(args) }
+            .getOrElse {
+                log.w(it) { "single-instance setup failed; proceeding as primary" }
+                true
+            }
+    }
+
+    private fun acquire(args: Array<String>): Boolean {
+        val dir =
+            File(System.getProperty("java.io.tmpdir"), "chefmate-singleinstance").apply { mkdirs() }
+        val portFile = File(dir, "port")
+        // The channel/lock are intentionally never closed: the lock is held for the whole process
+        // lifetime and released by the OS on exit, which is exactly the primary-election signal.
+        val lock = RandomAccessFile(File(dir, "lock"), "rw").channel.tryLock()
+
+        if (lock == null) {
+            // Another live instance holds the lock. Hand off our link and step aside.
+            forward(portFile, args.firstOrNull())
+            return false
+        }
+
+        startServer(portFile)
+        return true
+    }
+
+    private fun startServer(portFile: File) {
+        val server = ServerSocket(0, 50, InetAddress.getLoopbackAddress())
+        portFile.writeText(server.localPort.toString())
+        Thread(
+                {
+                    while (!server.isClosed) {
+                        runCatching {
+                            server.accept().use { socket ->
+                                val link = socket.getInputStream().bufferedReader().readLine()
+                                DeepLinkCoordinator.submit(link)
+                            }
+                        }
+                            .onFailure { log.w(it) { "single-instance accept failed" } }
+                    }
+                },
+                "chefmate-singleinstance",
+            )
+            .apply { isDaemon = true }
+            .start()
+    }
+
+    private fun forward(portFile: File, link: String?) {
+        if (link.isNullOrBlank()) return
+        runCatching {
+            val port = portFile.readText().trim().toInt()
+            Socket(InetAddress.getLoopbackAddress(), port).use { socket ->
+                socket.getOutputStream().bufferedWriter().apply {
+                    write(link)
+                    newLine()
+                    flush()
+                }
+            }
+        }
+            .onFailure { log.w(it) { "failed to forward deep link to the primary instance" } }
+    }
+}

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/main.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/main.kt
@@ -26,10 +26,14 @@ import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.backhandler.BackDispatcher
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.plusmobileapps.chefmate.buildconfig.BuildConfig
+import com.plusmobileapps.chefmate.deeplink.DeepLinkCoordinator
+import com.plusmobileapps.chefmate.deeplink.SchemeRegistrar
+import com.plusmobileapps.chefmate.deeplink.SingleInstance
 import com.plusmobileapps.chefmate.root.DeepLink
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import com.plusmobileapps.chefmate.update.DesktopUpdater
 import com.plusmobileapps.chefmate.update.UpdateBanner
+import java.awt.Desktop
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
@@ -42,6 +46,28 @@ private const val KEY_WINDOW_PLACEMENT = "window.placement"
 
 @OptIn(ExperimentalTime::class, FlowPreview::class)
 fun main(args: Array<String>) {
+    // Windows/Linux spawn a fresh process for every `chefmate://…` open. If another instance is
+    // already running, forward this launch's link to it and exit without opening a second window.
+    if (!SingleInstance.acquireOrForward(args)) return
+
+    // Make the OS route `chefmate://…` to this app. macOS uses the packaged Info.plist
+    // (CFBundleURLTypes) + the Apple Event handler below; Windows/Linux self-register at runtime.
+    SchemeRegistrar.registerIfPackaged()
+
+    // macOS delivers URL opens as Apple Events, not command-line args, both at cold launch and
+    // while
+    // running. Route them through the coordinator so the warm-delivery collector navigates the app.
+    // Throws on non-macOS / when unsupported, so it is guarded and swallowed.
+    runCatching {
+        val desktop = Desktop.getDesktop()
+        if (desktop.isSupported(Desktop.Action.APP_OPEN_URI)) {
+            desktop.setOpenURIHandler { event -> DeepLinkCoordinator.submit(event.uri.toString()) }
+        }
+    }
+
+    // Cold-start deep link from the launch arguments (Windows/Linux). On macOS argv is empty and
+    // the
+    // link instead arrives via the Apple Event handler above.
     val deepLink = DeepLink.parse(args.firstOrNull())
     // Initialize Bugsnag + Kermit logging for JVM
     BugsnagInitializer().initialize(BuildConfig.BUGSNAG_API_KEY)
@@ -131,6 +157,18 @@ fun main(args: Array<String>) {
                 }
             },
         ) {
+            // Deep links that arrive while the app is running (macOS Apple Events, or links
+            // forwarded
+            // from a second launch on Windows/Linux) route into the live RootBloc and raise the
+            // window. Cold-start links are already applied as the initial stack via [deepLink]
+            // above.
+            LaunchedEffect(rootBloc) {
+                DeepLinkCoordinator.links.collect { url ->
+                    rootBloc.handleDeepLink(url)
+                    window.toFront()
+                    window.requestFocus()
+                }
+            }
             Box(modifier = Modifier.fillMaxSize()) {
                 App(rootBloc = rootBloc, toastService = appComponent.toastService)
                 val updateState by updater.state.collectAsState()

--- a/client/composeApp/src/jvmTest/kotlin/com/plusmobileapps/chefmate/deeplink/DesktopDeepLinkTest.kt
+++ b/client/composeApp/src/jvmTest/kotlin/com/plusmobileapps/chefmate/deeplink/DesktopDeepLinkTest.kt
@@ -1,0 +1,54 @@
+package com.plusmobileapps.chefmate.deeplink
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SchemeRegistrarTest {
+    @Test
+    fun windows_reg_file_maps_the_scheme_to_the_quoted_launcher() {
+        val reg =
+            SchemeRegistrar.windowsRegFileContent("C:\\Program Files\\Chef Mate\\Chef Mate.exe")
+
+        assertTrue(reg.startsWith("Windows Registry Editor Version 5.00"), reg)
+        assertTrue(reg.contains("[HKEY_CURRENT_USER\\Software\\Classes\\chefmate]"), reg)
+        assertTrue(reg.contains("\"URL Protocol\"=\"\""), reg)
+        // The command value doubles backslashes and escapes quotes; %1 is the opened URL.
+        assertTrue(
+            reg.contains(
+                "@=\"\\\"C:\\\\Program Files\\\\Chef Mate\\\\Chef Mate.exe\\\" \\\"%1\\\"\""
+            ),
+            reg,
+        )
+    }
+
+    @Test
+    fun linux_desktop_file_declares_the_scheme_handler() {
+        val desktop = SchemeRegistrar.linuxDesktopFileContent("/opt/chef-mate/bin/Chef Mate")
+
+        assertTrue(desktop.contains("[Desktop Entry]"), desktop)
+        assertTrue(desktop.contains("Exec=\"/opt/chef-mate/bin/Chef Mate\" %u"), desktop)
+        assertTrue(desktop.contains("MimeType=x-scheme-handler/chefmate;"), desktop)
+        assertTrue(desktop.contains("NoDisplay=true"), desktop)
+    }
+}
+
+class DeepLinkCoordinatorTest {
+    @Test
+    fun submit_retains_the_trimmed_link_for_a_late_collector() {
+        DeepLinkCoordinator.submit("  chefmate://notifications  ")
+
+        assertEquals("chefmate://notifications", DeepLinkCoordinator.links.replayCache.last())
+    }
+
+    @Test
+    fun submit_ignores_null_and_blank_links() {
+        DeepLinkCoordinator.submit("chefmate://groceries")
+        val before = DeepLinkCoordinator.links.replayCache.last()
+
+        DeepLinkCoordinator.submit(null)
+        DeepLinkCoordinator.submit("   ")
+
+        assertEquals(before, DeepLinkCoordinator.links.replayCache.last())
+    }
+}

--- a/docs/navigation-deeplinks.md
+++ b/docs/navigation-deeplinks.md
@@ -47,7 +47,11 @@ Without `force-stop`, Android delivers the intent to the already-running activit
 
 ## Desktop (JVM)
 
-`main(args: Array<String>)` takes the first CLI argument and parses it as a deeplink.
+### Dev loop (`./gradlew run`)
+
+`main(args: Array<String>)` takes the first CLI argument and parses it as the cold-start deeplink.
+Scheme registration and single-instance forwarding are no-ops under Gradle (there is no installed
+launcher), so this is the way to exercise a deeplink during development:
 
 ```bash
 ./gradlew :client:composeApp:run --args="chefmate://recipe/1"
@@ -56,6 +60,38 @@ Without `force-stop`, Android delivers the intent to the already-running activit
 ./gradlew :client:composeApp:run --args="chefmate://settings"
 ./gradlew :client:composeApp:run --args="chefmate://signin"
 ./gradlew :client:composeApp:run --args="chefmate://signup"
+```
+
+### Packaged builds (how a real deeplink reaches the app)
+
+Unlike Android/iOS, a desktop app cannot claim an `https://` link — Windows and Linux have no App
+Links / Universal Links, and the browser owns `https:`. So the invite-email `https://` link lands on
+the [chefmate-site](https://chefmate.plusmobileapps.com) `/notifications` page, which redirects the
+browser to `chefmate://notifications`. The desktop app registers that custom scheme so the OS routes
+it back:
+
+- **macOS** — declared via `CFBundleURLTypes` in the packaged Info.plist
+  (`client/composeApp/build.gradle.kts`, `macOS { infoPlist { … } }`). LaunchServices registers it
+  when the `.app` is installed. macOS delivers the URL as an Apple Event, caught by
+  `Desktop.setOpenURIHandler` in `main.kt` (not as a command-line arg), for both cold and warm launches.
+- **Windows / Linux** — self-registered at runtime by
+  `client/composeApp/src/jvmMain/.../deeplink/SchemeRegistrar.kt` (a per-user registry entry / a
+  `~/.local/share/applications` `.desktop` handler). No admin, idempotent, re-derived from the
+  installed launcher each launch. The OS starts a **new process** per open, so
+  `deeplink/SingleInstance.kt` elects one primary via a file lock + loopback socket and forwards
+  later launches' links into it, raising the existing window instead of opening a second one.
+
+Warm deliveries (macOS Apple Event, or a forwarded Windows/Linux launch) flow through
+`deeplink/DeepLinkCoordinator.kt` into `RootBloc.handleDeepLink(url)`; cold-start links are still
+applied as the initial navigation stack.
+
+Test against an **installed** packaged build (`packageReleasePkg` / `packageReleaseMsi` /
+`packageReleaseDeb`), with the app both closed and already open:
+
+```bash
+open "chefmate://notifications"                 # macOS
+xdg-open "chefmate://notifications"             # Linux
+start "" "chefmate://notifications"             # Windows (cmd)
 ```
 
 ## iOS


### PR DESCRIPTION
## Why

Tapping the `https://chefmate.plusmobileapps.com/notifications` link in the invite email opens a browser instead of the desktop app. Two gaps caused this:

1. **The desktop app never registered the `chefmate://` scheme with any OS.** Android/iOS register it; the JVM build did not. `main()` only read a cold-start link from `argv`, and nothing delivered a link into an already-running window.
2. An `https://` link **can't** be claimed by a desktop app on Windows/Linux (no App Links / Universal Links). The cross-platform fix is the standard custom-scheme bounce — the web page redirects `https://…/notifications` → `chefmate://notifications`, which the app *can* register.

This PR is the **app half**. The **site half** (the `/notifications` redirect page in `chefmate-site`) is a separate PR; both must ship for the email to reach the app.

The shared parsing/routing (`DeepLink.parse`, `RootBloc.handleDeepLink`) already handled `/notifications` — this is entirely OS-integration glue.

## What

- **macOS** — declare `CFBundleURLTypes` in the packaged Info.plist; deliver URL opens via `Desktop.setOpenURIHandler` (macOS uses an Apple Event, not argv), buffered through `DeepLinkCoordinator` for the cold-launch race.
- **Windows/Linux** — `SchemeRegistrar` self-registers a per-user handler at launch (HKCU `.reg` import / `~/.local/share/applications` `.desktop` + `xdg-mime`), idempotent, re-derived from the installed launcher; no-op under `./gradlew run`.
- **`SingleInstance`** — a file lock + loopback socket elects one primary so a second Windows/Linux launch forwards its link into the open window instead of duplicating it (macOS is exempt — the OS reuses the instance via Apple Event).
- Docs + unit tests for the pure builders and the coordinator.

## Verification

- ✅ `:client:composeApp:jvmTest` compiles clean and passes.
- ⚠️ Full end-to-end needs a **packaged, installed** build per-OS (`packageReleasePkg`/`Msi`/`Deb`); test with `open` / `xdg-open` / `start "" "chefmate://notifications"` against an installed app, both closed and already open. Can't install all three OSes in this environment.
- ⚠️ Worth confirming the scheme resolves in a real **Mac App Store / TestFlight** sandboxed build (local `.app` sandbox behavior can differ). The listening socket is deliberately skipped on macOS, so the sandbox's network-server restriction doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)