### PR TITLE
fix(watch): make watch→phone grocery edits actually reach the phone

### DIFF
--- a/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/WatchDataBridge.kt
+++ b/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/WatchDataBridge.kt
@@ -62,16 +62,39 @@ class WatchDataBridge(
         scope.launch { onResult(snapshotFlow.first()) }
     }
 
-    fun addItem(listId: Long, name: String) {
+    /**
+     * Adds [name] to [listId] and pushes it to Supabase, invoking [onComplete] once the write has
+     * landed.
+     *
+     * [onComplete] is what lets the Swift caller hold the app alive while this runs. iOS wakes the
+     * phone app in the background purely to hand `WatchDataSender` a queued watch mutation and
+     * suspends it again the moment the delegate callback returns — so a fire-and-forget [launch]
+     * here is killed before it reaches the database, and the phone's next snapshot push then
+     * overwrites the watch's optimistic edit. See `WatchDataSender.keepingAlive`.
+     */
+    fun addItem(listId: Long, name: String, onComplete: () -> Unit) {
         scope.launch {
-            repository.addGrocery(listId, name)
-            repository.syncAllUnsynced()
+            try {
+                repository.addGrocery(listId, name)
+                repository.syncAllUnsynced()
+            } finally {
+                onComplete()
+            }
         }
     }
 
-    fun setChecked(itemId: Long, isChecked: Boolean) {
+    /** Toggles an item and pushes it to Supabase. [onComplete] behaves as in [addItem]. */
+    fun setChecked(itemId: Long, isChecked: Boolean, onComplete: () -> Unit) {
         scope.launch {
-            repository.getGrocery(itemId)?.let { repository.updateChecked(it, isChecked) }
+            try {
+                repository.getGrocery(itemId)?.let { repository.updateChecked(it, isChecked) }
+                // The local row is already marked dirty and self-heals on the next reconcile, but
+                // the phone may not be opened for hours — push now so a collaborator on a shared
+                // list sees the check without waiting for that.
+                repository.syncAllUnsynced()
+            } finally {
+                onComplete()
+            }
         }
     }
 

--- a/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/WatchDataBridge.kt
+++ b/client/composeApp/src/iosMain/kotlin/com/plusmobileapps/chefmate/WatchDataBridge.kt
@@ -1,5 +1,6 @@
 package com.plusmobileapps.chefmate
 
+import co.touchlab.kermit.Logger
 import com.plusmobileapps.chefmate.di.AppScope
 import com.plusmobileapps.chefmate.di.IO
 import com.plusmobileapps.chefmate.grocery.data.GroceryItem
@@ -83,15 +84,27 @@ class WatchDataBridge(
         }
     }
 
-    /** Toggles an item and pushes it to Supabase. [onComplete] behaves as in [addItem]. */
+    /**
+     * Toggles an item. [onComplete] behaves as in [addItem].
+     *
+     * Deliberately does *not* call `syncAllUnsynced()`: [GroceryRepository.updateChecked] already
+     * marks the row dirty and pushes it, and kicking off a full reconcile alongside that push races
+     * it — the reconcile can pull a pre-toggle copy of the row and write it back over the check
+     * once the push clears the dirty flag. The dirty row self-heals on the next reconcile either
+     * way.
+     */
     fun setChecked(itemId: Long, isChecked: Boolean, onComplete: () -> Unit) {
         scope.launch {
             try {
-                repository.getGrocery(itemId)?.let { repository.updateChecked(it, isChecked) }
-                // The local row is already marked dirty and self-heals on the next reconcile, but
-                // the phone may not be opened for hours — push now so a collaborator on a shared
-                // list sees the check without waiting for that.
-                repository.syncAllUnsynced()
+                val item = repository.getGrocery(itemId)
+                if (item == null) {
+                    // The watch is holding ids from a snapshot that no longer matches the
+                    // database (a remote reconcile can delete and recreate rows). Dropping this
+                    // silently is what makes a watch toggle look like it never happened.
+                    Logger.w(tag = TAG) { "setChecked: no local grocery with id=$itemId" }
+                } else {
+                    repository.updateChecked(item, isChecked)
+                }
             } finally {
                 onComplete()
             }
@@ -118,6 +131,10 @@ class WatchDataBridge(
             }
         }
         return json.encodeToString(WatchSnapshot(lists, items))
+    }
+
+    private companion object {
+        const val TAG = "WatchDataBridge"
     }
 }
 

