### PR TITLE
feat(desktop): right-click a recipe to open it in a new window

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -124,6 +124,7 @@ kotlin {
             api(projects.client.developerSettings.impl)
             api(projects.client.toast.impl)
             api(projects.client.toast.public)
+            api(projects.client.ui.public)
             api(libs.kermit)
             implementation(libs.supabase.client)
             implementation(libs.supabase.auth)

--- a/client/composeApp/src/commonMain/kotlin/com/plusmobileapps/chefmate/ApplicationComponent.kt
+++ b/client/composeApp/src/commonMain/kotlin/com/plusmobileapps/chefmate/ApplicationComponent.kt
@@ -2,12 +2,20 @@ package com.plusmobileapps.chefmate
 
 import com.plusmobileapps.chefmate.auth.data.AuthenticationRepository
 import com.plusmobileapps.chefmate.di.OnboardingRepository
+import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
 import com.plusmobileapps.chefmate.root.RootBloc
 import com.plusmobileapps.chefmate.toast.ToastService
 import com.russhwolf.settings.Settings
 
 interface ApplicationComponent {
     val rootBlocFactory: RootBloc.Factory
+
+    /**
+     * Builds a recipe stack outside the root stack. Desktop uses this to give each detached recipe
+     * window its own bloc tree; on the other targets nothing reaches for it.
+     */
+    val recipeRootBlocFactory: RecipeRootBloc.Factory
+
     val authenticationRepository: AuthenticationRepository
     val onboardingRepository: OnboardingRepository
     val settings: Settings

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/RecipeWindows.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/RecipeWindows.kt
@@ -1,0 +1,169 @@
+package com.plusmobileapps.chefmate
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.rememberWindowState
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.backhandler.BackDispatcher
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.destroy
+import com.arkivanov.essenty.lifecycle.resume
+import com.plusmobileapps.chefmate.recipe.core.root.RecipeRootBloc
+import com.plusmobileapps.chefmate.toast.LocalToastService
+import com.plusmobileapps.chefmate.toast.ToastService
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * One recipe torn off into its own OS window.
+ *
+ * It owns a private [LifecycleRegistry], [BackDispatcher] and bloc tree because Decompose state is
+ * per-tree — the main window's are already in use and cannot be shared. The DI graph *is* shared
+ * (it is app-scoped), so both windows read the same repositories over the same SQLDelight flows,
+ * and an edit in one shows up live in the other with no plumbing between them.
+ */
+class RecipeWindow(
+    val recipeId: Long,
+    val title: String,
+    applicationComponent: ApplicationComponent,
+    private val onOutput: (RecipeRootBloc.Output) -> Unit,
+    private val onClose: (RecipeWindow) -> Unit,
+) {
+    private val lifecycle = LifecycleRegistry()
+
+    val backDispatcher = BackDispatcher()
+
+    /**
+     * Bumped when the user re-opens a recipe that already has a window, so the existing window can
+     * come forward instead of a duplicate appearing behind it.
+     */
+    var focusRequests by mutableStateOf(0)
+        private set
+
+    val bloc: RecipeRootBloc =
+        applicationComponent.recipeRootBlocFactory.create(
+            context =
+                DefaultBlocContext(
+                    DefaultComponentContext(lifecycle = lifecycle, backHandler = backDispatcher)
+                ),
+            props = RecipeRootBloc.Props.Detail(recipeId),
+            output = { output ->
+                // Finished is this window saying it is done; everything else leaves the recipe
+                // stack entirely and only the main window can service it.
+                if (output == RecipeRootBloc.Output.Finished) close() else onOutput(output)
+            },
+        )
+
+    init {
+        lifecycle.resume()
+    }
+
+    fun requestFocus() {
+        focusRequests++
+    }
+
+    fun close() {
+        lifecycle.destroy()
+        onClose(this)
+    }
+}
+
+/**
+ * The set of open recipe windows. Held for the life of the process (not inside the composition) so
+ * that the `application { }` block recomposing never disturbs a window the user has open.
+ */
+class RecipeWindowManager(private val applicationComponent: ApplicationComponent) {
+    private val _windows = mutableStateListOf<RecipeWindow>()
+    val windows: List<RecipeWindow>
+        get() = _windows
+
+    private val _outputs =
+        MutableSharedFlow<RecipeRootBloc.Output>(replay = 0, extraBufferCapacity = 8)
+
+    /**
+     * Outputs raised in a detached window that need the main window's navigation stack. The main
+     * window collects these, routes them through its `RootBloc`, and comes to the front.
+     */
+    val outputs: SharedFlow<RecipeRootBloc.Output> = _outputs.asSharedFlow()
+
+    fun open(recipeId: Long, title: String) {
+        val existing = _windows.firstOrNull { it.recipeId == recipeId }
+        if (existing != null) {
+            existing.requestFocus()
+            return
+        }
+        _windows +=
+            RecipeWindow(
+                recipeId = recipeId,
+                title = title,
+                applicationComponent = applicationComponent,
+                onOutput = { _outputs.tryEmit(it) },
+                onClose = { _windows -= it },
+            )
+    }
+
+    /** Tears down every open window. Called when the app is quitting. */
+    fun closeAll() {
+        _windows.toList().forEach { it.close() }
+    }
+}
+
+@Composable
+fun RecipeWindows(manager: RecipeWindowManager, toastService: ToastService) {
+    for (recipeWindow in manager.windows) {
+        key(recipeWindow) {
+            val windowState = rememberWindowState(size = DpSize(900.dp, 780.dp))
+            Window(
+                onCloseRequest = recipeWindow::close,
+                state = windowState,
+                title = recipeWindow.title,
+                icon = painterResource("app-icon.png"),
+                onKeyEvent = { event ->
+                    if ((event.key == Key.Escape) && (event.type == KeyEventType.KeyUp)) {
+                        recipeWindow.backDispatcher.back()
+                    } else {
+                        false
+                    }
+                },
+            ) {
+                LaunchedEffect(recipeWindow.focusRequests) {
+                    if (recipeWindow.focusRequests > 0) {
+                        window.toFront()
+                        window.requestFocus()
+                    }
+                }
+                // The one global ToastScaffold lives in the main window and drains the app-scoped
+                // toast queue; a second host here would race it for the same messages and show
+                // each one twice. Provide the service on its own so composables that read it
+                // (RecipeDetailScreen does) still resolve — their toasts surface in the main
+                // window.
+                CompositionLocalProvider(LocalToastService provides toastService) {
+                    ChefMateTheme {
+                        Surface(modifier = Modifier.fillMaxSize()) {
+                            recipeWindow.bloc.Content(Modifier.fillMaxSize())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/main.kt
+++ b/client/composeApp/src/jvmMain/kotlin/com/plusmobileapps/chefmate/main.kt
@@ -4,9 +4,11 @@ package com.plusmobileapps.chefmate
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +32,8 @@ import com.plusmobileapps.chefmate.deeplink.DeepLinkCoordinator
 import com.plusmobileapps.chefmate.deeplink.SchemeRegistrar
 import com.plusmobileapps.chefmate.deeplink.SingleInstance
 import com.plusmobileapps.chefmate.root.DeepLink
+import com.plusmobileapps.chefmate.ui.LocalRecipeWindowOpener
+import com.plusmobileapps.chefmate.ui.RecipeWindowOpener
 import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
 import com.plusmobileapps.chefmate.update.DesktopUpdater
 import com.plusmobileapps.chefmate.update.UpdateBanner
@@ -76,6 +80,9 @@ fun main(args: Array<String>) {
     val backDispatcher = BackDispatcher()
     val appComponent = dev.zacsweers.metro.createGraph<JvmApplicationComponent>()
     val updater = DesktopUpdater()
+    // Lives outside the application block, like the lifecycle above: a recomposition of
+    // `application { }` must never drop a window the user has open.
+    val recipeWindows = RecipeWindowManager(appComponent)
 
     val settings = appComponent.settings
     val initialSize =
@@ -144,6 +151,7 @@ fun main(args: Array<String>) {
         Window(
             onCloseRequest = {
                 updater.close()
+                recipeWindows.closeAll()
                 exitApplication()
             },
             state = windowState,
@@ -169,8 +177,23 @@ fun main(args: Array<String>) {
                     window.requestFocus()
                 }
             }
+            // Anything a detached recipe window can't service itself (the grocery list, cook mode,
+            // AI chat, the meal planner, a web link) is routed into this window's stack, and this
+            // window comes forward so the user sees where it landed.
+            LaunchedEffect(rootBloc) {
+                recipeWindows.outputs.collect { output ->
+                    rootBloc.handleRecipeWindowOutput(output)
+                    window.toFront()
+                    window.requestFocus()
+                }
+            }
+            val windowOpener = remember { RecipeWindowOpener(recipeWindows::open) }
             Box(modifier = Modifier.fillMaxSize()) {
-                App(rootBloc = rootBloc, toastService = appComponent.toastService)
+                // Only desktop provides this, which is what turns the recipe list's right-click
+                // "open in new window" entry on — the other targets see a null opener and omit it.
+                CompositionLocalProvider(LocalRecipeWindowOpener provides windowOpener) {
+                    App(rootBloc = rootBloc, toastService = appComponent.toastService)
+                }
                 val updateState by updater.state.collectAsState()
                 ChefMateTheme {
                     UpdateBanner(
@@ -183,6 +206,9 @@ fun main(args: Array<String>) {
                 }
             }
         }
+
+        // Sibling windows of the main one, so closing a recipe leaves the app running.
+        RecipeWindows(manager = recipeWindows, toastService = appComponent.toastService)
     }
 }
 

--- a/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/recipe/list/public/src/commonMain/composeResources/values/strings.xml
@@ -110,6 +110,9 @@
     <string name="recipe_list_bulk_added_to_book">Added {count} recipes to {book}</string>
     <string name="recipe_list_bulk_added_to_category">Added {count} recipes to {category}</string>
 
+    <!-- Context Menu (desktop) -->
+    <string name="recipe_list_open_in_new_window">Open in new window</string>
+
     <!-- Cooking Session -->
     <string name="recipe_list_continue_cooking">Continue cooking</string>
     <string name="recipe_list_done_cooking">Done cooking</string>

--- a/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
+++ b/client/recipe/list/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/list/RecipeListScreen.kt
@@ -150,6 +150,7 @@ import chefmate.client.recipe.list.public.generated.resources.recipe_list_menu_e
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_menu_select
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_menu_sync
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_more_actions
+import chefmate.client.recipe.list.public.generated.resources.recipe_list_open_in_new_window
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scan_failed_title
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scan_from_photo
 import chefmate.client.recipe.list.public.generated.resources.recipe_list_scanning_message
@@ -193,6 +194,9 @@ import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.ResourceString
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.text.asTextData
+import com.plusmobileapps.chefmate.ui.LocalRecipeWindowOpener
+import com.plusmobileapps.chefmate.ui.components.PlusContextMenuArea
+import com.plusmobileapps.chefmate.ui.components.PlusContextMenuItem
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusDialogScaffold
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
@@ -1389,6 +1393,31 @@ private fun FilterEmptyState(
 
 // endregion
 
+// region Context Menu
+
+/**
+ * Adds the desktop right-click menu to a recipe row or card. On Android and iOS
+ * [LocalRecipeWindowOpener] is null — there is nothing to put in the menu and no mouse to open it
+ * with — so the item renders exactly as it did before.
+ */
+@Composable
+private fun RecipeContextMenu(recipe: RecipeListItem, content: @Composable () -> Unit) {
+    val windowOpener = LocalRecipeWindowOpener.current
+    if (windowOpener == null) {
+        content()
+        return
+    }
+    val label = stringResource(Res.string.recipe_list_open_in_new_window)
+    PlusContextMenuArea(
+        items = {
+            listOf(PlusContextMenuItem(label) { windowOpener.open(recipe.id, recipe.title) })
+        },
+        content = content,
+    )
+}
+
+// endregion
+
 // region Grid View
 
 @Composable
@@ -1418,13 +1447,15 @@ private fun RecipeGrid(
     ) {
         items(recipes.size, key = { recipes[it].id }) { index ->
             val recipe = recipes[index]
-            RecipeGridItem(
-                recipe = recipe,
-                onClick = { onRecipeClicked(recipe) },
-                onLongClick = { onRecipeLongClicked(recipe) },
-                isSelectionMode = isSelectionMode,
-                isSelected = recipe.id in selectedRecipeIds,
-            )
+            RecipeContextMenu(recipe) {
+                RecipeGridItem(
+                    recipe = recipe,
+                    onClick = { onRecipeClicked(recipe) },
+                    onLongClick = { onRecipeLongClicked(recipe) },
+                    isSelectionMode = isSelectionMode,
+                    isSelected = recipe.id in selectedRecipeIds,
+                )
+            }
         }
     }
 }
@@ -1539,13 +1570,15 @@ private fun RecipeList(
     ) {
         items(recipes.size, key = { recipes[it].id }) { index ->
             val recipe = recipes[index]
-            RecipeListItemContent(
-                recipe = recipe,
-                onClick = { onRecipeClicked(recipe) },
-                onLongClick = { onRecipeLongClicked(recipe) },
-                isSelectionMode = isSelectionMode,
-                isSelected = recipe.id in selectedRecipeIds,
-            )
+            RecipeContextMenu(recipe) {
+                RecipeListItemContent(
+                    recipe = recipe,
+                    onClick = { onRecipeClicked(recipe) },
+                    onLongClick = { onRecipeLongClicked(recipe) },
+                    isSelectionMode = isSelectionMode,
+                    isSelected = recipe.id in selectedRecipeIds,
+                )
+            }
         }
     }
 }

--- a/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
+++ b/client/root/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBlocImpl.kt
@@ -174,6 +174,13 @@ class RootBlocImpl(
         }
     }
 
+    override fun handleRecipeWindowOutput(output: RecipeRootBloc.Output) {
+        // Finished means "the detached window is done" — it closes itself, and the main window's
+        // stack has nothing to pop in response.
+        if (output == RecipeRootBloc.Output.Finished) return
+        handleRecipeRootOutput(output)
+    }
+
     private fun selectBottomNavTab(tab: BottomNavBloc.Tab) {
         stack.value.items
             .map { it.instance }

--- a/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
+++ b/client/root/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/root/RootBlocTest.kt
@@ -666,6 +666,43 @@ class RootBlocTest {
         rootBloc.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
         recipeProps shouldBe RecipeRootBloc.Props.CreateFromExtracted(extracted, fromAi = true)
     }
+
+    // A detached desktop recipe window has no stack of its own beyond the recipe, so anything that
+    // leaves it is forwarded here.
+
+    @Test
+    fun Given_a_detached_recipe_window_When_it_outputs_OpenCookMode_Then_cook_mode_is_shown() {
+        rootBloc.handleRecipeWindowOutput(RecipeRootBloc.Output.OpenCookMode(recipeId = 123L))
+
+        rootBloc.instance() should instanceOf<RootBloc.Child.CookMode>()
+    }
+
+    @Test
+    fun Given_a_detached_recipe_window_When_it_outputs_OpenGroceryList_Then_groceries_tab_shown() {
+        val bottomNavChild =
+            rootBloc.state.value.items
+                .map { it.instance }
+                .filterIsInstance<RootBloc.Child.BottomNavigation>()
+                .first()
+                .bloc
+
+        rootBloc.handleRecipeWindowOutput(RecipeRootBloc.Output.OpenGroceryList)
+
+        rootBloc.instance() should instanceOf<RootBloc.Child.BottomNavigation>()
+        dev.mokkery.verify { bottomNavChild.onTabSelected(BottomNavBloc.Tab.GROCERIES) }
+    }
+
+    @Test
+    fun Given_a_detached_recipe_window_When_it_outputs_Finished_Then_this_stack_is_untouched() {
+        // The window closes itself; popping the main stack in sympathy would strand the user.
+        bottomNavOutput.onNext(BottomNavBloc.Output.OpenRecipe(123L))
+        val backStackBefore = rootBloc.state.value.backStack.size
+
+        rootBloc.handleRecipeWindowOutput(RecipeRootBloc.Output.Finished)
+
+        rootBloc.instance() should instanceOf<RootBloc.Child.RecipeRoot>()
+        rootBloc.state.value.backStack.size shouldBe backStackBefore
+    }
 }
 
 private const val EMAIL = "chef@example.com"

--- a/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
+++ b/client/root/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/root/RootBloc.kt
@@ -37,6 +37,16 @@ interface RootBloc : BackHandlerOwner, BackClickBloc {
      */
     fun handleDeepLink(url: String)
 
+    /**
+     * Route an output from a detached recipe window (desktop) into this — the main — window's
+     * stack. Such a window renders only the recipe stack, so anything that leaves it (the grocery
+     * list, cook mode, AI chat, the meal planner, a web link) has to land here instead.
+     *
+     * [RecipeRootBloc.Output.Finished] is ignored: the detached window closes itself on that, and
+     * popping the main window's stack in sympathy would be wrong.
+     */
+    fun handleRecipeWindowOutput(output: RecipeRootBloc.Output)
+
     sealed class Child {
 
         abstract val bloc: ComposeScreen

--- a/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusContextMenuArea.android.kt
+++ b/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusContextMenuArea.android.kt
@@ -1,0 +1,14 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.runtime.Composable
+
+/** No mouse, no right-click — the menu is desktop-only, so the content passes straight through. */
+@Composable
+actual fun PlusContextMenuArea(
+    items: () -> List<PlusContextMenuItem>,
+    content: @Composable () -> Unit,
+) {
+    content()
+}

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/RecipeWindowOpener.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/RecipeWindowOpener.kt
@@ -1,0 +1,22 @@
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * Opens a single recipe in its own detached OS window.
+ *
+ * Desktop only. The JVM app provides an implementation from its `application { }` block, which is
+ * where the list of open windows lives; every other target leaves this `null`, and a `null` opener
+ * is the signal for UI to leave the "open in new window" affordance out entirely rather than show a
+ * dead menu item.
+ *
+ * This lives in the shared UI module rather than a recipe module because the provider
+ * (`composeApp`'s desktop entry point) and the consumer (the recipe list) share no recipe module,
+ * and it keeps company with the other app-wide composition locals here.
+ */
+fun interface RecipeWindowOpener {
+    /** [title] seeds the new window's title bar so it is identifiable before the recipe loads. */
+    fun open(recipeId: Long, title: String)
+}
+
+val LocalRecipeWindowOpener = compositionLocalOf<RecipeWindowOpener?> { null }

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusContextMenuArea.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusContextMenuArea.kt
@@ -1,0 +1,20 @@
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.runtime.Composable
+
+/** A single entry in a [PlusContextMenuArea] menu. */
+data class PlusContextMenuItem(val label: String, val onClick: () -> Unit)
+
+/**
+ * Wraps [content] in a right-click (secondary-click) context menu.
+ *
+ * Only desktop has a mouse to right-click with, so the JVM actual is the only one that renders a
+ * menu — Android and iOS emit [content] untouched. Gate the call site on something meaningful (a
+ * desktop-only composition local, say) rather than leaning on the no-op actuals, so touch platforms
+ * never build items they could not show.
+ */
+@Composable
+expect fun PlusContextMenuArea(
+    items: () -> List<PlusContextMenuItem>,
+    content: @Composable () -> Unit,
+)

--- a/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusContextMenuArea.ios.kt
+++ b/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusContextMenuArea.ios.kt
@@ -1,0 +1,14 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.runtime.Composable
+
+/** No mouse, no right-click — the menu is desktop-only, so the content passes straight through. */
+@Composable
+actual fun PlusContextMenuArea(
+    items: () -> List<PlusContextMenuItem>,
+    content: @Composable () -> Unit,
+) {
+    content()
+}

--- a/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusContextMenuArea.jvm.kt
+++ b/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/components/PlusContextMenuArea.jvm.kt
@@ -1,0 +1,18 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui.components
+
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun PlusContextMenuArea(
+    items: () -> List<PlusContextMenuItem>,
+    content: @Composable () -> Unit,
+) {
+    ContextMenuArea(
+        items = { items().map { ContextMenuItem(it.label, it.onClick) } },
+        content = content,
+    )
+}


### PR DESCRIPTION
Right-clicking a recipe in the list on desktop now offers **Open in new window**, which tears that recipe off into its own OS window.

## How it works

**Right-click detection.** `PlusContextMenuArea` is a new `expect`/`actual` wrapper in `client/ui/public`. The JVM actual delegates to Compose Desktop's `ContextMenuArea`; Android and iOS have no mouse, so their actuals pass the content straight through.

**Gating.** `LocalRecipeWindowOpener` is provided only by the desktop entry point. The recipe list builds the menu entry only when it is non-null, so touch platforms render exactly as before rather than carrying a menu nothing can open.

**Per-window bloc tree.** Each detached window owns a private `LifecycleRegistry`, `BackDispatcher` and `RecipeRootBloc` — Decompose state is per-tree and the main window's is already in use. The DI graph is app-scoped, so both windows read the same repositories over the same SQLDelight flows; an edit in one shows up live in the other with no plumbing between them.

## Decisions worth a look

- **Outputs that leave the recipe stack.** A detached window renders only detail + edit, so the grocery list, cook mode, AI chat, the meal planner and web links have nowhere local to land. `RootBloc.handleRecipeWindowOutput` forwards them into the main window's stack (reusing the existing `RecipeRoot` routing) and brings that window forward. `Finished` is dropped — the detached window closes itself, and popping the main stack in sympathy would strand the user.
- **Only the main window hosts `ToastScaffold`.** The toast queue is an app-scoped singleton; a second host would race it for the same messages and show each twice. The detached window provides the service alone so `RecipeDetailScreen`'s `LocalToastService.current` still resolves — those toasts surface in the main window.
- **The window manager lives outside `application { }`**, alongside the existing lifecycle, so a recomposition can never drop a window the user has open.
- **Re-opening an already-open recipe** brings the existing window forward instead of stacking a duplicate behind it.

## Not done

Detached windows use a fixed default size and `PlatformDefault` position — no per-window size persistence like the main window has. Easy to add later if it's wanted.

## Testing

- Compiles on desktop (JVM), Android, and iOS.
- Three new `RootBlocTest` cases cover the output forwarding; all 53 pass.
- `:client:root:impl`, `:client:composeApp`, `:client:recipe:core:impl`, `:client:ui:public` JVM tests green.
- **Not manually run.** I did not launch the desktop app, so the menu placement, window chrome and focus behavior are unverified against a running build — worth a quick manual pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)