### PR TITLE
feat(recipe): persist ingredient scale per recipe across detail & cook mode

### DIFF
--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeBlocImpl.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeBlocImpl.kt
@@ -37,6 +37,7 @@ class CookModeBlocImpl(
             CookModeBloc.Model(
                 isLoading = vm.isLoading,
                 activeRecipe = active,
+                ingredientScale = vm.ingredientScale,
                 activeSessions =
                     vm.cookingRecipes
                         .map { recipe ->
@@ -65,6 +66,10 @@ class CookModeBlocImpl(
 
     override fun onRecipeChipClicked(recipeId: Long) {
         viewModel.selectRecipe(recipeId)
+    }
+
+    override fun onScaleChanged(scale: Double) {
+        viewModel.setScale(scale)
     }
 
     override fun onAiChatClicked() {

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModel.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModel.kt
@@ -11,6 +11,8 @@ import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.featureflag.FeatureFlags
 import com.plusmobileapps.chefmate.featureflag.isEnabled
+import com.plusmobileapps.chefmate.recipe.data.DEFAULT_INGREDIENT_SCALE
+import com.plusmobileapps.chefmate.recipe.data.IngredientScalePreferences
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import com.russhwolf.settings.Settings
@@ -19,12 +21,17 @@ import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @AssistedInject
 class CookModeViewModel(
     @Assisted private val initialRecipeId: Long,
@@ -32,6 +39,7 @@ class CookModeViewModel(
     private val recipeRepository: RecipeRepository,
     private val sessionRepository: CookingSessionRepository,
     settings: Settings,
+    private val scalePreferences: IngredientScalePreferences,
     private val keepScreenOnRepository: KeepScreenOnRepository,
     private val coachMarkController: CoachMarkController,
     featureFlags: FeatureFlags,
@@ -94,10 +102,28 @@ class CookModeViewModel(
                 _state.update { it.copy(keepScreenOn = keepScreenOn) }
             }
         }
+        // Track the persisted scale of whichever recipe is active, switching the source flow as the
+        // user changes recipes so each shows its own saved factor (and one set here persists back).
+        scope.launch {
+            _state
+                .map { it.activeRecipeId }
+                .distinctUntilChanged()
+                .flatMapLatest { id ->
+                    if (id == null) MutableStateFlow(DEFAULT_INGREDIENT_SCALE)
+                    else scalePreferences.scaleFor(id)
+                }
+                .collect { scale -> _state.update { it.copy(ingredientScale = scale) } }
+        }
     }
 
     fun selectRecipe(recipeId: Long) {
         scope.launch { sessionRepository.markSelected(recipeId) }
+    }
+
+    /** Persist the chosen ingredient [scale] for the active recipe; the state flow reflects it. */
+    fun setScale(scale: Double) {
+        val recipeId = _state.value.activeRecipeId ?: return
+        scalePreferences.setScale(recipeId, scale)
     }
 
     /**
@@ -147,6 +173,7 @@ class CookModeViewModel(
         val isLoading: Boolean = true,
         val cookingRecipes: List<Recipe> = emptyList(),
         val activeRecipeId: Long? = null,
+        val ingredientScale: Double = DEFAULT_INGREDIENT_SCALE,
         val layoutMode: CookModeBloc.LayoutMode = CookModeBloc.LayoutMode.Split,
         val keepScreenOn: Boolean = true,
         val activeCoachMark: String? = null,

--- a/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/ui/CookModePreviews.kt
+++ b/client/cook/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/impl/ui/CookModePreviews.kt
@@ -45,6 +45,8 @@ private fun cookBloc(model: CookModeBloc.Model): CookModeBloc =
 
         override fun onRecipeChipClicked(recipeId: Long) = Unit
 
+        override fun onScaleChanged(scale: Double) = Unit
+
         override fun onAiChatClicked() = Unit
 
         override fun onLayoutToggled() = Unit

--- a/client/cook/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModelTest.kt
+++ b/client/cook/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/cook/impl/CookModeViewModelTest.kt
@@ -10,6 +10,7 @@ import com.plusmobileapps.chefmate.di.KeepScreenOnRepository
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeIngredientScalePreferences
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.russhwolf.settings.MapSettings
 import dev.mokkery.answering.returns
@@ -28,12 +29,14 @@ class CookModeViewModelTest {
 
     private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
     private val recipeRepository = FakeRecipeRepository(recipes)
+    private val recipeIds = MutableStateFlow<List<Long>>(emptyList())
     private val sessionRepository: CookingSessionRepository = mock {
-        every { observeRecipeIds() } returns MutableStateFlow(emptyList())
+        every { observeRecipeIds() } returns recipeIds
         everySuspend { start(any()) } returns Unit
         everySuspend { markSelected(any()) } returns Unit
         everySuspend { stopAll() } returns Unit
     }
+    private val scalePreferences = FakeIngredientScalePreferences()
 
     private fun createViewModel(
         coachMarkController: CoachMarkController = CoachMarkController(MapSettings()),
@@ -45,6 +48,7 @@ class CookModeViewModelTest {
             recipeRepository = recipeRepository,
             sessionRepository = sessionRepository,
             settings = MapSettings(),
+            scalePreferences = scalePreferences,
             keepScreenOnRepository = KeepScreenOnRepository(MapSettings()),
             coachMarkController = coachMarkController,
             featureFlags = featureFlags,
@@ -91,6 +95,35 @@ class CookModeViewModelTest {
 
         verifySuspend { sessionRepository.stopAll() }
         finished shouldBe true
+    }
+
+    @Test
+    fun When_recipe_has_saved_scale_Then_state_reflects_it() {
+        scalePreferences.setScale(1L, 2.0)
+        recipes.value = listOf(Recipe.Sample.copy(id = 1L))
+        recipeIds.value = listOf(1L)
+
+        val vm = createViewModel()
+
+        vm.state.value.ingredientScale shouldBe 2.0
+    }
+
+    @Test
+    fun When_setScale_called_Then_persisted_for_active_recipe_and_state_updates() {
+        recipes.value = listOf(Recipe.Sample.copy(id = 1L))
+        recipeIds.value = listOf(1L)
+        val vm = createViewModel()
+
+        vm.setScale(3.0)
+
+        scalePreferences.scaleFor(1L).value shouldBe 3.0
+        vm.state.value.ingredientScale shouldBe 3.0
+    }
+
+    @Test
+    fun When_no_active_recipe_Then_scale_defaults_to_one() {
+        val vm = createViewModel()
+        vm.state.value.ingredientScale shouldBe 1.0
     }
 
     @Test

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeBloc.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/CookModeBloc.kt
@@ -6,6 +6,7 @@ import com.plusmobileapps.chefmate.BackClickBloc
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.cook.ui.CookModeScreen
+import com.plusmobileapps.chefmate.recipe.data.DEFAULT_INGREDIENT_SCALE
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.ui.ComposeScreen
 import kotlinx.collections.immutable.ImmutableList
@@ -27,6 +28,12 @@ interface CookModeBloc : BackClickBloc, ComposeScreen {
     fun onFinishClicked()
 
     fun onRecipeChipClicked(recipeId: Long)
+
+    /**
+     * Pick a new ingredient scale factor (e.g. `2.0` for 2×) for the active recipe. Persisted per
+     * recipe so it carries over from recipe detail and survives leaving Cook Mode.
+     */
+    fun onScaleChanged(scale: Double)
 
     /** Open the AI chat grounded in the active recipe. Only surfaced when [Model.showAiChat]. */
     fun onAiChatClicked()
@@ -51,6 +58,10 @@ interface CookModeBloc : BackClickBloc, ComposeScreen {
     data class Model(
         val isLoading: Boolean = true,
         val activeRecipe: Recipe? = null,
+        /**
+         * Scale factor applied to the active recipe's ingredient amounts (1× = author's amounts).
+         */
+        val ingredientScale: Double = DEFAULT_INGREDIENT_SCALE,
         val activeSessions: ImmutableList<Chip> = persistentListOf(),
         val layoutMode: LayoutMode = LayoutMode.Split,
         val keepScreenOn: Boolean = true,

--- a/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/ui/CookModeScreen.kt
+++ b/client/cook/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/cook/ui/CookModeScreen.kt
@@ -142,9 +142,10 @@ fun CookModeScreen(bloc: CookModeBloc, modifier: Modifier = Modifier) {
     if (state.keepScreenOn) {
         KeepScreenOn()
     }
-    // Ingredient scale multiplier, reset whenever the active recipe changes. Hoisted here so it
-    // survives the compact <-> tablet layout swap and drives both the header control and the body.
-    var ingredientScale by remember(state.activeRecipe?.id) { mutableStateOf(1.0) }
+    // Ingredient scale multiplier for the active recipe. Owned by the BLoC so it persists per
+    // recipe
+    // across Cook Mode / recipe detail; the header control and body both read it from state.
+    val ingredientScale = state.ingredientScale
 
     Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
@@ -161,7 +162,7 @@ fun CookModeScreen(bloc: CookModeBloc, modifier: Modifier = Modifier) {
                     state = state,
                     windowSizeClass = windowSizeClass,
                     scale = ingredientScale,
-                    onScaleChange = { ingredientScale = it },
+                    onScaleChange = bloc::onScaleChanged,
                 )
             } else {
                 CookModeTabletLayout(
@@ -170,7 +171,7 @@ fun CookModeScreen(bloc: CookModeBloc, modifier: Modifier = Modifier) {
                     windowSizeClass = windowSizeClass,
                     isCompactHeight = isCompactHeight,
                     scale = ingredientScale,
-                    onScaleChange = { ingredientScale = it },
+                    onScaleChange = bloc::onScaleChanged,
                 )
             }
         }

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImpl.kt
@@ -121,6 +121,7 @@ class RecipeDetailBlocImpl(
                     it.recipe.cookTime?.let { time -> timeFormatterUtil.formatMinutes(time) },
                 formattedTotalTime =
                     it.recipe.totalTime?.let { time -> timeFormatterUtil.formatMinutes(time) },
+                ingredientScale = it.ingredientScale,
                 activeCoachMark = it.activeCoachMark,
                 showAiChat = it.showAiChat,
             )
@@ -204,6 +205,10 @@ class RecipeDetailBlocImpl(
 
     override fun onStopSharingClicked() {
         viewModel.onStopSharing()
+    }
+
+    override fun onScaleChanged(scale: Double) {
+        viewModel.setScale(scale)
     }
 
     override fun onDismissSheet() {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailViewModel.kt
@@ -12,6 +12,8 @@ import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.featureflag.FeatureFlagRegistry
 import com.plusmobileapps.chefmate.featureflag.FeatureFlags
 import com.plusmobileapps.chefmate.featureflag.isEnabled
+import com.plusmobileapps.chefmate.recipe.data.DEFAULT_INGREDIENT_SCALE
+import com.plusmobileapps.chefmate.recipe.data.IngredientScalePreferences
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
 import com.plusmobileapps.chefmate.text.ResourceString
@@ -36,6 +38,7 @@ class RecipeDetailViewModel(
     private val repository: RecipeRepository,
     private val coachMarkController: CoachMarkController,
     private val toastService: ToastService,
+    private val scalePreferences: IngredientScalePreferences,
     featureFlags: FeatureFlags,
 ) : ViewModel(mainContext) {
 
@@ -50,15 +53,23 @@ class RecipeDetailViewModel(
     private val showAiChat = featureFlags.isEnabled(FeatureFlagRegistry.AiChat)
 
     // Surface the shared controller's active mark so the screen can show one coach mark at a time;
-    // only ids in CoachMarkId.recipeDetailSequence are anchored on this screen.
+    // only ids in CoachMarkId.recipeDetailSequence are anchored on this screen. The persisted
+    // ingredient scale for this recipe is folded in so the picker reflects (and shares) whatever
+    // factor was last chosen — including one set over in Cook Mode.
     val state: StateFlow<State> =
         combineStates(
-            combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark ->
-                state.copy(activeCoachMark = activeCoachMark)
+            combineStates(
+                combineStates(_state, coachMarkController.activeCoachMark) { state, activeCoachMark
+                    ->
+                    state.copy(activeCoachMark = activeCoachMark)
+                },
+                showAiChat,
+            ) { state, showChat ->
+                state.copy(showAiChat = showChat)
             },
-            showAiChat,
-        ) { state, showChat ->
-            state.copy(showAiChat = showChat)
+            scalePreferences.scaleFor(recipeId),
+        ) { state, scale ->
+            state.copy(ingredientScale = scale)
         }
 
     init {
@@ -130,6 +141,13 @@ class RecipeDetailViewModel(
     }
 
     /**
+     * Persist the chosen ingredient [scale] for this recipe; the state flow reflects it in turn.
+     */
+    fun setScale(scale: Double) {
+        scalePreferences.setScale(recipeId, scale)
+    }
+
+    /**
      * Resolve a tapped recipe-to-recipe link's [clientId] to a locally-stored recipe and open it. A
      * miss (the target isn't in this device's collection) surfaces a toast instead of navigating.
      */
@@ -169,6 +187,7 @@ class RecipeDetailViewModel(
         val showDeleteConfirmationDialog: Boolean = false,
         val showShareConfirmation: Boolean = false,
         val recipe: Recipe = Recipe.Empty,
+        val ingredientScale: Double = DEFAULT_INGREDIENT_SCALE,
         val activeCoachMark: String? = null,
         val showAiChat: Boolean = false,
     )

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/detail/RecipeDetailBlocImplTest.kt
@@ -15,6 +15,7 @@ import com.plusmobileapps.chefmate.featureflag.testing.FakeFeatureFlags
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
 import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailBloc
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeIngredientScalePreferences
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.plusmobileapps.chefmate.testing.TestBlocContext
 import com.plusmobileapps.chefmate.testing.TestConsumer
@@ -44,6 +45,7 @@ class RecipeDetailBlocImplTest {
     private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
     private val repository = FakeRecipeRepository(recipes)
     private val toastService = FakeToastService()
+    private val scalePreferences = FakeIngredientScalePreferences()
 
     private val sampleRecipe =
         Recipe(
@@ -83,6 +85,7 @@ class RecipeDetailBlocImplTest {
                 repository = repository,
                 coachMarkController = coachMarkController,
                 toastService = toastService,
+                scalePreferences = scalePreferences,
                 featureFlags = featureFlags,
             )
         }
@@ -266,6 +269,29 @@ class RecipeDetailBlocImplTest {
         val bloc = createBloc(sampleRecipe.copy(isPublic = true, remoteId = "already-public"))
         bloc.onStopSharingClicked()
         repository.lastSetPublic shouldBe (sampleRecipe.id to false)
+    }
+
+    @Test
+    fun When_recipe_has_saved_scale_Then_state_reflects_it() {
+        scalePreferences.setScale(sampleRecipe.id, 2.0)
+        val bloc = createBloc()
+        bloc.state.value.ingredientScale shouldBe 2.0
+    }
+
+    @Test
+    fun When_onScaleChanged_Then_persisted_and_state_updates() {
+        val bloc = createBloc()
+
+        bloc.onScaleChanged(0.5)
+
+        scalePreferences.scaleFor(sampleRecipe.id).value shouldBe 0.5
+        bloc.state.value.ingredientScale shouldBe 0.5
+    }
+
+    @Test
+    fun When_never_scaled_Then_scale_defaults_to_one() {
+        val bloc = createBloc()
+        bloc.state.value.ingredientScale shouldBe 1.0
     }
 
     @Test

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailBloc.kt
@@ -8,6 +8,7 @@ import com.plusmobileapps.chefmate.BackClickBloc
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc
+import com.plusmobileapps.chefmate.recipe.data.DEFAULT_INGREDIENT_SCALE
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.ui.ComposeScreen
@@ -83,6 +84,12 @@ interface RecipeDetailBloc : BackClickBloc, ComposeScreen {
     /** Make a shared recipe private again so its link stops resolving for others. */
     fun onStopSharingClicked()
 
+    /**
+     * Pick a new ingredient scale factor (e.g. `2.0` for 2×). Persisted per recipe so the choice
+     * carries over to Cook Mode and survives leaving this screen.
+     */
+    fun onScaleChanged(scale: Double)
+
     fun onDismissSheet()
 
     data class Model(
@@ -97,6 +104,8 @@ interface RecipeDetailBloc : BackClickBloc, ComposeScreen {
         val formattedPrepTime: TextData? = null,
         val formattedCookTime: TextData? = null,
         val formattedTotalTime: TextData? = null,
+        /** The ingredient scale factor to render amounts at (1× = the author's amounts). */
+        val ingredientScale: Double = DEFAULT_INGREDIENT_SCALE,
         /** Id of the coach mark currently allowed to show on this screen, or null. */
         val activeCoachMark: String? = null,
         /** Gated on the AI Chat feature flag — hides the chat button entirely when off. */

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -460,6 +460,8 @@ private fun RecipeDetailBody(
                         onSourceUrlClicked = bloc::onSourceUrlClicked,
                         onImageClicked = bloc::onImageClicked,
                         onRecipeLinkClick = onRecipeLinkClick,
+                        scale = state.ingredientScale,
+                        onScaleChange = bloc::onScaleChanged,
                         listState = compactListState,
                         modifier = Modifier.weight(1f),
                     )
@@ -474,6 +476,8 @@ private fun RecipeDetailBody(
                         onSourceUrlClicked = bloc::onSourceUrlClicked,
                         onImageClicked = bloc::onImageClicked,
                         onRecipeLinkClick = onRecipeLinkClick,
+                        scale = state.ingredientScale,
+                        onScaleChange = bloc::onScaleChanged,
                         ingredientsListState = ingredientsListState,
                         directionsListState = directionsListState,
                     )
@@ -740,6 +744,8 @@ private fun RecipeDetailCompactContent(
     onSourceUrlClicked: (String) -> Unit,
     onImageClicked: () -> Unit,
     onRecipeLinkClick: (String) -> Unit,
+    scale: Double,
+    onScaleChange: (Double) -> Unit,
     listState: LazyListState = rememberLazyListState(),
     modifier: Modifier = Modifier,
 ) {
@@ -753,7 +759,6 @@ private fun RecipeDetailCompactContent(
         }
     val directionParagraphs = remember(recipe.directions) { directionSteps(recipe.directions) }
     var highlightedDirectionIndex by remember(recipe.directions) { mutableStateOf(-1) }
-    var ingredientScale by remember(recipe.ingredients) { mutableStateOf(1.0) }
 
     val navBarBottom = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
 
@@ -802,8 +807,8 @@ private fun RecipeDetailCompactContent(
         ingredientItems(
             lines = ingredientLines,
             crossedOut = crossedOut,
-            scale = ingredientScale,
-            onScaleChange = { ingredientScale = it },
+            scale = scale,
+            onScaleChange = onScaleChange,
             onRecipeLinkClick = onRecipeLinkClick,
             itemPadding = padding,
         )
@@ -835,6 +840,8 @@ private fun ColumnScope.RecipeDetailTwoColumnContent(
     onSourceUrlClicked: (String) -> Unit,
     onImageClicked: () -> Unit,
     onRecipeLinkClick: (String) -> Unit,
+    scale: Double,
+    onScaleChange: (Double) -> Unit,
     ingredientsListState: LazyListState = rememberLazyListState(),
     directionsListState: LazyListState = rememberLazyListState(),
 ) {
@@ -853,7 +860,6 @@ private fun ColumnScope.RecipeDetailTwoColumnContent(
         }
     val directionParagraphs = remember(recipe.directions) { directionSteps(recipe.directions) }
     var directionHighlightedIndex by remember(recipe.directions) { mutableStateOf(-1) }
-    var ingredientScale by remember(recipe.ingredients) { mutableStateOf(1.0) }
 
     Row(modifier = Modifier.weight(1f).fillMaxWidth().padding(horizontal = padding)) {
         // Column 1: metadata, then ingredients
@@ -899,8 +905,8 @@ private fun ColumnScope.RecipeDetailTwoColumnContent(
             ingredientItems(
                 lines = ingredientLines,
                 crossedOut = ingredientCrossedOut,
-                scale = ingredientScale,
-                onScaleChange = { ingredientScale = it },
+                scale = scale,
+                onScaleChange = onScaleChange,
                 onRecipeLinkClick = onRecipeLinkClick,
                 itemPadding = padding,
             )
@@ -1646,6 +1652,10 @@ val previewRecipeDetailBloc: RecipeDetailBloc =
         }
 
         override fun onStopSharingClicked() {
+            // Preview no-op
+        }
+
+        override fun onScaleChanged(scale: Double) {
             // Preview no-op
         }
 

--- a/client/recipe/data/impl/build.gradle.kts
+++ b/client/recipe/data/impl/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
             implementation(projects.client.recipe.data.testing)
             implementation(projects.client.recipebook.data.testing)
             implementation(projects.client.util.testing)
+            implementation(libs.multiplatform.settings.test)
         }
         jvmMain.dependencies { implementation(libs.ktor.client.cio) }
         androidMain.dependencies { implementation(libs.ktor.client.cio) }

--- a/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/IngredientScalePreferencesImpl.kt
+++ b/client/recipe/data/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/IngredientScalePreferencesImpl.kt
@@ -1,0 +1,49 @@
+package com.plusmobileapps.chefmate.recipe.data.impl
+
+import com.plusmobileapps.chefmate.di.AppScope
+import com.plusmobileapps.chefmate.recipe.data.DEFAULT_INGREDIENT_SCALE
+import com.plusmobileapps.chefmate.recipe.data.IngredientScalePreferences
+import com.russhwolf.settings.Settings
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class IngredientScalePreferencesImpl(private val settings: Settings) : IngredientScalePreferences {
+
+    // One hot flow per recipe id, created lazily from the persisted value and shared by every
+    // screen
+    // that scales that recipe so they update together. Accessed from BLoC view models on the main
+    // dispatcher, so a plain map is safe here.
+    private val flows = mutableMapOf<Long, MutableStateFlow<Double>>()
+
+    override fun scaleFor(recipeId: Long): StateFlow<Double> = flowFor(recipeId).asStateFlow()
+
+    override fun setScale(recipeId: Long, scale: Double) {
+        val key = key(recipeId)
+        // 1× is the author's own amounts — clear the key instead of storing the default so we don't
+        // accumulate an entry for every recipe the user merely opened.
+        if (scale == DEFAULT_INGREDIENT_SCALE) {
+            settings.remove(key)
+        } else {
+            settings.putDouble(key, scale)
+        }
+        flowFor(recipeId).value = scale
+    }
+
+    private fun flowFor(recipeId: Long): MutableStateFlow<Double> =
+        flows.getOrPut(recipeId) {
+            MutableStateFlow(settings.getDouble(key(recipeId), DEFAULT_INGREDIENT_SCALE))
+        }
+
+    private fun key(recipeId: Long): String = "$KEY_PREFIX$recipeId"
+
+    private companion object {
+        const val KEY_PREFIX = "recipe_scale_"
+    }
+}

--- a/client/recipe/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/IngredientScalePreferencesImplTest.kt
+++ b/client/recipe/data/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/data/impl/IngredientScalePreferencesImplTest.kt
@@ -1,0 +1,57 @@
+@file:Suppress("FunctionName")
+
+package com.plusmobileapps.chefmate.recipe.data.impl
+
+import com.russhwolf.settings.MapSettings
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class IngredientScalePreferencesImplTest {
+
+    private val settings = MapSettings()
+    private val prefs = IngredientScalePreferencesImpl(settings)
+
+    @Test
+    fun When_never_scaled_Then_defaults_to_one() {
+        prefs.scaleFor(7L).value shouldBe 1.0
+    }
+
+    @Test
+    fun When_scale_set_Then_flow_updates_and_value_persists() {
+        prefs.setScale(7L, 2.0)
+
+        prefs.scaleFor(7L).value shouldBe 2.0
+        // A fresh store reading the same settings sees the persisted factor.
+        IngredientScalePreferencesImpl(settings).scaleFor(7L).value shouldBe 2.0
+    }
+
+    @Test
+    fun When_same_recipe_requested_twice_Then_flows_share_updates() {
+        val first = prefs.scaleFor(7L)
+        val second = prefs.scaleFor(7L)
+
+        prefs.setScale(7L, 4.0)
+
+        // Backed by one shared source — a later reader sees the same value as an earlier one.
+        first.value shouldBe 4.0
+        second.value shouldBe 4.0
+    }
+
+    @Test
+    fun When_scale_reset_to_one_Then_key_is_cleared() {
+        prefs.setScale(7L, 3.0)
+        prefs.setScale(7L, 1.0)
+
+        prefs.scaleFor(7L).value shouldBe 1.0
+        settings.hasKey("recipe_scale_7") shouldBe false
+    }
+
+    @Test
+    fun When_two_recipes_scaled_Then_each_tracked_independently() {
+        prefs.setScale(1L, 2.0)
+        prefs.setScale(2L, 0.5)
+
+        prefs.scaleFor(1L).value shouldBe 2.0
+        prefs.scaleFor(2L).value shouldBe 0.5
+    }
+}

--- a/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/IngredientScalePreferences.kt
+++ b/client/recipe/data/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/IngredientScalePreferences.kt
@@ -1,0 +1,27 @@
+package com.plusmobileapps.chefmate.recipe.data
+
+import kotlinx.coroutines.flow.StateFlow
+
+/** The scale factor a recipe shows when the user has never scaled it — the author's own amounts. */
+const val DEFAULT_INGREDIENT_SCALE: Double = 1.0
+
+/**
+ * Remembers the ingredient scale factor (½× through 4×) the user picked for each recipe, stored
+ * locally and keyed by recipe id. This is what lets a scale chosen on the recipe detail screen
+ * carry over to Cook Mode — and survive leaving either screen — without ever syncing to the
+ * backend.
+ */
+interface IngredientScalePreferences {
+    /**
+     * The current scale factor for [recipeId] as a hot [StateFlow], defaulting to
+     * [DEFAULT_INGREDIENT_SCALE] when the recipe has never been scaled. Every flow returned for the
+     * same id is backed by one shared source, so all screens showing that recipe observe the same
+     * updates and stay in lock-step as the factor changes.
+     */
+    fun scaleFor(recipeId: Long): StateFlow<Double>
+
+    /**
+     * Persist [scale] as the chosen factor for [recipeId] and push it to that id's [scaleFor] flow.
+     */
+    fun setScale(recipeId: Long, scale: Double)
+}

--- a/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeIngredientScalePreferences.kt
+++ b/client/recipe/data/testing/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/data/testing/FakeIngredientScalePreferences.kt
@@ -1,0 +1,26 @@
+package com.plusmobileapps.chefmate.recipe.data.testing
+
+import com.plusmobileapps.chefmate.recipe.data.DEFAULT_INGREDIENT_SCALE
+import com.plusmobileapps.chefmate.recipe.data.IngredientScalePreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * In-memory [IngredientScalePreferences] for tests — same per-id hot-flow semantics, no storage.
+ */
+class FakeIngredientScalePreferences(initial: Map<Long, Double> = emptyMap()) :
+    IngredientScalePreferences {
+
+    private val flows =
+        initial.mapValuesTo(mutableMapOf()) { (_, scale) -> MutableStateFlow(scale) }
+
+    override fun scaleFor(recipeId: Long): StateFlow<Double> = flowFor(recipeId).asStateFlow()
+
+    override fun setScale(recipeId: Long, scale: Double) {
+        flowFor(recipeId).value = scale
+    }
+
+    private fun flowFor(recipeId: Long): MutableStateFlow<Double> =
+        flows.getOrPut(recipeId) { MutableStateFlow(DEFAULT_INGREDIENT_SCALE) }
+}


### PR DESCRIPTION
## What & why

Picking an ingredient scale (½× through 4×) was throwaway UI state: it reset to 1× on every navigation or screen close, and the recipe detail screen and Cook Mode each tracked their own. This makes the chosen scale **persist locally, per recipe, and shared between the two screens**.

- Set 2× on recipe detail → open Cook Mode → shows 2×.
- Change it in Cook Mode → return to detail → detail reflects the change.
- Close and reopen either screen → the factor is still there (survives app restart).
- In Cook Mode, switching between active recipes shows each one's own saved scale.

Local only — nothing syncs to Supabase.

## How

New `IngredientScalePreferences` store (`recipe/data`), an `AppScope` singleton backed by `multiplatform-settings` — the same local key-value mechanism already used for tab order, cook-mode layout, etc.:
- Keyed by recipe id (`recipe_scale_<id>`); exposes `scaleFor(recipeId): StateFlow<Double>` backed by one shared per-id source so both screens observe the same updates.
- 1× (the author's amounts) is stored as an absent key, so merely opening a recipe never accumulates state.

The scale then moved out of Compose `remember` into the BLoC layer for both screens — `RecipeDetailBloc` and `CookModeBloc` gained `ingredientScale` in their `Model` and an `onScaleChanged(scale)` handler; the view models read the persisted factor into state and write on change. Cook Mode tracks the active recipe's scale, switching the source as the user moves between cooking recipes.

## Commits (by concern)

1. `feat(recipe): persist ingredient scale per recipe locally` — the store (interface + impl + testing fake + unit test).
2. `feat(recipe): keep the recipe-detail ingredient scale across screens` — RecipeDetail BLoC/VM/impl/screen + bloc tests.
3. `feat(cook): persist the cook-mode ingredient scale per recipe` — CookMode BLoC/VM/impl/screen/previews + VM tests.

## Testing

- New `IngredientScalePreferencesImplTest`: default 1×, persistence across store instances (app restart), key cleared on reset to 1×, per-recipe independence, shared-flow updates.
- Added scale coverage to `RecipeDetailBlocImplTest` and `CookModeViewModelTest` (saved scale reflected in state, change persists + updates state, default).
- Existing `RecipeScaleIngredientsUiTest` still green through the real DI graph.
- Verified: `:client:recipe:data:impl`, `:client:recipe:core:impl`, `:client:cook:impl` `jvmTest`, plus `:client:composeApp:jvmTest` (confirms the Metro DI graph resolves the new binding).

## Reviewer notes

- No cross-screen **UI robot** flow was added — that would need a new `cook:impl-robots` module + `CookModeRobot`, disproportionate here. The cross-screen guarantee is covered at the unit level via the shared keyed store (a second reader sees the first writer's value).
- Editing a recipe's ingredients no longer resets the scale — it's now keyed by recipe id rather than ingredient text. This is intentional (the user's chosen scale sticks), but flagging it as a behavior change from the previous `remember(recipe.ingredients)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)