### PR TITLE
fix(recipe): stop static header gap from clipping scrolled content

### DIFF
--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -343,7 +343,16 @@ private fun RecipeDetailBody(
                                 )
                             },
                     ),
-                verticalArrangement = spacedBy(ChefMateTheme.dimens.paddingNormal),
+                // Compact's app bar collapses as the inner LazyColumn scrolls, so the header and
+                // content need to move as one continuous surface. A fixed arrangement gap here
+                // would sit outside the scroll and stay put while the header shrinks underneath
+                // it, leaving a seam that clips the first row of content — so compact carries its
+                // breathing room as the list's own top content padding instead (see
+                // RecipeDetailCompactContent) and this arrangement contributes none. The
+                // two-column layout keeps a fixed header, so its gap can stay a static spacing.
+                verticalArrangement =
+                    if (isCompact) Arrangement.Top
+                    else spacedBy(ChefMateTheme.dimens.paddingNormal),
                 scrollEnabled = false,
                 // Compact is a single linear scroll, so the title can grow large and collapse as
                 // the
@@ -761,7 +770,11 @@ private fun RecipeDetailCompactContent(
         modifier = modifier.fillMaxSize(),
         state = listState,
         verticalArrangement = spacedBy(dimens.paddingSmall),
-        contentPadding = PaddingValues(bottom = dimens.fabClearance + navBarBottom),
+        // The top inset lives here instead of as a fixed gap above the LazyColumn (see
+        // RecipeDetailScreen's PlusHeaderContainer call) so it scrolls away with the rest of the
+        // content as the collapsing app bar shrinks, instead of sitting still as a seam beneath it.
+        contentPadding =
+            PaddingValues(top = dimens.paddingNormal, bottom = dimens.fabClearance + navBarBottom),
     ) {
         // Hero section: image + key details side by side
         item(key = "hero") {


### PR DESCRIPTION
## Summary
- The recipe detail screen's compact layout put a fixed 16dp gap between the collapsing large app bar and the scrollable content `Surface`, living *outside* the `LazyColumn`'s scroll.
- Because that gap was static, it stayed put while the app bar shrank and the list scrolled underneath it, leaving a seam right where the first row of content sits — matching the "tiniest space that shouldn't cut off scrolling content" reported in the issue.
- Moved that breathing room into the `LazyColumn`'s own top `contentPadding` (compact layout only) so it scrolls away with the rest of the content, in lockstep with the collapsing header — the standard Material collapsing-toolbar pattern. The two-column (tablet/desktop) layout keeps its fixed header and static gap since it never collapses.

Closes #498

## Test plan
- [x] `./gradlew :client:recipe:core:public:compileKotlinJvm` — compiles
- [x] `./gradlew :client:ui:screenshot-test:updateDebugScreenshotTest --tests "*RecipeDetail*"` — reference PNGs unchanged (unscrolled state is pixel-identical, confirming no regression to the static layout)
- [x] Verified the fix with a throwaway headless Compose UI test (`runSkikoComposeUiTest`, phone-width viewport) that drove the recipe detail screen's scroll through the app bar's collapse transition and captured frames via `captureToImage()`, reproducing the reported recipe's shape (no rating/servings, so Prep/Cook/Total Time is the first row) — confirmed clean spacing throughout the collapse with the fix applied. Test was diagnostic-only and not included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)