### PR TITLE
feat(recipe): multi-select bulk add-to-book/category with long-press entry

### DIFF
--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/RecipeMultiSelectUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/RecipeMultiSelectUiTest.kt
@@ -1,0 +1,32 @@
+package com.plusmobileapps.chefmate.tests
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.plusmobileapps.chefmate.fixtures.TestRecipes
+import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.recipe.list.robots.recipeList
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class RecipeMultiSelectUiTest {
+
+    @Test
+    fun long_press_enters_selection_and_bulk_adds_to_a_category() = runRootBlocTest {
+        recipeList()
+            .longPressRecipe(TestRecipes.fullyPopulated.title)
+            .openSelectionOverflow()
+            .tapAddToCategory()
+            .assertBulkCategorySheetShown()
+            .selectBulkCategory("Dinner")
+            // Picking a category files the selection, closes the sheet, and drops back to the list.
+            .assertRecipeIsDisplayed(TestRecipes.fullyPopulated.title)
+    }
+
+    @Test
+    fun selection_overflow_opens_the_add_to_book_picker() = runRootBlocTest {
+        recipeList()
+            .longPressRecipe(TestRecipes.fullyPopulated.title)
+            .openSelectionOverflow()
+            .tapAddToBook()
+            .assertBulkBookSheetShown()
+    }
+}

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImpl.kt
@@ -215,6 +215,37 @@ class RecipeRepositoryImpl(
         return withContext(ioContext) { db.getById(id).executeAsOneOrNull()?.remoteId }
     }
 
