### PR TITLE
feat(watch): filter grocery items by purchased state

### DIFF
--- a/iosApp/ChefMateWatch/GroceryItemsView.swift
+++ b/iosApp/ChefMateWatch/GroceryItemsView.swift
@@ -36,6 +36,7 @@ struct GroceryItemsView: View {
                             .foregroundStyle(WatchTheme.onSurfaceVariant)
                             .padding(.horizontal, hInset)
                             .padding(.top, 6)
+                            .transition(.opacity)
                     }
 
                     ForEach(groups) { group in
@@ -45,16 +46,22 @@ struct GroceryItemsView: View {
                                     store.setChecked(itemId: item.id, isChecked: !item.isChecked)
                                 }
                                 .padding(.horizontal, hInset)
+                                .transition(.itemRemoval)
                                 if index < group.items.count - 1 {
-                                    Divider().padding(.leading, hInset)
+                                    Divider().padding(.leading, hInset).transition(.opacity)
                                 }
                             }
                         } header: {
                             CategoryHeader(title: group.title, textInset: hInset)
+                                .transition(.opacity)
                         }
                     }
                 }
                 .padding(.bottom, 8)
+                // Scoped to `groups` so only list changes animate — a filter switch, a phone
+                // snapshot, or an item leaving because it was just checked off. Rows below the
+                // departing one slide up to close the gap.
+                .animation(.snappy, value: groups)
             }
         }
         .ignoresSafeArea(.container, edges: .horizontal)
@@ -82,6 +89,18 @@ struct GroceryItemsView: View {
         .sheet(isPresented: $showingFilter) {
             GroceryFilterView(selection: $filter)
         }
+    }
+}
+
+extension AnyTransition {
+    /// How a row enters and leaves the list. Departures slide off toward the leading edge as they
+    /// fade — the item is being struck off — while arrivals just fade in, so a newly added item
+    /// doesn't fly across the screen on its way to the bottom.
+    static var itemRemoval: AnyTransition {
+        .asymmetric(
+            insertion: .opacity,
+            removal: .move(edge: .leading).combined(with: .opacity)
+        )
     }
 }
 
