### PR TITLE
feat(meal): persist the meal plan day/week/month tab

### DIFF
--- a/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanViewModel.kt
+++ b/client/meal/core/impl/src/commonMain/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanViewModel.kt
@@ -20,6 +20,8 @@ import com.plusmobileapps.chefmate.text.PhraseModel
 import com.plusmobileapps.chefmate.text.TextData
 import com.plusmobileapps.chefmate.toast.ToastService
 import com.plusmobileapps.chefmate.util.DateTimeUtil
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.string
 import dev.zacsweers.metro.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.collections.immutable.toImmutableList
@@ -42,9 +44,16 @@ class MealPlanViewModel(
     private val dateTimeUtil: DateTimeUtil,
     private val coachMarkController: CoachMarkController,
     private val toastService: ToastService,
+    settings: Settings,
 ) : ViewModel(mainContext) {
 
-    private val _state = MutableStateFlow(State())
+    // Persisted so the day/week/month tab the user last picked is still selected next launch.
+    private var viewModePref by settings.string(KEY_VIEW_MODE, MealPlanBloc.ViewMode.DAY.name)
+
+    private val initialViewMode =
+        MealPlanBloc.ViewMode.entries.find { it.name == viewModePref } ?: MealPlanBloc.ViewMode.DAY
+
+    private val _state = MutableStateFlow(State(viewMode = initialViewMode))
 
     // Fold the shared controller's active mark into state so the screen shows at most one coach
     // mark at a time across the whole app.
@@ -69,6 +78,7 @@ class MealPlanViewModel(
     }
 
     fun selectViewMode(mode: MealPlanBloc.ViewMode) {
+        viewModePref = mode.name
         _state.update { it.copy(viewMode = mode) }
         observeMeals()
     }
@@ -325,4 +335,8 @@ class MealPlanViewModel(
         val pendingReplaceCookMode: List<MealPlanItem>? = null,
         val activeCoachMark: String? = null,
     )
+
+    companion object {
+        private const val KEY_VIEW_MODE = "meal_plan_view_mode"
+    }
 }

--- a/client/meal/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocTest.kt
+++ b/client/meal/core/impl/src/commonTest/kotlin/com/plusmobileapps/chefmate/meal/core/impl/MealPlanBlocTest.kt
@@ -62,9 +62,13 @@ class MealPlanBlocTest {
 
     val toastService = FakeToastService()
 
-    val bloc =
+    val settings = MapSettings()
+
+    val bloc = createBloc()
+
+    private fun createBloc() =
         MealPlanBlocImpl(
-            context = context,
+            context = TestBlocContext.create(),
             output = output,
             viewModelFactory = {
                 MealPlanViewModel(
@@ -74,6 +78,7 @@ class MealPlanBlocTest {
                     dateTimeUtil = dateTimeUtil,
                     coachMarkController = coachMarkController,
                     toastService = toastService,
+                    settings = settings,
                 )
             },
         )
@@ -218,6 +223,28 @@ class MealPlanBlocTest {
         bloc.onViewModeSelected(MealPlanBloc.ViewMode.MONTH)
 
         bloc.state.test { awaitItem().viewMode shouldBe MealPlanBloc.ViewMode.MONTH }
+    }
+
+    @Test
+    fun WHEN_view_mode_selected_THEN_it_is_restored_on_next_launch() = runTest {
+        every { repository.getMealsByDateRange("2026-04-01", "2026-04-30") } returns mealsFlow
+
+        bloc.onViewModeSelected(MealPlanBloc.ViewMode.MONTH)
+
+        // A new bloc backed by the same settings stands in for a relaunch of the app.
+        createBloc().state.test { awaitItem().viewMode shouldBe MealPlanBloc.ViewMode.MONTH }
+    }
+
+    @Test
+    fun WHEN_no_view_mode_persisted_THEN_day_mode_is_used() = runTest {
+        createBloc().state.test { awaitItem().viewMode shouldBe MealPlanBloc.ViewMode.DAY }
+    }
+
+    @Test
+    fun WHEN_persisted_view_mode_is_unknown_THEN_day_mode_is_used() = runTest {
+        settings.putString("meal_plan_view_mode", "YEAR")
+
+        createBloc().state.test { awaitItem().viewMode shouldBe MealPlanBloc.ViewMode.DAY }
     }
 
     @Test
@@ -420,6 +447,7 @@ class MealPlanBlocTest {
                             dateTimeUtil = dateTimeUtil,
                             coachMarkController = CoachMarkController(MapSettings()),
                             toastService = toastService,
+                            settings = MapSettings(),
                         )
                     },
                 )


### PR DESCRIPTION
Closes #519

## What

The meal plan's day/week/month tab reset to **Day** on every launch. It now persists.

- `MealPlanViewModel` reads/writes the selected `ViewMode` through `multiplatform-settings` (`meal_plan_view_mode`), seeding `State.viewMode` on construction and writing on every `selectViewMode`.
- This is the same idiom `GroceryListViewModel` already uses for its sort/filter prefs, so no new preference plumbing was needed — `client:shared` already exposes `Settings` as `api`.
- An unrecognized stored value (e.g. a mode removed in a future release) falls back to `DAY`.

The date itself is deliberately **not** persisted — reopening the app still lands on today, just in the user's preferred view.

## Testing

`MealPlanBlocTest` gains three cases, using a shared `MapSettings` and a `createBloc()` helper that stands in for a relaunch:

- selecting Month is restored by a freshly constructed bloc
- no persisted value → Day
- unknown persisted value → Day

```bash
./gradlew :client:meal:core:impl:jvmTest
```

24 tests, all green. No UI files changed, so no snapshot references needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)