+    override suspend fun addRecipesToBook(recipeIds: Set<Long>, bookId: Long) {
+        if (recipeIds.isEmpty()) return
+        withContext(ioContext) {
+            db.transaction {
+                val now = dateTimeUtil.now.toString()
+                for (recipeId in recipeIds) {
+                    // attach is INSERT OR IGNORE, so a recipe already in the book is untouched.
+                    bookJoinDb.attach(recipeBookId = bookId, recipeId = recipeId)
+                    db.markDirty(id = recipeId, updatedAt = now)
+                }
+            }
+        }
+        // Push each in the background so the bulk action returns as soon as the local write lands;
+        // the dirty flag guarantees a retry on the next full sync if a push fails.
+        for (recipeId in recipeIds) scope.launch { pushUpdateToRemote(recipeId) }
+    }
+
+    override suspend fun addRecipesToCategory(recipeIds: Set<Long>, category: Category) {
+        if (recipeIds.isEmpty()) return
+        withContext(ioContext) {
+            db.transaction {
+                val now = dateTimeUtil.now.toString()
+                for (recipeId in recipeIds) {
+                    joinDb.attach(recipeId = recipeId, categoryId = category.id)
+                    db.markDirty(id = recipeId, updatedAt = now)
+                }
+            }
+        }
+        for (recipeId in recipeIds) scope.launch { pushUpdateToRemote(recipeId) }
+    }
+
     override suspend fun deleteRecipe(id: Long) {
         val entity = withContext(ioContext) { db.getById(id).executeAsOneOrNull() } ?: return
         val remoteId = entity.remoteId

--- a/client/recipe/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImplTest.kt
+++ b/client/recipe/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/RecipeRepositoryImplTest.kt
@@ -108,6 +108,46 @@ class RecipeRepositoryImplTest {
         }
 
     @Test
+    fun addRecipesToCategory_attaches_the_category_to_every_selected_recipe() =
+        runTest(testDispatcher) {
+            val breakfast = categoryRepository.materializeBuiltin(BuiltinCategory.BREAKFAST)
+            val one = recipeRepository.createRecipe(blankRecipe(title = "One"))
+            val two = recipeRepository.createRecipe(blankRecipe(title = "Two"))
+
+            recipeRepository.addRecipesToCategory(setOf(one.id, two.id), breakfast)
+
+            recipeRepository.getRecipes().test {
+                val recipes = awaitItem()
+                recipes.forEach { recipe ->
+                    recipe.categories.map { it.builtinId } shouldBe
+                        listOf(BuiltinCategory.BREAKFAST.id)
+                }
+            }
+        }
+
+    @Test
+    fun addRecipesToBook_files_every_selected_recipe_under_the_book() =
+        runTest(testDispatcher) {
+            db.recipeBookQueries.create(
+                name = "Weeknight",
+                isDefault = false,
+                createdAt = dateTimeUtil.now.toString(),
+                updatedAt = dateTimeUtil.now.toString(),
+                clientId = "book-client-1",
+                ownerId = null,
+            )
+            val bookId = db.recipeBookQueries.lastInsertId().executeAsOne().MAX!!
+            val one = recipeRepository.createRecipe(blankRecipe(title = "One"))
+            val two = recipeRepository.createRecipe(blankRecipe(title = "Two"))
+
+            recipeRepository.addRecipesToBook(setOf(one.id, two.id), bookId)
+
+            recipeRepository.getRecipes().test {
+                awaitItem().forEach { recipe -> (bookId in recipe.recipeBookIds) shouldBe true }
+            }
+        }
+
+    @Test
     fun getRecipes_filters_by_preset_using_attached_categories() =
         runTest(testDispatcher) {
             val breakfast = categoryRepository.materializeBuiltin(BuiltinCategory.BREAKFAST)

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeRepository.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/RecipeRepository.kt
@@ -53,6 +53,23 @@ interface RecipeRepository {
      */
     suspend fun setRecipePublic(id: Long, isPublic: Boolean): String?
 
+    /**
+     * Files every recipe in [recipeIds] under the book with local id [bookId], in a single
+     * transaction. Book membership is additive and many-to-many — a recipe already in [bookId] is
+     * left untouched, and its existing book memberships are preserved. Each affected recipe is
+     * marked dirty so the new attachment syncs to the remote. No-op when [recipeIds] is empty.
+     */
+    suspend fun addRecipesToBook(recipeIds: Set<Long>, bookId: Long)
+
+    /**
+     * Attaches [category] to every recipe in [recipeIds], in a single transaction. Additive and
+     * idempotent — a recipe already tagged with [category] is left untouched and its other
+     * categories are preserved. Each affected recipe is marked dirty so the new attachment syncs to
+     * the remote. Callers pass a materialized [Category] (see
+     * [CategoryRepository.materializeBuiltin]). No-op when [recipeIds] is empty.
+     */
+    suspend fun addRecipesToCategory(recipeIds: Set<Long>, category: Category)
+
     suspend fun deleteRecipe(id: Long)
 
     /**

--- a/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeRepository.kt
+++ b/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeRecipeRepository.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.recipe.data.testing
 
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
+import com.plusmobileapps.chefmate.recipe.data.Category
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import kotlinx.coroutines.flow.Flow
@@ -63,6 +64,20 @@ class FakeRecipeRepository(
         lastSetPublic = id to isPublic
         recipes.value = recipes.value.map { if (it.id == id) it.copy(isPublic = isPublic) else it }
         return setPublicResult
+    }
+
+    override suspend fun addRecipesToBook(recipeIds: Set<Long>, bookId: Long) {
+        recipes.value =
+            recipes.value.map {
+                if (it.id in recipeIds) it.copy(recipeBookIds = it.recipeBookIds + bookId) else it
+            }
+    }
+
+    override suspend fun addRecipesToCategory(recipeIds: Set<Long>, category: Category) {
+        recipes.value =
+            recipes.value.map {
+                if (it.id in recipeIds) it.copy(categories = it.categories + category) else it
+            }
     }
 
     override suspend fun deleteRecipe(id: Long) {

--- a/client/recipe/list/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/robots/RecipeListRobot.kt
+++ b/client/recipe/list/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/robots/RecipeListRobot.kt
@@ -8,8 +8,10 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import com.plusmobileapps.chefmate.recipe.list.RecipeListTestTags
 
@@ -95,6 +97,58 @@ class RecipeListRobot(private val test: ComposeUiTest) {
     fun tapCreateBook(): RecipeListRobot = apply {
         test.onNodeWithTag(RecipeListTestTags.BOOK_PICKER_CREATE).performClick()
     }
+
+    // region Multi-select
+
+    /** Long-presses a recipe row to enter multi-select mode with that recipe pre-selected. */
+    fun longPressRecipe(title: String): RecipeListRobot = apply {
+        test.onNode(hasText(title) and onScreen).assertIsDisplayed().performTouchInput {
+            longClick()
+        }
+    }
+
+    /** Opens the selection-mode overflow menu holding the bulk add-to-book/category actions. */
+    fun openSelectionOverflow(): RecipeListRobot = apply {
+        test.onNode(hasTestTag(RecipeListTestTags.SELECTION_OVERFLOW) and onScreen).performClick()
+    }
+
+    // The overflow items render in a popup outside the screen root, so these are not
+    // ancestor-scoped.
+
+    fun tapAddToBook(): RecipeListRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(RecipeListTestTags.SELECTION_ADD_TO_BOOK))
+        test.onNodeWithTag(RecipeListTestTags.SELECTION_ADD_TO_BOOK).performClick()
+    }
+
+    fun tapAddToCategory(): RecipeListRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(RecipeListTestTags.SELECTION_ADD_TO_CATEGORY))
+        test.onNodeWithTag(RecipeListTestTags.SELECTION_ADD_TO_CATEGORY).performClick()
+    }
+
+    fun assertBulkBookSheetShown(): RecipeListRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(RecipeListTestTags.BULK_BOOK_SHEET))
+        test.onNodeWithTag(RecipeListTestTags.BULK_BOOK_SHEET).assertIsDisplayed()
+    }
+
+    fun assertBulkCategorySheetShown(): RecipeListRobot = apply {
+        test.waitUntilExactlyOneExists(hasTestTag(RecipeListTestTags.BULK_CATEGORY_SHEET))
+        test.onNodeWithTag(RecipeListTestTags.BULK_CATEGORY_SHEET).assertIsDisplayed()
+    }
+
+    private val inBulkBookSheet = hasAnyAncestor(hasTestTag(RecipeListTestTags.BULK_BOOK_SHEET))
+
+    private val inBulkCategorySheet =
+        hasAnyAncestor(hasTestTag(RecipeListTestTags.BULK_CATEGORY_SHEET))
+
+    fun selectBulkBook(name: String): RecipeListRobot = apply {
+        test.onNode(hasText(name) and inBulkBookSheet).performClick()
+    }
+
+    fun selectBulkCategory(name: String): RecipeListRobot = apply {
+        test.onNode(hasText(name) and inBulkCategorySheet).performClick()
+    }
+
+    // endregion
 }
 
 fun ComposeUiTest.recipeList(): RecipeListRobot = RecipeListRobot(this)

--- a/client/recipe/list/impl/build.gradle.kts
+++ b/client/recipe/list/impl/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             implementation(projects.client.recipe.data.public)
             implementation(projects.client.recipebook.data.public)
             implementation(projects.client.cook.public)
+            implementation(projects.client.toast.public)
             implementation(projects.client.util.public)
             implementation(projects.client.featureflag.public)
             implementation(libs.multiplatform.settings)
@@ -24,6 +25,7 @@ kotlin {
             implementation(projects.client.recipe.data.testing)
             implementation(projects.client.featureflag.testing)
             implementation(projects.client.recipebook.data.testing)
+            implementation(projects.client.toast.testing)
             implementation(libs.multiplatform.settings.test)
         }
     }

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImpl.kt
@@ -13,6 +13,7 @@ import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc
 import com.plusmobileapps.chefmate.recipe.list.RecipeListBloc.Output
 import com.plusmobileapps.chefmate.recipe.list.RecipeListItem
 import com.plusmobileapps.chefmate.recipe.list.RecipeSortOption
+import com.plusmobileapps.chefmate.toast.ToastService
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
 import com.plusmobileapps.metro.extensions.assistedfactory.ContributesAssistedFactory
 import dev.zacsweers.metro.Assisted
