### PR TITLE
fix(browser): extract recipes from microdata/hrecipe pages

### DIFF
--- a/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/RecipeExtractorService.kt
+++ b/client/browser/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/impl/RecipeExtractorService.kt
@@ -1,7 +1,10 @@
 package com.plusmobileapps.chefmate.browser.impl
 
 import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Document
 import com.fleeksoft.ksoup.nodes.Element
+import com.fleeksoft.ksoup.nodes.Node
+import com.fleeksoft.ksoup.nodes.TextNode
 import com.fleeksoft.ksoup.parser.Parser
 import com.plusmobileapps.chefmate.ChefMateUrls
 import com.plusmobileapps.chefmate.di.AppScope
@@ -69,13 +72,16 @@ class RecipeExtractorServiceImpl(
             val jsonLdScripts = document.select("script[type=application/ld+json]")
 
             for (script in jsonLdScripts) {
-                val jsonText = script.data()
-                val recipeJson = findRecipeJson(jsonText) ?: continue
-                val data = parseRecipeFromJson(recipeJson, url)
+                val data = parseRecipeJsonText(script.data(), url) ?: continue
                 // schema.org flattens grouped ingredients, so recover any sub-section headers
                 // (e.g. "For the sauce:") from the page markup when present.
                 val grouped = parseIngredientSections(document)
                 return@withContext if (grouped != null) data.copy(ingredients = grouped) else data
+            }
+
+            // No JSON-LD recipe — fall back to microdata/microformat markup.
+            parseMicrodataRecipe(document, url)?.let {
+                return@withContext it
             }
 
             throw IllegalStateException("No recipe data found on this page")
@@ -144,10 +150,108 @@ class RecipeExtractorServiceImpl(
         return if (notes.isNotEmpty()) "$head, $notes" else head
     }
 
-    private fun findRecipeJson(jsonText: String): JsonObject? {
-        val element = json.parseToJsonElement(jsonText)
-        return findRecipeInElement(element)
+    /**
+     * Fallback for pages that describe their recipe with schema.org **microdata** or an
+     * **hrecipe/h-recipe microformat** instead of JSON-LD — most notably the Jetpack Recipe
+     * shortcode used by Smitten Kitchen and other WordPress.com-hosted blogs. Returns `null` when
+     * the page has no such markup, so the caller can report that no recipe was found.
+     */
+    internal fun parseMicrodataRecipe(html: String, sourceUrl: String): ExtractedRecipeData? =
+        parseMicrodataRecipe(Ksoup.parse(html), sourceUrl)
+
+    private fun parseMicrodataRecipe(document: Document, sourceUrl: String): ExtractedRecipeData? {
+        val root = document.selectFirst(RECIPE_ROOT_SELECTOR) ?: return null
+
+        val ingredients =
+            root.select(INGREDIENT_SELECTOR).mapNotNull { it.text().trim().nullIfBlank() }
+        val directions = root.selectFirst(INSTRUCTIONS_SELECTOR)?.let(::textBlocks).orEmpty()
+        // Both empty means we matched some unrelated markup, not a real recipe.
+        if (ingredients.isEmpty() && directions.isEmpty()) return null
+
+        val title =
+            root.selectFirst(NAME_SELECTOR)?.text()?.trim().nullIfBlank()
+                ?: document.metaContent("og:title")
+                ?: ""
+
+        return ExtractedRecipeData(
+            title = title,
+            description =
+                root.selectFirst(DESCRIPTION_SELECTOR)?.text()?.trim().nullIfBlank()
+                    ?: document.metaContent("og:description"),
+            ingredients = ingredients,
+            directions = directions,
+            imageUrl =
+                root.selectFirst(IMAGE_SELECTOR)?.imageUrl() ?: document.metaContent("og:image"),
+            sourceUrl = sourceUrl,
+            servings = root.selectFirst(YIELD_SELECTOR)?.text().firstNumber(),
+            prepTime = root.selectFirst(PREP_TIME_SELECTOR).durationMinutes(),
+            cookTime = root.selectFirst(COOK_TIME_SELECTOR).durationMinutes(),
+            totalTime = root.selectFirst(TOTAL_TIME_SELECTOR).durationMinutes(),
+            calories = root.selectFirst(CALORIES_SELECTOR)?.text().firstNumber(),
+        )
     }
+
+    private fun Document.metaContent(property: String): String? =
+        selectFirst("meta[property='$property'], meta[name='$property']")
+            ?.attr("content")
+            ?.trim()
+            .nullIfBlank()
+
+    /** Microdata/microformat markup carries the image url on any of these, depending on the tag. */
+    private fun Element.imageUrl(): String? =
+        listOf("src", "content", "href").firstNotNullOfOrNull { attr(it).trim().nullIfBlank() }
+
+    /**
+     * Durations are published as an ISO-8601 `datetime`/`title` attribute in well-formed markup,
+     * but plugins routinely put prose there instead (`datetime="1 hour, plus chopping"`), so fall
+     * back to reading the value as English.
+     */
+    private fun Element?.durationMinutes(): Int? {
+        if (this == null) return null
+        val candidates =
+            listOf(attr("datetime").trim(), attr("title").trim(), text().trim()).filter {
+                it.isNotEmpty()
+            }
+        return candidates.firstNotNullOfOrNull { parseDuration(it) }
+            ?: candidates.firstNotNullOfOrNull { parseLooseDuration(it) }
+    }
+
+    /**
+     * Splits an element's rendered text into one entry per block-level child, so a directions
+     * container written as a run of `<p>`s (or `<li>`s, or `<br>`-separated text) becomes one
+     * direction per line. Text sitting directly on the container counts as its own block, which
+     * matters because WordPress's auto-paragraph mangling routinely leaves the first step
+     * unwrapped.
+     */
+    private fun textBlocks(element: Element): List<String> {
+        val blocks = mutableListOf<String>()
+        val current = StringBuilder()
+
+        fun flush() {
+            val text = current.toString().collapseWhitespace()
+            if (text.isNotEmpty()) blocks += text
+            current.clear()
+        }
+
+        fun visit(node: Node) {
+            when (node) {
+                is TextNode -> current.append(node.text())
+                is Element -> {
+                    val isBlock = node.tagName() in BLOCK_TAGS
+                    if (isBlock) flush()
+                    node.childNodes().forEach(::visit)
+                    if (isBlock) flush()
+                }
+            }
+        }
+
+        element.childNodes().forEach(::visit)
+        flush()
+        return blocks
+    }
+
+    private fun findRecipeJson(jsonText: String): JsonObject? =
+        findRecipeInElement(json.parseToJsonElement(jsonText))
 
     private fun findRecipeInElement(element: JsonElement): JsonObject? {
         return when (element) {
@@ -176,10 +280,16 @@ class RecipeExtractorServiceImpl(
         }
     }
 
-    internal fun parseRecipeJsonText(jsonText: String, sourceUrl: String): ExtractedRecipeData? {
-        val recipeJson = findRecipeJson(jsonText) ?: return null
-        return parseRecipeFromJson(recipeJson, sourceUrl)
-    }
+    /**
+     * Returns `null` for anything that isn't a well-formed schema.org `Recipe`, including malformed
+     * JSON and unexpected value shapes, so one bad `ld+json` block on a page can't stop us from
+     * trying the remaining blocks — or the microdata fallback.
+     */
+    internal fun parseRecipeJsonText(jsonText: String, sourceUrl: String): ExtractedRecipeData? =
+        runCatching {
+            findRecipeJson(jsonText)?.let { parseRecipeFromJson(it, sourceUrl) }
+        }
+        .getOrNull()
 
     private fun String.decodeHtmlEntities(): String = Parser.unescapeEntities(this, false)
 
@@ -261,24 +371,14 @@ class RecipeExtractorServiceImpl(
     private fun parseServings(obj: JsonObject): Int? {
         val yield = obj["recipeYield"] ?: return null
         return when (yield) {
-            is JsonArray ->
-                yield
-                    .firstOrNull()
-                    ?.jsonPrimitive
-                    ?.contentOrNull
-                    ?.filter { it.isDigit() }
-                    ?.toIntOrNull()
-            else -> yield.jsonPrimitive.contentOrNull?.filter { it.isDigit() }?.toIntOrNull()
+            is JsonArray -> yield.firstOrNull()?.jsonPrimitive?.contentOrNull.firstNumber()
+            else -> yield.jsonPrimitive.contentOrNull.firstNumber()
         }
     }
 
     private fun parseCalories(obj: JsonObject): Int? {
         val nutrition = obj["nutrition"]?.jsonObject ?: return null
-        return nutrition["calories"]
-            ?.jsonPrimitive
-            ?.contentOrNull
-            ?.filter { it.isDigit() }
-            ?.toIntOrNull()
+        return nutrition["calories"]?.jsonPrimitive?.contentOrNull.firstNumber()
     }
 
     companion object {
@@ -287,6 +387,61 @@ class RecipeExtractorServiceImpl(
         private const val USER_AGENT =
             "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 " +
                 "(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+
+        // schema.org microdata first, then the older hrecipe/h-recipe microformat class names.
+        private const val RECIPE_ROOT_SELECTOR =
+            "[itemtype*=schema.org/Recipe], .hrecipe, .h-recipe"
+        private const val NAME_SELECTOR = "[itemprop=name], .fn, .p-name"
+        private const val DESCRIPTION_SELECTOR =
+            "[itemprop=description], .summary, .p-summary, .e-summary"
+        private const val INGREDIENT_SELECTOR =
+            "[itemprop=recipeIngredient], [itemprop=ingredients], .ingredient, .p-ingredient"
+        private const val INSTRUCTIONS_SELECTOR =
+            "[itemprop=recipeInstructions], .instructions, .e-instructions"
+        private const val IMAGE_SELECTOR = "[itemprop=image], .photo, .u-photo"
+        private const val YIELD_SELECTOR = "[itemprop=recipeYield], .yield, .p-yield"
+        private const val PREP_TIME_SELECTOR = "[itemprop=prepTime], .preptime, .dt-preptime"
+        private const val COOK_TIME_SELECTOR = "[itemprop=cookTime], .cooktime, .dt-cooktime"
+        private const val TOTAL_TIME_SELECTOR =
+            "[itemprop=totalTime], .totaltime, .dt-totaltime, .duration, .dt-duration"
+        private const val CALORIES_SELECTOR = "[itemprop=calories]"
+
+        private val BLOCK_TAGS =
+            setOf("p", "li", "div", "br", "tr", "h1", "h2", "h3", "h4", "h5", "h6")
+
+        private val WHITESPACE = Regex("\\s+")
+        private val NUMBER = Regex("\\d[\\d,]*")
+        // "1 hour", "1 hr 20 min", "1.5 hours", "45 minutes"
+        private val LOOSE_DURATION =
+            Regex(
+                "(\\d+(?:\\.\\d+)?)\\s*(hours?|hrs?|h|minutes?|mins?|m)\\b",
+                RegexOption.IGNORE_CASE,
+            )
+
+        private fun String?.nullIfBlank(): String? = this?.takeIf { it.isNotBlank() }
+
+        private fun String.collapseWhitespace(): String = replace(WHITESPACE, " ").trim()
+
+        /**
+         * Reads the leading count out of a free-form value. Yields are routinely written as a range
+         * ("Servings: 6 to 8"), where stripping every non-digit would produce a nonsense 68.
+         */
+        private fun String?.firstNumber(): Int? =
+            this?.let { NUMBER.find(it)?.value?.replace(",", "")?.toIntOrNull() }
+
+        /** Parses an English duration ("1 hour, plus chopping") into minutes. */
+        fun parseLooseDuration(text: String?): Int? {
+            if (text == null) return null
+            // Trailing "plus …" clauses describe unattended time we shouldn't add to the total.
+            val head = text.split(Regex("\\bplus\\b", RegexOption.IGNORE_CASE)).first()
+            var minutes = 0.0
+            for (match in LOOSE_DURATION.findAll(head)) {
+                val value = match.groupValues[1].toDoubleOrNull() ?: continue
+                val isHours = match.groupValues[2].lowercase().startsWith("h")
+                minutes += if (isHours) value * 60 else value
+            }
+            return minutes.toInt().takeIf { it > 0 }
+        }
 
         fun parseDuration(iso8601: String?): Int? {
             if (iso8601 == null) return null

--- a/client/browser/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/browser/impl/RecipeExtractorServiceTest.kt
+++ b/client/browser/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/browser/impl/RecipeExtractorServiceTest.kt
@@ -52,6 +52,40 @@ class RecipeExtractorServiceTest {
 
     // endregion
 
+    // region parseLooseDuration
+
+    @Test
+    fun parseLooseDuration_null_returns_null() {
+        RecipeExtractorServiceImpl.parseLooseDuration(null) shouldBe null
+    }
+
+    @Test
+    fun parseLooseDuration_hours_only() {
+        RecipeExtractorServiceImpl.parseLooseDuration("1 hour") shouldBe 60
+    }
+
+    @Test
+    fun parseLooseDuration_hours_and_minutes() {
+        RecipeExtractorServiceImpl.parseLooseDuration("1 hr 20 min") shouldBe 80
+    }
+
+    @Test
+    fun parseLooseDuration_fractional_hours() {
+        RecipeExtractorServiceImpl.parseLooseDuration("1.5 hours") shouldBe 90
+    }
+
+    @Test
+    fun parseLooseDuration_ignores_trailing_plus_clause() {
+        RecipeExtractorServiceImpl.parseLooseDuration("1 hour, plus 8 hours chilling") shouldBe 60
+    }
+
+    @Test
+    fun parseLooseDuration_without_a_duration_returns_null() {
+        RecipeExtractorServiceImpl.parseLooseDuration("overnight") shouldBe null
+    }
+
+    // endregion
+
     // region HTML entity decoding
 
     @Test
@@ -122,6 +156,18 @@ class RecipeExtractorServiceTest {
             """{"@graph":[{"@type":"Recipe","name":"Soup &amp; Salad","recipeIngredient":[],"recipeInstructions":[]}]}"""
         val recipe = service.parseRecipeJsonText(json, SOURCE_URL)
         recipe?.title shouldBe "Soup & Salad"
+    }
+
+    @Test
+    fun When_recipe_yield_is_a_range_Then_the_lower_bound_is_used() {
+        val json = """{"@type":"Recipe","name":"Chili","recipeYield":"6 to 8 servings"}"""
+        service.parseRecipeJsonText(json, SOURCE_URL)?.servings shouldBe 6
+    }
+
+    @Test
+    fun When_calories_are_comma_separated_Then_parsed_as_one_number() {
+        val json = """{"@type":"Recipe","name":"Feast","nutrition":{"calories":"1,240 kcal"}}"""
+        service.parseRecipeJsonText(json, SOURCE_URL)?.calories shouldBe 1240
     }
 
     // endregion
@@ -217,6 +263,116 @@ class RecipeExtractorServiceTest {
 
     private fun wprmIngredients(vararg groups: String): String =
         """<html><body>${groups.joinToString("")}</body></html>"""
+
+    // endregion
+
+    // region microdata / hrecipe fallback
+
+    @Test
+    fun When_page_has_no_json_ld_Then_hrecipe_markup_is_extracted() {
+        val recipe = service.parseMicrodataRecipe(JETPACK_RECIPE_PAGE, SOURCE_URL)
+
+        recipe?.title shouldBe "Baked Farro with Summer Vegetables"
+        recipe?.ingredients shouldBe
+            listOf("Olive oil", "Kosher salt", "1 cup (210 grams) uncooked farro")
+        recipe?.directions shouldBe
+            listOf(
+                "If you have an ovenproof 11-inch pan with a lid, use it here.",
+                "Heat your oven to 375°F.",
+                "Bake for 30 to 40 minutes, until the farro is cooked.",
+            )
+        recipe?.sourceUrl shouldBe SOURCE_URL
+    }
+
+    @Test
+    fun When_hrecipe_yield_is_a_range_Then_the_lower_bound_is_used() {
+        // "Servings: 6 to 8" — stripping non-digits would give a nonsense 68.
+        service.parseMicrodataRecipe(JETPACK_RECIPE_PAGE, SOURCE_URL)?.servings shouldBe 6
+    }
+
+    @Test
+    fun When_hrecipe_time_is_prose_Then_it_is_read_as_english() {
+        // The Jetpack shortcode puts prose in datetime, so ISO-8601 parsing can't apply.
+        service.parseMicrodataRecipe(JETPACK_RECIPE_PAGE, SOURCE_URL)?.totalTime shouldBe 60
+    }
+
+    @Test
+    fun When_hrecipe_has_no_image_or_description_Then_open_graph_tags_are_used() {
+        val recipe = service.parseMicrodataRecipe(JETPACK_RECIPE_PAGE, SOURCE_URL)
+
+        recipe?.imageUrl shouldBe "https://example.com/farro.jpg"
+        recipe?.description shouldBe "A pinnacle-of-summer baked grain dish."
+    }
+
+    @Test
+    fun When_page_has_no_recipe_markup_at_all_Then_returns_null() {
+        val html = "<html><body><p>Just a blog post.</p></body></html>"
+        service.parseMicrodataRecipe(html, SOURCE_URL) shouldBe null
+    }
+
+    @Test
+    fun When_recipe_root_has_no_ingredients_or_directions_Then_returns_null() {
+        val html =
+            """<html><body><div class="hrecipe"><h3 class="fn">Just a title</h3></div></body></html>"""
+        service.parseMicrodataRecipe(html, SOURCE_URL) shouldBe null
+    }
+
+    @Test
+    fun When_directions_use_list_items_Then_each_becomes_a_step() {
+        val html =
+            """
+            |<html><body><div class="hrecipe">
+            |<li class="ingredient">1 cup flour</li>
+            |<ol class="instructions"><li>Mix it.</li><li>Bake it.</li></ol>
+            |</div></body></html>
+            """
+                .trimMargin()
+
+        service.parseMicrodataRecipe(html, SOURCE_URL)?.directions shouldBe
+            listOf("Mix it.", "Bake it.")
+    }
+
+    @Test
+    fun When_directions_are_separated_by_line_breaks_Then_each_becomes_a_step() {
+        val html =
+            """
+            |<html><body><div class="hrecipe">
+            |<li class="ingredient">1 cup flour</li>
+            |<div class="instructions">Mix it.<br>Bake it.</div>
+            |</div></body></html>
+            """
+                .trimMargin()
+
+        service.parseMicrodataRecipe(html, SOURCE_URL)?.directions shouldBe
+            listOf("Mix it.", "Bake it.")
+    }
+
+    @Test
+    fun When_a_json_ld_script_is_malformed_Then_it_does_not_break_extraction() {
+        service.parseRecipeJsonText("{ not json", SOURCE_URL) shouldBe null
+    }
+
+    /**
+     * Mirrors the markup Smitten Kitchen (and other Jetpack Recipe shortcode blogs) publishes:
+     * schema.org microdata plus hrecipe classes, no JSON-LD, and WordPress's auto-paragraph
+     * mangling that leaves the first direction unwrapped and `<p>` tags interleaved with `</div>`.
+     */
+    private val JETPACK_RECIPE_PAGE =
+        """
+        |<html><head>
+        |<meta property="og:description" content="A pinnacle-of-summer baked grain dish." />
+        |<meta property="og:image" content="https://example.com/farro.jpg" />
+        |</head><body>
+        |<div class="hrecipe h-recipe jetpack-recipe" itemscope itemtype="https://schema.org/Recipe"><h3 class="p-name jetpack-recipe-title fn" itemprop="name">Baked Farro with Summer Vegetables</h3><ul class="jetpack-recipe-meta"><li class="jetpack-recipe-servings p-yield yield" itemprop="recipeYield"><strong>Servings: </strong>6 to 8</li><li class="jetpack-recipe-time"><time itemprop="totalTime" datetime="1 hour, plus chopping"><strong>Time:</strong> <span class="time">1 hour, plus chopping</span></time></li></ul><div class="jetpack-recipe-content"></p>
+        |<p><div class="jetpack-recipe-ingredients"><ul><li class="jetpack-recipe-ingredient p-ingredient ingredient" itemprop="recipeIngredient">Olive oil</li><li class="jetpack-recipe-ingredient p-ingredient ingredient" itemprop="recipeIngredient">Kosher salt</li><li class="jetpack-recipe-ingredient p-ingredient ingredient" itemprop="recipeIngredient">1 cup (210 grams) uncooked farro</li></ul></div></p>
+        |<p><div class="jetpack-recipe-directions e-instructions">If you have an ovenproof 11-inch pan with a lid, use it here.</p>
+        |<p>Heat your oven to 375°F.</p>
+        |<p>Bake for 30 to 40 minutes, until the farro is cooked.</p>
+        |<p></div></p>
+        |<p></div></div>
+        |</body></html>
+        """
+            .trimMargin()
 
     // endregion
 


### PR DESCRIPTION
Fixes #509 — https://smittenkitchen.com/2021/08/baked-farro-with-summer-vegetables/ failed to extract.

## Why it failed

`RecipeExtractorService` only understood JSON-LD (`<script type="application/ld+json">`). Smitten Kitchen publishes **zero** JSON-LD — it uses the Jetpack Recipe shortcode, which emits schema.org **microdata** (`itemtype="https://schema.org/Recipe"`, `itemprop="recipeIngredient"`) plus **hrecipe/h-recipe microformat** classes. The scripts loop found nothing and threw "No recipe data found on this page".

This affects every WordPress.com-hosted blog using that shortcode, not just this one URL.

## What changed

A microdata/microformat fallback that runs only when no JSON-LD recipe is found — so no behavior change for the sites that already work.

- Locates the recipe root via `[itemtype*=schema.org/Recipe]`, `.hrecipe`, or `.h-recipe`, then reads name/ingredients/instructions/yield/times from both the `itemprop` attributes and the microformat class names.
- Falls back to `og:image` / `og:description` / `og:title` when the recipe block itself carries none.
- Returns `null` when the root matches but has no ingredients *and* no directions, so unrelated markup can't produce an empty recipe.

Two details worth a reviewer's attention:

**Directions are split by block-level child, not by `select("p")`.** WordPress's auto-paragraph mangling leaves the first step as a bare text node with `<p>` tags interleaved across `</div>` boundaries — the raw markup really is `<div class="...e-instructions">First step.</p><p>Second step.</p>`. A `<p>` query silently drops step one. `textBlocks()` walks child nodes and flushes on block boundaries instead, which also handles `<li>`- and `<br>`-separated directions.

**Durations get a lenient English parser.** The shortcode writes prose into the attribute (`datetime="1 hour, plus chopping"`), so ISO-8601 parsing can't apply. `parseLooseDuration` reads it as English and stops at a trailing `plus …` clause, since that describes unattended time that shouldn't land in the total.

## Bugs fixed in passing

Both were on the existing JSON-LD path, so they affect sites that already extract today:

- **Servings/calories stripped every non-digit**, so a yield of `"6 to 8"` became **68**. Now takes the leading number (`6`); `"1,240 kcal"` → `1240`.
- **A single malformed or oddly-shaped `ld+json` block threw out of the whole extraction.** It now returns null for that block and continues. This is also what lets the new fallback get a turn on a page carrying both a broken JSON-LD blob and usable microdata.

## Testing

Ran the parser against the **live** page: all 17 ingredients, all 8 directions, title, servings 6, total time 60 min, and the image extract correctly. Also checked two other Smitten Kitchen recipes (blueberry muffins, chocolate pudding) — both clean — and a 2007 post with no recipe card at all, which correctly returns `null`.

39 tests in `RecipeExtractorServiceTest` (17 new), green on both JVM and iOS simulator; the whole `:client:browser:impl` suite passes. The test fixture reproduces the real broken-nesting markup rather than an idealized version of it, so it actually exercises the `<p>`-mangling case.

No UI changed, so no snapshot or robot test updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
