### PR TITLE
feat(ui): use the platform-native share icon on iOS and macOS

### DIFF
--- a/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
+++ b/client/recipe/core/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/recipe/core/detail/RecipeDetailScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Restaurant
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SoupKitchen
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Timer
@@ -159,6 +158,7 @@ import com.plusmobileapps.chefmate.ui.Content
 import com.plusmobileapps.chefmate.ui.LocalAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.LocalSecondaryAnimatedVisibilityScope
 import com.plusmobileapps.chefmate.ui.LocalSharedTransitionScope
+import com.plusmobileapps.chefmate.ui.PlusShareIcon
 import com.plusmobileapps.chefmate.ui.components.PlusDialog
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderContainer
 import com.plusmobileapps.chefmate.ui.components.PlusHeaderData
@@ -568,7 +568,7 @@ private fun ShareActionButton(
         var showShareMenu by remember { mutableStateOf(false) }
         IconButton(onClick = { showShareMenu = true }) {
             Icon(
-                imageVector = Icons.Default.Share,
+                imageVector = PlusShareIcon,
                 contentDescription = stringResource(Res.string.recipe_detail_share),
             )
         }
@@ -636,7 +636,7 @@ private fun RecipeShareMenuItems(
 ) {
     DropdownMenuItem(
         text = { Text(stringResource(Res.string.recipe_detail_share_link)) },
-        leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
+        leadingIcon = { Icon(PlusShareIcon, contentDescription = null) },
         onClick = {
             onClose()
             onShareLink()
@@ -645,7 +645,7 @@ private fun RecipeShareMenuItems(
     recipe.sourceUrl?.let { url ->
         DropdownMenuItem(
             text = { Text(stringResource(Res.string.recipe_detail_share_url)) },
-            leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
+            leadingIcon = { Icon(PlusShareIcon, contentDescription = null) },
             onClick = {
                 onClose()
                 onShare(url)
@@ -654,7 +654,7 @@ private fun RecipeShareMenuItems(
     }
     DropdownMenuItem(
         text = { Text(stringResource(Res.string.recipe_detail_share_text)) },
-        leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
+        leadingIcon = { Icon(PlusShareIcon, contentDescription = null) },
         onClick = {
             onClose()
             onShare(formatRecipeAsText(recipe))

--- a/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/ShareIcon.android.kt
+++ b/client/ui/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/ui/ShareIcon.android.kt
@@ -1,0 +1,10 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.ui.graphics.vector.ImageVector
+
+actual val PlusShareIcon: ImageVector
+    get() = Icons.Default.Share

--- a/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/ShareIcon.kt
+++ b/client/ui/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/ui/ShareIcon.kt
@@ -1,0 +1,9 @@
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * The platform's native share glyph: Apple's square-with-an-up-arrow on iOS and macOS, Material's
+ * three-node share icon on Android, Windows and Linux.
+ */
+expect val PlusShareIcon: ImageVector

--- a/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/ShareIcon.ios.kt
+++ b/client/ui/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/ui/ShareIcon.ios.kt
@@ -1,0 +1,10 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.IosShare
+import androidx.compose.ui.graphics.vector.ImageVector
+
+actual val PlusShareIcon: ImageVector
+    get() = Icons.Default.IosShare

--- a/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/ShareIcon.jvm.kt
+++ b/client/ui/public/src/jvmMain/kotlin/com/plusmobileapps/chefmate/ui/ShareIcon.jvm.kt
@@ -1,0 +1,20 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.plusmobileapps.chefmate.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.IosShare
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * macOS shares the Apple share glyph with iOS; Windows and Linux have no system equivalent, so they
+ * keep the Material icon.
+ */
+actual val PlusShareIcon: ImageVector
+    get() = if (isMacOs) Icons.Default.IosShare else Icons.Default.Share
+
+private val isMacOs: Boolean by lazy {
+    val os = System.getProperty("os.name").orEmpty().lowercase()
+    os.contains("mac") || os.contains("darwin")
+}


### PR DESCRIPTION
## What changed

The share affordance rendered Material's three-node share glyph on every target. On Apple platforms that looks foreign — users expect the square-with-an-up-arrow (SF Symbol `square.and.arrow.up`).

- New `PlusShareIcon` expect/actual in `client/ui/public`, alongside the existing `Platform.kt`:
  - **iOS** → `Icons.Default.IosShare`
  - **Android** → `Icons.Default.Share` (unchanged from today)
  - **JVM** → branches on `os.name`; macOS gets `IosShare`, Windows/Linux keep `Share` since neither has a system equivalent
- `RecipeDetailScreen` now uses it for all four share glyphs: the toolbar icon button and the three dropdown leading icons.

## Notes for reviewers

- No build file changes needed — `material-icons-extended` is already added to every compose module's `commonMain` by `ComposeConventionPlugin`.
- `RecipeDetailScreen` is the only place in the app that renders a share icon. `Icons.Default.LinkOff` on the "stop sharing" entry is untouched.
- **No snapshot reference updates.** The Android actual resolves to the exact same vector as before, so the recorded PNGs can't change.

## Testing

- `./gradlew :client:recipe:core:public:compileKotlinJvm :client:recipe:core:public:compileKotlinIosSimulatorArm64` — clean
- `./gradlew :client:recipe:core:public:compileAndroidMain` — clean
- Formatted with standalone ktfmt 0.63 (`--kotlinlang-style`) via the pre-commit hook

Not visually verified in a running desktop or iOS build — the change is a straight icon swap, but happy to run one if you'd like eyes on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)