@@ -33,6 +34,7 @@ class RecipeListBlocImpl(
     @Assisted private val output: Consumer<Output>,
     private val viewModelFactory: Provider<RecipeListViewModel>,
     private val timeFormatterUtil: TimeFormatterUtil,
+    private val toastService: ToastService,
 ) : RecipeListBloc, BlocContext by context {
     private val viewModel: RecipeListViewModel = instanceKeeper.getViewModel { viewModelFactory() }
     private val scope = createScope()
@@ -41,6 +43,7 @@ class RecipeListBlocImpl(
         viewModel.scannedRecipe
             .onEach { output.onNext(Output.OpenScannedRecipe(it)) }
             .launchIn(scope)
+        viewModel.bulkActionMessage.onEach { toastService.show(it) }.launchIn(scope)
     }
 
     override val state: StateFlow<RecipeListBloc.Model> =
@@ -63,6 +66,8 @@ class RecipeListBlocImpl(
                 showDoneCookingDialog = it.showDoneCookingDialog,
                 isSelectionMode = it.isSelectionMode,
                 selectedRecipeIds = it.selectedRecipeIds,
+                isBulkBookPickerOpen = it.isBulkBookPickerOpen,
+                isBulkCategoryPickerOpen = it.isBulkCategoryPickerOpen,
                 isScanning = it.isScanning,
                 scanError = it.scanError,
                 isScanFromPhotoEnabled = it.isScanFromPhotoEnabled,
@@ -173,8 +178,44 @@ class RecipeListBlocImpl(
         viewModel.toggleRecipeSelected(recipe.id)
     }
 
+    override fun onRecipeLongClicked(recipe: RecipeListItem) {
+        if (viewModel.state.value.isSelectionMode) {
+            viewModel.toggleRecipeSelected(recipe.id)
+        } else {
+            viewModel.enterSelectionModeWith(recipe.id)
+        }
+    }
+
     override fun onToggleSelectAllVisible() {
         viewModel.toggleSelectAllVisible()
+    }
+
+    override fun onAddToBookClicked() {
+        viewModel.openBulkBookPicker()
+    }
+
+    override fun onBulkBookPickerDismissed() {
+        viewModel.dismissBulkBookPicker()
+    }
+
+    override fun onAddSelectedToBook(bookId: Long) {
+        viewModel.addSelectedToBook(bookId)
+    }
+
+    override fun onAddToCategoryClicked() {
+        viewModel.openBulkCategoryPicker()
+    }
+
+    override fun onBulkCategoryPickerDismissed() {
+        viewModel.dismissBulkCategoryPicker()
+    }
+
+    override fun onAddSelectedToBuiltinCategory(category: BuiltinCategory) {
+        viewModel.addSelectedToBuiltinCategory(category)
+    }
+
+    override fun onAddSelectedToUserCategory(categoryId: Long) {
+        viewModel.addSelectedToUserCategory(categoryId)
     }
 
     override fun onExportClicked() {

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModel.kt
@@ -1,6 +1,18 @@
 package com.plusmobileapps.chefmate.recipe.list.impl
 
 import chefmate.client.recipe.list.public.generated.resources.Res
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_bulk_added_to_book
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_bulk_added_to_category
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_ai
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_appetizer
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_breakfast
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_dessert
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_dinner
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_drink
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_lunch
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_other
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_side
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_snack
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scan_failed
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scan_no_api_key
 import com.plusmobileapps.chefmate.ViewModel
@@ -28,6 +40,8 @@ import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookCollaborationRepository
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookInvite
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBookRepository
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.ResourceString
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.util.mimeTypeForImageExtension
@@ -50,6 +64,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.StringResource
 
 @Inject
 class RecipeListViewModel(
@@ -121,6 +136,19 @@ class RecipeListViewModel(
      * [com.plusmobileapps.chefmate.recipe.list.RecipeListBloc.Output.OpenScannedRecipe].
      */
     val scannedRecipe: SharedFlow<ExtractedRecipeData> = _scannedRecipe.asSharedFlow()
+
+    private val _bulkActionMessage =
+        MutableSharedFlow<TextData>(
+            replay = 0,
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    /**
+     * Emits a confirmation message each time a bulk selection action (add-to-book, add-to-category)
+     * completes. Collected by the BlocImpl, which surfaces it through the app-wide toast host.
+     */
+    val bulkActionMessage: SharedFlow<TextData> = _bulkActionMessage.asSharedFlow()
 
     init {
         // Queue every recipe-list coach mark in order; the controller shows them one at a time.
@@ -392,8 +420,100 @@ class RecipeListViewModel(
         _state.update { it.copy(isSelectionMode = true, selectedRecipeIds = emptySet()) }
     }
 
+    /** Enters selection mode with a single recipe pre-selected — the long-press gesture. */
+    fun enterSelectionModeWith(recipeId: Long) {
+        _state.update { it.copy(isSelectionMode = true, selectedRecipeIds = setOf(recipeId)) }
+    }
+
     fun exitSelectionMode() {
-        _state.update { it.copy(isSelectionMode = false, selectedRecipeIds = emptySet()) }
+        _state.update {
+            it.copy(
+                isSelectionMode = false,
+                selectedRecipeIds = emptySet(),
+                isBulkBookPickerOpen = false,
+                isBulkCategoryPickerOpen = false,
+            )
+        }
+    }
+
+    fun openBulkBookPicker() {
+        _state.update { it.copy(isBulkBookPickerOpen = true) }
+    }
+
+    fun dismissBulkBookPicker() {
+        _state.update { it.copy(isBulkBookPickerOpen = false) }
+    }
+
+    fun openBulkCategoryPicker() {
+        _state.update { it.copy(isBulkCategoryPickerOpen = true) }
+    }
+
+    fun dismissBulkCategoryPicker() {
+        _state.update { it.copy(isBulkCategoryPickerOpen = false) }
+    }
+
+    /** Files the current selection under [bookId], confirms via toast, and exits selection mode. */
+    fun addSelectedToBook(bookId: Long) {
+        val ids = _state.value.selectedRecipeIds
+        val bookName = _state.value.recipeBooks.firstOrNull { it.id == bookId }?.name
+        if (ids.isEmpty() || bookName == null) {
+            dismissBulkBookPicker()
+            return
+        }
+        scope.launch {
+            repository.addRecipesToBook(ids, bookId)
+            _bulkActionMessage.tryEmit(
+                PhraseModel(
+                    Res.string.recipe_list_bulk_added_to_book,
+                    "count" to FixedString(ids.size.toString()),
+                    "book" to FixedString(bookName),
+                )
+            )
+            exitSelectionMode()
+        }
+    }
+
+    /**
+     * Tags the current selection with the built-in [category], materializing its row first, then
+     * confirms via toast and exits selection mode.
+     */
+    fun addSelectedToBuiltinCategory(category: BuiltinCategory) {
+        val ids = _state.value.selectedRecipeIds
+        if (ids.isEmpty()) {
+            dismissBulkCategoryPicker()
+            return
+        }
+        scope.launch {
+            val materialized = categoryRepository.materializeBuiltin(category)
+            repository.addRecipesToCategory(ids, materialized)
+            emitCategoryAddedMessage(ids.size, ResourceString(category.labelRes()))
+            exitSelectionMode()
+        }
+    }
+
+    /** Tags the current selection with the user category [categoryId]. */
+    fun addSelectedToUserCategory(categoryId: Long) {
+        val ids = _state.value.selectedRecipeIds
+        val category = _state.value.availableUserCategories.firstOrNull { it.id == categoryId }
+        if (ids.isEmpty() || category == null) {
+            dismissBulkCategoryPicker()
+            return
+        }
+        scope.launch {
+            repository.addRecipesToCategory(ids, category)
+            emitCategoryAddedMessage(ids.size, FixedString(category.name))
+            exitSelectionMode()
+        }
+    }
+
+    private fun emitCategoryAddedMessage(count: Int, categoryLabel: TextData) {
+        _bulkActionMessage.tryEmit(
+            PhraseModel(
+                Res.string.recipe_list_bulk_added_to_category,
+                "count" to FixedString(count.toString()),
+                "category" to categoryLabel,
+            )
+        )
     }
 
     fun toggleRecipeSelected(recipeId: Long) {
@@ -435,6 +555,8 @@ class RecipeListViewModel(
         val showDoneCookingDialog: Boolean = false,
         val isSelectionMode: Boolean = false,
         val selectedRecipeIds: Set<Long> = emptySet(),
+        val isBulkBookPickerOpen: Boolean = false,
+        val isBulkCategoryPickerOpen: Boolean = false,
         val isScanning: Boolean = false,
         val scanError: TextData? = null,
         val isScanFromPhotoEnabled: Boolean = false,
@@ -458,6 +580,20 @@ class RecipeListViewModel(
                     .let { applySort(it, currentSort) }
     }
 }
+
+private fun BuiltinCategory.labelRes(): StringResource =
+    when (this) {
+        BuiltinCategory.BREAKFAST -> Res.string.recipe_list_category_breakfast
+        BuiltinCategory.LUNCH -> Res.string.recipe_list_category_lunch
+        BuiltinCategory.DINNER -> Res.string.recipe_list_category_dinner
+        BuiltinCategory.APPETIZER -> Res.string.recipe_list_category_appetizer
+        BuiltinCategory.SIDE -> Res.string.recipe_list_category_side
+        BuiltinCategory.DESSERT -> Res.string.recipe_list_category_dessert
+        BuiltinCategory.SNACK -> Res.string.recipe_list_category_snack
+        BuiltinCategory.DRINK -> Res.string.recipe_list_category_drink
+        BuiltinCategory.OTHER -> Res.string.recipe_list_category_other
+        BuiltinCategory.AI -> Res.string.recipe_list_category_ai
+    }
 
 private const val KEY_IS_GRID_VIEW = "recipe_list_is_grid_view"
 private const val KEY_SORT_OPTION = "recipe_list_sort_option"

--- a/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
+++ b/client/recipe/list/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/ui/RecipeListPreviews.kt
@@ -114,7 +114,23 @@ private fun recipeListBloc(model: RecipeListBloc.Model): RecipeListBloc =
 
         override fun onToggleRecipeSelected(recipe: RecipeListItem) = Unit
 
+        override fun onRecipeLongClicked(recipe: RecipeListItem) = Unit
+
         override fun onToggleSelectAllVisible() = Unit
+
+        override fun onAddToBookClicked() = Unit
+
+        override fun onBulkBookPickerDismissed() = Unit
+
+        override fun onAddSelectedToBook(bookId: Long) = Unit
+
+        override fun onAddToCategoryClicked() = Unit
+
+        override fun onBulkCategoryPickerDismissed() = Unit
+
+        override fun onAddSelectedToBuiltinCategory(category: BuiltinCategory) = Unit
+
+        override fun onAddSelectedToUserCategory(categoryId: Long) = Unit
 
         override fun onExportClicked() = Unit
 

--- a/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImplTest.kt
+++ b/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListBlocImplTest.kt
@@ -7,6 +7,7 @@ import app.cash.turbine.test
 import com.plusmobileapps.chefmate.cook.data.CookingSessionRepository
 import com.plusmobileapps.chefmate.di.CoachMarkController
 import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
+import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.SyncStatus
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeCategoryRepository
@@ -22,6 +23,7 @@ import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.TextData
+import com.plusmobileapps.chefmate.toast.testing.FakeToastService
 import com.plusmobileapps.chefmate.util.TimeFormatterUtil
 import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.Settings
@@ -65,6 +67,7 @@ class RecipeListBlocImplTest {
     private val imageExtractor = FakeRecipeImageExtractor()
     private val pendingPhotoStore = FakePendingRecipePhotoStore()
     private val featureFlags = FakeFeatureFlags()
+    private val toastService = FakeToastService()
 
     private val bloc =
         RecipeListBlocImpl(
@@ -86,6 +89,7 @@ class RecipeListBlocImplTest {
                 )
             },
             timeFormatterUtil = timeFormatterUtil,
+            toastService = toastService,
         )
 
     private fun recipe(
@@ -357,6 +361,50 @@ class RecipeListBlocImplTest {
             bloc.onToggleSelectAllVisible()
             awaitItem().selectedRecipeIds shouldBe emptySet()
         }
+    }
+
+    @Test
+    fun When_long_press_outside_selection_Then_enters_selection_with_that_recipe() = runTest {
+        bloc.state.test {
+            awaitItem() // initial
+            recipes.value = listOf(recipe(1), recipe(2))
+            awaitItem() // recipes loaded
+
+            bloc.onRecipeLongClicked(listItem(id = 2))
+            val next = awaitItem()
+            next.isSelectionMode shouldBe true
+            next.selectedRecipeIds shouldBe setOf(2L)
+        }
+        output.values shouldBe emptyList()
+    }
+
+    @Test
+    fun When_long_press_in_selection_mode_Then_toggles_like_a_tap() = runTest {
+        bloc.state.test {
+            awaitItem()
+            recipes.value = listOf(recipe(1), recipe(2))
+            awaitItem()
+            bloc.onEnterSelectionMode()
+            awaitItem()
+
+            bloc.onRecipeLongClicked(listItem(id = 1))
+            awaitItem().selectedRecipeIds shouldBe setOf(1L)
+            bloc.onRecipeLongClicked(listItem(id = 1))
+            awaitItem().selectedRecipeIds shouldBe emptySet()
+        }
+    }
+
+    @Test
+    fun When_bulk_category_add_completes_Then_confirmation_toast_shown() = runTest {
+        recipes.value = listOf(recipe(1))
+        bloc.onEnterSelectionMode()
+        bloc.onToggleRecipeSelected(listItem(id = 1))
+
+        bloc.onAddSelectedToBuiltinCategory(BuiltinCategory.DINNER)
+
+        toastService.shown.size shouldBe 1
+        recipes.value.first().categories.map { it.builtinId } shouldBe
+            listOf(BuiltinCategory.DINNER.id)
     }
 
     @Test

--- a/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
+++ b/client/recipe/list/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/list/impl/RecipeListViewModelTest.kt
@@ -25,6 +25,8 @@ import com.plusmobileapps.chefmate.recipe.list.RecipeSortOption
 import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookCollaborationRepository
 import com.plusmobileapps.chefmate.recipebook.data.testing.FakeRecipeBookRepository
+import com.plusmobileapps.chefmate.text.FixedString
+import com.plusmobileapps.chefmate.text.PhraseModel
 import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.Settings
 import dev.mokkery.answering.returns
@@ -33,6 +35,7 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlin.test.Test
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -826,6 +829,115 @@ class RecipeListViewModelTest {
         viewModel.clearFilters()
         viewModel.state.value.activeFilters shouldBe emptySet()
         viewModel.state.value.activeCategories shouldBe emptySet()
+    }
+
+    // endregion
+
+    // region Multi-select bulk actions
+
+    private fun booksViewModel(): RecipeListViewModel =
+        RecipeListViewModel(
+            mainContext = UnconfinedTestDispatcher(),
+            repository = repository,
+            recipeBookRepository = FakeRecipeBookRepository(MutableStateFlow(RecipeBook.Samples)),
+            collaborationRepository = FakeRecipeBookCollaborationRepository(),
+            categoryRepository = categoryRepository,
+            cookingSessionRepository = cookingSessionRepository,
+            imageExtractor = imageExtractor,
+            pendingPhotoStore = pendingPhotoStore,
+            featureFlags = featureFlags,
+            settings = settings,
+            coachMarkController = CoachMarkController(MapSettings()),
+        )
+
+    @Test
+    fun When_long_press_Then_selection_mode_entered_with_that_recipe() {
+        recipes.value = listOf(recipe(1), recipe(2))
+        viewModel.enterSelectionModeWith(2)
+        viewModel.state.value.isSelectionMode shouldBe true
+        viewModel.state.value.selectedRecipeIds shouldBe setOf(2L)
+    }
+
+    @Test
+    fun When_add_selected_to_book_Then_recipes_filed_and_selection_exited() = runTest {
+        recipes.value =
+            listOf(
+                recipe(1, recipeBookIds = setOf(1L)),
+                recipe(2, recipeBookIds = setOf(1L)),
+            )
+        val vm = booksViewModel()
+        vm.enterSelectionModeWith(1)
+        vm.toggleRecipeSelected(2)
+
+        vm.addSelectedToBook(3L)
+
+        recipes.value.first { it.id == 1L }.recipeBookIds shouldBe setOf(1L, 3L)
+        recipes.value.first { it.id == 2L }.recipeBookIds shouldBe setOf(1L, 3L)
+        vm.state.value.isSelectionMode shouldBe false
+        vm.state.value.selectedRecipeIds shouldBe emptySet()
+    }
+
+    @Test
+    fun When_add_selected_to_book_Then_confirmation_message_emitted() = runTest {
+        recipes.value = listOf(recipe(1, recipeBookIds = setOf(1L)))
+        val vm = booksViewModel()
+        vm.enterSelectionModeWith(1)
+
+        vm.bulkActionMessage.test {
+            vm.addSelectedToBook(3L)
+            val message = awaitItem()
+            message.shouldBeInstanceOf<PhraseModel>()
+            (message.args["book"] as FixedString).value shouldBe "Holiday Baking"
+            (message.args["count"] as FixedString).value shouldBe "1"
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun When_add_selected_to_builtin_category_Then_category_materialized_and_attached() = runTest {
+        recipes.value = listOf(recipe(1), recipe(2))
+        viewModel.enterSelectionModeWith(1)
+        viewModel.toggleRecipeSelected(2)
+
+        viewModel.addSelectedToBuiltinCategory(BuiltinCategory.DESSERT)
+
+        recipes.value.forEach { r ->
+            r.categories.map { it.builtinId } shouldBe listOf(BuiltinCategory.DESSERT.id)
+        }
+        // The preset was materialized into a concrete row as a side effect.
+        (categoryRepository.findBuiltin(BuiltinCategory.DESSERT) != null) shouldBe true
+        viewModel.state.value.isSelectionMode shouldBe false
+    }
+
+    @Test
+    fun When_add_selected_to_user_category_Then_attached_and_selection_exited() = runTest {
+        recipes.value = listOf(recipe(1))
+        val userCategory = categoryRepository.createUserCategory("Weeknight")
+        viewModel.enterSelectionModeWith(1)
+
+        viewModel.addSelectedToUserCategory(userCategory.id)
+
+        recipes.value.first().categories.map { it.id } shouldBe listOf(userCategory.id)
+        viewModel.state.value.isSelectionMode shouldBe false
+    }
+
+    @Test
+    fun When_bulk_book_picker_toggled_Then_flag_tracks_state() {
+        viewModel.openBulkBookPicker()
+        viewModel.state.value.isBulkBookPickerOpen shouldBe true
+        viewModel.dismissBulkBookPicker()
+        viewModel.state.value.isBulkBookPickerOpen shouldBe false
+    }
+
+    @Test
+    fun When_exit_selection_mode_Then_open_pickers_are_dismissed() {
+        viewModel.enterSelectionModeWith(1)
+        viewModel.openBulkCategoryPicker()
+
+        viewModel.exitSelectionMode()
+
+        viewModel.state.value.isSelectionMode shouldBe false
+        viewModel.state.value.isBulkCategoryPickerOpen shouldBe false
     }
 
     // endregion

--- a/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
@@ -102,6 +102,13 @@
     <string name="recipe_list_selection_select_all">Select all</string>
     <string name="recipe_list_selection_deselect_all">Deselect all</string>
     <string name="recipe_list_selection_export">Export selected</string>
+    <string name="recipe_list_selection_more">More actions</string>
+    <string name="recipe_list_selection_add_to_book">Add to recipe book</string>
+    <string name="recipe_list_selection_add_to_category">Add to category</string>
+    <string name="recipe_list_bulk_book_title">Add to recipe book</string>
+    <string name="recipe_list_bulk_category_title">Add to category</string>
+    <string name="recipe_list_bulk_added_to_book">Added {count} recipes to {book}</string>
+    <string name="recipe_list_bulk_added_to_category">Added {count} recipes to {category}</string>
 
     <!-- Cooking Session -->
     <string name="recipe_list_continue_cooking">Continue cooking</string>

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListBloc.kt
@@ -77,7 +77,35 @@ interface RecipeListBloc : ComposeScreen {
 
     fun onToggleRecipeSelected(recipe: RecipeListItem)
 
+    /**
+     * Long-press on a recipe row. Outside selection mode this enters it with [recipe] pre-selected
+     * (the standard mobile "long-press to multi-select" gesture); inside selection mode it toggles
+     * the row like a tap.
+     */
+    fun onRecipeLongClicked(recipe: RecipeListItem)
+
     fun onToggleSelectAllVisible()
+
+    /** Opens the picker to file the selected recipes under a recipe book. */
+    fun onAddToBookClicked()
+
+    fun onBulkBookPickerDismissed()
+
+    /** Files every selected recipe under book [bookId], then leaves selection mode. */
+    fun onAddSelectedToBook(bookId: Long)
+
+    /** Opens the picker to tag the selected recipes with a category. */
+    fun onAddToCategoryClicked()
+
+    fun onBulkCategoryPickerDismissed()
+
+    /** Tags every selected recipe with the built-in [category], then leaves selection mode. */
+    fun onAddSelectedToBuiltinCategory(category: BuiltinCategory)
+
+    /**
+     * Tags every selected recipe with the user category [categoryId], then leaves selection mode.
+     */
+    fun onAddSelectedToUserCategory(categoryId: Long)
 
     fun onExportClicked()
 
@@ -136,6 +164,10 @@ interface RecipeListBloc : ComposeScreen {
         val showDoneCookingDialog: Boolean = false,
         val isSelectionMode: Boolean = false,
         val selectedRecipeIds: Set<Long> = emptySet(),
+        /** True while the "add selected recipes to a book" picker is open. */
+        val isBulkBookPickerOpen: Boolean = false,
+        /** True while the "add selected recipes to a category" picker is open. */
+        val isBulkCategoryPickerOpen: Boolean = false,
         /** True while a picked photo is being scanned into a recipe via Gemini vision. */
         val isScanning: Boolean = false,
         /** Non-null when the most recent photo scan failed. */

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -3,8 +3,10 @@ package com.plusmobileapps.chefmate.recipe.list
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,10 +33,12 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ViewList
+import androidx.compose.material.icons.automirrored.outlined.MenuBook
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AddPhotoAlternate
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
@@ -68,8 +72,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
@@ -101,6 +107,8 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_list_add_re
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_apply
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_all_recipes
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_book_selector
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_bulk_book_title
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_bulk_category_title
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_ai
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_appetizer
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_category_breakfast
@@ -152,10 +160,13 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_list_search
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_empty
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_empty_book_hint
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_search_placeholder
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_add_to_book
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_add_to_category
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_count
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_deselect_all
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_exit
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_export
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_more
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_selection_select_all
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_sort_a_to_z
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_sort_and_filter
@@ -174,7 +185,9 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_sync_syncin
 import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.letIfTrue
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
+import com.plusmobileapps.chefmate.recipe.data.Category
 import com.plusmobileapps.chefmate.recipe.data.SyncStatus
+import com.plusmobileapps.chefmate.recipebook.data.RecipeBook
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.ResourceString
@@ -264,6 +277,11 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                                         stringResource(Res.string.recipe_list_selection_export),
                                 )
                             }
+                            SelectionOverflowMenu(
+                                enabled = state.selectedRecipeIds.isNotEmpty(),
+                                onAddToBookClicked = bloc::onAddToBookClicked,
+                                onAddToCategoryClicked = bloc::onAddToCategoryClicked,
+                            )
                             IconButton(onClick = bloc::onExitSelectionMode) {
                                 Icon(
                                     imageVector = Icons.Default.Close,
@@ -455,6 +473,7 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                                     modifier = Modifier.fillMaxSize(),
                                     recipes = state.recipes,
                                     onRecipeClicked = bloc::onRecipeClicked,
+                                    onRecipeLongClicked = bloc::onRecipeLongClicked,
                                     state = gridState,
                                     bottomContentPadding =
                                         if (state.cookingRecipeCount > 0) FabStackReserve else 0.dp,
@@ -467,6 +486,7 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                                     modifier = Modifier.fillMaxSize(),
                                     recipes = state.recipes,
                                     onRecipeClicked = bloc::onRecipeClicked,
+                                    onRecipeLongClicked = bloc::onRecipeLongClicked,
                                     state = listState,
                                     bottomContentPadding =
                                         if (state.cookingRecipeCount > 0) FabStackReserve else 0.dp,
@@ -533,6 +553,23 @@ fun RecipeListScreen(bloc: RecipeListBloc, modifier: Modifier = Modifier) {
                     onAllRecipesSelected = bloc::onAllRecipesSelected,
                     onEditBook = bloc::onEditBookClicked,
                     onCreateBook = bloc::onCreateBookClicked,
+                )
+            }
+
+            if (state.isBulkBookPickerOpen) {
+                BulkAddToBookSheet(
+                    books = state.recipeBooks,
+                    onDismiss = bloc::onBulkBookPickerDismissed,
+                    onBookSelected = bloc::onAddSelectedToBook,
+                )
+            }
+
+            if (state.isBulkCategoryPickerOpen) {
+                BulkAddToCategorySheet(
+                    userCategories = state.availableUserCategories,
+                    onDismiss = bloc::onBulkCategoryPickerDismissed,
+                    onBuiltinSelected = bloc::onAddSelectedToBuiltinCategory,
+                    onUserCategorySelected = bloc::onAddSelectedToUserCategory,
                 )
             }
         }
@@ -787,6 +824,143 @@ private fun OverflowMenu(
                     onCollaborateClicked()
                 },
             )
+        }
+    }
+}
+
+/**
+ * Overflow menu shown in the selection-mode app bar. Holds the bulk actions that don't warrant
+ * their own icon — filing the selection under a recipe book or tagging it with a category. Disabled
+ * while nothing is selected.
+ */
+@Composable
+private fun SelectionOverflowMenu(
+    enabled: Boolean,
+    onAddToBookClicked: () -> Unit,
+    onAddToCategoryClicked: () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(
+            onClick = { expanded = true },
+            enabled = enabled,
+            modifier = Modifier.testTag(RecipeListTestTags.SELECTION_OVERFLOW),
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = stringResource(Res.string.recipe_list_selection_more),
+            )
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.recipe_list_selection_add_to_book)) },
+                leadingIcon = {
+                    Icon(Icons.AutoMirrored.Outlined.MenuBook, contentDescription = null)
+                },
+                modifier = Modifier.testTag(RecipeListTestTags.SELECTION_ADD_TO_BOOK),
+                onClick = {
+                    expanded = false
+                    onAddToBookClicked()
+                },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.recipe_list_selection_add_to_category)) },
+                leadingIcon = { Icon(Icons.Default.Category, contentDescription = null) },
+                modifier = Modifier.testTag(RecipeListTestTags.SELECTION_ADD_TO_CATEGORY),
+                onClick = {
+                    expanded = false
+                    onAddToCategoryClicked()
+                },
+            )
+        }
+    }
+}
+
+/** Bottom sheet listing the user's recipe books so the current selection can be filed under one. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BulkAddToBookSheet(
+    books: List<RecipeBook>,
+    onDismiss: () -> Unit,
+    onBookSelected: (Long) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier.navigationBarsPadding().testTag(RecipeListTestTags.BULK_BOOK_SHEET)
+        ) {
+            Text(
+                text = stringResource(Res.string.recipe_list_bulk_book_title),
+                style = MaterialTheme.typography.titleLarge,
+                modifier =
+                    Modifier.padding(
+                        horizontal = ChefMateTheme.dimens.paddingNormal,
+                        vertical = ChefMateTheme.dimens.paddingSmall,
+                    ),
+            )
+            HorizontalDivider()
+            books.forEach { book ->
+                ListItem(
+                    headlineContent = { Text(book.name) },
+                    leadingContent = {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.MenuBook,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth().clickable { onBookSelected(book.id) },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Bottom sheet of category chips — built-in presets followed by the user's own categories — so the
+ * current selection can be tagged. Tapping a chip adds and closes.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun BulkAddToCategorySheet(
+    userCategories: List<Category>,
+    onDismiss: () -> Unit,
+    onBuiltinSelected: (BuiltinCategory) -> Unit,
+    onUserCategorySelected: (Long) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier =
+                Modifier.padding(horizontal = ChefMateTheme.dimens.paddingNormal)
+                    .navigationBarsPadding()
+                    .testTag(RecipeListTestTags.BULK_CATEGORY_SHEET)
+        ) {
+            Text(
+                text = stringResource(Res.string.recipe_list_bulk_category_title),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(vertical = ChefMateTheme.dimens.paddingSmall),
+            )
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                BuiltinCategory.entries.forEach { category ->
+                    FilterChip(
+                        selected = false,
+                        onClick = { onBuiltinSelected(category) },
+                        label = { Text(stringResource(category.labelRes())) },
+                    )
+                }
+                // User categories that aren't just a preset in disguise (those render above).
+                userCategories
+                    .filter { it.builtinId == null }
+                    .forEach { category ->
+                        FilterChip(
+                            selected = false,
+                            onClick = { onUserCategorySelected(category.id) },
+                            label = { Text(category.name) },
+                        )
+                    }
+            }
+            Spacer(Modifier.height(ChefMateTheme.dimens.paddingNormal))
         }
     }
 }
@@ -1222,6 +1396,7 @@ private fun RecipeGrid(
     recipes: List<RecipeListItem>,
     onRecipeClicked: (RecipeListItem) -> Unit,
     modifier: Modifier = Modifier,
+    onRecipeLongClicked: (RecipeListItem) -> Unit = {},
     state: LazyGridState = rememberLazyGridState(),
     bottomContentPadding: androidx.compose.ui.unit.Dp = 0.dp,
     isSelectionMode: Boolean = false,
@@ -1246,6 +1421,7 @@ private fun RecipeGrid(
             RecipeGridItem(
                 recipe = recipe,
                 onClick = { onRecipeClicked(recipe) },
+                onLongClick = { onRecipeLongClicked(recipe) },
                 isSelectionMode = isSelectionMode,
                 isSelected = recipe.id in selectedRecipeIds,
             )
@@ -1253,17 +1429,24 @@ private fun RecipeGrid(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun RecipeGridItem(
     recipe: RecipeListItem,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onLongClick: () -> Unit = {},
     isSelectionMode: Boolean = false,
     isSelected: Boolean = false,
 ) {
     Card(
-        onClick = onClick,
-        modifier = modifier.fillMaxWidth(),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = onLongClick,
+                ),
         colors =
             CardDefaults.cardColors(
                 containerColor =
@@ -1343,6 +1526,7 @@ private fun RecipeList(
     recipes: List<RecipeListItem>,
     onRecipeClicked: (RecipeListItem) -> Unit,
     modifier: Modifier = Modifier,
+    onRecipeLongClicked: (RecipeListItem) -> Unit = {},
     state: LazyListState = rememberLazyListState(),
     bottomContentPadding: androidx.compose.ui.unit.Dp = 0.dp,
     isSelectionMode: Boolean = false,
@@ -1358,6 +1542,7 @@ private fun RecipeList(
             RecipeListItemContent(
                 recipe = recipe,
                 onClick = { onRecipeClicked(recipe) },
+                onLongClick = { onRecipeLongClicked(recipe) },
                 isSelectionMode = isSelectionMode,
                 isSelected = recipe.id in selectedRecipeIds,
             )
@@ -1368,12 +1553,13 @@ private fun RecipeList(
 /** Approximate height of the Continue/Done Cooking FAB stack plus breathing room. */
 private val FabStackReserve = 152.dp
 