@@ -146,6 +165,7 @@ private struct GroceryItemRow: View {
                 Image(systemName: item.isChecked ? "checkmark.square.fill" : "square")
                     .font(.title3)
                     .foregroundStyle(item.isChecked ? WatchTheme.primary : WatchTheme.onSurfaceVariant)
+                    .contentTransition(.symbolEffect(.replace))
                 VStack(alignment: .leading, spacing: 2) {
                     Text(item.name)
                         .foregroundStyle(item.isChecked ? WatchTheme.onSurfaceVariant : WatchTheme.onSurface)

--- a/iosApp/ChefMateWatch/GroceryItemsView.swift
+++ b/iosApp/ChefMateWatch/GroceryItemsView.swift
@@ -8,8 +8,15 @@ struct GroceryItemsView: View {
 
     @EnvironmentObject private var store: GroceryStore
     @State private var showingAdd = false
+    @State private var showingFilter = false
 
-    private var groups: [WatchGroceryGroup] { store.items(for: listId).groupedByAisle() }
+    /// Persisted like the phone's filter preference, and shared across lists for the same reason:
+    /// the choice is about how you shop, not about one particular list.
+    @AppStorage("groceryFilter") private var filter: WatchGroceryFilter = .all
+
+    private var groups: [WatchGroceryGroup] {
+        store.items(for: listId).filtered(by: filter).groupedByAisle()
+    }
 
     var body: some View {
         // The list extends edge-to-edge horizontally so category headers can run the full width of
@@ -22,6 +29,14 @@ struct GroceryItemsView: View {
                     AddItemRow { showingAdd = true }
                         .padding(.horizontal, hInset)
                         .padding(.top, 2)
+
+                    if groups.isEmpty {
+                        Text(filter.emptyMessage)
+                            .font(.footnote)
+                            .foregroundStyle(WatchTheme.onSurfaceVariant)
+                            .padding(.horizontal, hInset)
+                            .padding(.top, 6)
+                    }
 
                     ForEach(groups) { group in
                         Section {
@@ -44,11 +59,62 @@ struct GroceryItemsView: View {
         }
         .ignoresSafeArea(.container, edges: .horizontal)
         .navigationTitle(title)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showingFilter = true
+                } label: {
+                    Image(
+                        systemName: filter == .all
+                            ? "line.3.horizontal.decrease.circle"
+                            : "line.3.horizontal.decrease.circle.fill"
+                    )
+                }
+                .foregroundStyle(filter == .all ? WatchTheme.onSurfaceVariant : WatchTheme.primary)
+                .accessibilityLabel("Filter: \(filter.displayName)")
+            }
+        }
         .sheet(isPresented: $showingAdd) {
             AddItemView { name in
                 store.addItem(listId: listId, name: name)
             }
         }
+        .sheet(isPresented: $showingFilter) {
+            GroceryFilterView(selection: $filter)
+        }
+    }
+}
+
+/// Filter picker, mirroring the options in the phone's Sort & Filter sheet.
+private struct GroceryFilterView: View {
+    @Binding var selection: WatchGroceryFilter
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List(WatchGroceryFilter.allCases) { option in
+                Button {
+                    selection = option
+                    dismiss()
+                } label: {
+                    HStack(spacing: 8) {
+                        Text(option.displayName)
+                            .foregroundStyle(WatchTheme.onSurface)
+                        Spacer(minLength: 0)
+                        if option == selection {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(WatchTheme.primary)
+                        }
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+            .listStyle(.plain)
+            .navigationTitle("Filter")
+        }
+        .tint(WatchTheme.primary)
     }
 }
 

--- a/iosApp/ChefMateWatch/WatchModels.swift
+++ b/iosApp/ChefMateWatch/WatchModels.swift
@@ -122,8 +122,9 @@ enum WatchGroceryFilter: String, CaseIterable, Identifiable {
     }
 }
 
-/// One aisle's worth of items, ready to render as a sticky-header section.
-struct WatchGroceryGroup: Identifiable {
+/// One aisle's worth of items, ready to render as a sticky-header section. `Equatable` so the items
+/// screen can drive its animations off the whole grouped list changing.
+struct WatchGroceryGroup: Identifiable, Equatable {
     let category: WatchGroceryCategory
     let items: [WatchGroceryItem]
     var id: String { category.rawValue }

--- a/iosApp/ChefMateWatch/WatchModels.swift
+++ b/iosApp/ChefMateWatch/WatchModels.swift
@@ -85,6 +85,43 @@ enum WatchGroceryCategory: String, CaseIterable {
     }
 }
 
+// MARK: - Filtering (mirrors the shared `GroceryListBloc.GroceryFilter`)
+
+/// The purchased/unpurchased views the phone offers in its Sort & Filter sheet. Raw values match
+/// the Kotlin enum names so the labels — and any future hand-off to the phone — line up.
+enum WatchGroceryFilter: String, CaseIterable, Identifiable {
+    case all = "ALL"
+    case unpurchased = "UNPURCHASED"
+    case purchased = "PURCHASED"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .all: return "All"
+        case .unpurchased: return "Unpurchased"
+        case .purchased: return "Purchased"
+        }
+    }
+
+    /// Shown when the filter hides every item in the list.
+    var emptyMessage: String {
+        switch self {
+        case .all: return "No items yet."
+        case .unpurchased: return "Everything's purchased."
+        case .purchased: return "Nothing purchased yet."
+        }
+    }
+
+    func matches(_ item: WatchGroceryItem) -> Bool {
+        switch self {
+        case .all: return true
+        case .unpurchased: return !item.isChecked
+        case .purchased: return item.isChecked
+        }
+    }
+}
+
 /// One aisle's worth of items, ready to render as a sticky-header section.
 struct WatchGroceryGroup: Identifiable {
     let category: WatchGroceryCategory
@@ -94,6 +131,11 @@ struct WatchGroceryGroup: Identifiable {
 }
 
 extension Array where Element == WatchGroceryItem {
+    /// Keeps only the items the given filter admits.
+    func filtered(by filter: WatchGroceryFilter) -> [WatchGroceryItem] {
+        filter == .all ? self : self.filter { filter.matches($0) }
+    }
+
     /// Groups items by aisle and orders the groups the way the phone does (by the shared enum's
     /// declaration order), preserving each item's incoming order within a group. Any unrecognised
     /// category falls into `OTHER`.


### PR DESCRIPTION
## What

Adds a purchased-state filter to the watchOS grocery items screen, mirroring the All / Unpurchased / Purchased filter the phone offers in its Sort & Filter sheet.

- `WatchGroceryFilter` in `WatchModels.swift` — raw values match the Kotlin `GroceryListBloc.GroceryFilter` names, and the labels match the phone's `grocery_filter_*` strings, so both apps read the same. Comes with a `filtered(by:)` array helper that runs ahead of the existing `groupedByAisle()`.
- A filter button in the top-bar trailing toolbar slot on `GroceryItemsView`: outline icon when showing All, filled and accent-tinted when a filter is active. Tapping it opens a sheet listing the three options with a checkmark on the current one.
- When a filter hides every item, an inline message explains why ("Everything's purchased." / "Nothing purchased yet.") instead of leaving a blank screen. The "Add item" row stays visible in all cases.

## Why

The watch listed every item in a list with no way to hide what was already in the cart — the thing you most want while actually standing in a store. The phone has had this filter for a while; this brings the watch in line.

## Notes for reviewers

Two choices worth a look:

- **The selection is `@AppStorage`-persisted and shared across lists**, rather than per-list. That matches the phone, which keeps its filter in settings — the choice is about how you shop, not about one particular list.
- **All three options ship, not just Unpurchased.** A sheet that only toggles one filter needs a way back to "All" anyway, so offering Purchased too costs nothing and matches the phone.

## Testing

`xcodebuild -scheme ChefMateWatch -destination 'generic/platform=watchOS Simulator'` — **BUILD SUCCEEDED**.

Not verified visually: the watch app gets its data over WatchConnectivity from a paired phone, so a standalone watch simulator only shows the "Open Chef Mate on iPhone" empty state. The layout of the toolbar button, the sheet, and the empty-state message should be eyeballed on a paired device or simulator pair before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)