### PR TITLE
fix(browser): white page background in dark mode + open in default browser

### DIFF
--- a/client/browser/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/browser/PlatformWebView.android.kt
+++ b/client/browser/public/src/androidMain/kotlin/com/plusmobileapps/chefmate/browser/PlatformWebView.android.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.arkivanov.essenty.instancekeeper.InstanceKeeper
 import com.multiplatform.webview.web.WebView
 import com.multiplatform.webview.web.rememberSaveableWebViewState
@@ -26,6 +27,11 @@ actual fun PlatformWebView(
     modifier: Modifier,
 ) {
     val webViewState = rememberSaveableWebViewState(url = url)
+    // The WebView library defaults its background to transparent, so a page that doesn't paint one
+    // lets the app's surface show through — which reads as a black page in dark mode. Browsers
+    // render on white; do the same so a site without dark styling stays legible. Sites that do
+    // support dark mode paint over this. Must be set before the AndroidView factory runs.
+    webViewState.webSettings.backgroundColor = Color.White
     val webViewNavigator = rememberWebViewNavigator()
     var lastCommandedUrl by rememberSaveable { mutableStateOf("") }
 

--- a/client/browser/public/src/commonMain/composeResources/values/strings.xml
+++ b/client/browser/public/src/commonMain/composeResources/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="browser_back">Back</string>
     <string name="browser_forward">Forward</string>
     <string name="browser_navigate">Navigate</string>
+    <string name="browser_open_in_default_browser">Open in browser</string>
     <string name="browser_download">Download</string>
     <string name="browser_landing_hint">Search {engine} or type a URL</string>
     <string name="browser_landing_tagline">Find your favorite recipes online, click download, and start cooking!</string>

--- a/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserPreviews.kt
+++ b/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserPreviews.kt
@@ -27,6 +27,33 @@ val previewBrowserSelectEngineBloc: BrowserSelectEngineBloc =
         override fun onEngineSelected(engine: SearchEngine) = Unit
     }
 