--- a/iosApp/ChefMateWatch/GroceryStore.swift
+++ b/iosApp/ChefMateWatch/GroceryStore.swift
@@ -11,11 +11,31 @@ final class GroceryStore: ObservableObject {
 
     private let connectivity = WatchConnectivityManager.shared
 
+    /// Checks made here that the phone hasn't confirmed yet, keyed by item id.
+    ///
+    /// Our mutation goes out on `transferUserInfo`, so the phone can already be mid-push with
+    /// pre-toggle data when it lands — that snapshot legitimately still shows the old value and
+    /// would visibly undo the tap. Re-applying pending checks on top of every incoming snapshot
+    /// holds the user's change until the phone agrees with it. Entries also expire, so a mutation
+    /// the phone genuinely dropped surfaces instead of being masked here forever.
+    private var pendingChecks: [Int64: (isChecked: Bool, sentAt: Date)] = [:]
+    private let pendingCheckTimeout: TimeInterval = 60
+
     init() {
         connectivity.onSnapshot = { [weak self] snapshot in
-            self?.snapshot = snapshot
-            self?.hasLoaded = true
+            self?.apply(snapshot)
         }
+    }
+
+    private func apply(_ incoming: WatchSnapshot) {
+        let now = Date()
+        pendingChecks = pendingChecks.filter { id, pending in
+            guard now.timeIntervalSince(pending.sentAt) < pendingCheckTimeout else { return false }
+            guard let item = incoming.items.first(where: { $0.id == id }) else { return false }
+            return item.isChecked != pending.isChecked  // still unconfirmed — keep overriding
+        }
+        snapshot = incoming.applyingChecked(pendingChecks.mapValues(\.isChecked))
+        hasLoaded = true
     }
 
     var lists: [WatchGroceryList] { snapshot.lists }
@@ -30,8 +50,8 @@ final class GroceryStore: ObservableObject {
     }
 
     func setChecked(itemId: Int64, isChecked: Bool) {
-        let updated = snapshot.items.map { $0.id == itemId ? $0.toggled() : $0 }
-        snapshot = WatchSnapshot(lists: snapshot.lists, items: updated)
+        pendingChecks[itemId] = (isChecked: isChecked, sentAt: Date())
+        snapshot = snapshot.applyingChecked([itemId: isChecked])
         connectivity.sendSetChecked(itemId: itemId, isChecked: isChecked)
     }
 

--- a/iosApp/ChefMateWatch/WatchConnectivityManager.swift
+++ b/iosApp/ChefMateWatch/WatchConnectivityManager.swift
@@ -52,23 +52,48 @@ final class WatchConnectivityManager: NSObject, WCSessionDelegate {
         WCSession.default.transferUserInfo(["type": "requestSnapshot"])
     }
 
+    /// Sends a mutation to the phone, preferring immediate delivery over a queued transfer.
+    ///
+    /// `transferUserInfo` on its own is not enough. It is an *opportunistic* transfer — the system
+    /// delivers it whenever it feels like it, which can be many minutes — so a checked item would
+    /// routinely still be sitting in the queue when the phone next pushed a snapshot built without
+    /// it, silently undoing the change. `sendMessage` delivers now and background-launches the phone
+    /// app if it isn't running; this is the same pattern `requestSnapshot` already uses, which is
+    /// why that path worked while these two didn't. The queued transfer stays as the out-of-range
+    /// fallback so nothing is lost when the phone genuinely isn't there.
+    private func send(_ info: [String: Any]) {
+        let session = WCSession.default
+        let type = info["type"] as? String ?? "?"
+        guard session.activationState == .activated else {
+            log.error("send(\(type)) skipped: session not activated")
+            return
+        }
+        guard session.isReachable else {
+            log.info("send(\(type)): phone unreachable, queueing transferUserInfo")
+            session.transferUserInfo(info)
+            return
+        }
+        session.sendMessage(info, replyHandler: { [weak self] _ in
+            self?.log.info("send(\(type)): delivered via sendMessage")
+        }, errorHandler: { [weak self] error in
+            self?.log.error("send(\(type)) sendMessage failed, queueing: \(error.localizedDescription)")
+            session.transferUserInfo(info)
+        })
+    }
+
     func sendSetChecked(itemId: Int64, isChecked: Bool) {
-        WCSession.default.transferUserInfo(["type": "setChecked", "itemId": itemId, "isChecked": isChecked])
+        send(["type": "setChecked", "itemId": itemId, "isChecked": isChecked])
     }
 
     /// `listId == nil` tells the phone to use the default list (used by the Siri intent).
     ///
-    /// Guards on activation state because `transferUserInfo` before the session is activated is a
-    /// programmer error (it throws). On a cold Siri launch use `sendAddItemAwaitingActivation`, which
-    /// waits for activation first.
+    /// [send] drops the call if the session isn't activated yet — sending before then is a
+    /// programmer error that throws. On a cold Siri launch use `sendAddItemAwaitingActivation`,
+    /// which waits for activation first.
     func sendAddItem(listId: Int64?, name: String) {
-        guard WCSession.default.activationState == .activated else {
-            log.info("sendAddItem skipped: session not activated")
-            return
-        }
         var info: [String: Any] = ["type": "addItem", "name": name]
         if let listId { info["listId"] = listId }
-        WCSession.default.transferUserInfo(info)
+        send(info)
     }
 
     /// Adds an item, waiting up to ~5s for the session to activate first.
@@ -106,5 +131,21 @@ final class WatchConnectivityManager: NSObject, WCSessionDelegate {
 
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
         decode(applicationContext)
+    }
+
+    /// Reports the fate of a queued `transferUserInfo`. Without this a fallback transfer that the
+    /// system never delivered looked identical to one the phone silently ignored, which is what made
+    /// the watch→phone direction so hard to pin down.
+    func session(
+        _ session: WCSession,
+        didFinish userInfoTransfer: WCSessionUserInfoTransfer,
+        error: Error?
+    ) {
+        let type = userInfoTransfer.userInfo["type"] as? String ?? "?"
+        if let error {
+            log.error("queued transfer(\(type)) failed: \(error.localizedDescription)")
+        } else {
+            log.info("queued transfer(\(type)) delivered")
+        }
     }
 }

