### PR TITLE
feat(recipe): scale the ingredients added to a grocery list

### DIFF
--- a/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/RecipeScaleIngredientsUiTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/com/plusmobileapps/chefmate/tests/RecipeScaleIngredientsUiTest.kt
@@ -3,6 +3,7 @@ package com.plusmobileapps.chefmate.tests
 import androidx.compose.ui.test.ExperimentalTestApi
 import com.plusmobileapps.chefmate.fixtures.TestRecipes
 import com.plusmobileapps.chefmate.harness.runRootBlocTest
+import com.plusmobileapps.chefmate.recipe.core.robots.addRecipeToGroceryList
 import com.plusmobileapps.chefmate.recipe.core.robots.recipeDetail
 import com.plusmobileapps.chefmate.recipe.list.robots.recipeList
 import kotlin.test.Test
@@ -20,5 +21,17 @@ class RecipeScaleIngredientsUiTest {
             .selectIngredientScale("2×")
             .assertIngredientScale("2×")
             .assertIngredientDisplayed("400g spaghetti")
+    }
+
+    @Test
+    fun scale_chosen_on_recipe_detail_carries_into_the_add_to_grocery_sheet() = runRootBlocTest {
+        // The scale is a per-recipe preference, so the sheet opens on the factor already chosen
+        // and offers the scaled amounts — no need to pick 2× a second time.
+        recipeList().clickRecipe(TestRecipes.fullyPopulated.title)
+        recipeDetail().awaitDisplayed().selectIngredientScale("2×").tapAddToGroceryList()
+        addRecipeToGroceryList()
+            .awaitDisplayed()
+            .assertIngredientScale("2×")
+            .assertIngredientDisplayed("400g")
     }
 }

--- a/client/recipe/core/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/robots/AddRecipeToGroceryListRobot.kt
+++ b/client/recipe/core/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/robots/AddRecipeToGroceryListRobot.kt
@@ -1,0 +1,57 @@
+package com.plusmobileapps.chefmate.recipe.core.robots
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListTestTags
+
+/**
+ * Robot for the sheet that picks which of a recipe's ingredients to add to a grocery list.
+ *
+ * Construct via [addRecipeToGroceryList] from inside a `runComposeUiTest { … }` block.
+ */
+@OptIn(ExperimentalTestApi::class)
+class AddRecipeToGroceryListRobot(private val test: ComposeUiTest) {
+
+    private val onScreen = hasTestTag(AddRecipeToGroceryListTestTags.SCREEN)
+
+    fun awaitDisplayed(): AddRecipeToGroceryListRobot = apply {
+        test.waitUntilExactlyOneExists(onScreen)
+    }
+
+    /** Asserts a row showing exactly [text] is on the sheet (an ingredient name or its amount). */
+    fun assertIngredientDisplayed(text: String): AddRecipeToGroceryListRobot = apply {
+        test.onNode(hasText(text) and hasAnyAncestor(onScreen)).assertIsDisplayed()
+    }
+
+    /** Opens the scale dropdown and picks the option with [label] (e.g. `2×`). */
+    fun selectIngredientScale(label: String): AddRecipeToGroceryListRobot = apply {
+        test
+            .onNode(
+                hasTestTag(AddRecipeToGroceryListTestTags.INGREDIENT_SCALE_BUTTON) and
+                    hasAnyAncestor(onScreen)
+            )
+            .performClick()
+        test.onNode(hasText(label)).performClick()
+    }
+
+    /** Asserts the scale button currently reads [label] (e.g. `2×`). */
+    fun assertIngredientScale(label: String): AddRecipeToGroceryListRobot = apply {
+        test
+            .onNode(
+                hasTestTag(AddRecipeToGroceryListTestTags.INGREDIENT_SCALE_BUTTON) and
+                    hasAnyAncestor(onScreen)
+            )
+            .assert(hasText(label))
+    }
+}
+
+@OptIn(ExperimentalTestApi::class)
+fun ComposeUiTest.addRecipeToGroceryList(): AddRecipeToGroceryListRobot =
+    AddRecipeToGroceryListRobot(this)

--- a/client/recipe/core/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/robots/RecipeDetailRobot.kt
+++ b/client/recipe/core/impl-robots/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/robots/RecipeDetailRobot.kt
@@ -58,6 +58,15 @@ class RecipeDetailRobot(private val test: ComposeUiTest) {
             .assert(hasText(label))
     }
 
