### PR TITLE
feat(fastlane): automate store listing screenshot deployment to Play and App Store

### DIFF
--- a/.agents/seed.md
+++ b/.agents/seed.md
@@ -35,6 +35,9 @@ This file provides shared guidance to Claude Code and Codex when working with co
 # Snapshot tests (record then verify)
 ./gradlew :client:ui:screenshot-test:updateDebugScreenshotTest
 ./gradlew :client:ui:screenshot-test:validateDebugScreenshotTest
+
+# Store listing screenshots (renders the Play + App Store art from the Compose previews)
+./gradlew :client:ui:store-screenshots:collectStoreScreenshots
 ```
 
 For iOS, open `/iosApp` in Xcode or use the IDE run configuration.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 client/ui/screenshot-test/src/screenshotTest*/reference/**/*.png filter=lfs diff=lfs merge=lfs -text
+fastlane/metadata/android/*/images/**/*.png filter=lfs diff=lfs merge=lfs -text
+fastlane/screenshots/**/*.png filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/store-screenshots.yml
+++ b/.github/workflows/store-screenshots.yml
@@ -1,0 +1,81 @@
+name: Store Screenshots
+
+# Renders the store listing screenshots from the Compose previews and uploads them to the Play
+# Store and/or App Store Connect.
+#
+# Deliberately manual and separate from the release workflows: a listing update changes what every
+# visitor to the storefront sees, on a completely different cadence from a binary release.
+#
+# No macOS runner is needed. The screenshots come from the Compose preview renderer (pure JVM) and
+# both upload paths are Ruby against the stores' web APIs — Xcode is never involved.
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Which store listing to update
+        type: choice
+        default: both
+        options: [both, android, ios]
+      publish:
+        description: "Publish for real. Leave off to render, validate with Google, and just upload the assets as an artifact."
+        type: boolean
+        default: false
+      refresh:
+        description: Re-render from the Compose previews instead of using the committed assets
+        type: boolean
+        default: true
+
+jobs:
+  screenshots:
+    name: Store screenshots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+
+      - name: Render screenshots
+        if: inputs.refresh
+        run: ./gradlew :client:ui:store-screenshots:collectStoreScreenshots
+
+      # Uploaded before any store call so the assets can be eyeballed even when a later step
+      # rejects them — and so a dry run still produces something reviewable.
+      - name: Upload rendered assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: store-screenshots
+          path: |
+            fastlane/metadata/android/*/images/
+            fastlane/screenshots/
+
+      - name: Show what changed
+        if: inputs.refresh
+        run: git --no-pager diff --stat -- fastlane/metadata fastlane/screenshots
+
+      - name: Play Store listing
+        if: inputs.platform == 'both' || inputs.platform == 'android'
+        env:
+          SUPPLY_JSON_KEY_DATA: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          STORE_SCREENSHOTS_UPLOAD: ${{ inputs.publish }}
+        run: bundle exec fastlane android screenshots
+
+      - name: App Store Connect listing
+        if: inputs.platform == 'both' || inputs.platform == 'ios'
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.ASC_API_KEY }}
+          STORE_SCREENSHOTS_UPLOAD: ${{ inputs.publish }}
+        run: bundle exec fastlane ios screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,13 @@ keystore.properties
 # Fastlane
 fastlane/report.xml
 fastlane/Preview.html
-fastlane/screenshots/
 fastlane/test_output/
+# fastlane/screenshots and fastlane/metadata/**/images hold the generated store listing art. They
+# are committed (via LFS) so the assets can be reviewed in a PR and uploaded without a Gradle build.
+
+# Intermediate renders behind those assets — collectStoreScreenshots turns these into the trees
+# above, so only the collected output is worth tracking.
+client/ui/store-screenshots/src/screenshotTestDebug/
 
 # Bundler
 vendor/bundle/

--- a/client/ui/store-screenshots/build.gradle.kts
+++ b/client/ui/store-screenshots/build.gradle.kts
@@ -1,0 +1,209 @@
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.Serializable
+import javax.imageio.ImageIO
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.androidBuiltInKotlin)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.screenshot)
+    alias(libs.plugins.plusKtfmt)
+}
+
+android {
+    namespace = "com.plusmobileapps.chefmate.ui.storescreenshots"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+    defaultConfig { minSdk = libs.versions.android.minSdk.get().toInt() }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    buildFeatures { compose = true }
+
+    experimentalProperties["android.experimental.enableScreenshotTest"] = true
+}
+
+kotlin { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } }
+
+dependencies {
+    implementation(project(":client:ui:public"))
+    implementation(project(":client:text:public"))
+    implementation(project(":client:aichat:public"))
+    implementation(project(":client:aichat:impl"))
+    implementation(project(":client:cook:public"))
+    implementation(project(":client:cook:impl"))
+    implementation(project(":client:grocery:core:public"))
+    implementation(project(":client:grocery:core:impl"))
+    implementation(project(":client:grocery:autocomplete:public"))
+    implementation(project(":client:meal:core:public"))
+    implementation(project(":client:meal:core:impl"))
+    implementation(project(":client:meal:data:public"))
+    implementation(project(":client:recipe:core:public"))
+    implementation(project(":client:recipe:core:impl"))
+    implementation(project(":client:recipe:data:public"))
+    implementation(project(":client:recipe:list:public"))
+    implementation(project(":client:recipe:list:impl"))
+    implementation(project(":client:toast:public"))
+    implementation(project(":client:toast:testing"))
+    implementation(libs.arkivanov.decompose.core)
+
+    screenshotTestImplementation(libs.screenshot.validation.api)
+    screenshotTestImplementation(libs.androidx.compose.ui.tooling)
+}
+
+// ── Store asset collection ─────────────────────────────────────────────────
+//
+// `updateDebugScreenshotTest` renders every @PreviewTest in this module into
+// src/screenshotTestDebug/reference/. Those PNGs are intermediates (gitignored) — this task turns
+// them into the two asset trees fastlane uploads from, and is the single place that enforces the
+// stores' hard requirements so a bad asset fails the build instead of a release.
+
+/** A store screenshot slot: which previews feed it, how big they must be, and where they land. */
+data class StoreSlot(
+    /** Function-name prefix in StoreScreenshots.kt. */
+    val prefix: String,
+    val expectedWidth: Int,
+    val expectedHeight: Int,
+    /** Prepended to the output file name; keeps the two Apple slots apart in one flat folder. */
+    val fileNamePrefix: String,
+    val minCount: Int,
+    val maxCount: Int,
+) : Serializable // Gradle fingerprints @Input values, which requires Java serialization.
+
+abstract class CollectStoreScreenshotsTask : DefaultTask() {
+
+    @get:InputDirectory abstract val renderedDir: DirectoryProperty
+
+    @get:OutputDirectory abstract val playPhoneDir: DirectoryProperty
+
+    @get:OutputDirectory abstract val playTabletDir: DirectoryProperty
+
+    @get:OutputDirectory abstract val appStoreDir: DirectoryProperty
+
+    @get:Input abstract val slots: MapProperty<String, StoreSlot>
+
+    @TaskAction
+    fun collect() {
+        val outputs =
+            mapOf(
+                "PlayPhone" to playPhoneDir.get().asFile,
+                "PlayTablet" to playTabletDir.get().asFile,
+                "IosPhone" to appStoreDir.get().asFile,
+                "IosTablet" to appStoreDir.get().asFile,
+            )
+        // Wipe first so a scene that was deleted from StoreScreenshots.kt also disappears from the
+        // store listing on the next upload, instead of lingering as an orphan file.
+        outputs.values.distinct().forEach { dir ->
+            dir.listFiles()?.filter { it.extension == "png" }?.forEach { it.delete() }
+            dir.mkdirs()
+        }
+
+        val namePattern = Regex("""^([A-Za-z]+?)(\d{2})([A-Za-z0-9]*)_[0-9a-f]+_\d+\.png$""")
+        val collected = mutableMapOf<String, MutableList<Int>>()
+        val rendered =
+            renderedDir.get().asFile.walkTopDown().filter { it.isFile && it.extension == "png" }
+
+        rendered.forEach { source ->
+            val match =
+                namePattern.matchEntire(source.name)
+                    ?: throw GradleException(
+                        "Unrecognised store screenshot '${source.name}'. Preview functions in " +
+                            "StoreScreenshots.kt must be named <Target><NN><Scene>, e.g. " +
+                            "PlayPhone01Recipes."
+                    )
+            val (prefix, index, scene) = match.destructured
+            val slot =
+                slots.get()[prefix]
+                    ?: throw GradleException(
+                        "'${source.name}' targets unknown slot '$prefix'. Known slots: " +
+                            slots.get().keys.sorted().joinToString()
+                    )
+
+            val image = ImageIO.read(source)
+            if (image.width != slot.expectedWidth || image.height != slot.expectedHeight) {
+                throw GradleException(
+                    "${source.name} rendered ${image.width}×${image.height}, but the $prefix slot " +
+                        "requires exactly ${slot.expectedWidth}×${slot.expectedHeight}. Check the " +
+                        "device spec in StoreDevices.kt — the renderer snaps `dpi` to the nearest " +
+                        "standard density bucket, so an off-bucket value is silently ignored."
+                )
+            }
+
+            val ordinals = collected.getOrPut(prefix) { mutableListOf() }
+            val ordinal = index.toInt()
+            if (ordinal in ordinals) {
+                throw GradleException(
+                    "Two $prefix previews both claim position $index. Each scene needs a unique " +
+                        "two-digit index within a slot."
+                )
+            }
+            ordinals += ordinal
+
+            // Play requires "24-bit PNG (no alpha)" and the renderer emits 32-bit RGBA, so flatten
+            // onto white. Apple accepts either, and uploading one format to both keeps the two
+            // trees byte-identical for a given scene.
+            val flattened = BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_RGB)
+            flattened.createGraphics().apply {
+                color = Color.WHITE
+                fillRect(0, 0, image.width, image.height)
+                drawImage(image, 0, 0, null)
+                dispose()
+            }
+
+            val snakeScene =
+                scene.replace(Regex("(?<=[a-z0-9])(?=[A-Z])"), "_").lowercase().ifEmpty { "scene" }
+            val target =
+                File(outputs.getValue(prefix), "${slot.fileNamePrefix}${index}_$snakeScene.png")
+            ImageIO.write(flattened, "png", target)
+            logger.lifecycle("store screenshot: ${target.name} (${image.width}×${image.height})")
+        }
+
+        slots.get().forEach { (prefix, slot) ->
+            val count = collected[prefix]?.size ?: 0
+            if (count < slot.minCount || count > slot.maxCount) {
+                throw GradleException(
+                    "The $prefix slot has $count screenshot(s); the store requires between " +
+                        "${slot.minCount} and ${slot.maxCount}. Add or remove $prefix* previews " +
+                        "in StoreScreenshots.kt."
+                )
+            }
+        }
+    }
+}
+
+val storeSlots =
+    mapOf(
+        // Play phone: no aspect-ratio rule, 320–3840px per side, longer side ≤ 2× shorter.
+        "PlayPhone" to StoreSlot("PlayPhone", 1080, 2100, "", minCount = 2, maxCount = 8),
+        // Play 10" tablet: must be exactly 9:16 portrait with the short side ≥ 1080px, and Google
+        // asks for at least 4 to demonstrate the large-screen experience.
+        "PlayTablet" to StoreSlot("PlayTablet", 1440, 2560, "", minCount = 4, maxCount = 8),
+        // App Store Connect resolves the device slot from the pixel size alone.
+        "IosPhone" to StoreSlot("IosPhone", 1320, 2868, "iphone_6_9_", minCount = 1, maxCount = 10),
+        "IosTablet" to StoreSlot("IosTablet", 2064, 2752, "ipad_13_", minCount = 1, maxCount = 10),
+    )
+
+// The only locale with a translated strings.xml. Add a locale here (and a matching render pass)
+// when the app actually ships one — uploading en-US art under another locale is worse than
+// leaving that locale to inherit the default listing.
+val storeLocale = "en-US"
+
+val fastlaneDir = rootProject.layout.projectDirectory.dir("fastlane")
+
+tasks.register<CollectStoreScreenshotsTask>("collectStoreScreenshots") {
+    group = "publishing"
+    description = "Render the store listing screenshots and lay them out for supply + deliver."
+
+    dependsOn("updateDebugScreenshotTest")
+
+    renderedDir.set(layout.projectDirectory.dir("src/screenshotTestDebug/reference"))
+    playPhoneDir.set(fastlaneDir.dir("metadata/android/$storeLocale/images/phoneScreenshots"))
+    playTabletDir.set(fastlaneDir.dir("metadata/android/$storeLocale/images/tenInchScreenshots"))
+    appStoreDir.set(fastlaneDir.dir("screenshots/$storeLocale"))
+    slots.set(storeSlots)
+}

--- a/client/ui/store-screenshots/src/main/AndroidManifest.xml
+++ b/client/ui/store-screenshots/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/client/ui/store-screenshots/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/storescreenshots/StoreDevices.kt
+++ b/client/ui/store-screenshots/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/storescreenshots/StoreDevices.kt
@@ -1,0 +1,37 @@
+package com.plusmobileapps.chefmate.ui.storescreenshots
+
+/**
+ * Preview device specs whose rendered pixel size is exactly what each store slot requires.
+ *
+ * The preview renderer rasterises at the device's full density, so the output pixel size is `dp *
+ * (dpi / 160)`. Every spec below is chosen so that product is an exact integer — if you change one,
+ * keep it exact, because `collectStoreScreenshots` fails the build on any image whose dimensions
+ * don't match its slot to the pixel.
+ *
+ * **Only standard Android density buckets survive.** The renderer snaps `dpi` to the nearest
+ * bucket, so an off-bucket value is silently ignored and the image comes out the wrong size:
+ * `dpi=400` rendered at 420 (density 2.625) and produced 1134×2016 instead of 1080×1920. Stick to
+ * 160 / 240 / 320 / 480 / 640.
+ *
+ * Store constraints these satisfy:
+ * * **Play phone** has no aspect-ratio rule — only 320–3840px per side, with the longer side no
+ *   more than twice the shorter. **Play 10" tablet** does require exactly 9:16 portrait, with the
+ *   shortest side ≥ 1080px.
+ * * **App Store Connect** matches a screenshot to a device slot by its pixel size alone. 2064×2752
+ *   is used for the iPad rather than 2048×2732 because fastlane lists the latter as ambiguous
+ *   between "iPad Pro 12.9"" and "iPad 13"" and refuses to guess.
+ */
+internal object StoreDevices {
+
+    /** Play "Phone" slot — 1080 × 2100 (1.94:1, safely inside Play's 2× cap). */
+    const val PLAY_PHONE = "spec:width=360dp,height=700dp,dpi=480"
+
+    /** Play "10-inch tablet" slot — 1440 × 2560 (9:16, shortest side ≥ 1080). */
+    const val PLAY_TABLET = "spec:width=720dp,height=1280dp,dpi=320"
+
+    /** App Store 6.9" iPhone slot — 1320 × 2868 (iPhone 16 Pro Max, 440 × 956 pt @3x). */
+    const val IOS_PHONE = "spec:width=440dp,height=956dp,dpi=480"
+
+    /** App Store 13" iPad slot — 2064 × 2752 (iPad Pro 13", 1032 × 1376 pt @2x). */
+    const val IOS_TABLET = "spec:width=1032dp,height=1376dp,dpi=320"
+}

--- a/client/ui/store-screenshots/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/storescreenshots/StoreScreenshots.kt
+++ b/client/ui/store-screenshots/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/storescreenshots/StoreScreenshots.kt
@@ -1,0 +1,192 @@
+package com.plusmobileapps.chefmate.ui.storescreenshots
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.aichat.impl.ui.previewAiChatBloc
+import com.plusmobileapps.chefmate.cook.impl.ui.previewCookBlocStacked
+import com.plusmobileapps.chefmate.grocery.core.impl.list.ui.previewGroceryListBloc
+import com.plusmobileapps.chefmate.meal.core.impl.ui.previewMealPlanBloc
+import com.plusmobileapps.chefmate.recipe.core.detail.RecipeDetailScreen
+import com.plusmobileapps.chefmate.recipe.core.detail.previewRecipeDetailBloc
+import com.plusmobileapps.chefmate.recipe.list.impl.ui.previewRecipeListBloc
+import com.plusmobileapps.chefmate.toast.LocalToastService
+import com.plusmobileapps.chefmate.toast.testing.FakeToastService
+import com.plusmobileapps.chefmate.ui.Content
+import com.plusmobileapps.chefmate.ui.theme.ChefMateTheme
+
+/**
+ * Store listing screenshots, rendered from the same public preview Blocs the regression snapshot
+ * suite in `:client:ui:screenshot-test` uses. `collectStoreScreenshots` turns the rendered PNGs
+ * into the Play and App Store Connect asset trees that fastlane uploads.
+ *
+ * **Function names are load-bearing.** `collectStoreScreenshots` parses each as
+ * `<Target><NN><Scene>` — the target picks the store slot, `NN` orders the screenshot within that
+ * slot, and `Scene` becomes the file name. Keep a scene at the same `NN` across all four targets so
+ * both stores tell the same story in the same order.
+ *
+ * These are marketing assets, not regression tests: there are no committed reference images to diff
+ * against, and nothing here runs on PRs. Adding a scene means adding all four wrappers.
+ */
+@Composable
+private fun Scene(content: @Composable () -> Unit) {
+    ChefMateTheme {
+        CompositionLocalProvider(LocalToastService provides FakeToastService()) {
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = MaterialTheme.colorScheme.background,
+            ) {
+                content()
+            }
+        }
+    }
+}
+
+// ── 01 · Recipe library ────────────────────────────────────────────────────
+
+@Composable private fun Recipes() = Scene { previewRecipeListBloc.Content() }
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_PHONE)
+@Composable
+fun PlayPhone01Recipes() = Recipes()
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_TABLET)
+@Composable
+fun PlayTablet01Recipes() = Recipes()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_PHONE)
+@Composable
+fun IosPhone01Recipes() = Recipes()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_TABLET)
+@Composable
+fun IosTablet01Recipes() = Recipes()
+
+// ── 02 · Recipe detail ─────────────────────────────────────────────────────
+
+// RecipeDetailScreen reads LocalToastService.current directly, so `Scene` must provide it for the
+// screen to compose at all.
+@Composable
+private fun RecipeDetail() = Scene { RecipeDetailScreen(bloc = previewRecipeDetailBloc) }
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_PHONE)
+@Composable
+fun PlayPhone02RecipeDetail() = RecipeDetail()
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_TABLET)
+@Composable
+fun PlayTablet02RecipeDetail() = RecipeDetail()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_PHONE)
+@Composable
+fun IosPhone02RecipeDetail() = RecipeDetail()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_TABLET)
+@Composable
+fun IosTablet02RecipeDetail() = RecipeDetail()
+
+// ── 03 · Cook mode ─────────────────────────────────────────────────────────
+
+@Composable private fun CookMode() = Scene { previewCookBlocStacked.Content() }
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_PHONE)
+@Composable
+fun PlayPhone03CookMode() = CookMode()
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_TABLET)
+@Composable
+fun PlayTablet03CookMode() = CookMode()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_PHONE)
+@Composable
+fun IosPhone03CookMode() = CookMode()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_TABLET)
+@Composable
+fun IosTablet03CookMode() = CookMode()
+
+// ── 04 · Grocery list ──────────────────────────────────────────────────────
+
+@Composable private fun GroceryList() = Scene { previewGroceryListBloc.Content() }
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_PHONE)
+@Composable
+fun PlayPhone04GroceryList() = GroceryList()
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_TABLET)
+@Composable
+fun PlayTablet04GroceryList() = GroceryList()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_PHONE)
+@Composable
+fun IosPhone04GroceryList() = GroceryList()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_TABLET)
+@Composable
+fun IosTablet04GroceryList() = GroceryList()
+
+// ── 05 · Meal plan ─────────────────────────────────────────────────────────
+
+@Composable private fun MealPlan() = Scene { previewMealPlanBloc.Content() }
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_PHONE)
+@Composable
+fun PlayPhone05MealPlan() = MealPlan()
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_TABLET)
+@Composable
+fun PlayTablet05MealPlan() = MealPlan()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_PHONE)
+@Composable
+fun IosPhone05MealPlan() = MealPlan()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_TABLET)
+@Composable
+fun IosTablet05MealPlan() = MealPlan()
+
+// ── 06 · AI chat ───────────────────────────────────────────────────────────
+
+@Composable private fun AiChat() = Scene { previewAiChatBloc.Content() }
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_PHONE)
+@Composable
+fun PlayPhone06AiChat() = AiChat()
+
+@PreviewTest
+@Preview(device = StoreDevices.PLAY_TABLET)
+@Composable
+fun PlayTablet06AiChat() = AiChat()
+
+@PreviewTest @Preview(device = StoreDevices.IOS_PHONE) @Composable fun IosPhone06AiChat() = AiChat()
+
+@PreviewTest
+@Preview(device = StoreDevices.IOS_TABLET)
+@Composable
+fun IosTablet06AiChat() = AiChat()

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,6 +21,8 @@ Either way, the tag triggers three independent workflows that run in parallel:
 
 All workflows also support manual triggering via the "Run workflow" button in the GitHub Actions UI (`workflow_dispatch`).
 
+Store **listing screenshots** are deployed separately, on their own cadence — see [Store Listing Screenshots](#store-listing-screenshots).
+
 ### Desktop update strategy
 
 Desktop distribution + updates depend on platform:
@@ -711,6 +713,59 @@ CLI flags are also available for non-interactive use:
 ./scripts/bump-version.sh --version 1.0.0 --build-number 1 # set both
 ```
 
