### PR TITLE
fix(watch): make the grocery filter icon visible again

### DIFF
--- a/iosApp/ChefMateWatch/GroceryItemsView.swift
+++ b/iosApp/ChefMateWatch/GroceryItemsView.swift
@@ -71,13 +71,18 @@ struct GroceryItemsView: View {
                 Button {
                     showingFilter = true
                 } label: {
-                    Image(
-                        systemName: filter == .all
-                            ? "line.3.horizontal.decrease.circle"
-                            : "line.3.horizontal.decrease.circle.fill"
-                    )
+                    // Bare glyph, no `.circle` variant: the watchOS toolbar already draws a circular
+                    // button behind it, and a circled symbol inside that reads as a ring on a ring.
+                    // The glyph has to be colored explicitly — the button fills its circle with the
+                    // tint and leaves the label near-white, which all but disappears on purple200.
+                    Image(systemName: "line.3.horizontal.decrease")
+                        .foregroundStyle(
+                            filter == .all ? WatchTheme.onSurface : WatchTheme.onPrimary
+                        )
                 }
-                .foregroundStyle(filter == .all ? WatchTheme.onSurfaceVariant : WatchTheme.primary)
+                // Tint colors the button's circle rather than the glyph, so an active filter reads
+                // as a filled purple chip and the default state stays a neutral surface chip.
+                .tint(filter == .all ? WatchTheme.surfaceVariant : WatchTheme.primary)
                 .accessibilityLabel("Filter: \(filter.displayName)")
             }
         }

--- a/iosApp/ChefMateWatch/WatchModels.swift
+++ b/iosApp/ChefMateWatch/WatchModels.swift
@@ -53,6 +53,7 @@ struct WatchGroceryItem: Codable, Identifiable, Hashable {
 /// values.
 enum WatchTheme {
     static let primary = Color(red: 0xBB / 255, green: 0x86 / 255, blue: 0xFC / 255) // purple200
+    static let onPrimary = Color(red: 0x37 / 255, green: 0x1E / 255, blue: 0x73 / 255)
     static let secondary = Color(red: 0x03 / 255, green: 0xDA / 255, blue: 0xC5 / 255) // teal200
     static let surfaceVariant = Color(red: 0x49 / 255, green: 0x45 / 255, blue: 0x4F / 255)
     static let onSurface = Color(red: 0xE6 / 255, green: 0xE1 / 255, blue: 0xE5 / 255)


### PR DESCRIPTION
## What

The filter button in the watch grocery items toolbar rendered as a solid purple circle with no discernible icon.

| Before | After (filtered) | After (All) |
| --- | --- | --- |
| solid purple disc | purple chip, dark-purple lines | neutral chip, light lines |

## Why

`.foregroundStyle(WatchTheme.primary)` was applied to the toolbar `Button` itself. On watchOS a `.topBarTrailing` button fills its own circular chrome from that color, so the circle *and* the glyph both came out purple200 — the icon was there, just invisible. The `line.3.horizontal.decrease.circle.fill` symbol compounded it: its own filled circle sat inside the button's circle, so even at 5× zoom there was nothing to read.

Swapping to `.tint` alone doesn't fix it either — the system leaves the label near-white, and white on `#BB86FC` is roughly 1.9:1 contrast, still effectively invisible. That intermediate state was tried on-device and rejected.

## How

- Tint the button, which colors the circular chrome (`surfaceVariant` when the filter is `All`, `primary` when a filter is active).
- Color the glyph explicitly (`onSurface` / `onPrimary`) rather than relying on the system's label color.
- Drop the `.circle` symbol variant — the toolbar already draws the circle, so `line.3.horizontal.decrease` is the right glyph.
- Add `WatchTheme.onPrimary` (`#371E73`), the M3 baseline dark on-primary that the Compose theme already inherits from `darkColorScheme()`, so the watch stays in step with the phone palette.

## Testing

Built and run on the 42mm watchOS 26.5 simulator. Both states verified visually at 5× zoom: active filter is a purple chip with dark-purple lines; the default `All` state is a neutral surface chip with light lines.

## Note for reviewers

The Filter sheet's system close button is white-on-purple200 via `.tint(WatchTheme.primary)` and has the same low contrast. Left as-is here — the X's strokes are thick enough to stay legible — but happy to tone it down in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)