+    /** Taps the add-to-grocery-list action, opening the ingredient-picking sheet. */
+    fun tapAddToGroceryList(): RecipeDetailRobot = apply {
+        test
+            .onNode(
+                hasTestTag(RecipeDetailTestTags.ADD_TO_GROCERY_BUTTON) and hasAnyAncestor(onScreen)
+            )
+            .performClick()
+    }
+
     /** Taps the AI chat action, opening the recipe-grounded chat sheet. */
     fun tapAiChat(): RecipeDetailRobot = apply {
         test

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListBlocImpl.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListBlocImpl.kt
@@ -37,6 +37,7 @@ class AddRecipeToGroceryListBlocImpl(
                 groupedIngredients = it.groupedIngredients.toImmutableList(),
                 groceryLists = it.groceryLists.toImmutableList(),
                 selectedGroceryList = it.selectedGroceryList,
+                ingredientScale = it.ingredientScale,
             )
         }
 
@@ -61,6 +62,10 @@ class AddRecipeToGroceryListBlocImpl(
 
     override fun onGroceryListSelected(listId: Long) {
         viewModel.onGroceryListSelected(listId)
+    }
+
+    override fun onScaleChanged(scale: Double) {
+        viewModel.setScale(scale)
     }
 
     override fun onSaveClicked() {

--- a/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListViewModel.kt
+++ b/client/recipe/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListViewModel.kt
@@ -1,12 +1,16 @@
 package com.plusmobileapps.chefmate.recipe.core.impl.addgrocery
 
 import com.plusmobileapps.chefmate.ViewModel
+import com.plusmobileapps.chefmate.combineStates
 import com.plusmobileapps.chefmate.di.Main
 import com.plusmobileapps.chefmate.grocery.data.GroceryRepository
 import com.plusmobileapps.chefmate.grocery.data.IngredientParser
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc.GroceryListItem
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc.IngredientGroup
 import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc.ListItem
+import com.plusmobileapps.chefmate.recipe.data.DEFAULT_INGREDIENT_SCALE
+import com.plusmobileapps.chefmate.recipe.data.IngredientScalePreferences
+import com.plusmobileapps.chefmate.recipe.data.IngredientScaler
 import com.plusmobileapps.chefmate.recipe.data.IngredientSection
 import com.plusmobileapps.chefmate.recipe.data.Recipe
 import com.plusmobileapps.chefmate.recipe.data.RecipeRepository
@@ -20,7 +24,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
@@ -32,12 +35,29 @@ class AddRecipeToGroceryListViewModel(
     @Main mainContext: CoroutineContext,
     private val recipeRepository: RecipeRepository,
     private val groceryRepository: GroceryRepository,
+    private val scalePreferences: IngredientScalePreferences,
     private val settings: Settings,
 ) : ViewModel(mainContext) {
     private val _output = Channel<Output>(Channel.BUFFERED)
     val output: Flow<Output> = _output.receiveAsFlow()
     private val _state = MutableStateFlow(State())
-    val state: StateFlow<State> = _state.asStateFlow()
+
+    // The ingredient rows are derived rather than stored: the persisted scale for this recipe is
+    // folded in here so the amounts shown — and the ones handed to the grocery list on save —
+    // always reflect whatever factor was last chosen, including one set over on recipe detail or
+    // in Cook Mode. Selection lives in the raw state as ids, so it survives a rescale.
+    val state: StateFlow<State> =
+        combineStates(_state, scalePreferences.scaleFor(recipeId)) { state, scale ->
+            state.copy(
+                ingredientScale = scale,
+                groupedIngredients =
+                    groupIngredients(
+                        lines = state.ingredientLines,
+                        deselectedIds = state.deselectedIngredientIds,
+                        scale = scale,
+                    ),
+            )
+        }
 
     init {
         loadGroceryLists()
@@ -51,24 +71,23 @@ class AddRecipeToGroceryListViewModel(
 
     fun toggleIngredient(ingredientId: Int) {
         _state.update {
+            val deselected = it.deselectedIngredientIds
             it.copy(
-                groupedIngredients =
-                    it.groupedIngredients.map { group ->
-                        group.copy(
-                            items =
-                                group.items
-                                    .map { ingredient ->
-                                        if (ingredient.id == ingredientId) {
-                                            ingredient.copy(isSelected = !ingredient.isSelected)
-                                        } else {
-                                            ingredient
-                                        }
-                                    }
-                                    .toImmutableList()
-                        )
+                deselectedIngredientIds =
+                    if (ingredientId in deselected) {
+                        deselected - ingredientId
+                    } else {
+                        deselected + ingredientId
                     }
             )
         }
+    }
+
+    /**
+     * Persist the chosen ingredient [scale] for this recipe; the state flow reflects it in turn.
+     */
+    fun setScale(scale: Double) {
+        scalePreferences.setScale(recipeId, scale)
     }
 
     fun onGroceryListSelected(listId: Long) {
@@ -125,40 +144,57 @@ class AddRecipeToGroceryListViewModel(
                         _output.send(Output.Finished)
                         return@launch
                     }
-            val grouped =
-                recipe.ingredients
-                    .split("\n")
-                    .filter { it.isNotBlank() && !IngredientSection.isHeader(it) }
-                    .mapIndexed { index, raw ->
-                        val parsed = IngredientParser.parse(raw)
-                        ListItem(
-                            id = index,
-                            name = raw,
-                            displayName = parsed.name,
-                            quantity = parsed.quantity,
-                            isSelected = true,
-                        ) to parsed.category
-                    }
-                    .groupBy { it.second }
-                    .entries
-                    .sortedBy { it.key.ordinal }
-                    .map { (category, pairs) ->
-                        IngredientGroup(
-                            category = category,
-                            items = pairs.map { it.first }.toImmutableList(),
-                        )
-                    }
-            _state.update {
-                it.copy(isLoading = false, recipe = recipe, groupedIngredients = grouped)
-            }
+            val lines =
+                recipe.ingredients.split("\n").filter {
+                    it.isNotBlank() && !IngredientSection.isHeader(it)
+                }
+            _state.update { it.copy(isLoading = false, recipe = recipe, ingredientLines = lines) }
         }
     }
+
+    /**
+     * Builds the category-grouped rows for [lines] at [scale]. Each row's `name` is the scaled line
+     * — that's what gets added to the grocery list — and its display name and quantity come from
+     * parsing that same scaled text, so the sheet and the resulting grocery item agree.
+     */
+    private fun groupIngredients(
+        lines: List<String>,
+        deselectedIds: Set<Int>,
+        scale: Double,
+    ): List<IngredientGroup> =
+        lines
+            .mapIndexed { index, raw ->
+                val scaled = IngredientScaler.scale(raw, scale)
+                val parsed = IngredientParser.parse(scaled)
+                ListItem(
+                    id = index,
+                    name = scaled,
+                    displayName = parsed.name,
+                    quantity = parsed.quantity,
+                    isSelected = index !in deselectedIds,
+                ) to parsed.category
+            }
+            .groupBy { it.second }
+            .entries
+            .sortedBy { it.key.ordinal }
+            .map { (category, pairs) ->
+                IngredientGroup(
+                    category = category,
+                    items = pairs.map { it.first }.toImmutableList(),
+                )
+            }
 
     data class State(
         val isLoading: Boolean = true,
         val isAdding: Boolean = false,
         val recipe: Recipe = Recipe.Empty,
+        /** The recipe's ingredient lines, headers and blanks dropped, at the author's amounts. */
+        val ingredientLines: List<String> = emptyList(),
+        /** Ids (indices into [ingredientLines]) the user unchecked; everything else is selected. */
+        val deselectedIngredientIds: Set<Int> = emptySet(),
+        /** Derived from [ingredientLines] and [ingredientScale] — never set directly. */
         val groupedIngredients: List<IngredientGroup> = emptyList(),
+        val ingredientScale: Double = DEFAULT_INGREDIENT_SCALE,
         val groceryLists: List<GroceryListItem> = emptyList(),
         val selectedGroceryList: GroceryListItem? = null,
     )

--- a/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListViewModelTest.kt
+++ b/client/recipe/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/recipe/core/impl/addgrocery/AddRecipeToGroceryListViewModelTest.kt
@@ -5,6 +5,7 @@ package com.plusmobileapps.chefmate.recipe.core.impl.addgrocery
 
 import com.plusmobileapps.chefmate.grocery.data.testing.FakeGroceryRepository
 import com.plusmobileapps.chefmate.recipe.data.Recipe
+import com.plusmobileapps.chefmate.recipe.data.testing.FakeIngredientScalePreferences
 import com.plusmobileapps.chefmate.recipe.data.testing.FakeRecipeRepository
 import com.russhwolf.settings.MapSettings
 import io.kotest.matchers.collections.shouldContainExactly
@@ -14,13 +15,16 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 
 class AddRecipeToGroceryListViewModelTest {
 
     private val recipes = MutableStateFlow<List<Recipe>>(emptyList())
     private val recipeRepository = FakeRecipeRepository(recipes)
     private val groceryRepository = FakeGroceryRepository()
+    private val scalePreferences = FakeIngredientScalePreferences()
 
     private fun recipe(ingredients: String): Recipe =
         Recipe(
@@ -49,6 +53,7 @@ class AddRecipeToGroceryListViewModelTest {
             mainContext = UnconfinedTestDispatcher(),
             recipeRepository = recipeRepository,
             groceryRepository = groceryRepository,
+            scalePreferences = scalePreferences,
             settings = MapSettings(),
         )
     }
@@ -75,5 +80,57 @@ class AddRecipeToGroceryListViewModelTest {
 
         val updated = viewModel.state.value.groupedIngredients.flatMap { it.items }
         updated.map { it.isSelected } shouldContainExactly listOf(false, true)
+    }
+
+    @Test
+    fun When_the_recipe_already_has_a_persisted_scale_Then_the_sheet_opens_at_that_scale() {
+        // Whatever factor was chosen on recipe detail (or in Cook Mode) is what this sheet shows.
+        scalePreferences.setScale(recipeId = 1L, scale = 2.0)
+
+        val viewModel = createViewModel(recipe(ingredients = "200g spaghetti\n2 large eggs"))
+
+        val state = viewModel.state.value
+        state.ingredientScale shouldBe 2.0
+        // Rows come out grouped by category — eggs (dairy) sort ahead of spaghetti (grains).
+        state.groupedIngredients.flatMap { it.items }.map { it.name } shouldContainExactly
+            listOf("4 large eggs", "400g spaghetti")
+    }
+
+    @Test
+    fun When_the_scale_changes_Then_the_displayed_amounts_scale_with_it() {
+        val viewModel = createViewModel(recipe(ingredients = "200g spaghetti"))
+
+        viewModel.setScale(0.5)
+
+        val item = viewModel.state.value.groupedIngredients.flatMap { it.items }.single()
+        item.quantity shouldBe "100g"
+        item.displayName shouldBe "spaghetti"
+    }
+
+    @Test
+    fun When_the_scale_changes_Then_the_chosen_ingredients_stay_chosen() {
+        // Selection is tracked by id rather than baked into the rows, so re-deriving the rows at a
+        // new scale must not silently re-check what the user unchecked.
+        val viewModel = createViewModel(recipe(ingredients = "200g spaghetti\n2 large eggs"))
+        val first = viewModel.state.value.groupedIngredients.flatMap { it.items }.first()
+        viewModel.toggleIngredient(first.id)
+
+        viewModel.setScale(2.0)
+
+        val items = viewModel.state.value.groupedIngredients.flatMap { it.items }
+        items.single { it.id == first.id }.isSelected shouldBe false
+        items.filter { it.id != first.id }.map { it.isSelected } shouldContainExactly listOf(true)
+    }
+
+    @Test
+    fun When_saving_at_a_scale_Then_the_scaled_amounts_are_added_to_the_list() = runTest {
+        val viewModel = createViewModel(recipe(ingredients = "200g spaghetti\n2 large eggs"))
+        viewModel.setScale(2.0)
+
+        viewModel.save()
+
+        val added = groceryRepository.getGroceries().first()
+        added.map { it.name } shouldContainExactly listOf("4 large eggs", "400g spaghetti")
+        added.map { it.quantity } shouldContainExactly listOf("4 large", "400g")
     }
 }

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -32,7 +32,7 @@
     <string name="recipe_detail_kcal">{calories} kcal</string>
     <string name="recipe_detail_source">Source</string>
     <string name="recipe_detail_ingredients">Ingredients</string>
-    <string name="recipe_detail_scale_ingredients">Scale ingredient amounts</string>
+    <string name="recipe_scale_ingredients">Scale ingredient amounts</string>
     <string name="recipe_detail_directions">Directions</string>
     <string name="recipe_detail_timestamps">Timestamps</string>
     <string name="recipe_detail_created">Created</string>

--- a/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/core/public/src/commonMain/composeResources/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="recipe_add_to_grocery_list_add">Add to Grocery List</string>
     <string name="recipe_add_to_grocery_list_no_ingredients">No ingredients available</string>
     <string name="recipe_add_to_grocery_list_select_list">Select grocery list</string>
+    <string name="recipe_add_to_grocery_list_scale">Scale</string>
     <string name="recipe_add_to_grocery_list_added">Ingredients added to grocery list</string>
     <string name="recipe_add_to_grocery_list_view">View</string>
     <string name="recipe_detail_back">Back</string>

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListBloc.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListBloc.kt
@@ -6,6 +6,7 @@ import com.plusmobileapps.chefmate.BackClickBloc
 import com.plusmobileapps.chefmate.BlocContext
 import com.plusmobileapps.chefmate.Consumer
 import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
+import com.plusmobileapps.chefmate.recipe.data.DEFAULT_INGREDIENT_SCALE
 import com.plusmobileapps.chefmate.ui.ComposeScreen
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -22,6 +23,12 @@ interface AddRecipeToGroceryListBloc : BackClickBloc, ComposeScreen {
     fun onIngredientToggled(ingredient: Int)
 
     fun onGroceryListSelected(listId: Long)
+
+    /**
+     * Pick a new ingredient scale factor (e.g. `2.0` for 2×). Shares the per-recipe preference with
+     * the recipe detail screen and Cook Mode, and is applied to the amounts added to the list.
+     */
+    fun onScaleChanged(scale: Double)
 
     fun onSaveClicked()
 
@@ -43,6 +50,8 @@ interface AddRecipeToGroceryListBloc : BackClickBloc, ComposeScreen {
         val groupedIngredients: ImmutableList<IngredientGroup>,
         val groceryLists: ImmutableList<GroceryListItem> = persistentListOf(),
         val selectedGroceryList: GroceryListItem? = null,
+        /** The factor the listed amounts are scaled by (1× = the recipe author's amounts). */
+        val ingredientScale: Double = DEFAULT_INGREDIENT_SCALE,
     ) {
         val hasSelectedIngredients: Boolean
             get() = groupedIngredients.any { group -> group.items.any { it.isSelected } }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListPreviews.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListPreviews.kt
@@ -1,0 +1,126 @@
+package com.plusmobileapps.chefmate.recipe.core.addgrocery
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.plusmobileapps.chefmate.grocery.data.GroceryCategory
+import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc.GroceryListItem
+import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc.IngredientGroup
+import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListBloc.ListItem
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.MutableStateFlow
+
+private fun addToGroceryBloc(model: AddRecipeToGroceryListBloc.Model): AddRecipeToGroceryListBloc =
+    object : AddRecipeToGroceryListBloc {
+        override val state = MutableStateFlow(model)
+
+        override fun onIngredientToggled(ingredient: Int) = Unit
+
+        override fun onGroceryListSelected(listId: Long) = Unit
+
+        override fun onScaleChanged(scale: Double) = Unit
+
+        override fun onSaveClicked() = Unit
+
+        override fun onBackClicked() = Unit
+    }
+
+private fun ingredientGroups(
+    spaghetti: String,
+    eggs: String,
+    spaghettiQuantity: String,
+    eggsQuantity: String,
+) =
+    persistentListOf(
+        IngredientGroup(
+            category = GroceryCategory.DAIRY,
+            items =
+                persistentListOf(
+                    ListItem(
+                        id = 0,
+                        name = eggs,
+                        displayName = "eggs",
+                        quantity = eggsQuantity,
+                        isSelected = true,
+                    )
+                ),
+        ),
+        IngredientGroup(
+            category = GroceryCategory.GRAINS,
+            items =
+                persistentListOf(
+                    ListItem(
+                        id = 1,
+                        name = spaghetti,
+                        displayName = "spaghetti",
+                        quantity = spaghettiQuantity,
+                        isSelected = true,
+                    )
+                ),
+        ),
+    )
+
+/** The sheet at the recipe author's own amounts (1×). */
+val previewAddToGroceryBloc: AddRecipeToGroceryListBloc =
+    addToGroceryBloc(
+        AddRecipeToGroceryListBloc.Model(
+            isLoading = false,
+            isAdding = false,
+            groupedIngredients =
+                ingredientGroups(
+                    spaghetti = "200g spaghetti",
+                    eggs = "2 large eggs",
+                    spaghettiQuantity = "200g",
+                    eggsQuantity = "2 large",
+                ),
+            groceryLists = persistentListOf(GroceryListItem(id = 1L, name = "My Grocery List")),
+            selectedGroceryList = GroceryListItem(id = 1L, name = "My Grocery List"),
+        )
+    )
+
+/** The sheet at a persisted 2× scale — the amounts and the control both reflect the factor. */
+val previewAddToGroceryBlocScaled: AddRecipeToGroceryListBloc =
+    addToGroceryBloc(
+        AddRecipeToGroceryListBloc.Model(
+            isLoading = false,
+            isAdding = false,
+            groupedIngredients =
+                ingredientGroups(
+                    spaghetti = "400g spaghetti",
+                    eggs = "4 large eggs",
+                    spaghettiQuantity = "400g",
+                    eggsQuantity = "4 large",
+                ),
+            groceryLists = persistentListOf(GroceryListItem(id = 1L, name = "My Grocery List")),
+            selectedGroceryList = GroceryListItem(id = 1L, name = "My Grocery List"),
+            ingredientScale = 2.0,
+        )
+    )
+
+/** No ingredients to pick from — the empty message replaces the list. */
+val previewAddToGroceryBlocEmpty: AddRecipeToGroceryListBloc =
+    addToGroceryBloc(
+        AddRecipeToGroceryListBloc.Model(
+            isLoading = false,
+            isAdding = false,
+            groupedIngredients = persistentListOf(),
+        )
+    )
+
+@Preview
+@Composable
+internal fun AddRecipeToGroceryListPreview() {
+    ChefMateTheme { AddRecipeToGroceryListScreen(bloc = previewAddToGroceryBloc) }
+}
+
+@Preview
+@Composable
+internal fun AddRecipeToGroceryListScaledPreview() {
+    ChefMateTheme { AddRecipeToGroceryListScreen(bloc = previewAddToGroceryBlocScaled) }
+}
+
+@Preview
+@Composable
+internal fun AddRecipeToGroceryListEmptyPreview() {
+    ChefMateTheme { AddRecipeToGroceryListScreen(bloc = previewAddToGroceryBlocEmpty) }
+}

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListScreen.kt
@@ -1,6 +1,7 @@
 package com.plusmobileapps.chefmate.recipe.core.addgrocery
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.displayCutout
@@ -25,15 +26,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import chefmate.client.recipe.core.public.generated.resources.Res
 import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list
 import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_add
 import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_no_ingredients
+import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_scale
 import chefmate.client.recipe.core.public.generated.resources.recipe_add_to_grocery_list_select_list
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryDisplayGroup
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryDisplayItem
 import com.plusmobileapps.chefmate.grocery.core.list.GroceryGroupedList
+import com.plusmobileapps.chefmate.recipe.core.ingredients.IngredientScaleSelector
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
@@ -48,7 +52,7 @@ fun AddRecipeToGroceryListScreen(bloc: AddRecipeToGroceryListBloc, modifier: Mod
     val state by bloc.state.collectAsState()
 
     PlusHeaderContainer(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize().testTag(AddRecipeToGroceryListTestTags.SCREEN),
         data =
             PlusHeaderData.Modal(
                 title = stringResource(Res.string.recipe_add_to_grocery_list).asTextData(),
@@ -93,6 +97,10 @@ fun AddRecipeToGroceryListScreen(bloc: AddRecipeToGroceryListBloc, modifier: Mod
                     selectedList = state.selectedGroceryList,
                     onListSelected = bloc::onGroceryListSelected,
                 )
+                IngredientScaleRow(
+                    scale = state.ingredientScale,
+                    onScaleChange = bloc::onScaleChanged,
+                )
                 GroceryGroupedList(
                     groups =
                         state.groupedIngredients.map { group ->
@@ -116,6 +124,38 @@ fun AddRecipeToGroceryListScreen(bloc: AddRecipeToGroceryListBloc, modifier: Mod
                 )
             }
         }
+    }
+}
+
+/**
+ * The ingredient-scale row: a label and the shared [IngredientScaleSelector]. The factor is the
+ * same per-recipe preference the recipe detail screen and Cook Mode use, so opening this sheet
+ * after scaling a recipe adds the scaled amounts without having to pick the factor again.
+ */
+@Composable
+private fun IngredientScaleRow(
+    scale: Double,
+    onScaleChange: (Double) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = ChefMateTheme.dimens.paddingNormal)
+                .padding(top = ChefMateTheme.dimens.paddingExtraSmall),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(Res.string.recipe_add_to_grocery_list_scale),
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.weight(1f),
+        )
+        IngredientScaleSelector(
+            scale = scale,
+            onScaleChange = onScaleChange,
+            buttonTestTag = AddRecipeToGroceryListTestTags.INGREDIENT_SCALE_BUTTON,
+        )
     }
 }
 

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListTestTags.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/addgrocery/AddRecipeToGroceryListTestTags.kt
@@ -1,0 +1,10 @@
+package com.plusmobileapps.chefmate.recipe.core.addgrocery
+
+/**
+ * Stable test tags applied to the add-recipe-to-grocery-list sheet. Shared with
+ * `AddRecipeToGroceryListRobot` so UI tests scope semantics-tree lookups to this screen.
+ */
+object AddRecipeToGroceryListTestTags {
+    const val SCREEN: String = "add_recipe_to_grocery_list_screen"
+    const val INGREDIENT_SCALE_BUTTON: String = "add_recipe_to_grocery_list_ingredient_scale_button"
+}

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -45,10 +45,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddShoppingCart
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CalendarMonth
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
@@ -126,7 +124,6 @@ import chefmate.client.recipe.core.public.generated.resources.recipe_detail_ingr
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_kcal
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_prep_time
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_remove_favorite
-import chefmate.client.recipe.core.public.generated.resources.recipe_detail_scale_ingredients
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_servings
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share
 import chefmate.client.recipe.core.public.generated.resources.recipe_detail_share_cancel
@@ -146,6 +143,7 @@ import com.arkivanov.decompose.value.Value
 import com.plusmobileapps.chefmate.ChefMateUrls
 import com.plusmobileapps.chefmate.di.CoachMarkId
 import com.plusmobileapps.chefmate.recipe.categories.pickerLabelRes
+import com.plusmobileapps.chefmate.recipe.core.ingredients.IngredientScaleSelector
 import com.plusmobileapps.chefmate.recipe.data.BuiltinCategory
 import com.plusmobileapps.chefmate.recipe.data.Category
 import com.plusmobileapps.chefmate.recipe.data.IngredientScaler
@@ -391,7 +389,11 @@ private fun RecipeDetailBody(
                             isLoading = state.isLoading,
                             onDismiss = bloc::onCoachMarkDismissed,
                         ) {
-                            IconButton(onClick = bloc::onAddToGroceryListClicked) {
+                            IconButton(
+                                onClick = bloc::onAddToGroceryListClicked,
+                                modifier =
+                                    Modifier.testTag(RecipeDetailTestTags.ADD_TO_GROCERY_BUTTON),
+                            ) {
                                 Icon(
                                     imageVector = Icons.Default.AddShoppingCart,
                                     contentDescription =
@@ -1015,48 +1017,11 @@ private fun IngredientsStickyHeader(
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.weight(1f).padding(vertical = 16.dp),
             )
-            IngredientScaleSelector(scale = scale, onScaleChange = onScaleChange)
-        }
-    }
-}
-
-/**
- * A compact dropdown button showing the current ingredient scale (e.g. `2×`). Tapping it opens a
- * menu of [IngredientScaler.DEFAULT_FACTORS] with the active one check-marked.
- */
-@Composable
-private fun IngredientScaleSelector(
-    scale: Double,
-    onScaleChange: (Double) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Box(modifier = modifier) {
-        var expanded by remember { mutableStateOf(false) }
-        TextButton(
-            onClick = { expanded = true },
-            modifier = Modifier.testTag(RecipeDetailTestTags.INGREDIENT_SCALE_BUTTON),
-        ) {
-            Text(IngredientScaler.label(scale))
-            Icon(
-                imageVector = Icons.Default.ArrowDropDown,
-                contentDescription = stringResource(Res.string.recipe_detail_scale_ingredients),
+            IngredientScaleSelector(
+                scale = scale,
+                onScaleChange = onScaleChange,
+                buttonTestTag = RecipeDetailTestTags.INGREDIENT_SCALE_BUTTON,
             )
-        }
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            IngredientScaler.DEFAULT_FACTORS.forEach { option ->
-                DropdownMenuItem(
-                    text = { Text(IngredientScaler.label(option)) },
-                    trailingIcon = {
-                        if (option == scale) {
-                            Icon(imageVector = Icons.Default.Check, contentDescription = null)
-                        }
-                    },
-                    onClick = {
-                        expanded = false
-                        onScaleChange(option)
-                    },
-                )
-            }
         }
     }
 }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailTestTags.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailTestTags.kt
@@ -7,5 +7,6 @@ package com.plusmobileapps.chefmate.recipe.core.detail
 object RecipeDetailTestTags {
     const val SCREEN: String = "recipe_detail_screen"
     const val AI_CHAT_BUTTON: String = "recipe_detail_ai_chat_button"
+    const val ADD_TO_GROCERY_BUTTON: String = "recipe_detail_add_to_grocery_button"
     const val INGREDIENT_SCALE_BUTTON: String = "recipe_detail_ingredient_scale_button"
 }

--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/ingredients/IngredientScaleSelector.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/ingredients/IngredientScaleSelector.kt
@@ -1,0 +1,65 @@
+package com.plusmobileapps.chefmate.recipe.core.ingredients
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import chefmate.client.recipe.core.public.generated.resources.Res
+import chefmate.client.recipe.core.public.generated.resources.recipe_scale_ingredients
+import com.plusmobileapps.chefmate.recipe.data.IngredientScaler
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * A compact dropdown button showing the current ingredient scale (e.g. `2×`). Tapping it opens a
+ * menu of [IngredientScaler.DEFAULT_FACTORS] with the active one check-marked.
+ *
+ * Shared by every surface that scales a recipe's ingredients — the recipe detail screen and the
+ * add-to-grocery-list sheet — so they offer the same factors and read the same way. [buttonTestTag]
+ * is applied to the button itself so each screen's robot can find its own control.
+ */
+@Composable
+internal fun IngredientScaleSelector(
+    scale: Double,
+    onScaleChange: (Double) -> Unit,
+    buttonTestTag: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        var expanded by remember { mutableStateOf(false) }
+        TextButton(onClick = { expanded = true }, modifier = Modifier.testTag(buttonTestTag)) {
+            Text(IngredientScaler.label(scale))
+            Icon(
+                imageVector = Icons.Default.ArrowDropDown,
+                contentDescription = stringResource(Res.string.recipe_scale_ingredients),
+            )
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            IngredientScaler.DEFAULT_FACTORS.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(IngredientScaler.label(option)) },
+                    trailingIcon = {
+                        if (option == scale) {
+                            Icon(imageVector = Icons.Default.Check, contentDescription = null)
+                        }
+                    },
+                    onClick = {
+                        expanded = false
+                        onScaleChange(option)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AddRecipeToGroceryListScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/AddRecipeToGroceryListScreenshotTest.kt
@@ -1,0 +1,42 @@
+package com.plusmobileapps.chefmate.ui.screenshot
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.recipe.core.addgrocery.AddRecipeToGroceryListScreen
+import com.plusmobileapps.chefmate.recipe.core.addgrocery.previewAddToGroceryBloc
+import com.plusmobileapps.chefmate.recipe.core.addgrocery.previewAddToGroceryBlocEmpty
+import com.plusmobileapps.chefmate.recipe.core.addgrocery.previewAddToGroceryBlocScaled
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+fun AddRecipeToGroceryListScreenshot() {
+    ChefMateTheme { AddRecipeToGroceryListScreen(bloc = previewAddToGroceryBloc) }
+}
+
+// A recipe the user has already scaled: the control reads 2× and the listed amounts are doubled.
+@PreviewTest
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+fun AddRecipeToGroceryListScaledScreenshot() {
+    ChefMateTheme { AddRecipeToGroceryListScreen(bloc = previewAddToGroceryBlocScaled) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 700, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun AddRecipeToGroceryListScaledDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) {
+        AddRecipeToGroceryListScreen(bloc = previewAddToGroceryBlocScaled)
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, heightDp = 700)
+@Composable
+fun AddRecipeToGroceryListEmptyScreenshot() {
+    ChefMateTheme { AddRecipeToGroceryListScreen(bloc = previewAddToGroceryBlocEmpty) }
+}

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AddRecipeToGroceryListScreenshotTestKt/AddRecipeToGroceryListEmptyScreenshot_f3522472_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AddRecipeToGroceryListScreenshotTestKt/AddRecipeToGroceryListEmptyScreenshot_f3522472_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:594affbbc02b320b8306c81444c8e1417afd5be929a15f7289c19e192ce4b2a1
+size 30307

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AddRecipeToGroceryListScreenshotTestKt/AddRecipeToGroceryListScaledDarkScreenshot_39847f23_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AddRecipeToGroceryListScreenshotTestKt/AddRecipeToGroceryListScaledDarkScreenshot_39847f23_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90b0b9159b5c910aa635a766fe06c513e699b071ae950767d2f5b7eca9036b91
+size 51715

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AddRecipeToGroceryListScreenshotTestKt/AddRecipeToGroceryListScaledScreenshot_f3522472_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AddRecipeToGroceryListScreenshotTestKt/AddRecipeToGroceryListScaledScreenshot_f3522472_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44a34dcfab9f3414b7ee5950713f2934775a58be8165a1c64d418eb1bbfd87a0
+size 56870

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AddRecipeToGroceryListScreenshotTestKt/AddRecipeToGroceryListScreenshot_f3522472_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/AddRecipeToGroceryListScreenshotTestKt/AddRecipeToGroceryListScreenshot_f3522472_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2961b53e8bfc23944db7705a4c4a79c185c1384d8d18b8e3fc4fc69f2c939c23
+size 56914


### PR DESCRIPTION
Adds the ingredient scale to the add-to-grocery-list sheet, reusing the per-recipe `IngredientScalePreferences` introduced in #500.

## What changed

- **A scale dropdown on the sheet**, sharing the same ½×–4× control as the recipe detail screen (extracted into a shared composable rather than copied a third time).
- **The scale is the recipe's, not the sheet's.** A recipe scaled to 2× on the detail screen or in Cook Mode opens this sheet at 2×, and changing it here carries back the other way.
- **The scaled amounts are what get added.** Previously the sheet always handed the author's amounts to the grocery list, so deciding to cook double meant fixing the quantities by hand afterwards.
- The ingredient rows are now derived from the raw lines plus the current factor instead of being stored, with selection tracked by id — so changing the scale re-renders the amounts without re-checking anything the user unchecked.

## Testing

- `AddRecipeToGroceryListViewModelTest`: opens at a persisted scale, rescaling updates the displayed amounts, selection survives a rescale, and saving adds the scaled names.
- New snapshot coverage for the sheet (it had none): 1×, a persisted 2× in light and dark, and the empty state.
- New `AddRecipeToGroceryListRobot` plus a `runRootBlocTest` flow: scale to 2× on recipe detail, open the sheet, and see 2× with `400g` already applied.
- Existing recipe-detail snapshots are unchanged, confirming the selector extraction is render-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)