--- a/iosApp/ChefMateWatch/WatchModels.swift
+++ b/iosApp/ChefMateWatch/WatchModels.swift
@@ -8,6 +8,19 @@ struct WatchSnapshot: Codable {
     let items: [WatchGroceryItem]
 
     static let empty = WatchSnapshot(lists: [], items: [])
+
+    /// Re-applies locally-made checks that the phone hasn't confirmed yet (see
+    /// `GroceryStore.pendingChecks`).
+    func applyingChecked(_ overrides: [Int64: Bool]) -> WatchSnapshot {
+        guard !overrides.isEmpty else { return self }
+        return WatchSnapshot(
+            lists: lists,
+            items: items.map { item in
+                guard let isChecked = overrides[item.id] else { return item }
+                return item.settingChecked(isChecked)
+            }
+        )
+    }
 }
 
 struct WatchGroceryList: Codable, Identifiable, Hashable {
@@ -24,10 +37,10 @@ struct WatchGroceryItem: Codable, Identifiable, Hashable {
     let category: String
     let isChecked: Bool
 
-    func toggled() -> WatchGroceryItem {
+    func settingChecked(_ isChecked: Bool) -> WatchGroceryItem {
         WatchGroceryItem(
             id: id, listId: listId, name: name, quantity: quantity, category: category,
-            isChecked: !isChecked
+            isChecked: isChecked
         )
     }
 }

--- a/iosApp/iosApp/AddGroceryItemIntent.swift
+++ b/iosApp/iosApp/AddGroceryItemIntent.swift
@@ -33,8 +33,10 @@ struct AddGroceryItemIntent: AppIntent {
 
         await withCheckedContinuation { continuation in
             bridge.ensureDefaultList { listId in
-                bridge.addItem(listId: listId.int64Value, name: name)
-                continuation.resume()
+                // Resume only once the add has actually been persisted. `addItem` applies the write
+                // on a coroutine, so resuming as soon as it returned let `perform()` finish — and
+                // the system tear down the background-launched process — before the item was saved.
+                bridge.addItem(listId: listId.int64Value, name: name) { continuation.resume() }
             }
         }
 

--- a/iosApp/iosApp/WatchDataSender.swift
+++ b/iosApp/iosApp/WatchDataSender.swift
@@ -1,4 +1,5 @@
 import ComposeApp
+import UIKit
 import os
 import WatchConnectivity
 
@@ -43,8 +44,38 @@ final class WatchDataSender: NSObject, WCSessionDelegate {
         if let error {
             log.error("activation failed: \(error.localizedDescription)")
         }
-        // Push a fresh snapshot to the watch on every grocery data change.
+        // Push a fresh snapshot to the watch on every grocery data change. Drop any previous
+        // observer first: `sessionDidDeactivate` re-activates the session, so this runs more than
+        // once per launch and would otherwise stack up a collector per activation.
+        cancelObserve?()
         cancelObserve = bridge.observeSnapshot { [weak self] json in self?.push(json) }
+    }
+
+    /// Keeps the app awake until an async watch mutation has actually been applied.
+    ///
+    /// iOS wakes this app in the background purely to deliver a queued `transferUserInfo` payload
+    /// and suspends it again as soon as the delegate callback returns. Every bridge call applies its
+    /// mutation on a Kotlin coroutine and returns immediately, so without an assertion the write is
+    /// killed mid-flight — the watch's edit never reaches the database, and the phone's next
+    /// snapshot push overwrites it on the watch. `work` must invoke the completion it is handed once
+    /// the mutation is durable.
+    private func keepingAlive(_ name: String, _ work: @escaping (@escaping () -> Void) -> Void) {
+        // `beginBackgroundTask` is a UIApplication API and WCSession delivers on a background queue,
+        // so hop to main — and keep the token main-confined so the expiration handler and the
+        // completion can't race each other into ending the same task twice.
+        DispatchQueue.main.async {
+            var token = UIBackgroundTaskIdentifier.invalid
+            let finish = {
+                guard token != .invalid else { return }
+                UIApplication.shared.endBackgroundTask(token)
+                token = .invalid
+            }
+            token = UIApplication.shared.beginBackgroundTask(withName: name) { [weak self] in
+                self?.log.error("background task '\(name)' expired before the watch action finished")
+                finish()
+            }
+            work { DispatchQueue.main.async(execute: finish) }
+        }
     }
 
     // Watch pulls the latest snapshot when it opens.
@@ -62,23 +93,38 @@ final class WatchDataSender: NSObject, WCSessionDelegate {
 
     // Watch toggle/add actions plus its queued snapshot request (all reliable, delivered even when
     // the phone was unreachable when the watch acted).
+    //
+    // Every branch runs inside `keepingAlive` because this is usually called on a background wake,
+    // where returning from here is what gets us suspended — see that method for why an unguarded
+    // bridge call silently loses the watch's edit.
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any]) {
         switch userInfo["type"] as? String {
         case "requestSnapshot":
             // Watch asked while we were unreachable; push the current snapshot so it can load.
-            bridge.currentSnapshot { [weak self] json in self?.push(json) }
+            keepingAlive("watch-snapshot") { [weak self] done in
+                guard let self else { return done() }
+                self.bridge.currentSnapshot { json in
+                    self.push(json)
+                    done()
+                }
+            }
         case "setChecked":
-            if let itemId = (userInfo["itemId"] as? NSNumber)?.int64Value,
-               let isChecked = userInfo["isChecked"] as? Bool {
-                bridge.setChecked(itemId: itemId, isChecked: isChecked)
+            guard let itemId = (userInfo["itemId"] as? NSNumber)?.int64Value,
+                  let isChecked = userInfo["isChecked"] as? Bool else { return }
+            keepingAlive("watch-set-checked") { [weak self] done in
+                guard let self else { return done() }
+                self.bridge.setChecked(itemId: itemId, isChecked: isChecked, onComplete: done)
             }
         case "addItem":
             guard let name = userInfo["name"] as? String, !name.isEmpty else { return }
-            if let listId = (userInfo["listId"] as? NSNumber)?.int64Value {
-                bridge.addItem(listId: listId, name: name)
-            } else {
-                bridge.ensureDefaultList { listId in
-                    self.bridge.addItem(listId: listId.int64Value, name: name)
+            keepingAlive("watch-add-item") { [weak self] done in
+                guard let self else { return done() }
+                if let listId = (userInfo["listId"] as? NSNumber)?.int64Value {
+                    self.bridge.addItem(listId: listId, name: name, onComplete: done)
+                } else {
+                    self.bridge.ensureDefaultList { listId in
+                        self.bridge.addItem(listId: listId.int64Value, name: name, onComplete: done)
+                    }
                 }
             }
         default:

--- a/iosApp/iosApp/WatchDataSender.swift
+++ b/iosApp/iosApp/WatchDataSender.swift
@@ -78,7 +78,49 @@ final class WatchDataSender: NSObject, WCSessionDelegate {
         }
     }
 
-    // Watch pulls the latest snapshot when it opens.
+    /// Applies one watch action, invoking `done` once it has been durably handled.
+    ///
+    /// Shared by both delivery routes: the watch sends mutations with `sendMessage` when the phone
+    /// is reachable and falls back to a queued `transferUserInfo`, so the same payload can arrive
+    /// through either delegate callback and must behave identically.
+    private func apply(_ payload: [String: Any], _ done: @escaping () -> Void) {
+        let type = payload["type"] as? String
+        switch type {
+        case "requestSnapshot":
+            bridge.currentSnapshot { [weak self] json in
+                self?.push(json)
+                done()
+            }
+        case "setChecked":
+            guard let itemId = (payload["itemId"] as? NSNumber)?.int64Value,
+                  let isChecked = (payload["isChecked"] as? NSNumber)?.boolValue else {
+                log.error("setChecked payload malformed: \(payload.keys.sorted())")
+                return done()
+            }
+            log.info("applying setChecked (itemId=\(itemId), isChecked=\(isChecked))")
+            bridge.setChecked(itemId: itemId, isChecked: isChecked, onComplete: done)
+        case "addItem":
+            guard let name = payload["name"] as? String, !name.isEmpty else {
+                log.error("addItem payload malformed: \(payload.keys.sorted())")
+                return done()
+            }
+            log.info("applying addItem")
+            if let listId = (payload["listId"] as? NSNumber)?.int64Value {
+                bridge.addItem(listId: listId, name: name, onComplete: done)
+            } else {
+                bridge.ensureDefaultList { [weak self] listId in
+                    guard let self else { return done() }
+                    self.bridge.addItem(listId: listId.int64Value, name: name, onComplete: done)
+                }
+            }
+        default:
+            log.error("ignoring unknown watch payload type: \(type ?? "nil")")
+            done()
+        }
+    }
+
+    // Immediate path: the watch uses `sendMessage` for snapshot pulls and, when the phone is
+    // reachable, for mutations too. Replying is what releases the watch's send.
     func session(
         _ session: WCSession,
         didReceiveMessage message: [String: Any],
@@ -87,48 +129,27 @@ final class WatchDataSender: NSObject, WCSessionDelegate {
         if message["type"] as? String == "requestSnapshot" {
             bridge.currentSnapshot { json in replyHandler(["snapshot": json]) }
         } else {
+            // Reply straight away — the watch only needs the handoff acknowledged, and holding the
+            // reply until the write finished would risk tripping WatchConnectivity's reply timeout.
             replyHandler([:])
+            keepingAlive("watch-message") { [weak self] done in
+                guard let self else { return done() }
+                self.apply(message, done)
+            }
         }
     }
 
-    // Watch toggle/add actions plus its queued snapshot request (all reliable, delivered even when
-    // the phone was unreachable when the watch acted).
+    // Queued path: whatever the watch couldn't hand over immediately (phone out of range, or the
+    // watch acted while the phone app wasn't reachable).
     //
-    // Every branch runs inside `keepingAlive` because this is usually called on a background wake,
-    // where returning from here is what gets us suspended — see that method for why an unguarded
-    // bridge call silently loses the watch's edit.
+    // Runs inside `keepingAlive` because this is usually a background wake, where returning from
+    // here is what gets us suspended — see that method for why an unguarded bridge call silently
+    // loses the watch's edit.
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any]) {
-        switch userInfo["type"] as? String {
-        case "requestSnapshot":
-            // Watch asked while we were unreachable; push the current snapshot so it can load.
-            keepingAlive("watch-snapshot") { [weak self] done in
-                guard let self else { return done() }
-                self.bridge.currentSnapshot { json in
-                    self.push(json)
-                    done()
-                }
-            }
-        case "setChecked":
-            guard let itemId = (userInfo["itemId"] as? NSNumber)?.int64Value,
-                  let isChecked = userInfo["isChecked"] as? Bool else { return }
-            keepingAlive("watch-set-checked") { [weak self] done in
-                guard let self else { return done() }
-                self.bridge.setChecked(itemId: itemId, isChecked: isChecked, onComplete: done)
-            }
-        case "addItem":
-            guard let name = userInfo["name"] as? String, !name.isEmpty else { return }
-            keepingAlive("watch-add-item") { [weak self] done in
-                guard let self else { return done() }
-                if let listId = (userInfo["listId"] as? NSNumber)?.int64Value {
-                    self.bridge.addItem(listId: listId, name: name, onComplete: done)
-                } else {
-                    self.bridge.ensureDefaultList { listId in
-                        self.bridge.addItem(listId: listId.int64Value, name: name, onComplete: done)
-                    }
-                }
-            }
-        default:
-            break
+        log.info("didReceiveUserInfo: \(userInfo["type"] as? String ?? "?")")
+        keepingAlive("watch-userinfo") { [weak self] done in
+            guard let self else { return done() }
+            self.apply(userInfo, done)
         }
     }
 


### PR DESCRIPTION
## The bug

Grocery edits made on the Apple Watch never reached the phone. Checking an item on the watch looked fine locally, then got wiped by the phone's next snapshot push. Phone→watch sync worked.

Two independent defects, both on the watch→phone path. The first commit fixed one; it wasn't enough, and the second round found the one that was actually dominant.

## Defect 1 — the write was killed by app suspension

The phone applied watch mutations through `WatchDataBridge`, whose `setChecked`/`addItem` were fire-and-forget:

```kotlin
fun setChecked(itemId: Long, isChecked: Boolean) {
    scope.launch { ... }   // returns instantly
}
```

Since `transferUserInfo` makes iOS wake the phone app in the background purely to deliver the payload, and returning from the WCSession delegate callback is what tells iOS the app is idle, the coroutine was killed before it reached SQLDelight.

Fixed by giving the bridge `onComplete` callbacks and having `WatchDataSender.keepingAlive` hold a `beginBackgroundTask` assertion until the write lands.

## Defect 2 — mutations were queued opportunistically (the dominant one)

The remaining difference between the watch→phone call that works and the two that didn't:

| action | delivery | worked? |
|---|---|---|
| `requestSnapshot` | `sendMessage` when reachable, `transferUserInfo` fallback | yes |
| `setChecked` | `transferUserInfo` only | no |
| `addItem` | `transferUserInfo` only | no |

`transferUserInfo` is an *opportunistic* transfer — the system delivers it whenever it chooses, which can be many minutes. A toggle would routinely still be sitting in the queue when the phone next pushed a snapshot built without it, silently undoing the change.

Mutations now go through a shared `send(_:)` mirroring the path already proven to work here: `sendMessage` for immediate delivery (it also background-launches the phone app), with the queued transfer kept as the out-of-range fallback. `WatchDataSender` grows a shared `apply(_:_:)` so a payload behaves identically whichever delegate callback it arrives through, since either route is now possible.

## Also fixed

- **A revert race the first commit introduced.** It added `syncAllUnsynced()` to `setChecked`, but `updateChecked` already marks the row dirty and pushes it — starting a full reconcile alongside that push races it, and the reconcile can pull a pre-toggle copy of the row and write it back over the check once the push clears the dirty flag. Removed.
- **`AddGroceryItemIntent` (iOS Siri)** had defect 1 too — it resumed its continuation before the add was persisted, so a background-launched intent process could be torn down first. Same class as #366, phone side.
- **Leaked snapshot observer**: `activationDidCompleteWith` stacked a new `observeSnapshot` collector on every activation (`sessionDidDeactivate` re-activates). Now cancels the previous.
- **`WatchGroceryItem.toggled()`** ignored the `isChecked` the caller had computed and flipped the current value instead. Replaced with `settingChecked(_:)`.
- **Watch-side race defense**: `GroceryStore` re-applies unconfirmed checks over incoming snapshots (the phone can legitimately be mid-push with pre-toggle data), dropping each once the phone agrees and expiring after 60s so a genuinely lost mutation surfaces rather than being masked.

## Diagnostics

This direction was misdiagnosed twice because every failure mode was silent. Added:
- watch logs which route each mutation took, and implements `didFinish:error:` so a queued transfer the system never delivered is distinguishable from one the phone ignored
- phone logs every received payload, malformed payloads, and unknown types
- `WatchDataBridge.setChecked` warns when no local row matches the incoming id instead of silently doing nothing

## Testing

- `linkDebugFrameworkIosSimulatorArm64` — BUILD SUCCESSFUL
- watch target and phone sources — `swiftc -typecheck` clean against the freshly built framework
- `ktfmt --kotlinlang-style` clean
- Ruled out by experiment: I suspected `userInfo["isChecked"] as? Bool` was returning nil (it was the one value decoded without an `NSNumber` hop). Round-tripping the payload through plist and `NSKeyedArchiver` showed the cast survives both, including from an integer-typed `NSNumber`. Not the bug — but the cast was made defensive anyway.

**No automated test coverage added.** `WatchDataBridge` lives in `composeApp/src/iosMain` with no existing test harness, and the WatchConnectivity behavior at the heart of both defects is only exercisable on a real paired device.

**Verified on real hardware.** Checking an item on the watch with the phone app backgrounded now reaches the phone and sticks.

Worth noting for future watch work: this could not have been caught in the simulator. Paired simulators deliver `transferUserInfo` essentially immediately and don't suspend the phone app the way a device does, so both defects here look like working code there. Changes to the watch↔phone path need a real pair to validate.

The logging added in this PR is kept deliberately — every failure mode on this path was previously silent, which is what made it take two rounds to diagnose. Filter Console on subsystem `com.plusmobileapps.chefmate` (phone) and `com.plusmobileapps.chefmate.watch` (watch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
