### PR TITLE
fix(aichat): stop the collapsed sheet peek from filling the window height

### DIFF
--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/AiChatSheetPeekSizingUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/AiChatSheetPeekSizingUiTest.kt
@@ -1,0 +1,47 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package com.plusmobileapps.chefmate.tests
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import com.plusmobileapps.chefmate.aichat.AiChatTestTags
+import com.plusmobileapps.chefmate.aichat.robots.aiChat
+import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
+import com.plusmobileapps.chefmate.fixtures.TestRecipes
+import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.recipe.core.robots.recipeDetail
+import com.plusmobileapps.chefmate.recipe.list.robots.recipeList
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Regression coverage for the collapsed sheet "peek": [AiChatSheetNavigationUiTest] only asserts
+ * that the peek node exists in the semantics tree, which doesn't catch the sheet's *measured*
+ * height being wrong. ModalBottomSheet's Dialog measures its content with a tight constraint
+ * matching the full window (see the comment on the Box in RootScreen.kt's AiChatSheet), so without
+ * relaxing that constraint the peek silently renders at full window height with the input pinned
+ * near the top, even though every node the navigation test checks for is still present.
+ */
+@OptIn(ExperimentalTestApi::class)
+class AiChatSheetPeekSizingUiTest {
+
+    @Test
+    fun peek_sheet_hugs_its_content_height_instead_of_filling_the_window() = runRootBlocTest {
+        it.testFeatureFlags.set(FeatureFlagRegistry.AiChat, true)
+
+        recipeList().clickRecipe(TestRecipes.fullyPopulated.title)
+        recipeDetail().awaitDisplayed().tapAiChat()
+        aiChat().awaitPeekShown()
+
+        val peekHeight = onNodeWithTag(AiChatTestTags.PEEK).fetchSemanticsNode().size.height
+        val windowHeight = onNodeWithTag(AiChatTestTags.PEEK).fetchSemanticsNode().boundsInWindow
+
+        // The peek is just a recipe chip + input row; it should be a small strip, nowhere close to
+        // filling the test window's height. This is a regression guard, not a pixel-exact bound.
+        assertTrue(
+            peekHeight < 400,
+            "expected the collapsed AI chat peek to hug its small content height, " +
+                "but it measured $peekHeight px tall (window bounds: $windowHeight)",
+        )
+    }
+}

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -118,9 +119,21 @@ private fun AiChatSheet(rootBloc: RootBloc) {
             // Grow (and shrink) the sheet smoothly between the compact peek and the full-height
             // chat instead of snapping. Anchoring the size change to the bottom keeps the input
             // pinned to the bottom edge while the app bar and messages fill in above as it expands.
+            //
+            // ModalBottomSheet's Dialog measures its content with a *tight* height constraint
+            // matching the full window (see androidx.compose.ui.window.RootMeasurePolicy) rather
+            // than a loose "up to this much" one, and nothing in Material3's Surface/Column relaxes
+            // it. Without wrapContentHeight(unbounded = true) here, the peek content is forced to
+            // report that full window height regardless of how small it actually is, leaving the
+            // input pinned near the top of an otherwise-empty full-height sheet. Only applied while
+            // collapsed: the expanded chat wants to actually fill the available height.
             Box(
                 modifier =
                     Modifier.fillMaxWidth()
+                        .then(
+                            if (expanded) Modifier
+                            else Modifier.wrapContentHeight(Alignment.Top, unbounded = true)
+                        )
                         .animateContentSize(
                             animationSpec = tween(),
                             alignment = Alignment.BottomCenter,


### PR DESCRIPTION
## Summary
- Opening the AI chat sheet from recipe detail or cook mode should peek up from the bottom (just the recipe chip + input, anchored to the bottom edge), then expand to full height when tapped/dragged.
- Instead, it was rendering full window height immediately, with the input pinned near the top of an otherwise-empty sheet.
- Root cause: `ModalBottomSheet`'s `Dialog` (`androidx.compose.ui.window.RootMeasurePolicy`, shared by the desktop + iOS "skiko" targets) measures its content with a **tight** constraint matching the full window, rather than a loose max-bound one — and nothing in Material3's `Surface`/`Column` relaxes that constraint on the way down. The peek's actual content (`AiChatPeek`) was always small, but it was being *forced* to report the full window height it had no ability to shrink out of.
- Fix: apply `Modifier.wrapContentHeight(Alignment.Top, unbounded = true)` on the sheet's content box while collapsed, which explicitly breaks out of that inherited tight constraint so the box reports its true (small) content height. The expanded state is untouched — it legitimately wants to fill the available height.

Confirmed via a `ComposeUiTest` harness (real Skia layout, not mocked) that measures actual pixel bounds — before the fix the peek's immediate parent measured ~720px tall in a 768px test window; after the fix it hugs the small peek content.

## Test plan
- [x] New regression test `AiChatSheetPeekSizingUiTest` asserts the peek's measured height stays well under the window height — the existing `AiChatSheetNavigationUiTest` only checks semantics-tree node *existence*, which doesn't catch a sizing bug like this.
- [x] Existing `AiChatSheetNavigationUiTest`, `AiChatNavigationUiTest`, `AiChatHistoryNavigationUiTest` all still pass (peek → expand transition unaffected).
- [ ] Manual verification on device/simulator (desktop build was smoke-tested via the app launching; recommend a quick visual check on iOS/Android before merge since the constraint behavior is platform-dependent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)