### PR TITLE
fix(recipe): stop new accounts syncing every public recipe (#487)

### DIFF
--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RecipeRemoteDataSource.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/RecipeRemoteDataSource.kt
@@ -7,7 +7,10 @@ interface RecipeRemoteDataSource {
 
     /**
      * Every recipe the current user can access — owned plus those in books shared with them.
-     * Row-level security scopes the result, so no owner filter is applied.
+     * Deliberately does **not** include recipes that are merely public: a plain `select()` would OR
+     * in every `is_public` row via the public-read RLS policy, so a new account would pull down the
+     * whole public catalog (#487). Backed by the `get_accessible_recipes` RPC, whose
+     * owned-or-shared scope is the sole gate.
      */
     suspend fun fetchAccessibleRecipes(): List<RemoteRecipe>
 

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipeRemoteDataSource.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/remote/SupabaseRecipeRemoteDataSource.kt
@@ -6,6 +6,7 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.postgrest.query.Columns
 
 @Inject
@@ -30,7 +31,11 @@ class SupabaseRecipeRemoteDataSource(private val supabaseClient: SupabaseClient)
     }
 
     override suspend fun fetchAccessibleRecipes(): List<RemoteRecipe> =
-        supabaseClient.from("recipes").select().decodeList<RemoteRecipe>()
+        // Deliberately NOT a blanket `from("recipes").select()`: the permissive "Anyone can view
+        // public recipes" RLS policy would OR every is_public row into the result, so a fresh
+        // account would sync down the entire public catalog (#487). The get_accessible_recipes()
+        // RPC returns exactly owned + shared-book recipes.
+        supabaseClient.postgrest.rpc("get_accessible_recipes").decodeList<RemoteRecipe>()
 
     override suspend fun fetchPublicRecipe(remoteId: String): RemoteRecipe? =
         supabaseClient

--- a/supabase/migrations/20260725_recipes_sync_excludes_public.sql
+++ b/supabase/migrations/20260725_recipes_sync_excludes_public.sql
@@ -1,0 +1,35 @@
+-- Stop the account-sync pull from dragging in every public recipe.
+--
+-- Bug (#487): a brand-new account immediately shows a handful of recipes it never added. The
+-- client sync does a blanket `SELECT * FROM recipes` (SupabaseRecipeRemoteDataSource
+-- .fetchAccessibleRecipes) and relies on RLS to scope the rows to "owned + shared". That stopped
+-- being true once public sharing landed: "Anyone can view public recipes" (20260713, widened to
+-- anon in 20260715) is a permissive SELECT policy, and Postgres ORs permissive policies together,
+-- so the blanket select also returns every row with is_public = true. A fresh account with no
+-- recipes of its own therefore syncs down the entire public catalog.
+--
+-- We can't drop the public-read policy — the share-link flow (fetchPublicRecipe: select by id +
+-- is_public) depends on it to let a non-owner read a shared recipe. Instead give the sync its own
+-- explicit source of truth that means exactly "owned + shared", never "public".
+--
+-- get_accessible_recipes() is SECURITY DEFINER so it bypasses RLS on `recipes` entirely: its WHERE
+-- clause is then the ONLY gate, and it re-scopes to the caller via auth.uid() + the existing
+-- can_access_recipe() helper (which checks accepted book membership for auth.uid()). Public-but-
+-- not-mine rows have neither owner_id = auth.uid() nor book access, so they're excluded — while a
+-- recipe that is BOTH shared with me AND public is still returned (via can_access_recipe), which a
+-- naive is_public = false filter would have wrongly dropped.
+--
+-- can_access_recipe() is itself SECURITY DEFINER (20260608 / 20260610), so nesting it here does not
+-- re-enter recipes RLS and cannot reintroduce the 42P17 recursion fixed in 20260610.
+
+CREATE OR REPLACE FUNCTION get_accessible_recipes()
+RETURNS SETOF recipes
+LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
+    SELECT r.*
+    FROM recipes r
+    WHERE r.owner_id = auth.uid()
+       OR can_access_recipe(r.id);
+$$;
+
+-- Real synced accounts are `authenticated`; anonymous share-link sessions never sync their library.
+GRANT EXECUTE ON FUNCTION get_accessible_recipes() TO authenticated;


### PR DESCRIPTION
Fixes #487.

## Problem

A brand-new account immediately shows a handful of recipes it never added.

The account sync does a blanket `from("recipes").select()` in `SupabaseRecipeRemoteDataSource.fetchAccessibleRecipes()` and relies on RLS to scope the rows to "owned + shared". That assumption broke when public sharing landed: the `"Anyone can view public recipes"` policy (`is_public = true`, added in `20260713`, widened to `anon` in `20260715`) is a **permissive** `SELECT` policy, and Postgres **ORs permissive policies together**. So the unfiltered select also returns every public row. A fresh account owns nothing, so its first sync inserts the entire public catalog into the local DB.

## Fix

Give the sync its own explicit source of truth instead of leaning on RLS:

- **`20260725_recipes_sync_excludes_public.sql`** — new `get_accessible_recipes()`, `SECURITY DEFINER` so its `WHERE owner_id = auth.uid() OR can_access_recipe(id)` is the **only** gate (it bypasses the permissive public OR). Reuses the existing `can_access_recipe()` collaboration helper, so a recipe that is *both* shared-with-me and public is still returned — a naive `is_public = false` filter would have wrongly dropped those. `GRANT EXECUTE TO authenticated`.
- **`SupabaseRecipeRemoteDataSource.fetchAccessibleRecipes()`** now calls `supabaseClient.postgrest.rpc("get_accessible_recipes")`, matching the existing RPC pattern used by the grocery / recipe-book collaborator lookups.
- Updated the `RecipeRemoteDataSource` interface doc to explain why it's deliberately not a blanket select.

The public-read policy is left intact — the share-link flow (`fetchPublicRecipe`) and the logged-out web fallback page depend on it.

## Reviewer notes

- **This migration must be applied to prod Supabase** to fix live accounts. It's a pure `CREATE OR REPLACE FUNCTION` + `GRANT`, idempotent and safe to apply directly.
- **Existing devices don't self-heal.** The sync loop only inserts, never prunes, so recipes already synced onto affected devices remain in the local DB until a reinstall / fresh re-sync. Adding a prune step to the sync is a separate change — happy to follow up if wanted.
- `compileKotlinMetadata` for the module builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)