+/**
+ * The browser's address bar in isolation. [BrowserScreen] itself can't be previewed because
+ * [PlatformWebView] needs a live platform WebView, so the bar is snapshotted on its own.
+ */
+@Composable
+fun PreviewBrowserAddressBar(modifier: Modifier = Modifier) {
+    BrowserAddressBar(
+        url = "https://www.seriouseats.com/classic-banana-bread-recipe",
+        canGoBack = true,
+        canGoForward = false,
+        canOpenExternally = true,
+        onUrlChanged = {},
+        onNavigate = {},
+        onGoBack = {},
+        onGoForward = {},
+        onAddressBarFocused = {},
+        onOpenInDefaultBrowser = {},
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+internal fun BrowserAddressBarPreview() {
+    ChefMateTheme { Surface { PreviewBrowserAddressBar() } }
+}
+
 @Preview
 @Composable
 internal fun BrowserLandingScreenPreview() {

--- a/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserScreen.kt
+++ b/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -36,6 +37,8 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
@@ -48,6 +51,7 @@ import chefmate.client.browser.public.generated.resources.browser_download
 import chefmate.client.browser.public.generated.resources.browser_extraction_failed_body
 import chefmate.client.browser.public.generated.resources.browser_forward
 import chefmate.client.browser.public.generated.resources.browser_navigate
+import chefmate.client.browser.public.generated.resources.browser_open_in_default_browser
 import com.plusmobileapps.chefmate.text.FixedString
 import com.plusmobileapps.chefmate.text.asTextData
 import com.plusmobileapps.chefmate.ui.components.PlusButton
@@ -62,6 +66,7 @@ fun BrowserScreen(
     modifier: Modifier = Modifier,
 ) {
     val viewState by bloc.state.collectAsState()
+    val uriHandler = LocalUriHandler.current
 
     val failureMessage = viewState.extractionFailureMessage
     if (failureMessage != null) {
@@ -76,15 +81,22 @@ fun BrowserScreen(
 
     Column(modifier = modifier.fillMaxSize()) {
         if (viewState.showControls) {
-            AddressBar(
+            BrowserAddressBar(
                 url = viewState.addressBarText,
                 canGoBack = viewState.canGoBack,
                 canGoForward = viewState.canGoForward,
+                canOpenExternally = viewState.currentUrl.isNotBlank(),
                 onUrlChanged = bloc::onUrlChanged,
                 onNavigate = bloc::onNavigate,
                 onGoBack = bloc::onGoBack,
                 onGoForward = bloc::onGoForward,
                 onAddressBarFocused = bloc::onAddressBarFocused,
+                // Hand the page that's actually loaded (not the possibly half-typed address text)
+                // to the OS, which routes it to the user's default browser. Guarded because a
+                // scheme with no handler installed makes the platform handler throw.
+                onOpenInDefaultBrowser = {
+                    runCatching { uriHandler.openUri(viewState.currentUrl) }
+                },
                 sharedTransitionScope = sharedTransitionScope,
                 animatedVisibilityScope = animatedVisibilityScope,
             )
@@ -110,16 +122,19 @@ fun BrowserScreen(
     }
 }
 
+/** Public so `client/ui/screenshot-test` can snapshot it without a live [PlatformWebView]. */
 @Composable
-private fun AddressBar(
+fun BrowserAddressBar(
     url: String,
     canGoBack: Boolean,
     canGoForward: Boolean,
+    canOpenExternally: Boolean,
     onUrlChanged: (String) -> Unit,
     onNavigate: () -> Unit,
     onGoBack: () -> Unit,
     onGoForward: () -> Unit,
     onAddressBarFocused: () -> Unit,
+    onOpenInDefaultBrowser: () -> Unit,
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
     modifier: Modifier = Modifier,
@@ -213,6 +228,16 @@ private fun AddressBar(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowForward,
                 contentDescription = stringResource(Res.string.browser_navigate),
+            )
+        }
+        IconButton(
+            onClick = onOpenInDefaultBrowser,
+            enabled = canOpenExternally,
+            modifier = Modifier.testTag(BrowserTestTags.OPEN_IN_DEFAULT_BROWSER),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                contentDescription = stringResource(Res.string.browser_open_in_default_browser),
             )
         }
     }

--- a/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserTestTags.kt
+++ b/client/browser/public/src/commonMain/kotlin/com/plusmobileapps/chefmate/browser/BrowserTestTags.kt
@@ -10,5 +10,8 @@ object BrowserTestTags {
     /** The engine dropdown control on the landing screen. */
     const val LANDING_ENGINE_DROPDOWN = "BrowserLandingEngineDropdown"
 
+    /** Address-bar action that hands the current page to the device's default browser. */
+    const val OPEN_IN_DEFAULT_BROWSER = "BrowserOpenInDefaultBrowser"
+
     fun engineOption(engine: SearchEngine): String = "$ENGINE_OPTION_PREFIX${engine.id}"
 }

--- a/client/browser/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/browser/PlatformWebView.ios.kt
+++ b/client/browser/public/src/iosMain/kotlin/com/plusmobileapps/chefmate/browser/PlatformWebView.ios.kt
@@ -26,6 +26,12 @@ actual fun PlatformWebView(
     modifier: Modifier,
 ) {
     val webViewState = rememberSaveableWebViewState(url = url)
+    // The WebView library defaults the WKWebView to non-opaque, so a page that doesn't paint its
+    // own background lets the app's surface show through — which reads as a black page in dark
+    // mode. An opaque WKWebView falls back to its own white canvas (and derives the overscroll
+    // colour from the page), matching what a real browser shows. Sites that do support dark mode
+    // paint over it. Must be set before the UIKitView factory runs.
+    webViewState.webSettings.iOSWebSettings.opaque = true
     val webViewNavigator = rememberWebViewNavigator()
     var lastCommandedUrl by rememberSaveable { mutableStateOf("") }
 

--- a/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/BrowserScreenshotTest.kt
+++ b/client/ui/screenshot-test/src/screenshotTest/kotlin/com/plusmobileapps/chefmate/ui/screenshot/BrowserScreenshotTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.android.tools.screenshot.PreviewTest
+import com.plusmobileapps.chefmate.browser.PreviewBrowserAddressBar
 import com.plusmobileapps.chefmate.browser.previewBrowserLandingBloc
 import com.plusmobileapps.chefmate.browser.previewBrowserSelectEngineBloc
 import com.plusmobileapps.chefmate.ui.Content
@@ -46,4 +47,18 @@ fun BrowserLandingDarkScreenshot() {
     ChefMateTheme(darkTheme = true) {
         Surface(modifier = Modifier.fillMaxSize()) { previewBrowserLandingBloc.Content() }
     }
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun BrowserAddressBarLightScreenshot() {
+    ChefMateTheme { Surface { PreviewBrowserAddressBar() } }
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun BrowserAddressBarDarkScreenshot() {
+    ChefMateTheme(darkTheme = true) { Surface { PreviewBrowserAddressBar() } }
 }

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BrowserScreenshotTestKt/BrowserAddressBarDarkScreenshot_4d30ee2f_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BrowserScreenshotTestKt/BrowserAddressBarDarkScreenshot_4d30ee2f_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10f5c0b00a05f8b15458d6cd6165f0673b90efb8aa5c8421c9c47c05d7f5509c
+size 13843

--- a/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BrowserScreenshotTestKt/BrowserAddressBarLightScreenshot_748aa731_0.png
+++ b/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BrowserScreenshotTestKt/BrowserAddressBarLightScreenshot_748aa731_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cdcd4e75f2232194ff2d2682b0f06faebef9125e39ddcaa07efa049c0217d65
+size 13705


### PR DESCRIPTION
Two fixes for the in-app browser screen.

## 1. Pages render black in dark mode

**Cause:** `compose-webview-multiplatform` defaults `WebSettings.backgroundColor` to `Color.Transparent`, and on iOS defaults `IOSWebSettings.opaque` to `false`. A page that doesn't paint its own background therefore let the app's Compose surface show through — black in dark mode — even though the site had no dark styling of its own.

**Fix:** give the WebView an opaque white canvas on both platforms, the same as a real browser. Sites that *do* support dark mode paint their own background over it, so they're unaffected. On iOS `opaque = true` also lets WKWebView derive the overscroll colour from the page instead of showing a fixed under-page colour.

Desktop (JavaFX) was already fine — `Scene`/`WebView.pageFill` default to white — so it's untouched.

## 2. Open in the device's default browser

New open-in-new action at the right edge of the address bar. It hands the page to the OS via `LocalUriHandler`, which routes it to whichever browser the user has set as default (Chrome intent on Android, Safari on iOS, system browser on desktop) — no new expect/actual needed.

- Uses `currentUrl` (what the WebView actually loaded) rather than the address-bar text, which may be half-typed.
- Disabled until a page has loaded.
- The `openUri` call is wrapped in `runCatching` because the Android handler throws when no activity can handle the scheme.

`AddressBar` became the public `BrowserAddressBar` so it can be snapshotted on its own — `BrowserScreen` can't be previewed at all because `PlatformWebView` needs a live platform WebView.

## Note for review

The address bar now carries four icon buttons, so the URL field is tighter on phone widths (~18 visible characters vs ~24 before) — visible in the snapshot below. The navigate arrow (→) duplicates the keyboard's Go action, so dropping it would buy the space back, but that's removing existing functionality and out of scope here.

| Light | Dark |
|---|---|
| ![light](https://github.com/Plus-Mobile-Apps/chef-mate/blob/claude/browser-dark-mode-external-link-e03d6f/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BrowserScreenshotTestKt/BrowserAddressBarLightScreenshot_748aa731_0.png?raw=true) | ![dark](https://github.com/Plus-Mobile-Apps/chef-mate/blob/claude/browser-dark-mode-external-link-e03d6f/client/ui/screenshot-test/src/screenshotTestDebug/reference/com/plusmobileapps/chefmate/ui/screenshot/BrowserScreenshotTestKt/BrowserAddressBarDarkScreenshot_4d30ee2f_0.png?raw=true) |

## Testing

- `:client:browser:public:assemble` — green (Android, iOS arm64/sim, JVM).
- `:client:browser:impl:jvmTest` — green.
- `:client:ui:screenshot-test:validateDebugScreenshotTest` — green against the newly recorded references.
- The background fix itself needs a device/simulator to confirm visually; it isn't covered by the snapshot tests, since the WebView can't render in Layoutlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)