+## Store Listing Screenshots
+
+The phone/tablet screenshots on the Play Store and App Store listings are **generated from the same Compose previews that back the snapshot tests**, not captured by hand. One Kotlin source produces both stores' assets, so there is no XCUITest target and no simulator involved — the whole pipeline runs on a Linux runner.
+
+### How it works
+
+1. `client/ui/store-screenshots` is a screenshot-test module (same `com.android.compose.screenshot` plugin as `client/ui/screenshot-test`, kept separate so 24 large marketing renders don't slow down the PR-gating snapshot job). `StoreScreenshots.kt` declares one `@PreviewTest` per **scene × store slot**, reusing the public `previewXxxBloc` values.
+2. `collectStoreScreenshots` renders them, then validates and lays out the assets.
+3. `fastlane android screenshots` / `fastlane ios screenshots` upload them.
+
+```bash
+./gradlew :client:ui:store-screenshots:collectStoreScreenshots
+```
+
+That rewrites the two committed asset trees — review the diff before committing:
+
+| Slot | Committed to | Pixels |
+|------|--------------|--------|
+| Play phone | `fastlane/metadata/android/en-US/images/phoneScreenshots/` | 1080 × 2100 |
+| Play 10" tablet | `fastlane/metadata/android/en-US/images/tenInchScreenshots/` | 1440 × 2560 |
+| App Store 6.9" iPhone | `fastlane/screenshots/en-US/iphone_6_9_*.png` | 1320 × 2868 |
+| App Store 13" iPad | `fastlane/screenshots/en-US/ipad_13_*.png` | 2064 × 2752 |
+
+The PNGs are tracked in Git LFS, like the snapshot references. The intermediate renders under `client/ui/store-screenshots/src/screenshotTestDebug/` are gitignored.
+
+### Adding or changing a scene
+
+Add all four wrappers (`PlayPhone`, `PlayTablet`, `IosPhone`, `IosTablet`) at the same two-digit index, so both stores tell the same story in the same order. `collectStoreScreenshots` derives the file name and ordering from the function name — `PlayPhone04GroceryList` becomes `04_grocery_list.png` — and fails the build on an unparseable name, a duplicate index, a wrong pixel size, or a slot count outside the store's limits.
+
+Two constraints are easy to trip over and are enforced for you:
+
+- **The preview renderer snaps `dpi` to the nearest standard density bucket.** An off-bucket value is silently ignored — `dpi=400` renders at 420 and produces 1134×2016 instead of 1080×1920. Stick to 160 / 240 / 320 / 480 / 640 in `StoreDevices.kt`.
+- **Play requires 24-bit PNG with no alpha**, and the renderer emits 32-bit RGBA. The collector flattens onto white.
+
+The two stores need genuinely different sizes, so renders cannot be shared: Play caps the longer side at twice the shorter, while Apple's 6.9" iPhone slot is 2.17:1.
+
+### Uploading
+
+Uploads run from the **Store Screenshots** workflow (`store-screenshots.yml`), triggered manually with a platform choice and a `publish` toggle. Every lane no-ops unless `STORE_SCREENSHOTS_UPLOAD=true`, so the default run is a dry run: it renders, uploads the assets as a build artifact for review, and asks Google to *validate* the listing edit without committing it.
+
+Screenshot upload is intentionally **not** part of the `release` lanes. A listing update and a binary release have different cadences and different blast radii — folding them together would push marketing art on every TestFlight build and let a rejected screenshot fail an unrelated release.
+
+Locally:
+
+```bash
+bundle exec fastlane android screenshots refresh:true
+```
+
+Two things to know before publishing for real:
+
+- **App Store Connect needs an editable version.** Screenshots attach to the version in "Prepare for Submission"; with no editable version the lane fails rather than touching the live listing.
+- **`overwrite_screenshots` clears every slot first, including Apple Watch.** Chef Mate ships a watchOS companion whose screenshots can't be rendered from Compose, so re-add those in App Store Connect afterwards — or drop watch-sized PNGs into `fastlane/screenshots/en-US/`, where `deliver` picks them up by resolution.
+
 ## Known Limitations
 
 - **Windows MSI and Linux DEB are unsigned.** macOS ships a Store-signed `.pkg` to the Mac App Store (see [macOS: Mac App Store](#macos-mac-app-store)) and Windows ships via the Microsoft Store (Store-signed), so this only affects the fallback MSI and the Linux DEB.
@@ -718,3 +773,7 @@ CLI flags are also available for non-interactive use:
 - **MSStore CLI is in preview** — the `publish-store` job's action ref and `publish` flags should be verified against current docs on first real submission.
 - **Store releases lag** — Microsoft Store certification review delays Windows releases relative to the GitHub Release and mobile stores.
 - **R8/ProGuard is disabled** — Android release builds are not minified. Enabling R8 requires ProGuard rules for KMP libraries (Ktor, Supabase, kotlinx.serialization, Decompose).
+- **Store screenshots render Android chrome on the iOS slots.** They come from the Compose preview renderer, so the App Store images show Material components at iPhone/iPad dimensions rather than real iOS rendering. Acceptable because the app's UI is Compose Multiplatform everywhere, but it is not a true iOS capture.
+- **Store screenshots show placeholder recipe images.** The preview Blocs carry no bitmaps, so recipe thumbnails render as empty image icons. Give the preview Blocs real sample imagery before treating the generated assets as final marketing art.
+- **Store screenshots are raw screens** — no device frames and no caption text, which most polished listings have. `frameit` can add both, but it needs ImageMagick plus frame/caption assets that don't exist in this repo yet.
+- **Store listings are `en-US` only**, matching the single `values/strings.xml`. Other locales inherit the default listing.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,57 @@
 default_platform(:android)
 
+# ── Store listing screenshots ────────────────────────────────────────────────
+#
+# The screenshots are rendered from the same Compose previews that back the regression snapshot
+# suite (see :client:ui:store-screenshots) and are committed under fastlane/metadata (Play) and
+# fastlane/screenshots (App Store Connect). The Gradle task enforces each store's pixel sizes and
+# flattens the alpha channel, so by the time fastlane sees them they are already store-legal.
+#
+# Screenshot upload is deliberately NOT part of the `release` lanes. A listing update and a binary
+# release have different cadences and different blast radii — folding them together would push
+# marketing art on every TestFlight build, and would make a rejected screenshot fail a build that
+# had nothing to do with it.
+
+# Uploading replaces what customers see on the storefront, so every lane below no-ops unless this
+# is set. Mirrors the MAC_UPLOAD guard on the mac release lane.
+def screenshot_upload_enabled?
+  ENV["STORE_SCREENSHOTS_UPLOAD"] == "true"
+end
+
+desc "Re-render the store listing screenshots from the Compose previews."
+desc "Rewrites fastlane/metadata/android/**/images and fastlane/screenshots — commit the diff."
+lane :render_screenshots do
+  gradle(task: ":client:ui:store-screenshots:collectStoreScreenshots")
+end
+
 platform :android do
+  desc "Upload the Play Store listing screenshots (phone + 10\" tablet)."
+  desc "Pass refresh:true to re-render them from the Compose previews first."
+  desc "Set STORE_SCREENSHOTS_UPLOAD=true to actually publish; otherwise Google only validates."
+  lane :screenshots do |options|
+    render_screenshots if options.fetch(:refresh, false)
+
+    # validate_only sends the whole edit to Google and reports what it would reject, then discards
+    # it. That makes the default path a genuine server-side check rather than a local guess.
+    validate_only = !screenshot_upload_enabled?
+    UI.important("STORE_SCREENSHOTS_UPLOAD != true — validating with Google, not publishing.") if validate_only
+
+    supply(
+      package_name: "com.plusmobileapps.chefmate",
+      json_key_data: ENV["SUPPLY_JSON_KEY_DATA"],
+      metadata_path: "fastlane/metadata/android",
+      validate_only: validate_only,
+      # Listing art only: no binary, no store text, and no icon/feature-graphic (those aren't
+      # generated from Compose and are managed by hand in the Play Console).
+      skip_upload_aab: true,
+      skip_upload_apk: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: false,
+    )
+  end
+
   desc "Build release AAB and upload to Play Store internal track"
   lane :release do
     gradle(
@@ -214,6 +265,46 @@ platform :ios do
       readonly: false,
       force: options.fetch(:force, false),
       api_key: api_key,
+    )
+  end
+
+  desc "Upload the App Store listing screenshots (6.9\" iPhone + 13\" iPad)."
+  desc "Pass refresh:true to re-render them from the Compose previews first."
+  desc "Set STORE_SCREENSHOTS_UPLOAD=true to actually publish."
+  lane :screenshots do |options|
+    render_screenshots if options.fetch(:refresh, false)
+
+    unless screenshot_upload_enabled?
+      UI.important(
+        "STORE_SCREENSHOTS_UPLOAD != true — skipping the App Store Connect upload. " \
+        "#{Dir[File.expand_path('screenshots/en-US/*.png', __dir__)].count} screenshot(s) are ready to send."
+      )
+      next
+    end
+
+    # Screenshots attach to the version that is currently editable, so there must be a version in
+    # "Prepare for Submission" on the App Store Connect record. With no editable version this fails
+    # rather than silently updating the live listing.
+    #
+    # WARNING: overwrite_screenshots clears EVERY screenshot slot on that version before uploading,
+    # including the Apple Watch slot. Chef Mate ships a watchOS companion whose screenshots cannot
+    # be rendered from Compose, so re-add those in App Store Connect (or drop PNGs sized for a
+    # watch into fastlane/screenshots/en-US, where deliver will pick them up by resolution).
+    UI.important("overwrite_screenshots clears all slots first — re-check the Apple Watch screenshots afterwards.")
+
+    upload_to_app_store(
+      api_key: asc_api_key,
+      app_identifier: "com.plusmobileapps.chefmate.ChefMate",
+      screenshots_path: "fastlane/screenshots",
+      skip_binary_upload: true,
+      skip_metadata: true,
+      skip_screenshots: false,
+      overwrite_screenshots: true,
+      submit_for_review: false,
+      run_precheck_before_submit: false,
+      precheck_include_in_app_purchases: false,
+      # Skips deliver's interactive HTML preview confirmation, which would hang a CI run.
+      force: true,
     )
   end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -13,7 +13,32 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 # Available Actions
 
+### render_screenshots
+
+```sh
+[bundle exec] fastlane render_screenshots
+```
+
+Re-render the store listing screenshots from the Compose previews.
+
+Rewrites fastlane/metadata/android/**/images and fastlane/screenshots — commit the diff.
+
+----
+
+
 ## Android
+
+### android screenshots
+
+```sh
+[bundle exec] fastlane android screenshots
+```
+
+Upload the Play Store listing screenshots (phone + 10" tablet).
+
+Pass refresh:true to re-render them from the Compose previews first.
+
+Set STORE_SCREENSHOTS_UPLOAD=true to actually publish; otherwise Google only validates.
 
 ### android release
 
@@ -64,6 +89,18 @@ Generate/refresh signing certificates and provisioning profiles (read-write matc
 Run this once after adding an app id (e.g. the watch app) so its profile is registered.
 
 Pass force:true to regenerate profiles after enabling a new capability on an App ID.
+
+### ios screenshots
+
+```sh
+[bundle exec] fastlane ios screenshots
+```
+
+Upload the App Store listing screenshots (6.9" iPhone + 13" iPad).
+
+Pass refresh:true to re-render them from the Compose previews first.
+
+Set STORE_SCREENSHOTS_UPLOAD=true to actually publish.
 
 ### ios release
 

--- a/fastlane/metadata/android/en-US/images/phoneScreenshots/01_recipes.png
+++ b/fastlane/metadata/android/en-US/images/phoneScreenshots/01_recipes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5214291bc9bd8c28bc376fc78d1395ac814913881c74078aee484a6bbde4513e
+size 112770

--- a/fastlane/metadata/android/en-US/images/phoneScreenshots/02_recipe_detail.png
+++ b/fastlane/metadata/android/en-US/images/phoneScreenshots/02_recipe_detail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06f31e9101cf5fd9c9d99c5c2949e366029134743b5eee63d93f9d0d6a5d2aec
+size 133166

--- a/fastlane/metadata/android/en-US/images/phoneScreenshots/03_cook_mode.png
+++ b/fastlane/metadata/android/en-US/images/phoneScreenshots/03_cook_mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41eaf6ae43bfa41a88c6340587e30ea438404544b74497b3d641ff9904440ec2
+size 136486

--- a/fastlane/metadata/android/en-US/images/phoneScreenshots/04_grocery_list.png
+++ b/fastlane/metadata/android/en-US/images/phoneScreenshots/04_grocery_list.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7976de1057f46da64858a863b95f12baaaef20555c824f04398e27ecc6f09580
+size 55874

--- a/fastlane/metadata/android/en-US/images/phoneScreenshots/05_meal_plan.png
+++ b/fastlane/metadata/android/en-US/images/phoneScreenshots/05_meal_plan.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dab23e80b45d0a199d6d7cd6684b81a5555306ef8ede3107bdaf9479f1677dcc
+size 74813

--- a/fastlane/metadata/android/en-US/images/phoneScreenshots/06_ai_chat.png
+++ b/fastlane/metadata/android/en-US/images/phoneScreenshots/06_ai_chat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aa9b23d6d3996bebe20de2d83a3bd12c1fa85b860264589a9fb5bf0eb2373c3
+size 127865

--- a/fastlane/metadata/android/en-US/images/tenInchScreenshots/01_recipes.png
+++ b/fastlane/metadata/android/en-US/images/tenInchScreenshots/01_recipes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e94bc424b86d8efce5761270b3792e228a0301d0e4716eabc7764e32e1374f8
+size 79650

--- a/fastlane/metadata/android/en-US/images/tenInchScreenshots/02_recipe_detail.png
+++ b/fastlane/metadata/android/en-US/images/tenInchScreenshots/02_recipe_detail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:625563b880de104639148827fb169f496e9e45d1c2803b33f87b3336cbe6add4
+size 148564

--- a/fastlane/metadata/android/en-US/images/tenInchScreenshots/03_cook_mode.png
+++ b/fastlane/metadata/android/en-US/images/tenInchScreenshots/03_cook_mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2390a2e4b5db20d34a8a81f7d62da84a8c6824176664f43addd2379b621355c
+size 94175

--- a/fastlane/metadata/android/en-US/images/tenInchScreenshots/04_grocery_list.png
+++ b/fastlane/metadata/android/en-US/images/tenInchScreenshots/04_grocery_list.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f760289b788b7d510a69ff5c2656144972a315d1b07d8109c3a7ec3f569adc5
+size 47351

--- a/fastlane/metadata/android/en-US/images/tenInchScreenshots/05_meal_plan.png
+++ b/fastlane/metadata/android/en-US/images/tenInchScreenshots/05_meal_plan.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4449c452149f42335ff805b0feeee3fa18ff5fd17e8f6f61a9479d6984d1fbfa
+size 59012

--- a/fastlane/metadata/android/en-US/images/tenInchScreenshots/06_ai_chat.png
+++ b/fastlane/metadata/android/en-US/images/tenInchScreenshots/06_ai_chat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5155e7bd5376bdb6fb34cf4f7914bd877eec7bbd2f22ec337c79efa6777c6ad0
+size 88970

--- a/fastlane/screenshots/en-US/ipad_13_01_recipes.png
+++ b/fastlane/screenshots/en-US/ipad_13_01_recipes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d74c6cdf753c20d1bfb71a9eb198d9d25d0d10f284b1316f6614c5a48cd15b56
+size 86629

--- a/fastlane/screenshots/en-US/ipad_13_02_recipe_detail.png
+++ b/fastlane/screenshots/en-US/ipad_13_02_recipe_detail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c8625faee4928844c8c5de678965f9d6f7eefc4495feb954e9a69cb6f6080c
+size 156596

--- a/fastlane/screenshots/en-US/ipad_13_03_cook_mode.png
+++ b/fastlane/screenshots/en-US/ipad_13_03_cook_mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76ec858c0761113141865b1038e3d9500adaac24b6f7585635a88bf79166fbb5
+size 101416

--- a/fastlane/screenshots/en-US/ipad_13_04_grocery_list.png
+++ b/fastlane/screenshots/en-US/ipad_13_04_grocery_list.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d07a35c1c505a606d2d3db3151e625bf4482201de1ce005a1326bb8142eb017b
+size 52417

--- a/fastlane/screenshots/en-US/ipad_13_05_meal_plan.png
+++ b/fastlane/screenshots/en-US/ipad_13_05_meal_plan.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5723e48f575724d82aeb4c5a1c41218ee843cc756038f3dad87181af8a2d32ec
+size 64864

--- a/fastlane/screenshots/en-US/ipad_13_06_ai_chat.png
+++ b/fastlane/screenshots/en-US/ipad_13_06_ai_chat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4524420015617dd90789ba471244b2b2df95a32f655e16337a353da536a46cc1
+size 96487

--- a/fastlane/screenshots/en-US/iphone_6_9_01_recipes.png
+++ b/fastlane/screenshots/en-US/iphone_6_9_01_recipes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1c420917c937b74a187acf1f83c7d56a8cda7b107a4335dffa7c39e6868a752
+size 116497

--- a/fastlane/screenshots/en-US/iphone_6_9_02_recipe_detail.png
+++ b/fastlane/screenshots/en-US/iphone_6_9_02_recipe_detail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65d05ed2e767d1213d57b3710df96118e1dbdc70e0cf7ea5f32a400d71c8e27e
+size 194355

--- a/fastlane/screenshots/en-US/iphone_6_9_03_cook_mode.png
+++ b/fastlane/screenshots/en-US/iphone_6_9_03_cook_mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd4a4b9f3551af03dbb47e5455a6adcf0b0daaab6d1c11bec58d2b186ff293e2
+size 139154

--- a/fastlane/screenshots/en-US/iphone_6_9_04_grocery_list.png
+++ b/fastlane/screenshots/en-US/iphone_6_9_04_grocery_list.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82ec6784b610a71db6f05a8ba3ebc3735e768ccd31ae4b543d33f9b8f2157bfb
+size 62491

--- a/fastlane/screenshots/en-US/iphone_6_9_05_meal_plan.png
+++ b/fastlane/screenshots/en-US/iphone_6_9_05_meal_plan.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd799c0e6342e4e1833c976215f5edbf2582c6fedda64f613405317489d0ef47
+size 80662

--- a/fastlane/screenshots/en-US/iphone_6_9_06_ai_chat.png
+++ b/fastlane/screenshots/en-US/iphone_6_9_06_ai_chat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c7dc1d88cdb15225f1f6da4432495beafcfdd8e8be1218890505770455bca04
+size 134746

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -229,3 +229,5 @@ include(":client:util:impl")
 include(":client:util:public")
 
 include(":client:util:testing")
+
+include(":client:ui:store-screenshots")


### PR DESCRIPTION
Generates the Play Store and App Store listing screenshots from the same Compose previews that back the snapshot suite, and uploads them via `supply` and `deliver`.

`iosApp` has no XCUITest target, so the canonical `fastlane snapshot` + `screengrab` route would have meant building simulator UI test flows from scratch for one platform and instrumented tests for the other. Driving both from the existing preview Blocs instead means one Kotlin source produces both stores' assets — and the entire pipeline, upload included, runs on `ubuntu-latest`.

## What changed

**`:client:ui:store-screenshots`** — a new screenshot-test module declaring 6 scenes × 4 store slots, reusing the public `previewXxxBloc` values. Kept separate from `:client:ui:screenshot-test` because these are 24 large marketing renders with no references to diff against; folding them in would slow every PR for assets that only change when the listing does.

**`collectStoreScreenshots`** — renders the previews and lays out both asset trees. Function names are the contract: `PlayPhone04GroceryList` becomes `04_grocery_list.png` in the Play phone slot. It fails the build on an unparseable name, a duplicate index, a wrong pixel size, or a slot count outside the store's limits.

| Slot | Committed to | Pixels |
|------|--------------|--------|
| Play phone | `fastlane/metadata/android/en-US/images/phoneScreenshots/` | 1080 × 2100 |
| Play 10" tablet | `fastlane/metadata/android/en-US/images/tenInchScreenshots/` | 1440 × 2560 |
| App Store 6.9" iPhone | `fastlane/screenshots/en-US/iphone_6_9_*.png` | 1320 × 2868 |
| App Store 13" iPad | `fastlane/screenshots/en-US/ipad_13_*.png` | 2064 × 2752 |

**Fastlane** — `render_screenshots`, `android screenshots`, `ios screenshots`, plus a manually triggered `store-screenshots.yml` with a platform choice and a `publish` toggle.

## Design notes for reviewers

**Screenshot upload is not part of the `release` lanes.** A listing update and a binary release have different cadences and different blast radii — bundling them would push marketing art on every TestFlight build and let a rejected screenshot fail an unrelated release.

**Both lanes no-op unless `STORE_SCREENSHOTS_UPLOAD=true`**, mirroring the existing `MAC_UPLOAD` guard. The default run is a genuine dry run: Google is asked to *validate* the listing edit and discard it, and the assets are uploaded as a build artifact for review.

**The assets are committed** (via Git LFS, like the snapshot references) so marketing art gets reviewed in a PR, and so the upload lanes stay fast without a Gradle build.

Two constraints worth knowing, both enforced in code:

- **The preview renderer snaps `dpi` to the nearest density bucket.** An off-bucket value is silently ignored — `dpi=400` rendered at 420 and produced 1134×2016 instead of 1080×1920. Stick to 160/240/320/480/640.
- **Play requires 24-bit PNG with no alpha** and the renderer emits 32-bit RGBA, so the collector flattens onto white.

The two stores can't share renders: Play caps the longer side at twice the shorter, while Apple's 6.9" slot is 2.17:1.

## Verification

- All 24 renders are pixel-exact for their slot, from a clean rebuild.
- `deliver` resolves the files to `APP_IPHONE_67` (6.9") and `APP_IPAD_PRO_3GEN_129` (13"), checked against the installed fastlane 2.235.0 gem. 2064×2752 is used for the iPad rather than 2048×2732 because fastlane lists the latter as ambiguous between two device slots and refuses to guess.
- Output verified 24-bit, no alpha.
- Negative test: a wrong-size asset fails the build with an actionable message.
- `:client:ui:screenshot-test:validateDebugScreenshotTest` still passes.

## Not verified

**Neither upload has run against a real store** — no Play service-account JSON or ASC key was available locally. The workflow's non-publish path is the safe first run.

## Known limitations (documented in `docs/deployment.md`)

- Recipe thumbnails render as empty placeholders — the preview Blocs carry no bitmaps. **Giving them real sample imagery is the highest-value follow-up before treating these as final marketing art.**
- The iOS slots show Material chrome, not real iOS rendering.
- No device frames or caption text; `frameit` would need ImageMagick plus assets that don't exist here yet.
- `en-US` only, matching the single `values/strings.xml`.

Before publishing for real: App Store Connect needs a version in "Prepare for Submission", and `overwrite_screenshots` clears every slot first — including the Apple Watch screenshots, which can't be rendered from Compose and must be re-added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)