-@OptIn(ExperimentalLayoutApi::class)
+@OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
 private fun RecipeListItemContent(
     recipe: RecipeListItem,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onLongClick: () -> Unit = {},
     isSelectionMode: Boolean = false,
     isSelected: Boolean = false,
 ) {
@@ -1384,7 +1570,7 @@ private fun RecipeListItemContent(
         modifier =
             modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                .combinedClickable(onClick = onClick, onLongClick = onLongClick)
                 .background(background)
                 .padding(16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListTestTags.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListTestTags.kt
@@ -17,4 +17,9 @@ object RecipeListTestTags {
     const val BOOK_PICKER_ALL_RECIPES: String = "recipe_list_book_picker_all_recipes"
     const val BOOK_PICKER_CREATE: String = "recipe_list_book_picker_create"
     const val BOOK_PICKER_SHARED_HEADER: String = "recipe_list_book_picker_shared_header"
+    const val SELECTION_OVERFLOW: String = "recipe_list_selection_overflow"
+    const val SELECTION_ADD_TO_BOOK: String = "recipe_list_selection_add_to_book"
+    const val SELECTION_ADD_TO_CATEGORY: String = "recipe_list_selection_add_to_category"
+    const val BULK_BOOK_SHEET: String = "recipe_list_bulk_book_sheet"
+    const val BULK_CATEGORY_SHEET: String = "recipe_list_bulk_category_sheet"
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionDarkScreenshot_805fa67c_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionDarkScreenshot_805fa67c_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77242779cf751b5a3b108bd4e9f1943a2df2c73b000d328089c3b37e1ffcf449
-size 118142
+oid sha256:2ee480c376af549569e57deb35873be9d2a2e220bd3171f5915bcea0449bccf9
+size 118670

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionEmptyScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionEmptyScreenshot_73588fdf_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc572bc34f71459af1b6a2f3c71c4cf7445c3ee388c85ea054df7e81648e7938
-size 118972
+oid sha256:0fa58fb1ea237021b5bee2294bcc11324f5e542565b581f1a664652107e993ab
+size 119525

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionLightScreenshot_73588fdf_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/RecipeListScreenshotTestKt/RecipeListSelectionLightScreenshot_73588fdf_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:befc2c6b60d64c15c45595ea40fa39f2aa7e9435f353b5112f76a4ea2d89156b
-size 118537
+oid sha256:4dc7265714c67d9eca5abc0a814021a8451cc77b736ef73eeac3e60456e94e3b
+size 119036


### PR DESCRIPTION
Closes #488.

Adds multi-select bulk management to the recipe list: pick several recipes and file them under a recipe book or tag them with a category in one action — the two options the issue called for.

## What's here

**Entry points**
- **Long-press** a recipe (mobile) enters selection mode with that recipe already picked — the standard gesture (Google Photos/Files).
- The existing overflow **"Select recipes"** stays as the cross-platform way in (desktop has no long-press).

**Bulk actions in the selection action bar**
- Selection app bar now has an **overflow menu** (between Export and Close) with **Add to recipe book** and **Add to category**.
- Each opens a bottom-sheet picker; choosing a target files the whole selection in a single transaction, confirms with a toast, and drops back to a clean list.
- **Export** is unchanged.

Both relationships are already many-to-many, so the actions are **additive and non-destructive** — a recipe keeps its existing books/categories. (Left "Move to book" out deliberately; see the issue discussion — additive "Add" is the honest default, and "remove from current book" is a cleaner future action than overloading the picker.)

## Layers
- **Data** — `RecipeRepository.addRecipesToBook` / `addRecipesToCategory`: one transaction, mark-dirty per recipe so memberships sync; idempotent `INSERT OR IGNORE`. Fake + real impl.
- **BLoC** — long-press handler (enter-with vs toggle), picker open/dismiss, bulk-add handlers; confirmation message flows out via a `SharedFlow` the `BlocImpl` surfaces through `ToastService` (mirrors the existing scanned-recipe pattern).
- **UI** — selection overflow, two picker sheets, `combinedClickable` long-press on list + grid rows.

## Tests
- ViewModel unit tests (long-press, bulk add-to-book/category, message emission, picker + exit state).
- BlocImpl tests (long-press branch, toast-on-add).
- Data-impl tests against the in-memory DB for both bulk methods.
- Snapshots refreshed for the new overflow (light/dark/empty selection).
- Robot vocabulary + a `RecipeMultiSelectUiTest` flow through the real bloc tree.

All unit/data/UI tests pass on JVM, Android, and iOS; the composeApp DI graph compiles with the new `ToastService` consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
